### PR TITLE
[Codegen][CPU] Add a VectorizeInnerTiled pattern.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -179,6 +179,7 @@ iree_compiler_cc_library(
         "UserConfig.cpp",
         "VectorLayoutAnalysis.cpp",
         "VectorTransferLowering.cpp",
+        "VectorizeInnerTiled.cpp",
         "VectorizeMemrefCopy.cpp",
         "VerifyPipelineConstraints.cpp",
         "VerifyWorkgroupDistribution.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -172,6 +172,7 @@ iree_cc_library(
     "UserConfig.cpp"
     "VectorLayoutAnalysis.cpp"
     "VectorTransferLowering.cpp"
+    "VectorizeInnerTiled.cpp"
     "VectorizeMemrefCopy.cpp"
     "VerifyPipelineConstraints.cpp"
     "VerifyWorkgroupDistribution.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -189,6 +189,15 @@ void transform_dialect::ApplyUnrollVectorsGpuWmmaSyncPatternsOp::
 }
 
 //===---------------------------------------------------------------------===//
+// ApplyVectorizeInnerTiledPatternsOp
+//===---------------------------------------------------------------------===//
+
+void transform_dialect::ApplyVectorizeInnerTiledPatternsOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  populateVectorizeInnerTiledPatterns(patterns);
+}
+
+//===---------------------------------------------------------------------===//
 // Remaining Apply...PatternsOp
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -186,6 +186,21 @@ def ApplyUnrollVectorsGpuWmmaSyncPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
+def ApplyVectorizeInnerTiledPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.vectorize_inner_tiled",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Populate the pattern that lifts a tensor-semantics
+    `iree_codegen.inner_tiled` op to vector semantics by reading each operand
+    with `vector.transfer_read`, replacing the op with a vector-semantics
+    `inner_tiled`, and writing each result back with `vector.transfer_write`.
+  }];
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let assemblyFormat = "attr-dict";
+}
+
 def CopyTensorOperandOp :  Op<Transform_Dialect, "iree.copy_tensor_operand",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      FunctionalStyleTransformOpTrait,

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/test/BUILD.bazel
@@ -21,6 +21,7 @@ iree_lit_test_suite(
         [
             "bufferization.mlir",
             "fuse_consumer.mlir",
+            "vectorize_inner_tiled.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "bufferization.mlir"
     "fuse_consumer.mlir"
+    "vectorize_inner_tiled.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/test/vectorize_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/test/vectorize_inner_tiled.mlir
@@ -1,0 +1,50 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+// Lifts a tensor-semantics `inner_tiled` to vector semantics: each operand
+// becomes a `vector.transfer_read`, the op itself rebuilds with vector
+// operands, and the result is written back through `vector.transfer_write`.
+// The iteration domain (here trivially unit) is left untouched — the
+// downstream `drop_inner_tiled_unit_dims` pattern will collapse it before the
+// final intrinsic lowering fires.
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @vectorize_inner_tiled_avx512_f32(
+    %lhs: tensor<1x1x1x1xf32>, %rhs: tensor<1x1x16x1xf32>,
+    %acc: tensor<1x1x1x16xf32>) -> tensor<1x1x1x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>,
+                      #linalg.iterator_type<parallel>,
+                      #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : tensor<1x1x1x1xf32>, tensor<1x1x16x1xf32> into tensor<1x1x1x16xf32>
+  return %0 : tensor<1x1x1x16xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.vectorize_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @vectorize_inner_tiled_avx512_f32
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9_]+]]: tensor<1x1x1x1xf32>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9_]+]]: tensor<1x1x16x1xf32>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9_]+]]: tensor<1x1x1x16xf32>
+//   CHECK-DAG:   %[[VLHS:.+]] = vector.transfer_read %[[LHS]]{{.*}}: tensor<1x1x1x1xf32>, vector<1x1x1x1xf32>
+//   CHECK-DAG:   %[[VRHS:.+]] = vector.transfer_read %[[RHS]]{{.*}}: tensor<1x1x16x1xf32>, vector<1x1x16x1xf32>
+//   CHECK-DAG:   %[[VACC:.+]] = vector.transfer_read %[[ACC]]{{.*}}: tensor<1x1x1x16xf32>, vector<1x1x1x16xf32>
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled ins(%[[VLHS]], %[[VRHS]]) outs(%[[VACC]])
+//  CHECK-SAME:       : vector<1x1x1x1xf32>, vector<1x1x16x1xf32> into vector<1x1x1x16xf32>
+//       CHECK:   %[[WRITE:.+]] = vector.transfer_write %[[INNER]], %[[ACC]]
+//       CHECK:   return %[[WRITE]]

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -164,6 +164,14 @@ void populateCombineRelayoutOpPatterns(
 /// Populate patterns to fuse tilable consumers of forall ops into it.
 void populateFuseTilableForallConsumersPattern(RewritePatternSet &patterns);
 
+/// Populate a pattern that lifts a tensor-semantics `iree_codegen.inner_tiled`
+/// op to vector semantics by reading each operand with `vector.transfer_read`,
+/// replacing the op with a vector-semantics `inner_tiled`, and writing each
+/// result back with `vector.transfer_write`. Used by the LLVM-CPU pipeline,
+/// which (unlike GPU's lane-distribution path) has no separate hook for
+/// turning tensor-semantics inner_tiled ops into vector-semantics ones.
+void populateVectorizeInnerTiledPatterns(RewritePatternSet &patterns);
+
 //===----------------------------------------------------------------------===//
 // Utilities for iteration space expansion transformations
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/VectorizeInnerTiled.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorizeInnerTiled.cpp
@@ -1,0 +1,96 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+// Lifts a tensor-semantics `iree_codegen.inner_tiled` op to vector semantics by
+// reading each operand with `vector.transfer_read`, replacing the op with a
+// vector-semantics `inner_tiled`, and writing each result back with
+// `vector.transfer_write`. The downstream `DropInnerTiledUnitDimsPattern` and
+// `LowerInnerTiledPattern` then handle the rest of the lowering.
+//
+// Used by the LLVM-CPU pipeline: GPU folds the read/write into its lane
+// distribution (`DistributeInnerTiledToLanes`), but CPU has no lane
+// distribution so the vectorize step is standalone.
+struct VectorizeInnerTiledPattern final
+    : OpRewritePattern<IREE::Codegen::InnerTiledOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(IREE::Codegen::InnerTiledOp tiledOp,
+                                PatternRewriter &rewriter) const override {
+    if (!tiledOp.hasTensorSemantics()) {
+      return rewriter.notifyMatchFailure(tiledOp, "expected tensor semantics");
+    }
+    // Statically-shaped operands only — `vector.transfer_read` of a dynamic
+    // tensor would need explicit bounds and we don't have them here. For the
+    // CPU codegen path, the tiling pipeline drives the iteration domain to
+    // unit bounds well before this pattern runs, so all operand shapes are
+    // static.
+    for (Value operand : tiledOp->getOperands()) {
+      auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
+      if (!tensorType || !tensorType.hasStaticShape()) {
+        return rewriter.notifyMatchFailure(tiledOp, "non-static operand shape");
+      }
+    }
+
+    Location loc = tiledOp.getLoc();
+    Value zeroIdx = arith::ConstantIndexOp::create(rewriter, loc, 0);
+
+    // Read each operand into a vector matching the operand's tensor shape.
+    SmallVector<Value> vectorOperands;
+    vectorOperands.reserve(tiledOp->getNumOperands());
+    for (Value operand : tiledOp->getOperands()) {
+      auto tensorType = cast<RankedTensorType>(operand.getType());
+      auto vectorType =
+          VectorType::get(tensorType.getShape(), tensorType.getElementType());
+      Value padding = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getZeroAttr(tensorType.getElementType()));
+      SmallVector<Value> indices(tensorType.getRank(), zeroIdx);
+      Value read = vector::TransferReadOp::create(rewriter, loc, vectorType,
+                                                  operand, indices, padding);
+      vectorOperands.push_back(read);
+    }
+
+    int64_t numInputs = tiledOp.getNumInputs();
+    auto newTiledOp = IREE::Codegen::InnerTiledOp::create(
+        rewriter, loc,
+        ValueRange(ArrayRef(vectorOperands).take_front(numInputs)),
+        ValueRange(ArrayRef(vectorOperands).drop_front(numInputs)),
+        tiledOp.getIndexingMapsAttr(), tiledOp.getIteratorTypesAttr(),
+        tiledOp.getKind(), tiledOp.getSemantics(),
+        tiledOp.getPermutationsAttr());
+
+    // Write each result back into the original init tensor.
+    SmallVector<Value> newResults;
+    newResults.reserve(tiledOp.getNumResults());
+    for (auto [vectorResult, tensorInit] :
+         llvm::zip_equal(newTiledOp.getResults(), tiledOp.getOutputs())) {
+      auto tensorType = cast<RankedTensorType>(tensorInit.getType());
+      SmallVector<Value> indices(tensorType.getRank(), zeroIdx);
+      auto writeOp = vector::TransferWriteOp::create(
+          rewriter, loc, vectorResult, tensorInit, indices);
+      newResults.push_back(writeOp.getResult());
+    }
+    rewriter.replaceOp(tiledOp, newResults);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateVectorizeInnerTiledPatterns(RewritePatternSet &patterns) {
+  patterns.add<VectorizeInnerTiledPattern>(patterns.getContext());
+}
+
+} // namespace mlir::iree_compiler


### PR DESCRIPTION
Lifts a tensor-semantics `iree_codegen.inner_tiled` op to vector semantics by reading each operand with `vector.transfer_read`, replacing the op with a vector-semantics `inner_tiled`, and writing each result back with `vector.transfer_write`. Statically-shaped operands only — the CPU codegen path drives the iteration domain to unit bounds well before this pattern runs.

This fills the gap between encoding-materialization (which produces a tensor-semantics inner_tiled) and the existing
`DropInnerTiledUnitDimsPattern` + `LowerInnerTiledPattern` (both vector-semantics-only) on the LLVM-CPU side. GPU folds the analogous read/write into its lane-distribution step (`DistributeInnerTiledToLanes`); CPU has no lane distribution so the vectorize step needs to be standalone.

Exposes the pattern as `populateVectorizeInnerTiledPatterns` from `Codegen/Common/Transforms.h`, plus a transform-dialect entry point `apply_patterns.iree.vectorize_inner_tiled` so the pattern can be exercised from a lit test.

Tested via a single-tile AVX-512 1x16x1 f32 example in TransformExtensions/test/vectorize_inner_tiled.mlir.

Progress towards #24323