### PR TITLE
Reapply "[Codegen] Use local binders for optimization flags in codegen (#24220)"

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/Internal/BUILD.bazel
@@ -83,7 +83,6 @@ iree_compiler_cc_library(
         "//compiler/bindings/c:headers",
         "//compiler/src/iree/compiler/Dialect/HAL/Target",
         "//compiler/src/iree/compiler/Dialect/VM/Target:init_targets",
-        "//compiler/src/iree/compiler/Pipelines:Options",
         "//compiler/src/iree/compiler/PluginAPI:PluginManager",
         "//compiler/src/iree/compiler/Tools:init_llvmir_translations",
         "//compiler/src/iree/compiler/Tools:init_passes_and_dialects",

--- a/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
@@ -85,7 +85,6 @@ iree_cc_library(
     MLIRSupport
     iree::compiler::Dialect::HAL::Target
     iree::compiler::Dialect::VM::Target::init_targets
-    iree::compiler::Pipelines::Options
     iree::compiler::PluginAPI::PluginManager
     iree::compiler::Tools::init_llvmir_translations
     iree::compiler::Tools::init_passes_and_dialects

--- a/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
@@ -10,7 +10,6 @@
 
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/Dialect/VM/Target/init_targets.h"
-#include "iree/compiler/Pipelines/Options.h"
 #include "iree/compiler/PluginAPI/PluginManager.h"
 #include "iree/compiler/Tools/init_dialects.h"
 #include "iree/compiler/Tools/init_llvmir_translations.h"
@@ -76,9 +75,6 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
   tracing::DebugCounter::registerCLOptions();
   auto &pluginManagerOptions =
       mlir::iree_compiler::PluginManagerOptions::FromFlags::get();
-  // Register the top-level optimization level flag (--iree-opt-level) and
-  // pipeline options so that optimization-level cascading works in iree-opt.
-  mlir::iree_compiler::GlobalPipelineOptions::FromFlags::get();
 
   // Build the list of dialects as a header for the --help message.
   std::string helpHeader = (toolName + "\nAvailable Dialects: ").str();
@@ -90,13 +86,6 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
 
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv, helpHeader);
-
-  // Apply optimization-level-dependent defaults to global options.
-  {
-    auto globalBinder = mlir::iree_compiler::OptionsBinder::global();
-    globalBinder.applyOptimizationDefaults();
-  }
-
   MlirOptMainConfig config = MlirOptMainConfig::createFromCLOptions();
 
   // The local binder is meant for overriding session-level options, but for

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -713,6 +713,16 @@ void buildLLVMCPULinkingPassPipeline(OpPassManager &modulePassManager,
 // Register LLVMCPU Passes
 //===---------------------------------------------------------------------===//
 
+template <typename PipelineOptionsT>
+static CPUCodegenOptions
+getCPUCodegenOptionsForTextualPipeline(const PipelineOptionsT &options) {
+  CPUCodegenOptions cpuOpts = CPUCodegenOptions::FromFlags::get();
+  if (options.optLevel.hasValue()) {
+    cpuOpts.setWithOptLevel(mapCodegenPipelineOptLevel(options.optLevel));
+  }
+  return cpuOpts;
+}
+
 /// CPU pipeline builder callback. Dispatches CPU::PipelineAttr to the
 /// appropriate pass pipeline construction function.
 static LogicalResult buildCPUPipeline(Attribute attr, OpPassManager &pm,
@@ -767,14 +777,32 @@ void registerCodegenLLVMCPUPasses() {
   // Generated.
   registerPasses();
 
-  static PassPipelineRegistration<> LLVMCPUConfigPipeline(
-      "iree-codegen-llvmcpu-configuration-pipeline",
-      "Runs the translation strategy configuration pipeline on Linalg for CPU",
-      [](OpPassManager &modulePassManager) {
-        const CPUCodegenOptions &cpuOpts = CPUCodegenOptions::FromFlags::get();
-        buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager,
-                                                         cpuOpts);
-      });
+  struct LLVMCPUConfigurationPipelineOptions final
+      : PassPipelineOptions<LLVMCPUConfigurationPipelineOptions> {
+    Option<CodegenPipelineOptLevel> optLevel{
+        *this, "opt-level",
+        llvm::cl::desc(
+            "Optimization level used to derive CPU codegen defaults."),
+        llvm::cl::values(
+            clEnumValN(CodegenPipelineOptLevel::O0, "O0", "Use O0 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O1, "O1", "Use O1 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O2, "O2", "Use O2 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O3, "O3", "Use O3 defaults.")),
+        llvm::cl::init(CodegenPipelineOptLevel::O0)};
+  };
+
+  static PassPipelineRegistration<LLVMCPUConfigurationPipelineOptions>
+      LLVMCPUConfigPipeline(
+          "iree-codegen-llvmcpu-configuration-pipeline",
+          "Runs the translation strategy configuration pipeline on Linalg for "
+          "CPU",
+          [](OpPassManager &modulePassManager,
+             const LLVMCPUConfigurationPipelineOptions &options) {
+            CPUCodegenOptions cpuOpts =
+                getCPUCodegenOptionsForTextualPipeline(options);
+            buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager,
+                                                             cpuOpts);
+          });
 
   static PassPipelineRegistration<> LLVMCPUBufferizationPipeline(
       "iree-codegen-llvmcpu-bufferization-pipeline",
@@ -794,6 +822,16 @@ void registerCodegenLLVMCPUPasses() {
 
   struct LLVMCPULoweringPipelineOptions
       : PassPipelineOptions<LLVMCPULoweringPipelineOptions> {
+    Option<CodegenPipelineOptLevel> optLevel{
+        *this, "opt-level",
+        llvm::cl::desc(
+            "Optimization level used to derive CPU codegen defaults."),
+        llvm::cl::values(
+            clEnumValN(CodegenPipelineOptLevel::O0, "O0", "Use O0 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O1, "O1", "Use O1 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O2, "O2", "Use O2 defaults."),
+            clEnumValN(CodegenPipelineOptLevel::O3, "O3", "Use O3 defaults.")),
+        llvm::cl::init(CodegenPipelineOptLevel::O0)};
     Option<bool> enableArmSME{
         *this, "enable-arm-sme",
         llvm::cl::desc("Enable the ArmSME lowering pipeline.")};
@@ -809,9 +847,8 @@ void registerCodegenLLVMCPUPasses() {
           "Runs the LLVMCPU lowering pipeline",
           [](OpPassManager &modulePassManager,
              LLVMCPULoweringPipelineOptions const &options) {
-            // Use global codegen options for pipeline registration.
-            const CPUCodegenOptions &cpuOpts =
-                CPUCodegenOptions::FromFlags::get();
+            CPUCodegenOptions cpuOpts =
+                getCPUCodegenOptionsForTextualPipeline(options);
             buildLLVMCPUCodegenPassPipeline(modulePassManager, cpuOpts,
                                             options.enableArmSME,
                                             options.includeLLVMLowering);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -89,7 +89,7 @@ def LLVMCPULowerExecutableTargetPass :
   }];
   let options = [
     Option<"cpuOptions", "cpu-options", "CPUCodegenOptions",
-      /*default=*/"CPUCodegenOptions::FromFlags::get()",
+      /*default=*/"CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel::O0)",
       "Session-scoped CPU codegen options controlling optimization level, "
       "distribution, etc.">,
   ];

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -89,9 +89,9 @@ def LLVMCPULowerExecutableTargetPass :
   }];
   let options = [
     Option<"cpuOptions", "cpu-options", "CPUCodegenOptions",
-      /*default=*/"CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel::O0)",
-      "Session-scoped CPU codegen options controlling optimization level, "
-      "distribution, etc.">,
+      /*default=*/"CPUCodegenOptions()",
+      "CPU codegen options consumed by this pass; see CPUCodegenOptions for "
+      "the available and default settings.">,
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
@@ -1,10 +1,12 @@
-// CPU backend disable fp reassociation for O0 and O1, so the checks should be the same.
+// CPU backend disables fp reassociation for O0 and O1, so the checks should be
+// the same.
 // RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-reassociate-fp-reductions=false --split-input-file %s | FileCheck %s
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O0 --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='opt-level=O0' --iree-codegen-llvmcpu-lowering-pipeline='opt-level=O0 include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
-// CPU backend enables fp reassociation starting from O2, so the checks should be the same.
+// CPU backend enables fp reassociation starting from O2, so the checks should
+// be the same.
 // RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-reassociate-fp-reductions=true --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='opt-level=O2' --iree-codegen-llvmcpu-lowering-pipeline='opt-level=O2 include-llvm-lowering=false' --split-input-file %s | FileCheck %s --check-prefix=REORDERCHECK
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline --iree-codegen-llvmcpu-lowering-pipeline='include-llvm-lowering=false' --iree-llvmcpu-mlir-opt-level=O2 --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-llvmcpu-configuration-pipeline='opt-level=O2' --iree-codegen-llvmcpu-lowering-pipeline='opt-level=O2 include-llvm-lowering=false' --split-input-file %s | FileCheck %s
 
 // Check that this dispatch compiles to vectors and that there are no allocas.
 // By proxy checks that destination passing style kicked in correctly

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -113,7 +113,7 @@ def LLVMGPUSelectLoweringStrategyPass :
   let summary = "Select a IREE::HAL::DispatchLoweringPassPipeline for lowering the target variant";
   let options = [
     Option<"gpuOptions", "gpu-options", "GPUCodegenOptions",
-      /*default=*/"GPUCodegenOptions::FromFlags::get()",
+      /*default=*/"GPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel::O0)",
       "Session-scoped GPU codegen options (tuning spec, etc.).">,
   ];
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -113,8 +113,9 @@ def LLVMGPUSelectLoweringStrategyPass :
   let summary = "Select a IREE::HAL::DispatchLoweringPassPipeline for lowering the target variant";
   let options = [
     Option<"gpuOptions", "gpu-options", "GPUCodegenOptions",
-      /*default=*/"GPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel::O0)",
-      "Session-scoped GPU codegen options (tuning spec, etc.).">,
+      /*default=*/"GPUCodegenOptions()",
+      "GPU codegen options consumed by this pass; see GPUCodegenOptions for "
+      "the available and default settings.">,
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -11,9 +11,40 @@ IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 
 namespace mlir::iree_compiler {
 
+namespace {
+
+// Applies the opt-level default cascade using a local binder.
+template <typename CodegenOptionsT>
+void applyOptLevelDefaults(CodegenOptionsT &opts,
+                           llvm::OptimizationLevel level) {
+  auto binder = OptionsBinder::local();
+  // Anchor the opt-level hierarchy so applyOptimizationDefaults can walk it.
+  binder.topLevelOpt("opt-level", level);
+  opts.bindOptions(binder);
+  binder.applyOptimizationDefaults();
+}
+
+} // namespace
+
 std::string CodegenOptions::tuningSpecPath = "";
 bool CodegenOptions::setTunerAttributes = false;
 bool CodegenOptions::emitPipelineConstraints = false;
+
+llvm::OptimizationLevel
+mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel) {
+  switch (optLevel) {
+  case CodegenPipelineOptLevel::O0:
+    return llvm::OptimizationLevel::O0;
+  case CodegenPipelineOptLevel::O1:
+    return llvm::OptimizationLevel::O1;
+  case CodegenPipelineOptLevel::O2:
+    return llvm::OptimizationLevel::O2;
+  case CodegenPipelineOptLevel::O3:
+    return llvm::OptimizationLevel::O3;
+  }
+  assert(false && "unhandled codegen pipeline optimization level");
+  return llvm::OptimizationLevel::O0;
+}
 
 void CodegenOptions::bindOptions(OptionsBinder &binder) {
   static llvm::cl::OptionCategory category("IREE Codegen Options");
@@ -40,6 +71,17 @@ void CodegenOptions::bindOptions(OptionsBinder &binder) {
       emitPipelineConstraints, llvm::cl::cat(category),
       llvm::cl::desc("Emit and verify SMT pipeline constraints for root ops. "
                      "Implies --iree-codegen-add-tuner-attributes."));
+}
+
+void CPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
+  applyOptLevelDefaults(*this, level);
+}
+
+CPUCodegenOptions
+CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
+  CPUCodegenOptions opts;
+  opts.setWithOptLevel(level);
+  return opts;
 }
 
 void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
@@ -104,6 +146,17 @@ void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
                    llvm::cl::desc("Experimental: enables vectorization to "
                                   "iree_vector_ext.transfer_gather."),
                    llvm::cl::cat(category));
+}
+
+void GPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
+  applyOptLevelDefaults(*this, level);
+}
+
+GPUCodegenOptions
+GPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
+  GPUCodegenOptions opts;
+  opts.setWithOptLevel(level);
+  return opts;
 }
 
 void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -12,18 +12,17 @@ IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 namespace mlir::iree_compiler {
 
 namespace {
-
-// Applies the opt-level default cascade using a local binder.
-template <typename CodegenOptionsT>
-void applyOptLevelDefaults(CodegenOptionsT &opts,
-                           llvm::OptimizationLevel level) {
-  auto binder = OptionsBinder::local();
-  // Anchor the opt-level hierarchy so applyOptimizationDefaults can walk it.
-  binder.topLevelOpt("opt-level", level);
-  opts.bindOptions(binder);
-  binder.applyOptimizationDefaults();
+// Single instance per option category, shared across all bind* methods so
+// that splitting bindOptions across functions does not register duplicate
+// categories with LLVM's command-line machinery.
+llvm::cl::OptionCategory &commonCategory() {
+  static llvm::cl::OptionCategory category("IREE Codegen Options");
+  return category;
 }
-
+llvm::cl::OptionCategory &cpuCategory() {
+  static llvm::cl::OptionCategory category("IREE CPU Codegen Options");
+  return category;
+}
 } // namespace
 
 std::string CodegenOptions::tuningSpecPath = "";
@@ -47,7 +46,7 @@ mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel) {
 }
 
 void CodegenOptions::bindOptions(OptionsBinder &binder) {
-  static llvm::cl::OptionCategory category("IREE Codegen Options");
+  llvm::cl::OptionCategory &category = commonCategory();
 
   binder.opt<std::string>(
       "iree-codegen-tuning-spec-path", tuningSpecPath, llvm::cl::cat(category),
@@ -73,25 +72,26 @@ void CodegenOptions::bindOptions(OptionsBinder &binder) {
                      "Implies --iree-codegen-add-tuner-attributes."));
 }
 
-void CPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
-  applyOptLevelDefaults(*this, level);
-}
-
-CPUCodegenOptions
-CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
-  CPUCodegenOptions opts;
-  opts.setWithOptLevel(level);
-  return opts;
-}
-
-void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
-  static llvm::cl::OptionCategory category("IREE CPU Codegen Options");
-  CodegenOptions::bindOptions(binder);
+void CPUCodegenOptions::bindOptLevelCascadeOptions(OptionsBinder &binder) {
+  llvm::cl::OptionCategory &category = cpuCategory();
 
   auto initAtOpt = binder.optimizationLevel(
       "iree-llvmcpu-mlir-opt-level", optLevel,
       llvm::cl::desc("Optimization level for MLIR codegen passes."),
       llvm::cl::cat(category));
+
+  binder.opt<bool>("iree-llvmcpu-reassociate-fp-reductions",
+                   reassociateFpReductions,
+                   {initAtOpt(llvm::OptimizationLevel::O0, false),
+                    initAtOpt(llvm::OptimizationLevel::O2, true)},
+                   llvm::cl::desc("Enables reassociation for FP reductions."),
+                   llvm::cl::cat(category));
+}
+
+void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
+  llvm::cl::OptionCategory &category = cpuCategory();
+  CodegenOptions::bindOptions(binder);
+  bindOptLevelCascadeOptions(binder);
 
   binder.opt<bool>("iree-llvmcpu-disable-distribution", disableDistribution,
                    llvm::cl::desc("Disable thread distribution in codegen."),
@@ -103,13 +103,6 @@ void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::desc("Fail if the upper bound of dynamic stack allocation "
                      "cannot be solved."),
       llvm::cl::cat(category));
-
-  binder.opt<bool>("iree-llvmcpu-reassociate-fp-reductions",
-                   reassociateFpReductions,
-                   {initAtOpt(llvm::OptimizationLevel::O0, false),
-                    initAtOpt(llvm::OptimizationLevel::O2, true)},
-                   llvm::cl::desc("Enables reassociation for FP reductions."),
-                   llvm::cl::cat(category));
 
   binder.opt<bool>(
       "iree-llvmcpu-use-fast-min-max-ops", useFastMinMaxOps,
@@ -148,8 +141,38 @@ void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
                    llvm::cl::cat(category));
 }
 
+void CPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
+  // Run the opt-level cascade on a local binder restricted to this instance's
+  // opt-level-sensitive fields. All bound storage lives on `*this` (a local
+  // object on the caller's stack), so concurrent invocations from parallel
+  // pass option defaults write only to thread-local memory.
+  auto binder = OptionsBinder::local();
+  binder.topLevelOpt("opt-level", level);
+  bindOptLevelCascadeOptions(binder);
+  binder.applyOptimizationDefaults();
+}
+
+CPUCodegenOptions
+CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
+  CPUCodegenOptions opts;
+  opts.setWithOptLevel(level);
+  return opts;
+}
+
+void GPUCodegenOptions::bindOptLevelCascadeOptions(OptionsBinder & /*binder*/) {
+  // No GPU-specific opt-level-sensitive fields yet.
+}
+
+void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {
+  CodegenOptions::bindOptions(binder);
+  bindOptLevelCascadeOptions(binder);
+}
+
 void GPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
-  applyOptLevelDefaults(*this, level);
+  auto binder = OptionsBinder::local();
+  binder.topLevelOpt("opt-level", level);
+  bindOptLevelCascadeOptions(binder);
+  binder.applyOptimizationDefaults();
 }
 
 GPUCodegenOptions
@@ -157,10 +180,6 @@ GPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
   GPUCodegenOptions opts;
   opts.setWithOptLevel(level);
   return opts;
-}
-
-void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {
-  CodegenOptions::bindOptions(binder);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -12,17 +12,18 @@ IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::GPUCodegenOptions);
 namespace mlir::iree_compiler {
 
 namespace {
-// Single instance per option category, shared across all bind* methods so
-// that splitting bindOptions across functions does not register duplicate
-// categories with LLVM's command-line machinery.
-llvm::cl::OptionCategory &commonCategory() {
-  static llvm::cl::OptionCategory category("IREE Codegen Options");
-  return category;
+
+// Applies the opt-level default cascade using a local binder.
+template <typename CodegenOptionsT>
+void applyOptLevelDefaults(CodegenOptionsT &opts,
+                           llvm::OptimizationLevel level) {
+  auto binder = OptionsBinder::local();
+  // Anchor the opt-level hierarchy so applyOptimizationDefaults can walk it.
+  binder.topLevelOpt("opt-level", level);
+  opts.bindOptions(binder);
+  binder.applyOptimizationDefaults();
 }
-llvm::cl::OptionCategory &cpuCategory() {
-  static llvm::cl::OptionCategory category("IREE CPU Codegen Options");
-  return category;
-}
+
 } // namespace
 
 std::string CodegenOptions::tuningSpecPath = "";
@@ -46,7 +47,7 @@ mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel) {
 }
 
 void CodegenOptions::bindOptions(OptionsBinder &binder) {
-  llvm::cl::OptionCategory &category = commonCategory();
+  static llvm::cl::OptionCategory category("IREE Codegen Options");
 
   binder.opt<std::string>(
       "iree-codegen-tuning-spec-path", tuningSpecPath, llvm::cl::cat(category),
@@ -72,26 +73,25 @@ void CodegenOptions::bindOptions(OptionsBinder &binder) {
                      "Implies --iree-codegen-add-tuner-attributes."));
 }
 
-void CPUCodegenOptions::bindOptLevelCascadeOptions(OptionsBinder &binder) {
-  llvm::cl::OptionCategory &category = cpuCategory();
+void CPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
+  applyOptLevelDefaults(*this, level);
+}
+
+CPUCodegenOptions
+CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
+  CPUCodegenOptions opts;
+  opts.setWithOptLevel(level);
+  return opts;
+}
+
+void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
+  static llvm::cl::OptionCategory category("IREE CPU Codegen Options");
+  CodegenOptions::bindOptions(binder);
 
   auto initAtOpt = binder.optimizationLevel(
       "iree-llvmcpu-mlir-opt-level", optLevel,
       llvm::cl::desc("Optimization level for MLIR codegen passes."),
       llvm::cl::cat(category));
-
-  binder.opt<bool>("iree-llvmcpu-reassociate-fp-reductions",
-                   reassociateFpReductions,
-                   {initAtOpt(llvm::OptimizationLevel::O0, false),
-                    initAtOpt(llvm::OptimizationLevel::O2, true)},
-                   llvm::cl::desc("Enables reassociation for FP reductions."),
-                   llvm::cl::cat(category));
-}
-
-void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
-  llvm::cl::OptionCategory &category = cpuCategory();
-  CodegenOptions::bindOptions(binder);
-  bindOptLevelCascadeOptions(binder);
 
   binder.opt<bool>("iree-llvmcpu-disable-distribution", disableDistribution,
                    llvm::cl::desc("Disable thread distribution in codegen."),
@@ -103,6 +103,13 @@ void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::desc("Fail if the upper bound of dynamic stack allocation "
                      "cannot be solved."),
       llvm::cl::cat(category));
+
+  binder.opt<bool>("iree-llvmcpu-reassociate-fp-reductions",
+                   reassociateFpReductions,
+                   {initAtOpt(llvm::OptimizationLevel::O0, false),
+                    initAtOpt(llvm::OptimizationLevel::O2, true)},
+                   llvm::cl::desc("Enables reassociation for FP reductions."),
+                   llvm::cl::cat(category));
 
   binder.opt<bool>(
       "iree-llvmcpu-use-fast-min-max-ops", useFastMinMaxOps,
@@ -141,38 +148,8 @@ void CPUCodegenOptions::bindOptions(OptionsBinder &binder) {
                    llvm::cl::cat(category));
 }
 
-void CPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
-  // Run the opt-level cascade on a local binder restricted to this instance's
-  // opt-level-sensitive fields. All bound storage lives on `*this` (a local
-  // object on the caller's stack), so concurrent invocations from parallel
-  // pass option defaults write only to thread-local memory.
-  auto binder = OptionsBinder::local();
-  binder.topLevelOpt("opt-level", level);
-  bindOptLevelCascadeOptions(binder);
-  binder.applyOptimizationDefaults();
-}
-
-CPUCodegenOptions
-CPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
-  CPUCodegenOptions opts;
-  opts.setWithOptLevel(level);
-  return opts;
-}
-
-void GPUCodegenOptions::bindOptLevelCascadeOptions(OptionsBinder & /*binder*/) {
-  // No GPU-specific opt-level-sensitive fields yet.
-}
-
-void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {
-  CodegenOptions::bindOptions(binder);
-  bindOptLevelCascadeOptions(binder);
-}
-
 void GPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {
-  auto binder = OptionsBinder::local();
-  binder.topLevelOpt("opt-level", level);
-  bindOptLevelCascadeOptions(binder);
-  binder.applyOptimizationDefaults();
+  applyOptLevelDefaults(*this, level);
 }
 
 GPUCodegenOptions
@@ -180,6 +157,10 @@ GPUCodegenOptions::getWithOptLevel(llvm::OptimizationLevel level) {
   GPUCodegenOptions opts;
   opts.setWithOptLevel(level);
   return opts;
+}
+
+void GPUCodegenOptions::bindOptions(OptionsBinder &binder) {
+  CodegenOptions::bindOptions(binder);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -11,6 +11,19 @@
 
 namespace mlir::iree_compiler {
 
+// Bridge type for MLIR pass/pipeline options, which cannot store
+// llvm::OptimizationLevel directly because it is a final class.
+enum class CodegenPipelineOptLevel {
+  O0 = 0,
+  O1 = 1,
+  O2 = 2,
+  O3 = 3,
+};
+
+// Maps the pass/pipeline bridge enum to llvm::OptimizationLevel.
+llvm::OptimizationLevel
+mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel);
+
 // A base class that defines common codegen options that are shared across
 // different backends (e.g., CPU and GPU). Derived classes can add
 // backend-specific options as needed.
@@ -61,11 +74,27 @@ struct CPUCodegenOptions : CodegenOptions {
 
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<CPUCodegenOptions>;
+
+  // Applies opt-level-dependent defaults to the current option set.
+  void setWithOptLevel(llvm::OptimizationLevel level);
+
+  // Returns a CPUCodegenOptions with all opt-level-dependent defaults derived
+  // from `level`. Uses a local OptionsBinder so the global flags are not
+  // touched.
+  static CPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 
 struct GPUCodegenOptions : CodegenOptions {
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<GPUCodegenOptions>;
+
+  // Applies opt-level-dependent defaults to the current option set.
+  void setWithOptLevel(llvm::OptimizationLevel level);
+
+  // Returns a GPUCodegenOptions with all opt-level-dependent defaults derived
+  // from `level`. Uses a local OptionsBinder so the global flags are not
+  // touched.
+  static GPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -28,9 +28,12 @@ mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel);
 // different backends (e.g., CPU and GPU). Derived classes can add
 // backend-specific options as needed.
 //
-// Note: We need static members because they are shared across all derived
-// instances to bind LLVM cl::opt registration at the single storage when
-// multiple backends inherit from this class.
+// Note: We keep a few members static so that CPU and GPU subclasses' global
+// CLI bindings share the same storage (and so dedup-by-name works across the
+// two FromFlags singletons). Static storage is only safe to bind on the
+// global binder singleton, not on per-instance local binders; see
+// bindOptLevelCascadeOptions() on each subclass for the thread-safe cascade
+// path.
 struct CodegenOptions {
   // Path to a module containing a tuning spec.
   static std::string tuningSpecPath;
@@ -41,6 +44,10 @@ struct CodegenOptions {
   // Whether to emit pipeline constraints for root ops.
   static bool emitPipelineConstraints;
 
+  // Registers the shared CLI flags that back CodegenOptions' static members.
+  // Must only be called on the global binder (via the FromFlags singleton);
+  // binding on a local binder would write through shared static storage and
+  // is not safe under MLIR's parallel pass pipelines.
   void bindOptions(OptionsBinder &binder);
 };
 
@@ -72,28 +79,49 @@ struct CPUCodegenOptions : CodegenOptions {
   // Enables experimental vectorization to transfer_gather.
   bool enableTransferGather = false;
 
+  // Registers all CPU codegen CLI flags, including the opt-level cascade and
+  // the shared CodegenOptions statics. Intended for the FromFlags singleton
+  // on the global binder only.
   void bindOptions(OptionsBinder &binder);
+
+  // Registers only the opt-level-sensitive instance fields on the provided
+  // binder. Safe to call per-instance on a local binder: every bound flag
+  // points at a field on `*this` (thread-local), so concurrent invocations
+  // from pass option defaults do not race.
+  void bindOptLevelCascadeOptions(OptionsBinder &binder);
+
   using FromFlags = OptionsFromFlags<CPUCodegenOptions>;
 
-  // Applies opt-level-dependent defaults to the current option set.
+  // Applies opt-level-dependent defaults to this instance by running the
+  // binder-driven cascade on a local binder bound solely to this instance's
+  // opt-level-sensitive fields.
   void setWithOptLevel(llvm::OptimizationLevel level);
 
   // Returns a CPUCodegenOptions with all opt-level-dependent defaults derived
-  // from `level`. Uses a local OptionsBinder so the global flags are not
-  // touched.
+  // from `level`.
   static CPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 
 struct GPUCodegenOptions : CodegenOptions {
+  // Registers all GPU codegen CLI flags, including the shared CodegenOptions
+  // statics. Intended for the FromFlags singleton on the global binder only.
   void bindOptions(OptionsBinder &binder);
+
+  // Registers only the opt-level-sensitive instance fields on the provided
+  // binder. Today GPU has no opt-level-sensitive fields, so this is a no-op.
+  // Kept parallel to the CPU side so both backends share the same cascade
+  // shape; extend here when GPU adds opt-level-sensitive defaults.
+  void bindOptLevelCascadeOptions(OptionsBinder &binder);
+
   using FromFlags = OptionsFromFlags<GPUCodegenOptions>;
 
-  // Applies opt-level-dependent defaults to the current option set.
+  // Applies opt-level-dependent defaults to this instance by running the
+  // binder-driven cascade on a local binder bound solely to this instance's
+  // opt-level-sensitive fields.
   void setWithOptLevel(llvm::OptimizationLevel level);
 
   // Returns a GPUCodegenOptions with all opt-level-dependent defaults derived
-  // from `level`. Uses a local OptionsBinder so the global flags are not
-  // touched.
+  // from `level`.
   static GPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -28,12 +28,9 @@ mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel);
 // different backends (e.g., CPU and GPU). Derived classes can add
 // backend-specific options as needed.
 //
-// Note: We keep a few members static so that CPU and GPU subclasses' global
-// CLI bindings share the same storage (and so dedup-by-name works across the
-// two FromFlags singletons). Static storage is only safe to bind on the
-// global binder singleton, not on per-instance local binders; see
-// bindOptLevelCascadeOptions() on each subclass for the thread-safe cascade
-// path.
+// Note: We need static members because they are shared across all derived
+// instances to bind LLVM cl::opt registration at the single storage when
+// multiple backends inherit from this class.
 struct CodegenOptions {
   // Path to a module containing a tuning spec.
   static std::string tuningSpecPath;
@@ -44,10 +41,6 @@ struct CodegenOptions {
   // Whether to emit pipeline constraints for root ops.
   static bool emitPipelineConstraints;
 
-  // Registers the shared CLI flags that back CodegenOptions' static members.
-  // Must only be called on the global binder (via the FromFlags singleton);
-  // binding on a local binder would write through shared static storage and
-  // is not safe under MLIR's parallel pass pipelines.
   void bindOptions(OptionsBinder &binder);
 };
 
@@ -79,49 +72,28 @@ struct CPUCodegenOptions : CodegenOptions {
   // Enables experimental vectorization to transfer_gather.
   bool enableTransferGather = false;
 
-  // Registers all CPU codegen CLI flags, including the opt-level cascade and
-  // the shared CodegenOptions statics. Intended for the FromFlags singleton
-  // on the global binder only.
   void bindOptions(OptionsBinder &binder);
-
-  // Registers only the opt-level-sensitive instance fields on the provided
-  // binder. Safe to call per-instance on a local binder: every bound flag
-  // points at a field on `*this` (thread-local), so concurrent invocations
-  // from pass option defaults do not race.
-  void bindOptLevelCascadeOptions(OptionsBinder &binder);
-
   using FromFlags = OptionsFromFlags<CPUCodegenOptions>;
 
-  // Applies opt-level-dependent defaults to this instance by running the
-  // binder-driven cascade on a local binder bound solely to this instance's
-  // opt-level-sensitive fields.
+  // Applies opt-level-dependent defaults to the current option set.
   void setWithOptLevel(llvm::OptimizationLevel level);
 
   // Returns a CPUCodegenOptions with all opt-level-dependent defaults derived
-  // from `level`.
+  // from `level`. Uses a local OptionsBinder so the global flags are not
+  // touched.
   static CPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 
 struct GPUCodegenOptions : CodegenOptions {
-  // Registers all GPU codegen CLI flags, including the shared CodegenOptions
-  // statics. Intended for the FromFlags singleton on the global binder only.
   void bindOptions(OptionsBinder &binder);
-
-  // Registers only the opt-level-sensitive instance fields on the provided
-  // binder. Today GPU has no opt-level-sensitive fields, so this is a no-op.
-  // Kept parallel to the CPU side so both backends share the same cascade
-  // shape; extend here when GPU adds opt-level-sensitive defaults.
-  void bindOptLevelCascadeOptions(OptionsBinder &binder);
-
   using FromFlags = OptionsFromFlags<GPUCodegenOptions>;
 
-  // Applies opt-level-dependent defaults to this instance by running the
-  // binder-driven cascade on a local binder bound solely to this instance's
-  // opt-level-sensitive fields.
+  // Applies opt-level-dependent defaults to the current option set.
   void setWithOptLevel(llvm::OptimizationLevel level);
 
   // Returns a GPUCodegenOptions with all opt-level-dependent defaults derived
-  // from `level`.
+  // from `level`. Uses a local OptionsBinder so the global flags are not
+  // touched.
   static GPUCodegenOptions getWithOptLevel(llvm::OptimizationLevel level);
 };
 


### PR DESCRIPTION
Previously, I made a workaround in https://github.com/iree-org/iree/commit/1b75890ac8093dd9b74b8110833bd2a46b3da7f0. The main reason is that all the codegen pipeline tests were anchor on a single pass (e.g., `XXXLowerExecutableTargetPass`), which makes plumbing through options infeasible.

After migrating to the real pipeline transformations, we are able to use the option in whole pipeline tests; we can drop the old workaround from iree-opt changes.

The revision introduces the option for each backend (default `O0`) and use local binders to apply the optimization flags. It drops the `XXX::FromFlags::get()` uses from Codegen.

The additional change is updating the default value in `Passes.td` to not apply optimization level. It was a workaround when we abused the pass for optimization control. Now all the pipeline tests use textual pass pipelines, so we no longer need the workaround.

ci-extra: linux_x64_clang_tsan