### PR TITLE
[Codegen] Use divisibility analysis for im2col vectorization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
@@ -418,6 +418,11 @@ public:
     // so tile sizes go directly on the result lattice.
     if (auto im2colOp = dyn_cast<IREE::LinalgExt::Im2colOp>(op)) {
       OpBuilder builder(op);
+      // The dependent determines what reruns if the divisibility lattice for
+      // `val` changes below. Sparse forward analyses visit operations from the
+      // program point after the operation, so use `after(op)` to rerun this op.
+      // This dependency is not expected to affect convergence in practice:
+      // divisibility is solved to fixpoint before tile-size analysis starts.
       ProgramPoint *dependent = getProgramPointAfter(op);
       std::optional<SmallVector<int64_t>> maybeTileSizes =
           IREE::LinalgExt::computeIm2colVectorTileSizes(

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
@@ -10,7 +10,10 @@
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/Im2colUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
@@ -18,6 +21,8 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/SymbolTable.h"
+
+#include <algorithm>
 
 namespace mlir::iree_compiler {
 #define GEN_PASS_DEF_MATERIALIZEVECTORTILESIZESPASS
@@ -338,6 +343,10 @@ class TileSizeForwardAnalysis
 public:
   using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
 
+  static bool classof(const DataFlowAnalysis *a) {
+    return a->getTypeID() == TypeID::get<TileSizeForwardAnalysis>();
+  }
+
   void setToEntryState(TileSizeLattice *lattice) override {
     // Entry state is uninitialized (identity for join).
     propagateIfChanged(lattice, lattice->join(TileSizes()));
@@ -413,8 +422,20 @@ public:
     // so tile sizes go directly on the result lattice.
     if (auto im2colOp = dyn_cast<IREE::LinalgExt::Im2colOp>(op)) {
       OpBuilder builder(op);
+      ProgramPoint *dependent = getProgramPointAfter(op);
       std::optional<SmallVector<int64_t>> maybeTileSizes =
-          IREE::LinalgExt::computeIm2colVectorTileSizes(builder, im2colOp);
+          IREE::LinalgExt::computeIm2colVectorTileSizes(
+              builder, im2colOp, [this, dependent](Value val) {
+                const auto *lattice =
+                    getOrCreateFor<IREE::Util::IntegerDivisibilityLattice>(
+                        dependent, val);
+                if (!lattice || lattice->getValue().isUninitialized()) {
+                  return uint64_t{1};
+                }
+                const IREE::Util::ConstantIntDivisibility &div =
+                    lattice->getValue().getValue();
+                return div.sdiv();
+              });
       if (maybeTileSizes) {
         TileSizes tileSizes(*maybeTileSizes);
         propagateIfChanged(results[0], results[0]->join(tileSizes));
@@ -460,6 +481,10 @@ class TileSizeBackwardAnalysis
     : public dataflow::SparseBackwardDataFlowAnalysis<TileSizeLattice> {
 public:
   using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+
+  static bool classof(const DataFlowAnalysis *a) {
+    return a->getTypeID() == TypeID::get<TileSizeBackwardAnalysis>();
+  }
 
   void setToExitState(TileSizeLattice *lattice) override {
     // Exit state is uninitialized (identity for meet).
@@ -765,13 +790,26 @@ public:
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
 
+    // Stage 1: run baseline analyses and IntegerDivisibilityAnalysis to
+    // convergence. We need these results to be stable before the tile size
+    // analyses consult them, so we use the staged-solve pattern enabled by
+    // `DataFlowSolver::initializeAndRun`'s analysis filter.
     DataFlowSolver solver;
     dataflow::loadBaselineAnalyses(solver);
+    solver.load<IREE::Util::IntegerDivisibilityAnalysis>();
+    if (failed(solver.initializeAndRun(funcOp))) {
+      return signalPassFailure();
+    }
+
+    // Stage 2: load the tile size analyses and initialize only those.
+    // The existing divisibility lattices are left initialized from stage 1 and
+    // can be queried by the vector size analyses when determining vector sizes.
     solver.load<TileSizeForwardAnalysis>();
     SymbolTableCollection symbolTable;
     solver.load<TileSizeBackwardAnalysis>(symbolTable);
-
-    if (failed(solver.initializeAndRun(funcOp))) {
+    if (failed(solver.initializeAndRun(
+            funcOp, llvm::IsaPred<TileSizeForwardAnalysis,
+                                  TileSizeBackwardAnalysis>))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
@@ -12,8 +12,6 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.h"
 
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
@@ -21,8 +19,6 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/SymbolTable.h"
-
-#include <algorithm>
 
 namespace mlir::iree_compiler {
 #define GEN_PASS_DEF_MATERIALIZEVECTORTILESIZESPASS

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
@@ -661,6 +661,106 @@ func.func @im2col_tile_sizes_non_contiguous(
 
 // -----
 
+// Im2col: offset produced by `arith.muli %k, %c4`, not by an `affine.apply`.
+// The static `affine.apply` pattern match cannot see through `arith.muli`, so
+// contiguity recognition here relies on `IntegerDivisibilityAnalysis` running
+// as stage 1 of the solver and reporting divisibility of 4 on the offset.
+// Without that analysis the tile size attribute would not be stamped.
+
+// CHECK-LABEL: @im2col_tile_sizes_divisibility_muli
+func.func @im2col_tile_sizes_divisibility_muli(
+    %input: tensor<2x34x34x640xf32>, %m_off: index, %k: index
+) -> tensor<2x2x4xf32> {
+  %0 = tensor.empty() : tensor<2x2x4xf32>
+  %c4 = arith.constant 4 : index
+  %k_off = arith.muli %k, %c4 : index
+  // CHECK: iree_linalg_ext.im2col
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 1, 1, 4>
+  %1 = iree_linalg_ext.im2col
+          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+          offsets = [0, %m_off, %k_off] output_sizes = [[2], [32, 32], [3, 3, 640]]
+          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+          ins(%input : tensor<2x34x34x640xf32>)
+          outs(%0 : tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+  return %1 : tensor<2x2x4xf32>
+}
+
+// -----
+
+// Im2col: offset divisibility communicated via `util.assume.int`. This is the
+// canonical way a frontend or an earlier pass tells the compiler that a
+// dynamic value is a known multiple. `IntegerDivisibilityAnalysis` threads
+// the assumption through to the contiguity check.
+
+// CHECK-LABEL: @im2col_tile_sizes_divisibility_assume
+func.func @im2col_tile_sizes_divisibility_assume(
+    %input: tensor<2x34x34x640xf32>, %m_off: index, %k: index
+) -> tensor<2x2x4xf32> {
+  %0 = tensor.empty() : tensor<2x2x4xf32>
+  %k_off = util.assume.int %k<udiv = 4> : index
+  // CHECK: iree_linalg_ext.im2col
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 1, 1, 4>
+  %1 = iree_linalg_ext.im2col
+          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+          offsets = [0, %m_off, %k_off] output_sizes = [[2], [32, 32], [3, 3, 640]]
+          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+          ins(%input : tensor<2x34x34x640xf32>)
+          outs(%0 : tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+  return %1 : tensor<2x2x4xf32>
+}
+
+// -----
+
+// Im2col: offset that `IntegerDivisibilityAnalysis` proves is exactly zero.
+// Zero is divisible by every tile size, and this case is not covered by the
+// fallback static `affine.apply` map match.
+
+// CHECK-LABEL: @im2col_tile_sizes_divisibility_zero
+func.func @im2col_tile_sizes_divisibility_zero(
+    %input: tensor<2x34x34x640xf32>, %m_off: index, %k: index
+) -> tensor<2x2x4xf32> {
+  %0 = tensor.empty() : tensor<2x2x4xf32>
+  %c0 = arith.constant 0 : index
+  %k_off = arith.muli %k, %c0 : index
+  // CHECK: iree_linalg_ext.im2col
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 1, 1, 4>
+  %1 = iree_linalg_ext.im2col
+          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+          offsets = [0, %m_off, %k_off] output_sizes = [[2], [32, 32], [3, 3, 640]]
+          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+          ins(%input : tensor<2x34x34x640xf32>)
+          outs(%0 : tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+  return %1 : tensor<2x2x4xf32>
+}
+
+// -----
+
+// Im2col: no divisibility information available (offset is an opaque function
+// argument). The analysis cannot prove contiguity, so no tile sizes attribute
+// is stamped. This is the negative control for the two preceding tests.
+
+// CHECK-LABEL: @im2col_tile_sizes_divisibility_unknown
+func.func @im2col_tile_sizes_divisibility_unknown(
+    %input: tensor<2x34x34x640xf32>, %m_off: index, %k_off: index
+) -> tensor<2x2x4xf32> {
+  %0 = tensor.empty() : tensor<2x2x4xf32>
+  // CHECK: iree_linalg_ext.im2col
+  // CHECK-NOT: iree_codegen.vector_tile_sizes
+  %1 = iree_linalg_ext.im2col
+          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+          offsets = [0, %m_off, %k_off] output_sizes = [[2], [32, 32], [3, 3, 640]]
+          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+          ins(%input : tensor<2x34x34x640xf32>)
+          outs(%0 : tensor<2x2x4xf32>) -> tensor<2x2x4xf32>
+  return %1 : tensor<2x2x4xf32>
+}
+
+// -----
+
 // Im2col: wider vectorization. Vectorizes along the innermost channel dim
 // with width 8. Non-vectorized spatial dims are tiled to 1.
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
@@ -713,9 +713,7 @@ func.func @im2col_tile_sizes_divisibility_assume(
 
 // -----
 
-// Im2col: offset that `IntegerDivisibilityAnalysis` proves is exactly zero.
-// Zero is divisible by every tile size, and this case is not covered by the
-// fallback static `affine.apply` map match.
+// Im2col: offset that `IntegerDivisibilityAnalysis` proves is exactly zero, which is always aligned.
 
 // CHECK-LABEL: @im2col_tile_sizes_divisibility_zero
 func.func @im2col_tile_sizes_divisibility_zero(
@@ -742,8 +740,8 @@ func.func @im2col_tile_sizes_divisibility_zero(
 // argument). The analysis cannot prove contiguity, so no tile sizes attribute
 // is stamped. This is the negative control for the two preceding tests.
 
-// CHECK-LABEL: @im2col_tile_sizes_divisibility_unknown
-func.func @im2col_tile_sizes_divisibility_unknown(
+// CHECK-LABEL: @negative_im2col_tile_sizes_divisibility_unknown
+func.func @negative_im2col_tile_sizes_divisibility_unknown(
     %input: tensor<2x34x34x640xf32>, %m_off: index, %k_off: index
 ) -> tensor<2x2x4xf32> {
   %0 = tensor.empty() : tensor<2x2x4xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/Im2colUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/Im2colUtils.cpp
@@ -315,9 +315,14 @@ Value computeIm2colValidSize(OpBuilder &b, Location loc, Im2colOp im2colOp,
 
 /// Helper to check if a slice will be contiguous given the offset and
 /// slice size. Checks that `inputSize` and `offset` are both evenly
-/// divisible by `tileSize`.
+/// divisible by `tileSize`. When `getOffsetDivisibility` is non-null, it is
+/// consulted for runtime offset values — a returned factor that is a multiple
+/// of `tileSize` is enough to consider the slice contiguous. This is a
+/// strictly more general signal than the static `affine.apply` map match used
+/// as a fallback below.
 static bool willBeContiguousSlice(OpFoldResult inputSize, OpFoldResult tileSize,
-                                  OpFoldResult offset) {
+                                  OpFoldResult offset,
+                                  OffsetDivisibilityFn getOffsetDivisibility) {
   std::optional<int64_t> constInputSize = getConstantIntValue(inputSize);
   std::optional<int64_t> constTileSize = getConstantIntValue(tileSize);
   if (!constTileSize.has_value() || !constInputSize.has_value() ||
@@ -332,15 +337,26 @@ static bool willBeContiguousSlice(OpFoldResult inputSize, OpFoldResult tileSize,
   if (!val) {
     return false;
   }
+  uint64_t tile = static_cast<uint64_t>(constTileSize.value());
+  if (getOffsetDivisibility) {
+    uint64_t div = getOffsetDivisibility(val);
+    if (div == 0 || div % tile == 0) {
+      return true;
+    }
+  }
+  // Fallback for callers that can't (or don't) consult a divisibility analysis:
+  // recognize the common case where the offset is an `affine.apply` whose
+  // result expression is statically a multiple of the tile size.
   auto affineOp = val.getDefiningOp<affine::AffineApplyOp>();
   return affineOp &&
          affineOp.getMap().getResult(0).isMultipleOf(constTileSize.value());
 }
 
-std::optional<int64_t> chooseDimToVectorize(OpBuilder &b, Location loc,
-                                            Im2colOp im2colOp,
-                                            ArrayRef<Range> iterationDomain,
-                                            ArrayRef<OpFoldResult> offsets) {
+std::optional<int64_t>
+chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
+                     ArrayRef<Range> iterationDomain,
+                     ArrayRef<OpFoldResult> offsets,
+                     OffsetDivisibilityFn getOffsetDivisibility) {
   int64_t innerInputDim = im2colOp.getInputRank() - 1;
   SmallVector<OpFoldResult> inputSizes =
       tensor::getMixedSizes(b, loc, im2colOp.getInput());
@@ -426,7 +442,8 @@ std::optional<int64_t> chooseDimToVectorize(OpBuilder &b, Location loc,
     }
 
     OpFoldResult outputDimSize = iterationDomain[outputDimToVectorize].size;
-    if (!willBeContiguousSlice(innerSliceSize, outputDimSize, offset)) {
+    if (!willBeContiguousSlice(innerSliceSize, outputDimSize, offset,
+                               getOffsetDivisibility)) {
       continue;
     }
     return outputDimToVectorize;
@@ -435,12 +452,13 @@ std::optional<int64_t> chooseDimToVectorize(OpBuilder &b, Location loc,
 }
 
 std::optional<SmallVector<int64_t>>
-computeIm2colVectorTileSizes(OpBuilder &b, Im2colOp im2colOp) {
+computeIm2colVectorTileSizes(OpBuilder &b, Im2colOp im2colOp,
+                             OffsetDivisibilityFn getOffsetDivisibility) {
   Location loc = im2colOp.getLoc();
   SmallVector<Range> iterationDomain(im2colOp.getIterationDomain(b));
   SmallVector<OpFoldResult> mixedOffsets = im2colOp.getMixedOffsets();
-  std::optional<int64_t> dimToVectorize =
-      chooseDimToVectorize(b, loc, im2colOp, iterationDomain, mixedOffsets);
+  std::optional<int64_t> dimToVectorize = chooseDimToVectorize(
+      b, loc, im2colOp, iterationDomain, mixedOffsets, getOffsetDivisibility);
 
   int64_t outputRank = im2colOp.getOutputRank();
   SmallVector<int64_t> tileSizes(outputRank, 1);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/Im2colUtils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/Im2colUtils.h
@@ -14,9 +14,16 @@
 // Im2colOp.
 
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "mlir/IR/OpDefinition.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
+
+/// Callback returning the known divisibility (greatest N such that the value is
+/// guaranteed to be a multiple of N) for a given Value. A return value of 1
+/// means "no information". Typically backed by `IntegerDivisibilityAnalysis`
+/// results from the caller's dataflow solver.
+using OffsetDivisibilityFn = llvm::function_ref<uint64_t(Value)>;
 
 /// Holds the computed source indices for an im2col operation at a given
 /// output position. These indices describe where to read from the input tensor.
@@ -71,17 +78,28 @@ Value computeIm2colValidSize(OpBuilder &b, Location loc, Im2colOp im2colOp,
 /// \p offsets are the per-output-dim offsets from the im2col op's attributes.
 /// For K output dims, the offset of the specific dim being considered is used
 /// directly for the contiguity check (no linearization needed).
-std::optional<int64_t> chooseDimToVectorize(OpBuilder &b, Location loc,
-                                            Im2colOp im2colOp,
-                                            ArrayRef<Range> iterationDomain,
-                                            ArrayRef<OpFoldResult> offsets);
+///
+/// When \p getOffsetDivisibility is set, the contiguity check queries it for
+/// runtime (non-constant) offset Values. Returning a factor that is a multiple
+/// of the tile size lets this helper recognize vectorizable cases that the
+/// static `affine.apply` pattern match cannot.
+std::optional<int64_t>
+chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
+                     ArrayRef<Range> iterationDomain,
+                     ArrayRef<OpFoldResult> offsets,
+                     OffsetDivisibilityFn getOffsetDivisibility = nullptr);
 
 /// Compute vector tile sizes for an im2col op. Returns a vector of tile sizes
 /// with one entry per output dimension. The vectorizable dimension (if any)
 /// gets its full iteration size; all other dimensions get 1. Returns nullopt
 /// if no vectorizable dimension is found (e.g. no contiguous slice exists).
-std::optional<SmallVector<int64_t>>
-computeIm2colVectorTileSizes(OpBuilder &b, Im2colOp im2colOp);
+///
+/// \p getOffsetDivisibility, when non-null, is forwarded to the contiguity
+/// check so that runtime offset divisibility (typically from
+/// `IntegerDivisibilityAnalysis`) can be used.
+std::optional<SmallVector<int64_t>> computeIm2colVectorTileSizes(
+    OpBuilder &b, Im2colOp im2colOp,
+    OffsetDivisibilityFn getOffsetDivisibility = nullptr);
 
 } // namespace mlir::iree_compiler::IREE::LinalgExt
 


### PR DESCRIPTION
Adds the divisibility analysis to the MaterializeVectorTileSizesPass, and uses it for determining im2col vector sizes. The im2col op vector sizes depend on the offset computation because of load contiguity constraints, so we need to have divisibility information to accurately determine good vector sizes. This used to be done by matching affine ops, but this PR makes the divisibility analysis available when determining the divisibility, which enables better vectorization for more complex offset computation cases.

In the MaterializeVectorTileSizesPass, the divisibility analysis is run to a fixpoint before the vector size analyses are loaded and initialized, because the vector size analyses depend on the fully converged divisibility results.