### PR TITLE
[Codegen][CPU] Fix RHS indexing map in materialize-encoding inner_tiled lowering.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
@@ -176,6 +176,9 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
   return %5 : tensor<?x?xf32>
 }
 //   CHECK-DAG: #[[$MAP_INNER:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
+//   CHECK-DAG: #[[$MAP_LHS:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+//   CHECK-DAG: #[[$MAP_RHS:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+//   CHECK-DAG: #[[$MAP_ACC:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-LABEL: func @pack_gemm_fill_dynamic_inner_tiled_avx512(
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
@@ -192,6 +195,11 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
 //       CHECK:   %[[FILL:.+]] = linalg.fill
 //  CHECK-SAME:       outs(%[[EMPTY]] :
 //       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled ins(%[[PACK_LHS]], %[[PACK_RHS]]) outs(%[[FILL]])
+// The RHS pack uses `outer_dims_perm = [1, 0]`, so its outer dims come out as
+// (N_iter, K_iter) — mmt4d-style — not (K_iter, N_iter). The inner_tiled op
+// must label its RHS operand with the matching `(d1, d2)` map, otherwise the
+// verifier rejects the op with "shape does not match iteration bounds".
+//  CHECK-SAME:       indexing_maps = [#[[$MAP_LHS]], #[[$MAP_RHS]], #[[$MAP_ACC]]]
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 16>, semantics = #iree_cpu.mma_semantics<>
 //       CHECK:   %[[UNPACK:.+]] = linalg.unpack %[[INNER]]
 //       CHECK:   return %[[UNPACK]]

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -611,9 +611,13 @@ static Operation *lowerContractionToInnerTiled(
   AffineExpr d0 = builder.getAffineDimExpr(0);
   AffineExpr d1 = builder.getAffineDimExpr(1);
   AffineExpr d2 = builder.getAffineDimExpr(2);
+  // RHS uses (d1, d2) i.e. (N_iter, K_iter) outer ordering — mmt4d-style — to
+  // match the packed RHS operand shape produced upstream (the RHS pack uses
+  // `outer_dims_perm = [1, 0]` so its outer dims come out as N_iter, K_iter,
+  // not K_iter, N_iter).
   SmallVector<AffineMap> indexingMaps = {
       AffineMap::get(3, 0, {d0, d2}, ctx),
-      AffineMap::get(3, 0, {d2, d1}, ctx),
+      AffineMap::get(3, 0, {d1, d2}, ctx),
       AffineMap::get(3, 0, {d0, d1}, ctx),
   };
   SmallVector<utils::IteratorType> iteratorTypes = {


### PR DESCRIPTION
The CPU encoding-materialization path (`lowerContractionOpToInnerTiled`) emits an `iree_codegen.inner_tiled` op with the standard matmul indexing maps `[(d0, d2), (d2, d1), (d0, d1)]`, but the RHS pack it lowers to uses `outer_dims_perm = [1, 0]` so the packed RHS comes out with outer dims in `(N_iter, K_iter)` order — i.e. mmt4d-style, not standard-matmul style. The two interpretations of the same operand shape disagree, and the inner_tiled verifier rejects the op with:

    error: 'iree_codegen.inner_tiled' op shape does not match
           iteration bounds

Switching the RHS map to `(d0, d1, d2) -> (d1, d2)` matches what the pack actually produces and lets the verifier project a consistent iteration domain across all three operands. The semantics are still a valid contraction (one parallel + one reduction on each input, two parallels on the output), just with the RHS walked in mmt4d order.

Without this fix, data-tiled `linalg.matmul` -> `inner_tiled` lowering on CPU fails the verifier on the very first dispatch and never gets near codegen; with it, end-to-end compile gets past verification all the way to bufferization (where a separate, pre-existing pipeline gap takes over: there is no CPU pass yet that vectorizes/lowers `inner_tiled` before bufferize).

Progress towards #24323