### PR TITLE
[Codegen][CPU] Teach the lowering strategy about inner_tiled.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenEnums.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
 #include "iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h"
@@ -3019,6 +3020,69 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
       getCPUTranslationInfo(op.getContext(), CPUPipeline::Default));
 }
 
+/// Sets the lowering configuration for a dispatch region rooted at an
+/// `iree_codegen.inner_tiled` op. The op already has the inner-tile shape
+/// baked into the operand layout (one inner tile per iteration of its
+/// iter domain), so each iter dim should be tiled to a single iteration:
+///   * `vector_common_parallel` tiles the M and N parallel iter dims to 1,
+///     turning the outer parallel loops into a single forall body.
+///   * `vector_reduction` tiles the K reduction iter dim to 1, leaving an
+///     scf.for around the inner_tiled body.
+/// With all iter bounds collapsed to 1, the unit-iter-dim drop and per-
+/// intrinsic lower patterns in `LLVMCPULowerInnerTiledPass` fire on a
+/// single-tile op rather than getting fully unrolled over K. Distribution
+/// is parallel-only (M, N).
+///
+/// We route through `Mmt4dTilingExpert` rather than `DataTiling` because
+/// the former has the modern lowerings (tile-and-fuse, vectorization via
+/// the `VectorizableOpInterface` external model, generic vector lowering
+/// after bufferize) that data-tiled MMA dispatches need; `DataTiling` was
+/// designed for pack/unpack ops and not all of those passes kick in there.
+static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
+                                   IREE::Codegen::InnerTiledOp op) {
+  assert(!getLoweringConfig(op) && "expected lowering_config is not set");
+  SmallVector<int64_t> bounds;
+  op.getIterationBounds(bounds);
+  unsigned numLoops = bounds.size();
+  assert(numLoops >= 2 && "inner_tiled iter domain must have at least M, N");
+
+  SmallVector<utils::IteratorType> iteratorTypes;
+  for (Attribute it : op.getIteratorTypes()) {
+    iteratorTypes.push_back(cast<linalg::IteratorTypeAttr>(it).getValue());
+  }
+  assert(iteratorTypes.size() == numLoops);
+
+  // Distribution: one inner tile per workgroup along each parallel iter
+  // dim; reduction dims are not distributed. The same constant 1 works for
+  // static and dynamic outer extents — for static, it caps the workgroup
+  // tile at one inner tile (smaller than the matmul); for dynamic, it lets
+  // the workgroup count scale with the runtime extent. Larger workgroup
+  // tiles are a perf optimization; the mmt4d cost model is the template
+  // for porting that to inner_tiled in a follow-up.
+  SmallVector<int64_t> distTileSizes(numLoops, 0);
+  for (auto [i, kind] : llvm::enumerate(iteratorTypes)) {
+    if (kind == utils::IteratorType::parallel) {
+      distTileSizes[i] = 1;
+    }
+  }
+
+  // Vector tiling: every iter dim down to a single inner tile. The
+  // generator's `splitParallelAndReductionTiles` lifts the parallel entries
+  // into `vector_common_parallel` and the reduction entries into
+  // `vector_reduction`.
+  SmallVector<int64_t> vecTileSizes(numLoops, 1);
+
+  LoweringConfigGenerator generator(op);
+  generator.setDistributionTileSizes(distTileSizes);
+  generator.setVectorTileSizes(vecTileSizes);
+  IREE::CPU::LoweringConfigAttr loweringConfig =
+      generator.generateCPULoweringConfig();
+  LDBG() << "Set lowering_config for inner_tiled op: " << loweringConfig;
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPointFn, op, loweringConfig,
+      getCPUTranslationInfo(op.getContext(), CPUPipeline::Mmt4dTilingExpert));
+}
+
 /// Redirects to methods that set the configuration based on operation type.
 static LogicalResult
 setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
@@ -3032,7 +3096,8 @@ setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
           })
           .Case<IREE::LinalgExt::OnlineAttentionOp, IREE::LinalgExt::FftOp,
                 IREE::LinalgExt::GatherOp, linalg::PackOp, tensor::PadOp,
-                linalg::UnPackOp, linalg::Mmt4DOp, linalg::BatchMmt4DOp>(
+                linalg::UnPackOp, linalg::Mmt4DOp, linalg::BatchMmt4DOp,
+                IREE::Codegen::InnerTiledOp>(
               [&](auto op) { return setRootConfig(entryPointFn, op); })
           .Case<IREE::LinalgExt::WinogradFilterTransformOp,
                 IREE::LinalgExt::WinogradInputTransformOp,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1674,3 +1674,34 @@ func.func @gather(%source: tensor<16x8x32x128xf16>, %indices: tensor<4xi64>, %ou
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.gather
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+// `iree_codegen.inner_tiled` rooted dispatches go through the
+// Mmt4dTilingExpert pipeline. The op's iter domain is already in
+// inner-tile units (M_iter, N_iter, K_iter), so each iter dim is tiled to
+// a single iteration: `vector_common_parallel` collapses the M and N
+// parallel iter dims to 1 and `vector_reduction` collapses the K
+// reduction iter dim to 1. Distribution is parallel-only (M, N).
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
+func.func @inner_tiled_avx512_1x16x1_f32(%lhs: tensor<2x4x2x1xf32>, %rhs: tensor<2x4x32x1xf32>, %acc: tensor<2x2x2x32xf32>) -> tensor<2x2x2x32xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d0, d2)>,
+      affine_map<(d0, d1, d2) -> (d1, d2)>,
+      affine_map<(d0, d1, d2) -> (d0, d1)>
+    ],
+    iterator_types = [#linalg.iterator_type<parallel>,
+                      #linalg.iterator_type<parallel>,
+                      #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 2, intrinsics_n = 2>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : tensor<2x4x2x1xf32>, tensor<2x4x32x1xf32> into tensor<2x2x2x32xf32>
+  return %0 : tensor<2x2x2x32xf32>
+}
+//   CHECK-DAG: #[[INNER_TILED_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0], vector_common_parallel = [1, 1, 0], vector_reduction = [0, 0, 1]>
+//   CHECK-DAG: #[[INNER_TILED_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<Mmt4dTilingExpert>>
+//       CHECK: func.func @inner_tiled_avx512_1x16x1_f32(
+//  CHECK-SAME:     translation_info = #[[INNER_TILED_TRANSLATION]]
+//       CHECK:   iree_codegen.inner_tiled
+//  CHECK-SAME:       lowering_config = #[[INNER_TILED_CONFIG]]


### PR DESCRIPTION
Adds a `setRootConfig(InnerTiledOp)` overload in `KernelDispatch.cpp`
that:

  * routes `iree_codegen.inner_tiled` roots through the
    `Mmt4dTilingExpert` pipeline. The DataTiling pipeline is the
    pack/unpack-focused pipeline and not all the modern lowerings (e.g.
    tile-and-fuse, post-bufferize vector lowering) kick in there;
    Mmt4dTilingExpert has them, plus its `GenericVectorizationPass` step
    is where vector-semantics lifting of `inner_tiled` happens via the
    in-tree `VectorizableOpInterface` external model. The previous
    commit schedules `LLVMCPULowerInnerTiledPass` right after
    `GenericVectorizationPass` in this pipeline.
  * sets `distribution = (1, 1, 0)` (one inner tile per workgroup in
    the M and N parallel iter dims, K not distributed);
  * sets `vector_common_parallel = (1, 1, 0)` and
    `vector_reduction = (0, 0, 1)` so the K dim is tiled to a real
    `scf.for` instead of being fully unrolled inside the
    `LLVMCPULowerInnerTiledPass` greedy fixed point.

Without this commit, a `linalg.matmul` with
`--iree-opt-data-tiling --iree-llvmcpu-enable-inner-tiled` ended up on
the `Default` pipeline (which has no inner_tiled lowering hook) and
either failed bufferization (for non-trivial K) or compiled in time
exponential in K (after the previous "unroll inner_tiled" commit
turned the survival into a compile-time blow-up). With this commit,
a 256x256x256 f32 matmul on znver5 now compiles end-to-end in seconds:
the workgroup body is a tight scf.for(K_iter) wrapping a single
`llvm.call_intrinsic "llvm.fma.v16f32"` per intrinsics_m unroll.

Distribution tile sizing is deliberately conservative (1 inner tile
per parallel dim) — the mmt4d cost-model-driven sizing heuristic
should be ported to inner_tiled as a follow-up.

Progress towards #24323