### PR TITLE
Update CODEOWNERS for spreading review responsibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,7 @@
 /compiler/src/iree/compiler/API/ @benvanik @IanWood1
 /compiler/src/iree/compiler/Codegen/ @MaheshRavishankar
 /compiler/src/iree/compiler/Codegen/Common @hanhanW @Max191 @MaheshRavishankar @qedawkins
+/compiler/src/iree/compiler/Codegen/**/*Vector* @amd-eochoalo @Groverkss @hanhanW @sommerlukas
 /compiler/src/iree/compiler/Codegen/Common/GPU @qedawkins @Groverkss @kuhar
 /compiler/src/iree/compiler/Codegen/Dialect/Codegen @Max191 @MaheshRavishankar @qedawkins
 /compiler/src/iree/compiler/Codegen/Dialect/CPU @hanhanW
@@ -70,7 +71,7 @@
 /compiler/src/iree/compiler/ConstEval/ @hanhanW @MaheshRavishankar
 /compiler/src/iree/compiler/Dialect/Encoding/ @bjacob @hanhanW @Max191 @jtuyls
 /compiler/src/iree/compiler/Dialect/Flow/ @hanhanW @MaheshRavishankar @IanWood1
-/compiler/src/iree/compiler/Dialect/LinalgExt/ @hanhanW @MaheshRavishankar @Groverkss @Max191 @IanWood1
+/compiler/src/iree/compiler/Dialect/LinalgExt/ @hanhanW @MaheshRavishankar @Groverkss @Max191 @IanWood1 @bangtianliu
 /compiler/src/iree/compiler/Dialect/Stream/ @benvanik @hanhanW @MaheshRavishankar
 /compiler/src/iree/compiler/Dialect/TensorExt/ @hanhanW @MaheshRavishankar @IanWood1
 /compiler/src/iree/compiler/Dialect/Vulkan/ @kuhar


### PR DESCRIPTION
- Add bangtianliu to LinalgExt since he's been contributing new LinalgExt ops and transformations.
- Add a new `Codegen/**/*Vector*` category and add myself and active owners and reviewers to code owners (based on my observation).

Note that the new category is added after `Codegen/Common` so only new owners will show up on the new matching. From Github's doc:

```
# Order is important; the last matching pattern takes the most
# precedence. When someone opens a pull request that only
# modifies JS files, only @js-owner and not the global
# owner(s) will be requested for a review.
*.js    @js-owner #This is an inline comment.
```

It adds the owners to all vectorization and vector transformations, except VectorExt (which is a later rule that owned by Groverkss).