### PR TITLE
[CPU] Add ContiguousMemrefGather1DToConditionalLoads vector lowering.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -164,6 +164,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:MemRefToLLVM",
         "@llvm-project//mlir:MemRefTransforms",
+        "@llvm-project//mlir:MemRefUtils",
         "@llvm-project//mlir:PDLDialect",
         "@llvm-project//mlir:PDLInterpDialect",
         "@llvm-project//mlir:Pass",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -127,6 +127,7 @@ iree_cc_library(
     MLIRMemRefDialect
     MLIRMemRefToLLVM
     MLIRMemRefTransforms
+    MLIRMemRefUtils
     MLIRPDLDialect
     MLIRPDLInterpDialect
     MLIRPass

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -8,9 +8,16 @@
 #include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ArmNeon/ArmNeonDialect.h"
 #include "mlir/Dialect/ArmNeon/Transforms.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Pass/Pass.h"
@@ -24,14 +31,124 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h.inc"
 
 namespace {
+
+// Returns true if `type` is a row-major contiguous memref. For such memrefs the
+// per-dimension form `[i0, ..., i_{k-1} + idx]` and the linearize/delinearize
+// form address the same byte for each lane. Identity-layout memrefs (with
+// static or dynamic shape) qualify by construction; an explicit strided layout
+// qualifies only when its strides form the row-major contiguous sequence,
+// which currently requires a static shape.
+static bool isRowMajorContiguousMemRef(MemRefType type) {
+  if (type.getLayout().isIdentity()) {
+    return true;
+  }
+  return memref::isStaticShapeAndContiguousRowMajor(type);
+}
+
+// IREE-local override of upstream `Gather1DToConditionalLoads` (in
+// mlir/lib/Dialect/Vector/Transforms/LowerVectorGather.cpp). Registered with
+// higher benefit alongside the upstream pattern so that this version takes
+// precedence on its target case (a rank > 1 row-major contiguous memref base)
+// and the upstream pattern handles every other case.
+//
+// Upstream emits, per lane, a
+// `delinearize(linearize(offsets, shape) + idx, shape)` to produce N-D load
+// indices. It recovers the flatten index behavior from vectorization, which
+// corrects the indices for strided memrefs. Because the "OOB access" needs to
+// take strides into account, and it recovers the logical indices. It is a
+// correct form for loading ops. However, it adds additional computation, which
+// is not easy to remove, when it is a contiguous memref. For such cases, the
+// vector.load -> LLVM dialect lowering linearizes the indices based on the
+// strides, which results in the same physical address. Thus, the correction is
+// not needed, because we rely on the vector -> LLVM lowering for the fixup.
+// From the upstream doc, the value is target specific, so it is hard to
+// upstream this "optimization".
+// The root cause is the flatten index behavior of vectorization, and it is not
+// an easy fix today.
+struct ContiguousMemrefGather1DToConditionalLoads
+    : OpRewritePattern<vector::GatherOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(vector::GatherOp op,
+                                PatternRewriter &rewriter) const override {
+    VectorType resultTy = op.getType();
+    if (resultTy.getRank() != 1) {
+      return rewriter.notifyMatchFailure(op, "unsupported rank");
+    }
+    if (resultTy.isScalable()) {
+      return rewriter.notifyMatchFailure(op, "not a fixed-width vector");
+    }
+
+    auto memType = dyn_cast<MemRefType>(op.getBase().getType());
+    if (!memType) {
+      return rewriter.notifyMatchFailure(op, "non-memref base");
+    }
+    if (memType.getRank() <= 1) {
+      return rewriter.notifyMatchFailure(op, "rank-1 memref handled upstream");
+    }
+    if (!isRowMajorContiguousMemRef(memType)) {
+      return rewriter.notifyMatchFailure(op, "not row-major contiguous");
+    }
+
+    Location loc = op.getLoc();
+    Type elemTy = resultTy.getElementType();
+    VectorType elemVecTy = VectorType::get({1}, elemTy);
+
+    Value condMask = op.getMask();
+    Value base = op.getBase();
+    Value indexVec = rewriter.createOrFold<arith::IndexCastOp>(
+        loc, op.getIndexVectorType().clone(rewriter.getIndexType()),
+        op.getIndices());
+    auto loadOffsets = llvm::to_vector(op.getOffsets());
+    Value lastLoadOffset = loadOffsets.back();
+
+    Value result = op.getPassThru();
+    BoolAttr nontemporalAttr = nullptr;
+    IntegerAttr alignmentAttr = op.getAlignmentAttr();
+
+    for (int64_t i = 0, e = resultTy.getNumElements(); i < e; ++i) {
+      int64_t thisIdx[1] = {i};
+      Value condition =
+          vector::ExtractOp::create(rewriter, loc, condMask, thisIdx);
+      Value index = vector::ExtractOp::create(rewriter, loc, indexVec, thisIdx);
+      loadOffsets.back() =
+          rewriter.createOrFold<arith::AddIOp>(loc, lastLoadOffset, index);
+
+      auto loadBuilder = [&](OpBuilder &b, Location loc) {
+        Value load =
+            vector::LoadOp::create(b, loc, elemVecTy, base, loadOffsets,
+                                   nontemporalAttr, alignmentAttr);
+        int64_t zeroIdx[1] = {0};
+        Value extracted = vector::ExtractOp::create(b, loc, load, zeroIdx);
+        Value newResult =
+            vector::InsertOp::create(b, loc, extracted, result, thisIdx);
+        scf::YieldOp::create(b, loc, newResult);
+      };
+      auto passThruBuilder = [result](OpBuilder &b, Location loc) {
+        scf::YieldOp::create(b, loc, result);
+      };
+
+      result = scf::IfOp::create(rewriter, loc, condition,
+                                 /*thenBuilder=*/loadBuilder,
+                                 /*elseBuilder=*/passThruBuilder)
+                   .getResult(0);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 class LLVMCPUVirtualVectorLoweringPass
     : public impl::LLVMCPUVirtualVectorLoweringPassBase<
           LLVMCPUVirtualVectorLoweringPass> {
 public:
   using Base::Base;
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<linalg::LinalgDialect, vector::VectorDialect,
-                    arm_neon::ArmNeonDialect>();
+    registry.insert<affine::AffineDialect, arith::ArithDialect,
+                    linalg::LinalgDialect, memref::MemRefDialect,
+                    scf::SCFDialect, tensor::TensorDialect,
+                    vector::VectorDialect, arm_neon::ArmNeonDialect>();
   }
   void runOnOperation() override;
 };
@@ -93,6 +210,12 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
     if (!targetConfig || !isRISCV(targetConfig) ||
         !hasAnyVFeature(targetConfig)) {
       vector::populateVectorGatherToConditionalLoadPatterns(patterns);
+      // Higher benefit so this takes precedence over the upstream
+      // `Gather1DToConditionalLoads` on the contiguous-memref case it targets;
+      // upstream still owns every other case (rank-1, scalable, tensor base,
+      // non-row-major-contiguous memref).
+      patterns.add<ContiguousMemrefGather1DToConditionalLoads>(ctx,
+                                                               /*benefit=*/100);
     }
     vector::populateVectorGatherLoweringPatterns(patterns);
     vector::populateVectorContractLoweringPatterns(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -73,6 +73,7 @@ iree_lit_test_suite(
             "vectorize_with_masking_and_hoist.mlir",
             "verify_linalg_transform_legality.mlir",
             "verify_vector_size_legality.mlir",
+            "virtual_vector_lowering.mlir",
         ],
         include = ["*.mlir"],
         exclude = ["tuning_spec_matmul.mlir"],

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -68,6 +68,7 @@ iree_lit_test_suite(
     "vectorize_with_masking_and_hoist.mlir"
     "verify_linalg_transform_legality.mlir"
     "verify_vector_size_legality.mlir"
+    "virtual_vector_lowering.mlir"
   TOOLS
     FileCheck
     iree-compile

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/virtual_vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/virtual_vector_lowering.mlir
@@ -1,0 +1,120 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmcpu-virtual-vector-lowering))" --split-input-file %s | FileCheck %s
+
+// For an n-D row-major contiguous memref, the gather lowering should add the
+// gather index directly into the innermost offset rather than emit a per-lane
+// affine.linearize_index/affine.delinearize_index pair.
+
+func.func @gather_contiguous_3d(%buffer: memref<50x40x40xi8>,
+                                %idx: vector<8xindex>,
+                                %mask: vector<8xi1>,
+                                %pass: vector<8xi8>,
+                                %i: index, %j: index, %k: index)
+    -> vector<8xi8> {
+  %r = vector.gather %buffer[%i, %j, %k] [%idx], %mask, %pass
+     : memref<50x40x40xi8>, vector<8xindex>, vector<8xi1>, vector<8xi8>
+       into vector<8xi8>
+  return %r : vector<8xi8>
+}
+
+// CHECK-LABEL:   func.func @gather_contiguous_3d(
+// CHECK-SAME:        %[[BUF:[^:]+]]: memref<50x40x40xi8>
+// CHECK-SAME:        %[[I:[^:]+]]: index, %[[J:[^:]+]]: index, %[[K:[^:]+]]: index
+// CHECK-NOT:   vector.gather
+// CHECK-NOT:   affine.linearize_index
+// CHECK-NOT:   affine.delinearize_index
+// CHECK:       arith.addi %[[K]],
+// CHECK:       vector.load %[[BUF]][%[[I]], %[[J]], %{{.+}}] : memref<50x40x40xi8>, vector<1xi8>
+
+// -----
+
+// For a non-contiguous (strided, non-row-major) memref, the gather lowering
+// must keep the linearize/delinearize path because the per-dimension and
+// linearized addresses no longer agree.
+
+func.func @gather_non_contiguous_2d(
+    %buffer: memref<10x20xf32, strided<[40, 1]>>,
+    %idx: vector<4xindex>, %mask: vector<4xi1>, %pass: vector<4xf32>,
+    %i: index, %j: index) -> vector<4xf32> {
+  %r = vector.gather %buffer[%i, %j] [%idx], %mask, %pass
+     : memref<10x20xf32, strided<[40, 1]>>, vector<4xindex>,
+       vector<4xi1>, vector<4xf32> into vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// CHECK-LABEL:   func.func @gather_non_contiguous_2d(
+// CHECK-NOT:   vector.gather
+// CHECK:       affine.linearize_index
+// CHECK:       affine.delinearize_index
+
+// -----
+
+// Dynamic-shape identity-layout memref also qualifies as row-major contiguous,
+// so the gather lowering should still take the contiguous path even though
+// `memref::isStaticShapeAndContiguousRowMajor` returns false here.
+
+func.func @gather_dynamic_identity_2d(%buffer: memref<?x?xf32>,
+                                      %idx: vector<4xindex>,
+                                      %mask: vector<4xi1>,
+                                      %pass: vector<4xf32>,
+                                      %i: index, %j: index) -> vector<4xf32> {
+  %r = vector.gather %buffer[%i, %j] [%idx], %mask, %pass
+     : memref<?x?xf32>, vector<4xindex>, vector<4xi1>, vector<4xf32>
+       into vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// CHECK-LABEL:   func.func @gather_dynamic_identity_2d(
+// CHECK-SAME:        %[[BUF:[^:]+]]: memref<?x?xf32>
+// CHECK-SAME:        %[[I:[^:]+]]: index, %[[J:[^:]+]]: index
+// CHECK-NOT:   vector.gather
+// CHECK-NOT:   affine.linearize_index
+// CHECK-NOT:   affine.delinearize_index
+// CHECK:       arith.addi %[[J]],
+// CHECK:       vector.load %[[BUF]][%[[I]], %{{.+}}] : memref<?x?xf32>, vector<1xf32>
+
+// -----
+
+// A static-shape memref with an explicit strided<[N, 1]> layout whose strides
+// match the row-major contiguous sequence should also take the contiguous
+// path via `isStaticShapeAndContiguousRowMajor`.
+
+func.func @gather_strided_contiguous_2d(
+    %buffer: memref<10x20xf32, strided<[20, 1]>>,
+    %idx: vector<4xindex>, %mask: vector<4xi1>, %pass: vector<4xf32>,
+    %i: index, %j: index) -> vector<4xf32> {
+  %r = vector.gather %buffer[%i, %j] [%idx], %mask, %pass
+     : memref<10x20xf32, strided<[20, 1]>>, vector<4xindex>,
+       vector<4xi1>, vector<4xf32> into vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// CHECK-LABEL:   func.func @gather_strided_contiguous_2d(
+// CHECK-SAME:        %[[BUF:[^:]+]]: memref<10x20xf32, strided<[20, 1]>>
+// CHECK-SAME:        %[[I:[^:]+]]: index, %[[J:[^:]+]]: index
+// CHECK-NOT:   vector.gather
+// CHECK-NOT:   affine.linearize_index
+// CHECK-NOT:   affine.delinearize_index
+// CHECK:       arith.addi %[[J]],
+// CHECK:       vector.load %[[BUF]][%[[I]], %{{.+}}] : memref<10x20xf32, strided<[20, 1]>>, vector<1xf32>
+
+// -----
+
+// Tensor base falls through to the upstream pattern, which lowers each lane
+// to a `tensor.extract`. The IREE-local pattern does not match (memref-only)
+// and must not interfere.
+
+func.func @gather_tensor_base_2d(%buffer: tensor<10x20xf32>,
+                                 %idx: vector<4xindex>,
+                                 %mask: vector<4xi1>,
+                                 %pass: vector<4xf32>,
+                                 %i: index, %j: index) -> vector<4xf32> {
+  %r = vector.gather %buffer[%i, %j] [%idx], %mask, %pass
+     : tensor<10x20xf32>, vector<4xindex>, vector<4xi1>, vector<4xf32>
+       into vector<4xf32>
+  return %r : vector<4xf32>
+}
+
+// CHECK-LABEL:   func.func @gather_tensor_base_2d(
+// CHECK-SAME:        %[[BUF:[^:]+]]: tensor<10x20xf32>
+// CHECK-NOT:   vector.gather
+// CHECK:       tensor.extract %[[BUF]]

--- a/tests/e2e/stablehlo_ops/reverse.mlir
+++ b/tests/e2e/stablehlo_ops/reverse.mlir
@@ -20,3 +20,25 @@ func.func @xla_reverse() {
   ) : tensor<2x3xf32>
   return
 }
+
+// Regression test for https://github.com/iree-org/iree/issues/23637.
+func.func @xla_reverse_after_slice() {
+  %t1 = util.unfoldable_constant dense<[
+      [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]],
+      [[9.0, 10.0], [11.0, 12.0], [13.0, 14.0], [15.0, 16.0]]
+  ]> : tensor<2x4x2xf32>
+  %sliced = "stablehlo.slice"(%t1) {
+      start_indices = array<i64: 0, 1, 0>,
+      limit_indices = array<i64: 2, 3, 2>,
+      strides = array<i64: 1, 1, 1>
+  } : (tensor<2x4x2xf32>) -> tensor<2x2x2xf32>
+  %reversed = "stablehlo.reverse"(%sliced) {dimensions = array<i64: 1>} : (tensor<2x2x2xf32>) -> tensor<2x2x2xf32>
+  check.expect_almost_eq_const(
+      %reversed,
+      dense<[
+          [[5.0, 6.0], [3.0, 4.0]],
+          [[13.0, 14.0], [11.0, 12.0]]
+      ]> : tensor<2x2x2xf32>
+  ) : tensor<2x2x2xf32>
+  return
+}


### PR DESCRIPTION
Upstream emits, per lane, a
`delinearize(linearize(offsets, shape) + idx, shape)` to produce N-D load indices. It recovers the flatten index behavior from vectorization, which corrects the indices for strided memrefs. Because the "OOB access" needs to take strides into account, and it recovers the logical indices. It is a correct form for loading ops.

However, it adds additional computation, which is not easy to remove, when it is a contiguous memref. For such cases, the vector.load -> LLVM dialect lowering linearizes the indices based on the strides, which results in the same physical address. Thus, the correction is not needed, because we rely on the vector -> LLVM lowering for the fixup.

From the upstream doc, the value is target specific, so it is hard to upstream this "optimization".

The root cause is the flatten index behavior of vectorization, and it is not an easy fix today.