### PR TITLE
[Codegen] NFC: Lift DataTiledMMA inner_tiled lowering helpers into MMAUtils.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel
@@ -34,3 +34,22 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
     ],
 )
+
+iree_compiler_cc_library(
+    name = "MMAUtils",
+    srcs = [
+        "MMAUtils.cpp",
+    ],
+    hdrs = [
+        "MMAUtils.h",
+    ],
+    deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Dialect/Util/IR",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:VectorDialect",
+    ],
+)

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/CMakeLists.txt
@@ -31,4 +31,22 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    MMAUtils
+  HDRS
+    "MMAUtils.h"
+  SRCS
+    "MMAUtils.cpp"
+  DEPS
+    LLVMSupport
+    MLIRArithDialect
+    MLIRIR
+    MLIRSupport
+    MLIRVectorDialect
+    iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Dialect::Util::IR
+  PUBLIC
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.cpp
@@ -1,0 +1,138 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.h"
+
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::iree_compiler::IREE::Codegen {
+
+bool incrementIndices(MutableArrayRef<int64_t> indices,
+                      ArrayRef<int64_t> sizes) {
+  for (int i = indices.size() - 1; i >= 0; --i) {
+    if (++indices[i] == sizes[i]) {
+      indices[i] = 0;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Flattens vector `value` to 1-D if its rank is greater than 1; otherwise
+// returns it unchanged.
+static Value flattenVector(OpBuilder &builder, Location loc, Value value) {
+  auto vectorType = cast<VectorType>(value.getType());
+  if (vectorType.getRank() <= 1) {
+    return value;
+  }
+  auto flatVectorType = VectorType::get({vectorType.getNumElements()},
+                                        vectorType.getElementType());
+  return vector::ShapeCastOp::create(builder, loc, flatVectorType, value);
+}
+
+SmallVector<Value>
+distributeMmaFragmentToIntrinsics(OpBuilder &builder, Location loc, Value value,
+                                  const TileSwizzle &swizzle) {
+  auto internalShape = sliceSwizzledShape(swizzle, [](TileSwizzle::Dim dim) {
+    return dim.kind() == TileSwizzle::Dim::Kind::Internal;
+  });
+  auto crossIntrinsicShape =
+      sliceSwizzledShape(swizzle, [](TileSwizzle::Dim dim) {
+        return dim.kind() == TileSwizzle::Dim::Kind::CrossIntrinsic;
+      });
+  int rank = internalShape.size();
+  SmallVector<int64_t> indices(rank, 0);
+  SmallVector<int64_t> strides(rank, 1);
+  SmallVector<Value> distributedValues;
+  do {
+    Value extract = vector::ExtractStridedSliceOp::create(
+        builder, loc, value, indices, internalShape, strides);
+    distributedValues.push_back(flattenVector(builder, loc, extract));
+  } while (incrementIndices(indices, crossIntrinsicShape));
+  return distributedValues;
+}
+
+LogicalResult buildDataTiledMMAUnderlyingOperations(
+    OpBuilder &builder, Location loc, const TileSwizzle &lhsSwizzle,
+    const TileSwizzle &rhsSwizzle, const TileSwizzle &accSwizzle,
+    int64_t intrinsicsM, int64_t intrinsicsN, int64_t intrinsicsK,
+    ValueRange inputs, ValueRange outputs,
+    DataTiledMMAIntrinsicEmitter emitIntrinsic,
+    SmallVectorImpl<Value> &results) {
+  if (inputs.size() != 2 || outputs.size() != 1) {
+    return failure();
+  }
+
+  // Prepare LHS/RHS operand slices to feed the per-intrinsic emitter.
+  SmallVector<Value> intrinsicsLhs =
+      distributeMmaFragmentToIntrinsics(builder, loc, inputs[0], lhsSwizzle);
+  SmallVector<Value> intrinsicsRhs =
+      distributeMmaFragmentToIntrinsics(builder, loc, inputs[1], rhsSwizzle);
+
+  // Distribute the accumulator into per-intrinsic slices; the reassembly
+  // conversion will be hoisted out of the reduction loop.
+  auto distributeAccOp = IREE::Util::HoistableConversionOp::create(
+      builder, loc, /*tag=*/kDataTiledAccDistribute,
+      /*inverseTag=*/kDataTiledAccReassemble, ValueRange{outputs[0]},
+      [&](OpBuilder &b, Location loc, ValueRange args) -> SmallVector<Value> {
+        return distributeMmaFragmentToIntrinsics(b, loc, args[0], accSwizzle);
+      });
+  SmallVector<Value> intrinsicsAcc(distributeAccOp.getResults());
+
+  // Loop over the unroll_{m,n,k} dimensions to emit per-intrinsic ops.
+  for (int64_t mu = 0; mu < intrinsicsM; ++mu) {
+    for (int64_t nu = 0; nu < intrinsicsN; ++nu) {
+      for (int64_t ku = 0; ku < intrinsicsK; ++ku) {
+        Value lhsPiece = intrinsicsLhs[mu * intrinsicsK + ku];
+        Value rhsPiece = intrinsicsRhs[nu * intrinsicsK + ku];
+        Value &acc = intrinsicsAcc[mu * intrinsicsN + nu];
+        Value newAcc = emitIntrinsic(builder, loc, lhsPiece, rhsPiece, acc);
+        if (!newAcc) {
+          return failure();
+        }
+        acc = newAcc;
+      }
+    }
+  }
+
+  // Reassemble per-intrinsic ACC pieces into the original accumulator tile.
+  SmallVector<int64_t> accCrossIntrinsicShape =
+      sliceSwizzledShape(accSwizzle, [](TileSwizzle::Dim dim) {
+        return dim.kind() == TileSwizzle::Dim::Kind::CrossIntrinsic;
+      });
+  SmallVector<int64_t> accInternalShape =
+      sliceSwizzledShape(accSwizzle, [](TileSwizzle::Dim dim) {
+        return dim.kind() == TileSwizzle::Dim::Kind::Internal;
+      });
+  Type accElemType = cast<VectorType>(outputs[0].getType()).getElementType();
+
+  auto reassembleOp = IREE::Util::HoistableConversionOp::create(
+      builder, loc, /*tag=*/kDataTiledAccReassemble,
+      /*inverseTag=*/kDataTiledAccDistribute, intrinsicsAcc,
+      [&](OpBuilder &b, Location loc, ValueRange args) -> SmallVector<Value> {
+        int64_t dstRank = accCrossIntrinsicShape.size();
+        SmallVector<int64_t> strides(dstRank, 1);
+        SmallVector<int64_t> indices(dstRank, 0);
+        Value acc = arith::ConstantOp::create(
+            b, loc, b.getZeroAttr(outputs[0].getType()));
+        for (Value intrAcc : args) {
+          Value expandedAcc = vector::ShapeCastOp::create(
+              b, loc, VectorType::get(accInternalShape, accElemType), intrAcc);
+          acc = vector::InsertStridedSliceOp::create(b, loc, expandedAcc, acc,
+                                                     indices, strides);
+          incrementIndices(indices, accCrossIntrinsicShape);
+        }
+        return {acc};
+      });
+  results.push_back(reassembleOp.getResult(0));
+  return success();
+}
+
+} // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.h
@@ -1,0 +1,99 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_UTILS_MMAUTILS_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_UTILS_MMAUTILS_H_
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+
+namespace mlir::iree_compiler::IREE::Codegen {
+
+//===----------------------------------------------------------------------===//
+// HoistableConversionOp tag pairs used by inner_tiled lowerings.
+//===----------------------------------------------------------------------===//
+//
+// Each pair labels a `IREE::Util::HoistableConversionOp` and its inverse so
+// `IREE::Util::eliminateHoistableConversions` can cancel them across
+// reduction-loop boundaries. The pairing is by string match, so both halves of
+// a pair must agree on the spelling — keeping them all here, in one place,
+// avoids the interaction-at-a-distance hazard of having paired strings defined
+// in separate translation units.
+//
+// Currently these are emitted from:
+//   * `buildDataTiledMMAUnderlyingOperations` below (CPU + GPU DataTiledMMA),
+//     and from GPU's `DataTiledScaledMMAAttr::buildUnderlyingOperations`
+//     which reuses the helpers below: kDataTiledAcc{Distribute,Reassemble}.
+//   * GPU `createMmaOp` for RDNA3 WMMA half-acc widening:
+//     kRdna3{Interleave,Deinterleave}Acc.
+//   * GPU `createMmaOp` for AMD VDMFMA acc handling:
+//     kVDMFMA{Interleave,Deinterleave}Acc.
+
+inline constexpr llvm::StringLiteral kDataTiledAccDistribute =
+    "data_tiled_acc_distribute";
+inline constexpr llvm::StringLiteral kDataTiledAccReassemble =
+    "data_tiled_acc_reassemble";
+
+inline constexpr llvm::StringLiteral kRdna3InterleaveAcc =
+    "rdna3_interleave_acc";
+inline constexpr llvm::StringLiteral kRdna3DeinterleaveAcc =
+    "rdna3_deinterleave_acc";
+
+inline constexpr llvm::StringLiteral kVDMFMAInterleaveAcc =
+    "vdmfma_interleave_acc";
+inline constexpr llvm::StringLiteral kVDMFMADeinterleaveAcc =
+    "vdmfma_deinterleave_acc";
+
+//===----------------------------------------------------------------------===//
+// Shared body of DataTiledMMAAttr::buildUnderlyingOperations, plus the
+// distribution helpers it relies on. Both helpers are also reused by GPU's
+// `DataTiledScaledMMAAttr::buildUnderlyingOperations`, which has a different
+// operand layout (extra scales) but the same data-tiled distribution model.
+//===----------------------------------------------------------------------===//
+
+/// Increments `indices` row-major under `sizes`. Returns false on overflow.
+bool incrementIndices(MutableArrayRef<int64_t> indices,
+                      ArrayRef<int64_t> sizes);
+
+/// Distributes a multi-MMA-level tile `value` into per-intrinsic 1-D slices.
+/// The input must already be in the swizzle's distributed N-D form (rank
+/// equals `swizzle.getExpandedSize()`, with CrossThread dim sizes collapsed
+/// to 1). Iterates cross-intrinsic indices in row-major order; each returned
+/// value has the swizzle's "internal-only" shape, flattened to 1-D.
+SmallVector<Value>
+distributeMmaFragmentToIntrinsics(OpBuilder &builder, Location loc, Value value,
+                                  const TileSwizzle &swizzle);
+
+/// Callback emitting one architecture-specific MMA intrinsic op. Receives flat
+/// 1-D operands sized for one intrinsic invocation. Must return a value with
+/// the same type as the input `acc`, or a null Value to signal failure.
+using DataTiledMMAIntrinsicEmitter = llvm::function_ref<Value(
+    OpBuilder &builder, Location loc, Value lhs, Value rhs, Value acc)>;
+
+/// Common body of `DataTiledMMAAttr::buildUnderlyingOperations`. Distributes
+/// `inputs` and `outputs[0]` into per-intrinsic flat vectors using the three
+/// swizzles, runs an `(mu, nu, ku)` unroll loop calling `emitIntrinsic` for
+/// each combination, and reassembles the final accumulator into the original
+/// output type. The accumulator distribute and reassemble are wrapped in
+/// `IREE::Util::HoistableConversionOp` pairs (tagged
+/// kDataTiledAcc{Distribute,Reassemble}) so they can sink/hoist out of
+/// reduction loops.
+///
+/// `inputs` are LHS and RHS in that order. `outputs[0]` is the accumulator.
+/// Each operand vector must already have the swizzle's full expanded rank.
+LogicalResult buildDataTiledMMAUnderlyingOperations(
+    OpBuilder &builder, Location loc, const TileSwizzle &lhsSwizzle,
+    const TileSwizzle &rhsSwizzle, const TileSwizzle &accSwizzle,
+    int64_t intrinsicsM, int64_t intrinsicsN, int64_t intrinsicsK,
+    ValueRange inputs, ValueRange outputs,
+    DataTiledMMAIntrinsicEmitter emitIntrinsic,
+    SmallVectorImpl<Value> &results);
+
+} // namespace mlir::iree_compiler::IREE::Codegen
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_UTILS_MMAUTILS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -89,6 +89,7 @@ iree_compiler_cc_library(
         "//compiler/bindings/c:headers",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils",
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils:MMAUtils",
         "//compiler/src/iree/compiler/Codegen/Dialect/PCF/IR",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
         "//compiler/src/iree/compiler/Codegen/Interfaces:HoistableRegionOpInterface",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -71,6 +71,7 @@ iree_cc_library(
     MLIRVectorDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::Codegen::Utils
+    iree::compiler::Codegen::Dialect::Codegen::Utils::MMAUtils
     iree::compiler::Codegen::Dialect::PCF::IR
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
     iree::compiler::Codegen::Interfaces::HoistableRegionOpInterface

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
@@ -47,22 +48,19 @@
 
 #define DEBUG_TYPE "iree-gpu-attrs"
 
-// Tag constants for HoistableConversionOp pairs.
-static constexpr llvm::StringLiteral kRdna3InterleaveAcc =
-    "rdna3_interleave_acc";
-static constexpr llvm::StringLiteral kRdna3DeinterleaveAcc =
-    "rdna3_deinterleave_acc";
-static constexpr llvm::StringLiteral kDataTiledAccDistribute =
-    "data_tiled_acc_distribute";
-static constexpr llvm::StringLiteral kDataTiledAccReassemble =
-    "data_tiled_acc_reassemble";
-static constexpr llvm::StringLiteral kVDMFMAInterleaveAcc =
-    "vdmfma_interleave_acc";
-static constexpr llvm::StringLiteral kVDMFMADeinterleaveAcc =
-    "vdmfma_deinterleave_acc";
-
 namespace mlir::iree_compiler::IREE::GPU {
 
+// HoistableConversionOp tag constants — definitions live in
+// `Codegen/Utils/MMAUtils.h` so paired tags (which match by string) can't
+// silently drift between translation units.
+using ::mlir::iree_compiler::IREE::Codegen::distributeMmaFragmentToIntrinsics;
+using ::mlir::iree_compiler::IREE::Codegen::incrementIndices;
+using ::mlir::iree_compiler::IREE::Codegen::kDataTiledAccDistribute;
+using ::mlir::iree_compiler::IREE::Codegen::kDataTiledAccReassemble;
+using ::mlir::iree_compiler::IREE::Codegen::kRdna3DeinterleaveAcc;
+using ::mlir::iree_compiler::IREE::Codegen::kRdna3InterleaveAcc;
+using ::mlir::iree_compiler::IREE::Codegen::kVDMFMADeinterleaveAcc;
+using ::mlir::iree_compiler::IREE::Codegen::kVDMFMAInterleaveAcc;
 using ::mlir::iree_compiler::IREE::Codegen::TileSwizzle;
 
 //===----------------------------------------------------------------------===//
@@ -1380,159 +1378,30 @@ DataTiledMMAAttr::getOperandIteratorTypes() const {
           {utils::IteratorType::parallel, utils::IteratorType::parallel}};
 }
 
-/// Increment the mutable vector `indices` to traverse the index space below
-/// `sizes`, with the last dimension moving fastest, or returns false if that
-/// index space was exhausted.
-static bool incrementIndices(MutableArrayRef<int64_t> indices,
-                             ArrayRef<int64_t> sizes) {
-  for (int i = indices.size() - 1; i >= 0; --i) {
-    if (++indices[i] == sizes[i]) {
-      indices[i] = 0;
-    } else {
-      return true; // Found an index that we could increment without wrapping.
-    }
-  }
-  return false; // All indices wrapped around.
-}
-
-/// Flattens the input vector `value` to 1-D if the rank is greater than 1. Note
-/// that it returns the value directly if it is a 0-D vector.
-static Value flattenVector(OpBuilder &builder, Location loc, Value value) {
-  Type type = value.getType();
-  VectorType vectorType = dyn_cast<VectorType>(type);
-  assert(vectorType);
-  if (vectorType.getRank() <= 1) {
-    return value;
-  }
-  auto flatVectorType = VectorType::get({vectorType.getNumElements()},
-                                        vectorType.getElementType());
-  return vector::ShapeCastOp::create(builder, loc, flatVectorType, value);
-}
-
-/// Returns intrinsic-level slices tiling the input multi-MMA-level tile
-/// `value`.
-static SmallVector<Value>
-distributeMmaFragmentToIntrinsics(OpBuilder &builder, Location loc, Value value,
-                                  const TileSwizzle &swizzle) {
-  auto internalShape =
-      Codegen::sliceSwizzledShape(swizzle, [](TileSwizzle::Dim dim) {
-        return dim.kind() == TileSwizzle::Dim::Kind::Internal;
-      });
-  auto crossIntrinsicShape =
-      Codegen::sliceSwizzledShape(swizzle, [](TileSwizzle::Dim dim) {
-        return dim.kind() == TileSwizzle::Dim::Kind::CrossIntrinsic;
-      });
-  LDBG() << "crossIntrinsicShape: " << llvm::interleaved(crossIntrinsicShape);
-  int rank = internalShape.size();
-  SmallVector<int64_t> indices(rank, 0);
-  SmallVector<int64_t> strides(rank, 1);
-  SmallVector<Value> distributedValues;
-  do {
-    Value extract = vector::ExtractStridedSliceOp::create(
-        builder, loc, value, indices, internalShape, strides);
-    distributedValues.push_back(flattenVector(builder, loc, extract));
-  } while (incrementIndices(indices, crossIntrinsicShape));
-  return distributedValues;
-}
-
 LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
     OpBuilder &builder, Location loc, ValueRange inputs, ValueRange outputs,
     SmallVectorImpl<Value> &results) const {
-  // Validation. Similar to MMAAttr::buildMmaOperation.
-  if (inputs.size() != 2) {
-    return failure();
-  }
-  if (outputs.size() != 1) {
-    return failure();
-  }
   SmallVector<VectorType> regTypes;
   getDistributedTileTypes(regTypes);
-  if (!llvm::equal(regTypes,
+  if (inputs.size() != 2 || outputs.size() != 1 ||
+      !llvm::equal(regTypes,
                    llvm::concat<Type>(inputs.getTypes(), outputs.getTypes()))) {
     return failure();
   }
 
-  // Prepare Lhs/Rhs/Acc operand slices to feed the intrinsic.
-  TileSwizzle lhsSwizzle = getSwizzle(*this, kMMAOperandLhs);
-  LDBG() << "DataTiledMMAAttr::buildMmaOperation";
-  LDBG() << "    lhsSwizzle: " << lhsSwizzle;
-  SmallVector<Value> intrinsicsLhs =
-      distributeMmaFragmentToIntrinsics(builder, loc, inputs[0], lhsSwizzle);
-
-  TileSwizzle rhsSwizzle = getSwizzle(*this, kMMAOperandRhs);
-  LDBG() << "DataTiledMMAAttr::buildMmaOperation";
-  LDBG() << "    rhsSwizzle: " << rhsSwizzle;
-  SmallVector<Value> intrinsicsRhs =
-      distributeMmaFragmentToIntrinsics(builder, loc, inputs[1], rhsSwizzle);
-
-  TileSwizzle accSwizzle = getSwizzle(*this, kMMAOperandAcc);
-  LDBG() << "DataTiledMMAAttr::buildMmaOperation";
-  LDBG() << "    accSwizzle: " << accSwizzle;
-
-  // Distribute the accumulator into per-intrinsic slices; the reassembly
-  // conversion will be hoisted out of the reduction loop.
-  auto distributeAccOp = IREE::Util::HoistableConversionOp::create(
-      builder, loc, /*tag=*/kDataTiledAccDistribute,
-      /*inverseTag=*/kDataTiledAccReassemble, ValueRange{outputs[0]},
-      [&](OpBuilder &b, Location loc, ValueRange args) -> SmallVector<Value> {
-        return distributeMmaFragmentToIntrinsics(b, loc, args[0], accSwizzle);
-      });
-  SmallVector<Value> intrinsicsAcc(distributeAccOp.getResults());
-
   MMAIntrinsic intrinsic = getIntrinsic();
-  VectorType intrinCType =
-      getThreadVectorType(builder.getContext(), intrinsic, kMMAOperandAcc);
-
-  // Loop over the 3 unroll_{m,n,k} dimensions to create the intrinsics.
-  for (int mu = 0; mu < getIntrinsicsM(); ++mu) {
-    for (int nu = 0; nu < getIntrinsicsN(); ++nu) {
-      for (int ku = 0; ku < getIntrinsicsK(); ++ku) {
-        Value lhs = intrinsicsLhs[mu * getIntrinsicsK() + ku];
-        Value rhs = intrinsicsRhs[nu * getIntrinsicsK() + ku];
-        Value &acc = intrinsicsAcc[mu * getIntrinsicsN() + nu];
-        acc = createMmaOp(builder, loc, intrinsic, intrinCType, lhs, rhs, acc);
-      }
-    }
-  }
-
-  // Insert the results into the destination accumulator.
-  SmallVector<int64_t> accCrossIntrinsicShape =
-      Codegen::sliceSwizzledShape(accSwizzle, [](TileSwizzle::Dim dim) {
-        return dim.kind() == TileSwizzle::Dim::Kind::CrossIntrinsic;
-      });
-  SmallVector<int64_t> accInternalShape =
-      Codegen::sliceSwizzledShape(accSwizzle, [](TileSwizzle::Dim dim) {
-        return dim.kind() == TileSwizzle::Dim::Kind::Internal;
-      });
-
-  LDBG() << "accCrossIntrinsicShape: "
-         << llvm::interleaved(accCrossIntrinsicShape);
-  LDBG() << "accInternalShape: " << llvm::interleaved(accInternalShape);
-
-  auto reassembleOp = IREE::Util::HoistableConversionOp::create(
-      builder, loc, /*tag=*/kDataTiledAccReassemble,
-      /*inverseTag=*/kDataTiledAccDistribute, intrinsicsAcc,
-      [&](OpBuilder &b, Location loc, ValueRange args) -> SmallVector<Value> {
-        int64_t dstRank = accCrossIntrinsicShape.size();
-        SmallVector<int64_t> strides(dstRank, 1);
-        SmallVector<int64_t> indices(dstRank, 0);
-        Value acc = arith::ConstantOp::create(
-            b, loc, b.getZeroAttr(outputs[0].getType()));
-        for (Value intrAcc : args) {
-          auto expandedAcc = vector::ShapeCastOp::create(
-              b, loc,
-              VectorType::get(
-                  accInternalShape,
-                  cast<VectorType>(outputs[0].getType()).getElementType()),
-              intrAcc);
-          acc = vector::InsertStridedSliceOp::create(b, loc, expandedAcc, acc,
-                                                     indices, strides);
-          incrementIndices(indices, accCrossIntrinsicShape);
-        }
-        return {acc};
-      });
-  results.push_back(reassembleOp.getResult(0));
-  return success();
+  auto emitIntrinsic = [&](OpBuilder &b, Location loc, Value lhs, Value rhs,
+                           Value acc) -> Value {
+    // For GPU, the per-intrinsic acc type matches `getThreadVectorType` for
+    // the ACC operand; createMmaOp uses it to broadcast a scalar mfma result
+    // back to the per-intrinsic vector if the acc happens to be 1-element.
+    return createMmaOp(b, loc, intrinsic, acc.getType(), lhs, rhs, acc);
+  };
+  return Codegen::buildDataTiledMMAUnderlyingOperations(
+      builder, loc, getSwizzle(*this, kMMAOperandLhs),
+      getSwizzle(*this, kMMAOperandRhs), getSwizzle(*this, kMMAOperandAcc),
+      getIntrinsicsM(), getIntrinsicsN(), getIntrinsicsK(), inputs, outputs,
+      emitIntrinsic, results);
 }
 
 TileSwizzle DataTiledMMAAttr::getTileSwizzle(unsigned operandIndex) const {


### PR DESCRIPTION
Moves the body of `DataTiledMMAAttr::buildUnderlyingOperations` and its private helpers (`incrementIndices`, `flattenVector`, `distributeMmaFragmentToIntrinsics`) out of the GPU dialect into a new `Codegen/Utils/MMAUtils.{h,cpp}`. The shared
`buildDataTiledMMAUnderlyingOperations` takes a callback for the architecture-specific MMA op emission, so future CPU support can reuse everything except the per-intrinsic op creation.

Also consolidates the HoistableConversionOp tag string literals (kDataTiledAcc{Distribute,Reassemble}, kRdna3{Interleave,Deinterleave}Acc, kVDMFMA{Interleave,Deinterleave}Acc) into the new header so that paired tags — which match by string — can no longer drift between translation units.

GPU's `DataTiledMMAAttr::buildUnderlyingOperations` is now a thin wrapper that supplies a callback delegating to the existing `createMmaOp`. GPU's `DataTiledScaledMMAAttr::buildUnderlyingOperations` keeps using the helpers via `using` declarations.

No functional change.

Progress towards #24323
