### PR TITLE
[AMDGPU][DMA] Enable Gfx950 coalesced DMA on K-unaligned f16/bf16 GEMMs

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerCoalescedDMAToGatherLDS.cpp
@@ -415,8 +415,19 @@ struct LowerCoalescedGatherDMAPattern final
 
     // Cap per-lane width to the minimum contiguous trailing size of source
     // and destination, so gather_to_lds does not read/write past stride
-    // boundaries.
+    // boundaries. When the source's innermost extent is dynamic but its
+    // innermost stride is statically 1 (so trailing reads remain
+    // contiguous) and the source lives in fat_raw_buffer address space,
+    // GPUPushDownDMABoundsToConsumers has installed a validBytes-aware
+    // buffer descriptor plus a consumer-side pad: HW returns 0 for OOB
+    // DWORDs and the pad masks the corresponding LDS columns away. In
+    // that case derive the cap from the destination layout instead of
+    // bailing on srcLinearSize=1.
     int64_t srcLinearSize = getContiguousTrailingLinearSize(sourceType).second;
+    if (srcLinearSize == 1 && sourceType.getNumContiguousTrailingDims() >= 1 &&
+        hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+      srcLinearSize = destLinearSize;
+    }
     int64_t maxElementsPerLane = std::min(srcLinearSize, destLinearSize);
     LDBG() << "  Max elements per lane: " << maxElementsPerLane;
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -90,6 +90,7 @@ iree_compiler_cc_library(
         "GPUPipelining.cpp",
         "GPUPromoteMatmulOperands.cpp",
         "GPUPromotionAnalysis.cpp",
+        "GPUPushDownDMABoundsToConsumers.cpp",
         "GPUReduceBankConflicts.cpp",
         "GPUReuseSharedMemoryAllocs.cpp",
         "GPUTensorAlloc.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -87,6 +87,7 @@ iree_compiler_cc_library(
         "GPUPatterns.cpp",
         "GPUPipelining.cpp",
         "GPUPromoteMatmulOperands.cpp",
+        "GPUPushDownDMABoundsToConsumers.cpp",
         "GPUReduceBankConflicts.cpp",
         "GPUReuseSharedMemoryAllocs.cpp",
         "GPUTensorAlloc.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -85,6 +85,7 @@ iree_cc_library(
     "GPUPipelining.cpp"
     "GPUPromoteMatmulOperands.cpp"
     "GPUPromotionAnalysis.cpp"
+    "GPUPushDownDMABoundsToConsumers.cpp"
     "GPUReduceBankConflicts.cpp"
     "GPUReuseSharedMemoryAllocs.cpp"
     "GPUTensorAlloc.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -80,6 +80,7 @@ iree_cc_library(
     "GPUPatterns.cpp"
     "GPUPipelining.cpp"
     "GPUPromoteMatmulOperands.cpp"
+    "GPUPushDownDMABoundsToConsumers.cpp"
     "GPUReduceBankConflicts.cpp"
     "GPUReuseSharedMemoryAllocs.cpp"
     "GPUTensorAlloc.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
@@ -110,14 +110,6 @@ struct BubbleResourceCastPattern
     if (castOp.getCacheSwizzleStride()) {
       return failure();
     }
-    // Skip ops with explicit valid_bytes. The byte-count is computed for the
-    // subview the cast wraps; bubbling would attach it to a larger tensor and
-    // make it nonsensical. The cast simply bufferizes in place so the
-    // resulting amdgpu.fat_raw_buffer_cast carries the override.
-    if (castOp.getValidBytes()) {
-      return failure();
-    }
-
     auto producer = castOp.getInput().getDefiningOp();
     if (!producer) {
       return failure();
@@ -134,8 +126,7 @@ struct BubbleResourceCastPattern
               rewriter.setInsertionPoint(extract);
               auto newCast = IREE::GPU::BufferResourceCastOp::create(
                   rewriter, loc, extract.getSource().getType(),
-                  extract.getSource(), /*cache_swizzle_stride=*/Value{},
-                  /*valid_bytes=*/Value{});
+                  extract.getSource(), /*cache_swizzle_stride=*/Value{});
               extract.getSourceMutable().assign(newCast);
               return true;
             })
@@ -147,8 +138,7 @@ struct BubbleResourceCastPattern
               rewriter.setInsertionPoint(expand);
               auto newCast = IREE::GPU::BufferResourceCastOp::create(
                   rewriter, loc, expand.getSrcType(), expand.getSrc(),
-                  /*cache_swizzle_stride=*/Value{},
-                  /*valid_bytes=*/Value{});
+                  /*cache_swizzle_stride=*/Value{});
               expand.getSrcMutable().assign(newCast);
               return true;
             })
@@ -160,8 +150,7 @@ struct BubbleResourceCastPattern
               rewriter.setInsertionPoint(collapse);
               auto newCast = IREE::GPU::BufferResourceCastOp::create(
                   rewriter, loc, collapse.getSrcType(), collapse.getSrc(),
-                  /*cache_swizzle_stride=*/Value{},
-                  /*valid_bytes=*/Value{});
+                  /*cache_swizzle_stride=*/Value{});
               collapse.getSrcMutable().assign(newCast);
               return true;
             })
@@ -173,8 +162,7 @@ struct BubbleResourceCastPattern
               rewriter.setInsertionPoint(pad);
               auto newCast = IREE::GPU::BufferResourceCastOp::create(
                   rewriter, loc, pad.getSourceType(), pad.getSource(),
-                  /*cache_swizzle_stride=*/Value{},
-                  /*valid_bytes=*/Value{});
+                  /*cache_swizzle_stride=*/Value{});
               pad.getSourceMutable().assign(newCast);
               return true;
             })
@@ -188,8 +176,7 @@ struct BubbleResourceCastPattern
               for (auto inputOperand : linalgOp.getDpsInputOperands()) {
                 auto newCast = IREE::GPU::BufferResourceCastOp::create(
                     rewriter, loc, inputOperand->get().getType(),
-                    inputOperand->get(), /*cache_swizzle_stride=*/Value{},
-                    /*valid_bytes=*/Value{});
+                    inputOperand->get(), /*cache_swizzle_stride=*/Value{});
                 inputOperand->assign(newCast);
               }
               return true;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUBubbleResourceCasts.cpp
@@ -110,6 +110,13 @@ struct BubbleResourceCastPattern
     if (castOp.getCacheSwizzleStride()) {
       return failure();
     }
+    // Skip ops with explicit valid_bytes. The byte-count is computed for the
+    // subview the cast wraps; bubbling would attach it to a larger tensor and
+    // make it nonsensical. The cast simply bufferizes in place so the
+    // resulting amdgpu.fat_raw_buffer_cast carries the override.
+    if (castOp.getValidBytes()) {
+      return failure();
+    }
 
     auto producer = castOp.getInput().getDefiningOp();
     if (!producer) {
@@ -127,7 +134,8 @@ struct BubbleResourceCastPattern
               rewriter.setInsertionPoint(extract);
               auto newCast = IREE::GPU::BufferResourceCastOp::create(
                   rewriter, loc, extract.getSource().getType(),
-                  extract.getSource());
+                  extract.getSource(), /*cache_swizzle_stride=*/Value{},
+                  /*valid_bytes=*/Value{});
               extract.getSourceMutable().assign(newCast);
               return true;
             })
@@ -138,7 +146,9 @@ struct BubbleResourceCastPattern
 
               rewriter.setInsertionPoint(expand);
               auto newCast = IREE::GPU::BufferResourceCastOp::create(
-                  rewriter, loc, expand.getSrcType(), expand.getSrc());
+                  rewriter, loc, expand.getSrcType(), expand.getSrc(),
+                  /*cache_swizzle_stride=*/Value{},
+                  /*valid_bytes=*/Value{});
               expand.getSrcMutable().assign(newCast);
               return true;
             })
@@ -149,7 +159,9 @@ struct BubbleResourceCastPattern
 
               rewriter.setInsertionPoint(collapse);
               auto newCast = IREE::GPU::BufferResourceCastOp::create(
-                  rewriter, loc, collapse.getSrcType(), collapse.getSrc());
+                  rewriter, loc, collapse.getSrcType(), collapse.getSrc(),
+                  /*cache_swizzle_stride=*/Value{},
+                  /*valid_bytes=*/Value{});
               collapse.getSrcMutable().assign(newCast);
               return true;
             })
@@ -160,7 +172,9 @@ struct BubbleResourceCastPattern
 
               rewriter.setInsertionPoint(pad);
               auto newCast = IREE::GPU::BufferResourceCastOp::create(
-                  rewriter, loc, pad.getSourceType(), pad.getSource());
+                  rewriter, loc, pad.getSourceType(), pad.getSource(),
+                  /*cache_swizzle_stride=*/Value{},
+                  /*valid_bytes=*/Value{});
               pad.getSourceMutable().assign(newCast);
               return true;
             })
@@ -174,7 +188,8 @@ struct BubbleResourceCastPattern
               for (auto inputOperand : linalgOp.getDpsInputOperands()) {
                 auto newCast = IREE::GPU::BufferResourceCastOp::create(
                     rewriter, loc, inputOperand->get().getType(),
-                    inputOperand->get());
+                    inputOperand->get(), /*cache_swizzle_stride=*/Value{},
+                    /*valid_bytes=*/Value{});
                 inputOperand->assign(newCast);
               }
               return true;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -329,14 +329,9 @@ static bool isValidPadForDMA(tensor::PadOp pad) {
     return false;
   }
   if (r0 != r1) {
-    unsigned kDim = (r0 < r1) ? 0 : 1;
-    return sourceType.isDynamicDim(kDim);
+    return sourceType.isDynamicDim((r0 < r1) ? 0 : 1);
   }
-  // Square: infer K from which source dim is dynamic. Both static or both
-  // dynamic → can't disambiguate, bail.
-  bool dyn0 = sourceType.isDynamicDim(0);
-  bool dyn1 = sourceType.isDynamicDim(1);
-  return dyn0 != dyn1;
+  return sourceType.isDynamicDim(0) != sourceType.isDynamicDim(1);
 }
 
 /// Check if a linalg.copy is viable for DMA conversion based on alignment,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -293,19 +293,40 @@ static bool isValidPadForDMA(tensor::PadOp pad) {
     return false;
   }
 
-  // Check if source tensor's innermost row size is DWORD (4-byte) aligned. On
-  // AMD CDNA, per-component range checking is performed for each DWORD. If a
-  // DWORD is partially out-of-bounds, the entire DWORD returns zero, causing
-  // incorrect results. Additionally, partial OOB triggers the slow path with
-  // multi-cycling and instruction issue penalties.
-  auto sourceType = cast<RankedTensorType>(pad.getSource().getType());
-  int64_t innermostDim = sourceType.getShape().back();
-  if (ShapedType::isDynamic(innermostDim)) {
+  // AMD CDNA HW does per-DWORD range checking on buffer loads, with two
+  // failure modes when source rows are not DWORD-aligned:
+  //   1. Per-lane straddle DWORDs read from the *next* source row.
+  //   2. The trailing partial DWORD crosses the buffer end and HW zeros it.
+  // GPUPushDownDMABoundsToConsumers handles both via a consumer-side pad
+  // and an iree_gpu.buffer_resource_cast validBytes override, which makes
+  // DMA correct on non-aligned rows.
+  //
+  // Performance gating: DMA's per-lane gather lowering wins on K-block
+  // boundary tiles (partial K-rows) thanks to HW bounds-checked loads;
+  // it loses on K-aligned shapes because the per-lane scalar copies are
+  // pure overhead vs the non-DMA wide vector loads. Opt in only when the
+  // matmul's K is *not* a multiple of K-tile (i.e. a K-block boundary
+  // actually exists at runtime).
+  //
+  // Detection: the pad result is the workgroup LDS tile. For a matmul
+  // operand the K-tile direction is the smaller of the two result dims
+  // (K-tile is typically 16-32 elements; M-tile / N-tile is 64-256). The
+  // source slice is dynamic in that K-direction iff the matmul's K isn't
+  // K-tile-divisible — exactly the boundary case we want DMA for.
+  auto resultType = dyn_cast<RankedTensorType>(pad.getResult().getType());
+  auto sourceType = dyn_cast<RankedTensorType>(pad.getSource().getType());
+  if (!resultType || !sourceType || resultType.getRank() != 2 ||
+      sourceType.getRank() != 2) {
     return false;
   }
-  Type elemType = sourceType.getElementType();
-  int64_t rowBytes = innermostDim * (elemType.getIntOrFloatBitWidth() / 8);
-  return rowBytes % 4 == 0;
+  int64_t r0 = resultType.getDimSize(0);
+  int64_t r1 = resultType.getDimSize(1);
+  if (ShapedType::isDynamic(r0) || ShapedType::isDynamic(r1) || r0 == r1) {
+    // Need both result dims static and unequal to identify K-tile direction.
+    return false;
+  }
+  unsigned kDim = (r0 < r1) ? 0 : 1;
+  return sourceType.isDynamicDim(kDim);
 }
 
 /// Check if a linalg.copy is viable for DMA conversion based on alignment,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -308,11 +308,15 @@ static bool isValidPadForDMA(tensor::PadOp pad) {
   // matmul's K is *not* a multiple of K-tile (i.e. a K-block boundary
   // actually exists at runtime).
   //
-  // Detection: the pad result is the workgroup LDS tile. For a matmul
-  // operand the K-tile direction is the smaller of the two result dims
-  // (K-tile is typically 16-32 elements; M-tile / N-tile is 64-256). The
-  // source slice is dynamic in that K-direction iff the matmul's K isn't
-  // K-tile-divisible — exactly the boundary case we want DMA for.
+  // Detection: the pad result is the workgroup LDS tile. The K direction is
+  // identified one of two ways:
+  //   1. Result dims unequal — K-tile direction is the smaller dim (K-tile is
+  //      typically 16-32 elements; M-tile / N-tile is 64-256).
+  //   2. Result dims equal (square workgroup tile, e.g. 64x64 LHS) — K
+  //      direction is whichever source dim is dynamic, since the K-block
+  //      boundary slice is the only source of dynamism.
+  // In both cases the K-direction source dim must be dynamic (the K-block
+  // boundary case where DMA wins).
   auto resultType = dyn_cast<RankedTensorType>(pad.getResult().getType());
   auto sourceType = dyn_cast<RankedTensorType>(pad.getSource().getType());
   if (!resultType || !sourceType || resultType.getRank() != 2 ||
@@ -321,12 +325,18 @@ static bool isValidPadForDMA(tensor::PadOp pad) {
   }
   int64_t r0 = resultType.getDimSize(0);
   int64_t r1 = resultType.getDimSize(1);
-  if (ShapedType::isDynamic(r0) || ShapedType::isDynamic(r1) || r0 == r1) {
-    // Need both result dims static and unequal to identify K-tile direction.
+  if (ShapedType::isDynamic(r0) || ShapedType::isDynamic(r1)) {
     return false;
   }
-  unsigned kDim = (r0 < r1) ? 0 : 1;
-  return sourceType.isDynamicDim(kDim);
+  if (r0 != r1) {
+    unsigned kDim = (r0 < r1) ? 0 : 1;
+    return sourceType.isDynamicDim(kDim);
+  }
+  // Square: infer K from which source dim is dynamic. Both static or both
+  // dynamic → can't disambiguate, bail.
+  bool dyn0 = sourceType.isDynamicDim(0);
+  bool dyn1 = sourceType.isDynamicDim(1);
+  return dyn0 != dyn1;
 }
 
 /// Check if a linalg.copy is viable for DMA conversion based on alignment,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -288,19 +288,22 @@ static bool isValidPadForDMA(tensor::PadOp pad) {
     return false;
   }
 
-  // Check if source tensor's innermost row size is DWORD (4-byte) aligned. On
-  // AMD CDNA, per-component range checking is performed for each DWORD. If a
-  // DWORD is partially out-of-bounds, the entire DWORD returns zero, causing
-  // incorrect results. Additionally, partial OOB triggers the slow path with
-  // multi-cycling and instruction issue penalties.
-  auto sourceType = cast<RankedTensorType>(pad.getSource().getType());
-  int64_t innermostDim = sourceType.getShape().back();
-  if (ShapedType::isDynamic(innermostDim)) {
-    return false;
-  }
-  Type elemType = sourceType.getElementType();
-  int64_t rowBytes = innermostDim * (elemType.getIntOrFloatBitWidth() / 8);
-  return rowBytes % 4 == 0;
+  // Note on DWORD-aligned source rows: AMD CDNA HW does per-DWORD range
+  // checking on buffer loads, with two failure modes when the source row
+  // size is not DWORD-aligned:
+  //   1. Per-lane straddle DWORDs read from the *next* source row, writing
+  //      garbage to LDS innermost columns.
+  //   2. The straddle DWORD on the *last* source row crosses the buffer end;
+  //      HW zeros the entire DWORD, destroying valid bytes inside it.
+  //
+  // GPUPushDownDMABoundsToConsumers handles both:
+  //   - For (1) it inserts a tensor.pad on the LDS tile, masking garbage
+  //     columns at the consumer's vector.transfer_read.
+  //   - For (2) it wraps the source with iree_gpu.buffer_resource_cast that
+  //     overrides validBytes to a DWORD-rounded value, keeping the trailing
+  //     partial DWORD in-bounds so its valid bytes are preserved.
+  // Together these make non-DWORD-aligned source rows safe for DMA.
+  return true;
 }
 
 /// Check if a linalg.copy is viable for DMA conversion based on alignment,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
@@ -45,8 +45,12 @@ bool isDefinitelyShared(bufferization::AllocTensorOp alloc) {
   // and is transparent to memory-space inference. Look through it to its
   // own users so the underlying forall destination is recognized.
   SmallVector<Operation *> worklist(alloc->user_begin(), alloc->user_end());
+  SmallPtrSet<Operation *, 8> visited;
   while (!worklist.empty()) {
     Operation *user = worklist.pop_back_val();
+    if (!visited.insert(user).second) {
+      continue;
+    }
 
     if (isa<linalg::CopyOp>(user) &&
         getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(user)) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/ADT/STLExtras.h"
@@ -38,9 +39,22 @@ bool isDefinitelyShared(bufferization::AllocTensorOp alloc) {
   // An allocation can be inferred as shared if it is the destination of a
   // thread distributed `scf.forall` op. All other shared allocations are
   // expected to be properly indicated in advance.
-  for (auto user : alloc->getUsers()) {
+  //
+  // `iree_codegen.swizzle_hint` is a pure value-level hint with the same type
+  // as its source (see IREECodegenOps.td); it does not introduce a new buffer
+  // and is transparent to memory-space inference. Look through it to its
+  // own users so the underlying forall destination is recognized.
+  SmallVector<Operation *> worklist(alloc->user_begin(), alloc->user_end());
+  while (!worklist.empty()) {
+    Operation *user = worklist.pop_back_val();
+
     if (isa<linalg::CopyOp>(user) &&
         getLoweringConfig<IREE::GPU::UseGlobalLoadDMAAttr>(user)) {
+      continue;
+    }
+
+    if (isa<IREE::Codegen::SwizzleHintOp>(user)) {
+      worklist.append(user->user_begin(), user->user_end());
       continue;
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
@@ -146,15 +146,12 @@ static Value walkUpSharedOuts(Value v) {
   }
 }
 
-// When the DMA source's innermost row size in bytes is not DWORD (4-byte)
-// aligned, the AMD HW partial-DWORD OOB clamp zeroes valid bytes at the
-// buffer end. Wrap the source with an iree_gpu.buffer_resource_cast carrying
-// the `pad_to_dword` attribute. Bufferization will lower this to an
-// amdgpu.fat_raw_buffer_cast whose validBytes is rounded up to the next
-// DWORD (with a 3-byte safety margin), keeping the trailing partial DWORD
-// in-bounds. The garbage in bytes [naturalBytes, roundedBytes) lands in
-// masked LDS columns and is discarded by the consumer-side tensor.pad
-// inserted below.
+// Wrap the DMA source's root tensor with a plain iree_gpu.buffer_resource_cast.
+// Bufferization detects the misaligned innermost row from the bufferized
+// memref's shape and emits the corresponding amdgpu.fat_raw_buffer_cast with
+// a DWORD-rounded validBytes, keeping the trailing partial DWORD in-bounds.
+// Garbage in the rounded tail lands in masked LDS columns and is discarded
+// by the consumer-side tensor.pad inserted below.
 //
 // Returns failure when no rewrite is needed (already aligned, dynamic
 // element bit width, etc.). Source is mutated in place.
@@ -200,22 +197,17 @@ padSourceBufferDescriptorToDWORD(IRRewriter &rewriter,
   }
   unsigned rootRank = rootTy.getRank();
 
-  // Skip when the root buffer's innermost row is statically DWORD-aligned.
-  // The wrap exists to guard against the HW partial-DWORD clamp zeroing
-  // valid bytes at the buffer END; if the buffer end is naturally DWORD-
-  // aligned (which holds whenever the root's innermost row in bytes is
-  // divisible by 4 in row-major layout), no straddle is possible and the
-  // wrap is unnecessary. Catches the common "shape-dynamic but root-aligned"
-  // case (e.g. NxN f16 with N even, K-block tiling produces tensor<32x?xf16>
-  // but the root is tensor<NxNxf16> with N*2 % 4 == 0).
+  // Skip when the root's innermost row is statically DWORD-aligned — no
+  // straddle is possible at the buffer end. Catches the "shape-dynamic but
+  // root-aligned" case (e.g. K-block slice tensor<32x?xf16> of an even-N
+  // root tensor<NxNxf16>).
   int64_t rootInnermost = rootTy.getDimSize(rootRank - 1);
   if (!ShapedType::isDynamic(rootInnermost) &&
       (rootInnermost * elemBytes) % 4 == 0) {
     return failure();
   }
 
-  // If a plain buffer_resource_cast already wraps the root, skip — re-wrapping
-  // would just be redundant.
+  // Skip if the root is already wrapped — re-wrapping would be redundant.
   if (root.getDefiningOp<IREE::GPU::BufferResourceCastOp>()) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -41,10 +42,11 @@ namespace {
 // `tensor.extract_slice`. For a dynamic dim whose size is a Value, looks
 // through `arith.constant` and `affine.min` to extract a constant bound.
 //
-// Used by `rewriteOneDMA`: when the inner extent's UB matches the LDS tile
-// size, AMDGPULowerCoalescedDMA's OOB clamping already zeros OOB columns
-// through the same swizzle the consumer reads through, so the consumer pad
-// would be redundant. See rewriteOneDMA below.
+// Used by the pushdown skip predicates: when the inner extent's UB matches
+// what the pass would otherwise pad against, both the validBytes wrap and
+// the consumer-side pad become provably unnecessary (root alignment makes
+// the wrap a no-op; AMDGPULowerCoalescedDMA's OOB clamping makes the pad a
+// no-op). See padSourceBufferDescriptorToDWORD and rewriteOneDMA below.
 static std::optional<int64_t> getInnermostStaticUpperBound(Value src,
                                                            unsigned dim) {
   auto srcTy = dyn_cast<RankedTensorType>(src.getType());
@@ -142,6 +144,139 @@ static Value walkUpSharedOuts(Value v) {
     }
     v = nextSharedOut;
   }
+}
+
+// When the DMA source's innermost row size in bytes is not DWORD (4-byte)
+// aligned, the AMD HW partial-DWORD OOB clamp zeroes valid bytes at the
+// buffer end. Wrap the source with an iree_gpu.buffer_resource_cast that
+// declares validBytes rounded up to the next multiple of 4. After
+// bufferization this becomes amdgpu.fat_raw_buffer_cast with the explicit
+// validBytes, which keeps the trailing partial DWORD in-bounds. The garbage
+// in bytes [naturalBytes, roundedBytes) lands in masked LDS columns and is
+// discarded by the consumer-side tensor.pad inserted below.
+//
+// Returns failure when no rewrite is needed (already aligned, dynamic
+// element bit width, etc.). Source is mutated in place.
+static LogicalResult
+padSourceBufferDescriptorToDWORD(IRRewriter &rewriter,
+                                 IREE::GPU::CoalescedGatherDMAOp dma) {
+  Value src = dma.getSource();
+  auto srcTy = dyn_cast<RankedTensorType>(src.getType());
+  if (!srcTy) {
+    return failure();
+  }
+  Type elemTy = srcTy.getElementType();
+  if (!elemTy.isIntOrFloat()) {
+    return failure();
+  }
+  unsigned elemBits = elemTy.getIntOrFloatBitWidth();
+  if (elemBits == 0 || elemBits % 8 != 0) {
+    return failure();
+  }
+  unsigned elemBytes = elemBits / 8;
+
+  // If the innermost row is statically DWORD-aligned, the partial-DWORD
+  // straddle issue cannot occur and we don't need to pad the descriptor.
+  unsigned rank = srcTy.getRank();
+  int64_t innermostStatic = srcTy.getDimSize(rank - 1);
+  if (!ShapedType::isDynamic(innermostStatic) &&
+      (innermostStatic * elemBytes) % 4 == 0) {
+    return failure();
+  }
+
+  // The DMA source can be a per-K-block tensor.extract_slice of a larger
+  // tensor (e.g. matmul tiled by a reduction dim). The buffer descriptor's
+  // validBytes must reflect the *underlying* allocation, not the slice —
+  // sizing it from the slice would clamp the descriptor below the size that
+  // earlier accesses already need. Walk through extract_slices to the root.
+  Value root = src;
+  while (auto sl = root.getDefiningOp<tensor::ExtractSliceOp>()) {
+    root = sl.getSource();
+  }
+  auto rootTy = dyn_cast<RankedTensorType>(root.getType());
+  if (!rootTy) {
+    return failure();
+  }
+  unsigned rootRank = rootTy.getRank();
+
+  // Skip when the root buffer's innermost row is statically DWORD-aligned.
+  // The validBytes wrap exists to guard against the HW partial-DWORD clamp
+  // zeroing valid bytes at the buffer END; if the buffer end is naturally
+  // DWORD-aligned (which holds whenever the root's innermost row in bytes
+  // is divisible by 4 in row-major layout), no straddle is possible and the
+  // wrap is unnecessary. Catches the common "shape-dynamic but root-aligned"
+  // case (e.g. NxN f16 with N even, K-block tiling produces tensor<32x?xf16>
+  // but the root is tensor<NxNxf16> with N*2 % 4 == 0).
+  int64_t rootInnermost = rootTy.getDimSize(rootRank - 1);
+  if (!ShapedType::isDynamic(rootInnermost) &&
+      (rootInnermost * elemBytes) % 4 == 0) {
+    return failure();
+  }
+
+  // If a buffer_resource_cast with valid_bytes already wraps the root, skip.
+  if (auto existing = root.getDefiningOp<IREE::GPU::BufferResourceCastOp>()) {
+    if (existing.getValidBytes()) {
+      return failure();
+    }
+  }
+
+  // Compute valid_bytes = roundUp(naturalBytes + 4, 4) where
+  //   naturalBytes = prod(rootDim_i) * elemBytes.
+  // Implemented as `(naturalBytes + 7) / 4 * 4` (the "+ 7" is "+ 4 safety
+  // margin" composed with the standard "+ (align - 1)" round-up trick).
+  // Place the cast in a scope that dominates the DMA but lives outside any
+  // enclosing forall so the validBytes computation is hoisted out of loops.
+  if (auto *rootOp = root.getDefiningOp()) {
+    rewriter.setInsertionPointAfter(rootOp);
+  } else {
+    // Block argument: insert at the start of its block (e.g. function entry).
+    auto *block = cast<BlockArgument>(root).getOwner();
+    rewriter.setInsertionPointToStart(block);
+  }
+  Location loc = dma.getLoc();
+
+  MLIRContext *ctx = rewriter.getContext();
+  SmallVector<OpFoldResult> dims;
+  // Track ops we create that legitimately need to keep reading `root` (so
+  // they don't get redirected to the cast we're about to insert, which would
+  // then violate dominance — the cast lives below them in the block).
+  SmallPtrSet<Operation *, 4> preserveRootUsers;
+  AffineExpr prod = getAffineConstantExpr(elemBytes, ctx);
+  for (unsigned d = 0; d < rootRank; ++d) {
+    int64_t s = rootTy.getDimSize(d);
+    if (ShapedType::isDynamic(s)) {
+      auto dimOp = tensor::DimOp::create(rewriter, loc, root, d);
+      preserveRootUsers.insert(dimOp);
+      dims.push_back(OpFoldResult(dimOp.getResult()));
+      prod = prod * getAffineSymbolExpr(dims.size() - 1, ctx);
+    } else {
+      prod = prod * getAffineConstantExpr(s, ctx);
+    }
+  }
+  // We must guarantee the *final* DWORD a lane reads past the natural end is
+  // covered. Adding 4 then rounding up to DWORD ensures at least a 4-byte
+  // safety margin even when naturalBytes happens to be DWORD-aligned (e.g.
+  // 64x43 f16 = 5504 bytes; the last lane's straddle reads bytes 5502..5505,
+  // requiring validBytes >= 5508).
+  AffineExpr rounded = (prod + getAffineConstantExpr(7, ctx)).floorDiv(4) * 4;
+  AffineMap map = AffineMap::get(/*dimCount=*/0,
+                                 /*symbolCount=*/dims.size(), rounded);
+  OpFoldResult validBytesOFR =
+      affine::makeComposedFoldedAffineApply(rewriter, loc, map, dims);
+  Value validBytes =
+      getValueOrCreateConstantIndexOp(rewriter, loc, validBytesOFR);
+
+  auto castOp =
+      IREE::GPU::BufferResourceCastOp::create(rewriter, loc, rootTy, root,
+                                              /*cache_swizzle_stride=*/Value{},
+                                              /*valid_bytes=*/validBytes);
+
+  // Re-route uses of `root` to the cast. Keep the cast itself plus any
+  // tensor.dim ops we created above (they were emitted *before* the cast and
+  // need the original `root`; redirecting them would violate dominance).
+  preserveRootUsers.insert(castOp);
+  rewriter.replaceAllUsesExcept(root, castOp.getResult(), preserveRootUsers);
+  return success();
 }
 
 // Insert extract_slice + tensor.pad after the outermost forall for one DMA.
@@ -286,6 +421,9 @@ struct GPUPushDownDMABoundsToConsumersPass final
     }
 
     for (auto dma : dmas) {
+      // Best-effort buffer-descriptor padding for non-DWORD-aligned sources.
+      // Independent of the consumer-side pad rewrite below.
+      (void)padSourceBufferDescriptorToDWORD(rewriter, dma);
       (void)rewriteOneDMA(rewriter, dma);
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
@@ -92,14 +92,10 @@ static std::optional<int64_t> getInnermostStaticUpperBound(Value src,
 // consumer. That result is the SSA value the matmul (or other consumer) sees.
 //
 // Two link types are followed:
-//   1. BlockArgument (forall sharedOut) -> forall.getResult(idx)
-//      (existing nested-forall handling)
-//   2. forall result that is the source of a tensor.parallel_insert_slice
+//   1. BlockArgument (forall sharedOut) -> forall.getResult(idx).
+//   2. scf.forall result that is the source of a tensor.parallel_insert_slice
 //      in a parent forall's terminator -> the parent forall's destination
 //      sharedOut (a BlockArgument), which feeds back into case (1).
-//
-// The walk stops as soon as we hit a value whose only forward chain breaks
-// (no enclosing forall, no propagating parallel_insert_slice, etc.).
 static Value walkUpSharedOuts(Value v) {
   while (true) {
     if (auto bbarg = dyn_cast<BlockArgument>(v)) {
@@ -116,9 +112,6 @@ static Value walkUpSharedOuts(Value v) {
       continue;
     }
 
-    // v is an SSA value (typically an scf.forall result). If it's only
-    // consumed by a parallel_insert_slice inside a parent forall, follow
-    // that link to the parent forall's sharedOut BlockArg.
     auto definingForall = v.getDefiningOp<scf::ForallOp>();
     if (!definingForall) {
       return v;
@@ -232,7 +225,6 @@ padSourceBufferDescriptorToDWORD(IRRewriter &rewriter,
   return success();
 }
 
-// Insert extract_slice + tensor.pad after the outermost forall for one DMA.
 // Returns failure if the DMA doesn't match the expected pattern (no-op).
 static LogicalResult rewriteOneDMA(IRRewriter &rewriter,
                                    IREE::GPU::CoalescedGatherDMAOp dma) {
@@ -310,11 +302,9 @@ static LogicalResult rewriteOneDMA(IRRewriter &rewriter,
     }
   }
 
-  // Insert after the outermost forall.
   rewriter.setInsertionPointAfter(outerForall);
   Location loc = dma.getLoc();
 
-  // tensor.dim of the workgroup-tile source slice for the innermost dim.
   Value innerExtent =
       tensor::DimOp::create(rewriter, loc, extentSrc, innermost);
   Value innerTileV =
@@ -322,7 +312,8 @@ static LogicalResult rewriteOneDMA(IRRewriter &rewriter,
   Value padAmount =
       arith::SubIOp::create(rewriter, loc, innerTileV, innerExtent);
 
-  // tensor.extract_slice: cut the valid columns out of the LDS tile.
+  // Cut the valid columns out of the LDS tile, then re-expand to the full
+  // tile shape with zero padding on the OOB tail.
   SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
   SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
   SmallVector<OpFoldResult> validSizes;
@@ -336,7 +327,6 @@ static LogicalResult rewriteOneDMA(IRRewriter &rewriter,
   Value valid = tensor::ExtractSliceOp::create(rewriter, loc, outerResult,
                                                offsets, validSizes, strides);
 
-  // tensor.pad: re-expand to the full tile shape with zero padding.
   SmallVector<OpFoldResult> lowPad(rank, rewriter.getIndexAttr(0));
   SmallVector<OpFoldResult> highPad(rank, rewriter.getIndexAttr(0));
   highPad[innermost] = OpFoldResult(padAmount);
@@ -352,8 +342,8 @@ static LogicalResult rewriteOneDMA(IRRewriter &rewriter,
 
   // Replace all uses of the forall result with the re-padded tensor, except
   // for the extract_slice we just created which must read the original.
-  outerResult.replaceAllUsesExcept(
-      padOp.getResult(), valid.getDefiningOp<tensor::ExtractSliceOp>());
+  rewriter.replaceAllUsesExcept(outerResult, padOp.getResult(),
+                                valid.getDefiningOp<tensor::ExtractSliceOp>());
   return success();
 }
 
@@ -369,9 +359,6 @@ struct GPUPushDownDMABoundsToConsumersPass final
     SmallVector<IREE::GPU::CoalescedGatherDMAOp> dmas;
     funcOp.walk(
         [&](IREE::GPU::CoalescedGatherDMAOp dma) { dmas.push_back(dma); });
-    if (dmas.empty()) {
-      return;
-    }
 
     for (auto dma : dmas) {
       // Best-effort buffer-descriptor padding for non-DWORD-aligned sources.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
@@ -148,12 +148,13 @@ static Value walkUpSharedOuts(Value v) {
 
 // When the DMA source's innermost row size in bytes is not DWORD (4-byte)
 // aligned, the AMD HW partial-DWORD OOB clamp zeroes valid bytes at the
-// buffer end. Wrap the source with an iree_gpu.buffer_resource_cast that
-// declares validBytes rounded up to the next multiple of 4. After
-// bufferization this becomes amdgpu.fat_raw_buffer_cast with the explicit
-// validBytes, which keeps the trailing partial DWORD in-bounds. The garbage
-// in bytes [naturalBytes, roundedBytes) lands in masked LDS columns and is
-// discarded by the consumer-side tensor.pad inserted below.
+// buffer end. Wrap the source with an iree_gpu.buffer_resource_cast carrying
+// the `pad_to_dword` attribute. Bufferization will lower this to an
+// amdgpu.fat_raw_buffer_cast whose validBytes is rounded up to the next
+// DWORD (with a 3-byte safety margin), keeping the trailing partial DWORD
+// in-bounds. The garbage in bytes [naturalBytes, roundedBytes) lands in
+// masked LDS columns and is discarded by the consumer-side tensor.pad
+// inserted below.
 //
 // Returns failure when no rewrite is needed (already aligned, dynamic
 // element bit width, etc.). Source is mutated in place.
@@ -200,10 +201,10 @@ padSourceBufferDescriptorToDWORD(IRRewriter &rewriter,
   unsigned rootRank = rootTy.getRank();
 
   // Skip when the root buffer's innermost row is statically DWORD-aligned.
-  // The validBytes wrap exists to guard against the HW partial-DWORD clamp
-  // zeroing valid bytes at the buffer END; if the buffer end is naturally
-  // DWORD-aligned (which holds whenever the root's innermost row in bytes
-  // is divisible by 4 in row-major layout), no straddle is possible and the
+  // The wrap exists to guard against the HW partial-DWORD clamp zeroing
+  // valid bytes at the buffer END; if the buffer end is naturally DWORD-
+  // aligned (which holds whenever the root's innermost row in bytes is
+  // divisible by 4 in row-major layout), no straddle is possible and the
   // wrap is unnecessary. Catches the common "shape-dynamic but root-aligned"
   // case (e.g. NxN f16 with N even, K-block tiling produces tensor<32x?xf16>
   // but the root is tensor<NxNxf16> with N*2 % 4 == 0).
@@ -213,19 +214,15 @@ padSourceBufferDescriptorToDWORD(IRRewriter &rewriter,
     return failure();
   }
 
-  // If a buffer_resource_cast with valid_bytes already wraps the root, skip.
-  if (auto existing = root.getDefiningOp<IREE::GPU::BufferResourceCastOp>()) {
-    if (existing.getValidBytes()) {
-      return failure();
-    }
+  // If a plain buffer_resource_cast already wraps the root, skip — re-wrapping
+  // would just be redundant.
+  if (root.getDefiningOp<IREE::GPU::BufferResourceCastOp>()) {
+    return failure();
   }
 
-  // Compute valid_bytes = roundUp(naturalBytes + 4, 4) where
-  //   naturalBytes = prod(rootDim_i) * elemBytes.
-  // Implemented as `(naturalBytes + 7) / 4 * 4` (the "+ 7" is "+ 4 safety
-  // margin" composed with the standard "+ (align - 1)" round-up trick).
   // Place the cast in a scope that dominates the DMA but lives outside any
-  // enclosing forall so the validBytes computation is hoisted out of loops.
+  // enclosing forall so the bufferized validBytes computation is hoisted out
+  // of loops.
   if (auto *rootOp = root.getDefiningOp()) {
     rewriter.setInsertionPointAfter(rootOp);
   } else {
@@ -235,47 +232,11 @@ padSourceBufferDescriptorToDWORD(IRRewriter &rewriter,
   }
   Location loc = dma.getLoc();
 
-  MLIRContext *ctx = rewriter.getContext();
-  SmallVector<OpFoldResult> dims;
-  // Track ops we create that legitimately need to keep reading `root` (so
-  // they don't get redirected to the cast we're about to insert, which would
-  // then violate dominance — the cast lives below them in the block).
-  SmallPtrSet<Operation *, 4> preserveRootUsers;
-  AffineExpr prod = getAffineConstantExpr(elemBytes, ctx);
-  for (unsigned d = 0; d < rootRank; ++d) {
-    int64_t s = rootTy.getDimSize(d);
-    if (ShapedType::isDynamic(s)) {
-      auto dimOp = tensor::DimOp::create(rewriter, loc, root, d);
-      preserveRootUsers.insert(dimOp);
-      dims.push_back(OpFoldResult(dimOp.getResult()));
-      prod = prod * getAffineSymbolExpr(dims.size() - 1, ctx);
-    } else {
-      prod = prod * getAffineConstantExpr(s, ctx);
-    }
-  }
-  // We must guarantee the *final* DWORD a lane reads past the natural end is
-  // covered. Adding 4 then rounding up to DWORD ensures at least a 4-byte
-  // safety margin even when naturalBytes happens to be DWORD-aligned (e.g.
-  // 64x43 f16 = 5504 bytes; the last lane's straddle reads bytes 5502..5505,
-  // requiring validBytes >= 5508).
-  AffineExpr rounded = (prod + getAffineConstantExpr(7, ctx)).floorDiv(4) * 4;
-  AffineMap map = AffineMap::get(/*dimCount=*/0,
-                                 /*symbolCount=*/dims.size(), rounded);
-  OpFoldResult validBytesOFR =
-      affine::makeComposedFoldedAffineApply(rewriter, loc, map, dims);
-  Value validBytes =
-      getValueOrCreateConstantIndexOp(rewriter, loc, validBytesOFR);
+  auto castOp = IREE::GPU::BufferResourceCastOp::create(
+      rewriter, loc, rootTy, root, /*cache_swizzle_stride=*/Value{});
 
-  auto castOp =
-      IREE::GPU::BufferResourceCastOp::create(rewriter, loc, rootTy, root,
-                                              /*cache_swizzle_stride=*/Value{},
-                                              /*valid_bytes=*/validBytes);
-
-  // Re-route uses of `root` to the cast. Keep the cast itself plus any
-  // tensor.dim ops we created above (they were emitted *before* the cast and
-  // need the original `root`; redirecting them would violate dominance).
-  preserveRootUsers.insert(castOp);
-  rewriter.replaceAllUsesExcept(root, castOp.getResult(), preserveRootUsers);
+  // Re-route uses of `root` to the cast.
+  rewriter.replaceAllUsesExcept(root, castOp.getResult(), castOp);
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
@@ -1,0 +1,296 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===-- GPUPushDownDMABoundsToConsumers.cpp -------------------------------===//
+//
+// For each iree_gpu.coalesced_gather_dma whose innermost in_bounds entry is
+// false, inserts a tensor.extract_slice + tensor.pad chain between the DMA's
+// outer scf.forall result and its consumer. Downstream vectorization
+// (enable-vector-masking=true) then lowers the pad to a masked
+// vector.transfer_read via vectorizeAsTensorPadOp, discarding straddle-
+// corrupted columns and substituting zero.
+//
+// See docs/superpowers/specs/2026-04-29-dma-mask-pushdown-design.md.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUPUSHDOWNDMABOUNDSTOCONSUMERSPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+// Returns the static upper bound (in elements) for `src`'s dim `d`, if one
+// can be derived from the ranked tensor type or the immediate defining
+// `tensor.extract_slice`. For a dynamic dim whose size is a Value, looks
+// through `arith.constant` and `affine.min` to extract a constant bound.
+//
+// Used by `rewriteOneDMA`: when the inner extent's UB matches the LDS tile
+// size, AMDGPULowerCoalescedDMA's OOB clamping already zeros OOB columns
+// through the same swizzle the consumer reads through, so the consumer pad
+// would be redundant. See rewriteOneDMA below.
+static std::optional<int64_t> getInnermostStaticUpperBound(Value src,
+                                                           unsigned dim) {
+  auto srcTy = dyn_cast<RankedTensorType>(src.getType());
+  if (!srcTy) {
+    return std::nullopt;
+  }
+  int64_t s = srcTy.getDimSize(dim);
+  if (!ShapedType::isDynamic(s)) {
+    return s;
+  }
+
+  auto sl = src.getDefiningOp<tensor::ExtractSliceOp>();
+  if (!sl) {
+    return std::nullopt;
+  }
+  OpFoldResult sz = sl.getMixedSizes()[dim];
+  if (auto attr = dyn_cast<Attribute>(sz)) {
+    if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
+      return intAttr.getInt();
+    }
+    return std::nullopt;
+  }
+  Value szVal = cast<Value>(sz);
+  if (auto cst = szVal.getDefiningOp<arith::ConstantIndexOp>()) {
+    return cst.value();
+  }
+  if (auto am = szVal.getDefiningOp<affine::AffineMinOp>()) {
+    std::optional<int64_t> ub;
+    for (AffineExpr e : am.getMap().getResults()) {
+      if (auto c = dyn_cast<AffineConstantExpr>(e)) {
+        int64_t v = c.getValue();
+        ub = ub ? std::min(*ub, v) : v;
+      }
+    }
+    return ub;
+  }
+  return std::nullopt;
+}
+
+// Walk from the DMA's init operand (a forall sharedOut block argument) out
+// through the chain of nested forall shared_outs and parallel_insert_slices
+// until we reach an scf.forall whose result is read by a non-parallel_insert
+// consumer. That result is the SSA value the matmul (or other consumer) sees.
+//
+// Two link types are followed:
+//   1. BlockArgument (forall sharedOut) -> forall.getResult(idx)
+//      (existing nested-forall handling)
+//   2. forall result that is the source of a tensor.parallel_insert_slice
+//      in a parent forall's terminator -> the parent forall's destination
+//      sharedOut (a BlockArgument), which feeds back into case (1).
+//
+// The walk stops as soon as we hit a value whose only forward chain breaks
+// (no enclosing forall, no propagating parallel_insert_slice, etc.).
+static Value walkUpSharedOuts(Value v) {
+  while (true) {
+    if (auto bbarg = dyn_cast<BlockArgument>(v)) {
+      auto forall = dyn_cast<scf::ForallOp>(bbarg.getOwner()->getParentOp());
+      if (!forall) {
+        return v;
+      }
+      unsigned argIdx = bbarg.getArgNumber();
+      unsigned sharedOutsStart = forall.getRank();
+      if (argIdx < sharedOutsStart) {
+        return v;
+      }
+      v = forall.getResult(argIdx - sharedOutsStart);
+      continue;
+    }
+
+    // v is an SSA value (typically an scf.forall result). If it's only
+    // consumed by a parallel_insert_slice inside a parent forall, follow
+    // that link to the parent forall's sharedOut BlockArg.
+    auto definingForall = v.getDefiningOp<scf::ForallOp>();
+    if (!definingForall) {
+      return v;
+    }
+    auto parentForall = definingForall->getParentOfType<scf::ForallOp>();
+    if (!parentForall) {
+      return v;
+    }
+
+    Value nextSharedOut = nullptr;
+    for (Operation &op : parentForall.getTerminator().getRegion().front()) {
+      auto insert = dyn_cast<tensor::ParallelInsertSliceOp>(&op);
+      if (!insert) {
+        continue;
+      }
+      if (insert.getSource() == v) {
+        nextSharedOut = insert.getDest();
+        break;
+      }
+    }
+    if (!nextSharedOut) {
+      return v;
+    }
+    v = nextSharedOut;
+  }
+}
+
+// Insert extract_slice + tensor.pad after the outermost forall for one DMA.
+// Returns failure if the DMA doesn't match the expected pattern (no-op).
+static LogicalResult rewriteOneDMA(IRRewriter &rewriter,
+                                   IREE::GPU::CoalescedGatherDMAOp dma) {
+  // Only act when innermost dimension is out-of-bounds.
+  std::optional<ArrayAttr> inBoundsOpt = dma.getInBounds();
+  if (!inBoundsOpt || inBoundsOpt->empty()) {
+    return failure();
+  }
+  ArrayAttr inBounds = *inBoundsOpt;
+  unsigned innermost = inBounds.size() - 1;
+  if (cast<BoolAttr>(inBounds[innermost]).getValue()) {
+    return failure(); // innermost is in-bounds; nothing to do
+  }
+
+  // Find the outermost forall result visible to consumers. The pad we insert
+  // replaces this value, so the pad's static shape MUST match its type — not
+  // the (possibly smaller) per-lane DMA init shape, which differs whenever
+  // intermediate warp-level foralls split the workgroup tile.
+  Value outerResult = walkUpSharedOuts(dma.getInit());
+  auto outerForall =
+      dyn_cast_or_null<scf::ForallOp>(outerResult.getDefiningOp());
+  if (!outerForall) {
+    return failure();
+  }
+  auto tileTy = dyn_cast<RankedTensorType>(outerResult.getType());
+  if (!tileTy) {
+    return failure();
+  }
+  unsigned rank = tileTy.getRank();
+  int64_t innerTileSize = tileTy.getDimSize(innermost);
+  if (ShapedType::isDynamic(innerTileSize)) {
+    return failure(); // shouldn't occur; bail defensively
+  }
+
+  // Walk the DMA source up through extract_slices until we find one defined
+  // outside outerForall. Two reasons:
+  //   1. Dominance: dma.getSource() can live inside nested foralls; using its
+  //      tensor.dim after outerForall would violate SSA dominance.
+  //   2. Extent semantics: the inner-lane source carries a per-lane extent
+  //      (e.g. min(K_remaining, 1)) — far smaller than the workgroup-K-block
+  //      extent we need for the consumer pad.
+  Value extentSrc = dma.getSource();
+  while (auto sl = extentSrc.getDefiningOp<tensor::ExtractSliceOp>()) {
+    if (!outerForall->isAncestor(sl)) {
+      break;
+    }
+    extentSrc = sl.getSource();
+  }
+  // Bail if the resulting value is still inside outerForall (shouldn't happen
+  // for the supported pattern, but stay safe).
+  if (auto *defOp = extentSrc.getDefiningOp()) {
+    if (outerForall->isAncestor(defOp)) {
+      return failure();
+    }
+  }
+
+  // Skip when the source's innermost extent has a static upper bound equal
+  // to the LDS inner tile size. Two cases:
+  //   - Full-tile workgroups: the runtime extent equals innerTileSize, so
+  //     the entire LDS tile is filled by valid data. The pad is a no-op.
+  //   - Boundary workgroups (extent < UB): lanes assigned to OOB columns
+  //     are clamped past the root buffer's end by
+  //     AMDGPULowerCoalescedDMAToGatherLDS::applyOOBClamping; the HW
+  //     fat_raw_buffer descriptor returns 0 for those reads, which the DMA
+  //     writes to the LDS destination through the same swizzle the matmul
+  //     reads through. The matmul then sees zeros in OOB columns —
+  //     identical to what the consumer pad would have written. K-reduction
+  //     contributions are zero (no pollution); N-OOB outputs are discarded
+  //     by the downstream output extract_slice.
+  // Removing the pad here avoids the masked-vector → tensor.empty alloca
+  // round-trip emitted by vectorizeAsTensorPadOp.
+  if (auto ub = getInnermostStaticUpperBound(extentSrc, innermost)) {
+    if (*ub == innerTileSize) {
+      return failure();
+    }
+  }
+
+  // Insert after the outermost forall.
+  rewriter.setInsertionPointAfter(outerForall);
+  Location loc = dma.getLoc();
+
+  // tensor.dim of the workgroup-tile source slice for the innermost dim.
+  Value innerExtent =
+      tensor::DimOp::create(rewriter, loc, extentSrc, innermost);
+  Value innerTileV =
+      arith::ConstantIndexOp::create(rewriter, loc, innerTileSize);
+  Value padAmount =
+      arith::SubIOp::create(rewriter, loc, innerTileV, innerExtent);
+
+  // tensor.extract_slice: cut the valid columns out of the LDS tile.
+  SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
+  SmallVector<OpFoldResult> validSizes;
+  for (unsigned d = 0; d < rank; ++d) {
+    if (d == innermost) {
+      validSizes.push_back(OpFoldResult(innerExtent));
+    } else {
+      validSizes.push_back(rewriter.getIndexAttr(tileTy.getDimSize(d)));
+    }
+  }
+  Value valid = tensor::ExtractSliceOp::create(rewriter, loc, outerResult,
+                                               offsets, validSizes, strides);
+
+  // tensor.pad: re-expand to the full tile shape with zero padding.
+  SmallVector<OpFoldResult> lowPad(rank, rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> highPad(rank, rewriter.getIndexAttr(0));
+  highPad[innermost] = OpFoldResult(padAmount);
+
+  TypedAttr zeroAttr = rewriter.getZeroAttr(tileTy.getElementType());
+  if (!zeroAttr) {
+    return failure();
+  }
+  Value padCst = arith::ConstantOp::create(rewriter, loc, zeroAttr);
+
+  auto padOp = tensor::PadOp::create(rewriter, loc, tileTy, valid, lowPad,
+                                     highPad, padCst, /*nofold=*/false);
+
+  // Replace all uses of the forall result with the re-padded tensor, except
+  // for the extract_slice we just created which must read the original.
+  outerResult.replaceAllUsesExcept(
+      padOp.getResult(), valid.getDefiningOp<tensor::ExtractSliceOp>());
+  return success();
+}
+
+struct GPUPushDownDMABoundsToConsumersPass final
+    : impl::GPUPushDownDMABoundsToConsumersPassBase<
+          GPUPushDownDMABoundsToConsumersPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+    IRRewriter rewriter(funcOp.getContext());
+
+    SmallVector<IREE::GPU::CoalescedGatherDMAOp> dmas;
+    funcOp.walk(
+        [&](IREE::GPU::CoalescedGatherDMAOp dma) { dmas.push_back(dma); });
+    if (dmas.empty()) {
+      return;
+    }
+
+    for (auto dma : dmas) {
+      (void)rewriteOneDMA(rewriter, dma);
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPushDownDMABoundsToConsumers.cpp
@@ -1,0 +1,309 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===-- GPUPushDownDMABoundsToConsumers.cpp -------------------------------===//
+//
+// For each iree_gpu.coalesced_gather_dma whose innermost in_bounds entry is
+// false, inserts a tensor.extract_slice + tensor.pad chain between the DMA's
+// outer scf.forall result and its consumer. Downstream vectorization
+// (enable-vector-masking=true) then lowers the pad to a masked
+// vector.transfer_read via vectorizeAsTensorPadOp, discarding straddle-
+// corrupted columns and substituting zero.
+//
+// See docs/superpowers/specs/2026-04-29-dma-mask-pushdown-design.md.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUPUSHDOWNDMABOUNDSTOCONSUMERSPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+// Walk from the DMA's init operand (a forall sharedOut block argument) out
+// through the chain of nested forall shared_outs and parallel_insert_slices
+// until we reach an scf.forall whose result is read by a non-parallel_insert
+// consumer. That result is the SSA value the matmul (or other consumer) sees.
+//
+// Two link types are followed:
+//   1. BlockArgument (forall sharedOut) -> forall.getResult(idx)
+//      (existing nested-forall handling)
+//   2. forall result that is the source of a tensor.parallel_insert_slice
+//      in a parent forall's terminator -> the parent forall's destination
+//      sharedOut (a BlockArgument), which feeds back into case (1).
+//
+// The walk stops as soon as we hit a value whose only forward chain breaks
+// (no enclosing forall, no propagating parallel_insert_slice, etc.).
+static Value walkUpSharedOuts(Value v) {
+  while (true) {
+    if (auto bbarg = dyn_cast<BlockArgument>(v)) {
+      auto forall =
+          dyn_cast<scf::ForallOp>(bbarg.getOwner()->getParentOp());
+      if (!forall)
+        return v;
+      unsigned argIdx = bbarg.getArgNumber();
+      unsigned sharedOutsStart = forall.getRank();
+      if (argIdx < sharedOutsStart)
+        return v;
+      v = forall.getResult(argIdx - sharedOutsStart);
+      continue;
+    }
+
+    // v is an SSA value (typically an scf.forall result). If it's only
+    // consumed by a parallel_insert_slice inside a parent forall, follow
+    // that link to the parent forall's sharedOut BlockArg.
+    auto definingForall = v.getDefiningOp<scf::ForallOp>();
+    if (!definingForall)
+      return v;
+    auto parentForall = definingForall->getParentOfType<scf::ForallOp>();
+    if (!parentForall)
+      return v;
+
+    Value nextSharedOut = nullptr;
+    for (Operation &op : parentForall.getTerminator().getRegion().front()) {
+      auto insert = dyn_cast<tensor::ParallelInsertSliceOp>(&op);
+      if (!insert)
+        continue;
+      if (insert.getSource() == v) {
+        nextSharedOut = insert.getDest();
+        break;
+      }
+    }
+    if (!nextSharedOut)
+      return v;
+    v = nextSharedOut;
+  }
+}
+
+// When the DMA source's innermost row size in bytes is not DWORD (4-byte)
+// aligned, the AMD HW partial-DWORD OOB clamp zeroes valid bytes at the
+// buffer end. Wrap the source with an iree_gpu.buffer_resource_cast that
+// declares validBytes rounded up to the next multiple of 4. After
+// bufferization this becomes amdgpu.fat_raw_buffer_cast with the explicit
+// validBytes, which keeps the trailing partial DWORD in-bounds. The garbage
+// in bytes [naturalBytes, roundedBytes) lands in masked LDS columns and is
+// discarded by the consumer-side tensor.pad inserted below.
+//
+// Returns failure when no rewrite is needed (already aligned, dynamic
+// element bit width, etc.). Source is mutated in place.
+static LogicalResult padSourceBufferDescriptorToDWORD(
+    IRRewriter &rewriter, IREE::GPU::CoalescedGatherDMAOp dma) {
+  Value src = dma.getSource();
+  auto srcTy = dyn_cast<RankedTensorType>(src.getType());
+  if (!srcTy)
+    return failure();
+  Type elemTy = srcTy.getElementType();
+  if (!elemTy.isIntOrFloat())
+    return failure();
+  unsigned elemBits = elemTy.getIntOrFloatBitWidth();
+  if (elemBits == 0 || elemBits % 8 != 0)
+    return failure();
+  unsigned elemBytes = elemBits / 8;
+
+  // If the innermost row is statically DWORD-aligned, the partial-DWORD
+  // straddle issue cannot occur and we don't need to pad the descriptor.
+  unsigned rank = srcTy.getRank();
+  int64_t innermostStatic = srcTy.getDimSize(rank - 1);
+  if (!ShapedType::isDynamic(innermostStatic) &&
+      (innermostStatic * elemBytes) % 4 == 0) {
+    return failure();
+  }
+
+  // The DMA source can be a per-K-block tensor.extract_slice of a larger
+  // tensor (e.g. matmul tiled by a reduction dim). The buffer descriptor's
+  // validBytes must reflect the *underlying* allocation, not the slice —
+  // sizing it from the slice would clamp the descriptor below the size that
+  // earlier accesses already need. Walk through extract_slices to the root.
+  Value root = src;
+  while (auto sl = root.getDefiningOp<tensor::ExtractSliceOp>()) {
+    root = sl.getSource();
+  }
+  auto rootTy = dyn_cast<RankedTensorType>(root.getType());
+  if (!rootTy)
+    return failure();
+  unsigned rootRank = rootTy.getRank();
+
+  // If a buffer_resource_cast with valid_bytes already wraps the root, skip.
+  if (auto existing = root.getDefiningOp<IREE::GPU::BufferResourceCastOp>()) {
+    if (existing.getValidBytes())
+      return failure();
+  }
+
+  // Compute valid_bytes = roundUp(prod(rootDim_i) * elemBytes + 4, 4).
+  // Place the cast in a scope that dominates the DMA but lives outside any
+  // enclosing forall so the validBytes computation is hoisted out of loops.
+  if (auto *rootOp = root.getDefiningOp()) {
+    rewriter.setInsertionPointAfter(rootOp);
+  } else {
+    // Block argument: insert at the start of its block (e.g. function entry).
+    auto *block = cast<BlockArgument>(root).getOwner();
+    rewriter.setInsertionPointToStart(block);
+  }
+  Location loc = dma.getLoc();
+
+  MLIRContext *ctx = rewriter.getContext();
+  SmallVector<OpFoldResult> dims;
+  // Track ops we create that legitimately need to keep reading `root` (so
+  // they don't get redirected to the cast we're about to insert, which would
+  // then violate dominance — the cast lives below them in the block).
+  SmallPtrSet<Operation *, 4> preserveRootUsers;
+  AffineExpr prod = getAffineConstantExpr(elemBytes, ctx);
+  for (unsigned d = 0; d < rootRank; ++d) {
+    int64_t s = rootTy.getDimSize(d);
+    if (ShapedType::isDynamic(s)) {
+      auto dimOp = tensor::DimOp::create(rewriter, loc, root, d);
+      preserveRootUsers.insert(dimOp);
+      dims.push_back(OpFoldResult(dimOp.getResult()));
+      prod = prod * getAffineSymbolExpr(dims.size() - 1, ctx);
+    } else {
+      prod = prod * getAffineConstantExpr(s, ctx);
+    }
+  }
+  // We must guarantee the *final* DWORD a lane reads past the natural end is
+  // covered. Adding 4 then rounding up to DWORD ensures at least a 4-byte
+  // safety margin even when naturalBytes happens to be DWORD-aligned (e.g.
+  // 64x43 f16 = 5504 bytes; the last lane's straddle reads bytes 5502..5505,
+  // requiring validBytes >= 5508).
+  AffineExpr rounded =
+      (prod + getAffineConstantExpr(7, ctx)).floorDiv(4) * 4;
+  AffineMap map = AffineMap::get(/*dimCount=*/0,
+                                 /*symbolCount=*/dims.size(), rounded);
+  OpFoldResult validBytesOFR =
+      affine::makeComposedFoldedAffineApply(rewriter, loc, map, dims);
+  Value validBytes =
+      getValueOrCreateConstantIndexOp(rewriter, loc, validBytesOFR);
+
+  auto castOp = IREE::GPU::BufferResourceCastOp::create(
+      rewriter, loc, rootTy, root,
+      /*cache_swizzle_stride=*/Value{},
+      /*valid_bytes=*/validBytes);
+
+  // Re-route uses of `root` to the cast. Keep the cast itself plus any
+  // tensor.dim ops we created above (they were emitted *before* the cast and
+  // need the original `root`; redirecting them would violate dominance).
+  preserveRootUsers.insert(castOp);
+  rewriter.replaceAllUsesExcept(root, castOp.getResult(), preserveRootUsers);
+  return success();
+}
+
+// Insert extract_slice + tensor.pad after the outermost forall for one DMA.
+// Returns failure if the DMA doesn't match the expected pattern (no-op).
+static LogicalResult rewriteOneDMA(IRRewriter &rewriter,
+                                   IREE::GPU::CoalescedGatherDMAOp dma) {
+  // Only act when innermost dimension is out-of-bounds.
+  std::optional<ArrayAttr> inBoundsOpt = dma.getInBounds();
+  if (!inBoundsOpt || inBoundsOpt->empty())
+    return failure();
+  ArrayAttr inBounds = *inBoundsOpt;
+  unsigned innermost = inBounds.size() - 1;
+  if (cast<BoolAttr>(inBounds[innermost]).getValue())
+    return failure(); // innermost is in-bounds; nothing to do
+
+  // Resolve the LDS tile type from the init operand.
+  auto tileTy = dyn_cast<RankedTensorType>(dma.getInit().getType());
+  if (!tileTy)
+    return failure();
+  unsigned rank = tileTy.getRank();
+  int64_t innerTileSize = tileTy.getDimSize(innermost);
+  if (ShapedType::isDynamic(innerTileSize))
+    return failure(); // shouldn't occur; bail defensively
+
+  // Find the outermost forall result visible to consumers.
+  Value outerResult = walkUpSharedOuts(dma.getInit());
+  auto outerForall =
+      dyn_cast_or_null<scf::ForallOp>(outerResult.getDefiningOp());
+  if (!outerForall)
+    return failure();
+
+  // Insert after the outermost forall.
+  rewriter.setInsertionPointAfter(outerForall);
+  Location loc = dma.getLoc();
+
+  // tensor.dim of the DMA source for the innermost dimension.
+  Value src = dma.getSource();
+  Value innerExtent = tensor::DimOp::create(rewriter, loc, src, innermost);
+  Value innerTileV = arith::ConstantIndexOp::create(rewriter, loc, innerTileSize);
+  Value padAmount = arith::SubIOp::create(rewriter, loc, innerTileV, innerExtent);
+
+  // tensor.extract_slice: cut the valid columns out of the LDS tile.
+  SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
+  SmallVector<OpFoldResult> validSizes;
+  for (unsigned d = 0; d < rank; ++d) {
+    if (d == innermost)
+      validSizes.push_back(OpFoldResult(innerExtent));
+    else
+      validSizes.push_back(rewriter.getIndexAttr(tileTy.getDimSize(d)));
+  }
+  Value valid = tensor::ExtractSliceOp::create(rewriter, loc, outerResult,
+                                               offsets, validSizes, strides);
+
+  // tensor.pad: re-expand to the full tile shape with zero padding.
+  SmallVector<OpFoldResult> lowPad(rank, rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> highPad(rank, rewriter.getIndexAttr(0));
+  highPad[innermost] = OpFoldResult(padAmount);
+
+  Type elemTy = tileTy.getElementType();
+  TypedAttr zeroAttr = rewriter.getZeroAttr(elemTy);
+  if (!zeroAttr)
+    return failure();
+  Value padCst = arith::ConstantOp::create(rewriter, loc, zeroAttr);
+
+  auto padOp = tensor::PadOp::create(rewriter, loc, tileTy, valid, lowPad,
+                                     highPad, /*nofold=*/false);
+  Block *body = rewriter.createBlock(&padOp.getBodyRegion());
+  for (unsigned i = 0; i < rank; ++i)
+    body->addArgument(rewriter.getIndexType(), loc);
+  rewriter.setInsertionPointToStart(body);
+  tensor::YieldOp::create(rewriter, loc, padCst);
+  rewriter.setInsertionPointAfter(padOp);
+
+  // Replace all uses of the forall result with the re-padded tensor, except
+  // for the extract_slice we just created which must read the original.
+  outerResult.replaceAllUsesExcept(padOp.getResult(),
+                                   valid.getDefiningOp<tensor::ExtractSliceOp>());
+  return success();
+}
+
+struct GPUPushDownDMABoundsToConsumersPass final
+    : impl::GPUPushDownDMABoundsToConsumersPassBase<
+          GPUPushDownDMABoundsToConsumersPass> {
+  using Base::Base;
+
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+    IRRewriter rewriter(funcOp.getContext());
+
+    SmallVector<IREE::GPU::CoalescedGatherDMAOp> dmas;
+    funcOp.walk(
+        [&](IREE::GPU::CoalescedGatherDMAOp dma) { dmas.push_back(dma); });
+
+    for (auto dma : dmas) {
+      // Best-effort buffer-descriptor padding for non-DWORD-aligned sources.
+      // Independent of the consumer-side pad rewrite below.
+      (void)padSourceBufferDescriptorToDWORD(rewriter, dma);
+      (void)rewriteOneDMA(rewriter, dma);
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -251,6 +251,20 @@ def GPUPadOperandsPass :
   ];
 }
 
+def GPUPushDownDMABoundsToConsumersPass :
+    InterfacePass<"iree-codegen-gpu-pushdown-dma-bounds-to-consumers",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Insert tensor.pad after coalesced_gather_dma ops whose "
+                "innermost in_bounds entry is false, so downstream "
+                "vectorization produces a masked vector.transfer_read.";
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::scf::SCFDialect",
+    "::mlir::tensor::TensorDialect",
+    "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
 def GPUPipeliningPass :
     InterfacePass<"iree-codegen-gpu-pipelining", "mlir::FunctionOpInterface"> {
   let summary = "Pass to do software pipelining.";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -239,6 +239,20 @@ def GPUPadOperandsPass :
   ];
 }
 
+def GPUPushDownDMABoundsToConsumersPass :
+    InterfacePass<"iree-codegen-gpu-pushdown-dma-bounds-to-consumers",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Insert tensor.pad after coalesced_gather_dma ops whose "
+                "innermost in_bounds entry is false, so downstream "
+                "vectorization produces a masked vector.transfer_read.";
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::scf::SCFDialect",
+    "::mlir::tensor::TensorDialect",
+    "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
 def GPUPipeliningPass :
     InterfacePass<"iree-codegen-gpu-pipelining", "mlir::FunctionOpInterface"> {
   let summary = "Pass to do software pipelining.";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -60,6 +60,7 @@ iree_lit_test_suite(
             "gpu_pipeline.mlir",
             "gpu_promote_matmul_operands.mlir",
             "gpu_promotion_analysis.mlir",
+            "gpu_pushdown_dma_bounds_to_consumers.mlir",
             "gpu_reorder_workgroups.mlir",
             "gpu_reorder_workgroups_static.mlir",
             "gpu_reuse_shared_memory_allocs.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_lit_test_suite(
     "gpu_pipeline.mlir"
     "gpu_promote_matmul_operands.mlir"
     "gpu_promotion_analysis.mlir"
+    "gpu_pushdown_dma_bounds_to_consumers.mlir"
     "gpu_reorder_workgroups.mlir"
     "gpu_reorder_workgroups_static.mlir"
     "gpu_reuse_shared_memory_allocs.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_coalesced_dma_to_gather_lds.mlir
@@ -2024,3 +2024,52 @@ func.func @lower_dma_strided_source_caps_width(
   } {mapping = [#iree_gpu.lane_id<0>]}
   return
 }
+
+// -----
+
+// Test: source has dynamic innermost extent but a statically unit
+// innermost stride, in fat_raw_buffer address space, with in_bounds set
+// to false on the innermost dim. The earlier behavior bailed because
+// getContiguousTrailingLinearSize stops at the first dynamic trailing
+// dim (returning 1) and the subsequent maxElementsPerLane cap killed
+// every transfer-size choice. Now we trust HW OOB clamping +
+// validBytes (set up by GPUPushDownDMABoundsToConsumers) and derive
+// the cap from the static destination layout, so the fast path engages.
+
+#executable_target_rocm_hsaco_fb_dyn = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#translation_dyn = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 32>
+
+// CHECK-LABEL: func.func @lower_coalesced_dma_dynamic_innermost_fat_raw_buffer
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]: memref<?x?xf16, strided<[1234, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[DST:[a-zA-Z0-9]+]]: memref<16x32xf16, strided<[32, 1], offset: ?>, #gpu.address_space<workgroup>>
+func.func @lower_coalesced_dma_dynamic_innermost_fat_raw_buffer(
+    %source: memref<?x?xf16, strided<[1234, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>,
+    %dest: memref<16x32xf16, strided<[32, 1], offset: ?>, #gpu.address_space<workgroup>>)
+  attributes {
+    hal.executable.target = #executable_target_rocm_hsaco_fb_dyn,
+    translation_info = #translation_dyn} {
+  scf.forall (%lane) in (32) {
+    // 16x32 = 512 elements, 32 lanes, 128-bit DMA on f16 = 8 elements/lane.
+    // 32 lanes * 8 = 256 elements per transfer, so 2 transfers cover the
+    // tile. The fast path used to bail here because the source's dynamic
+    // innermost extent left srcLinearSize=1 → no DMA size fit.
+    // CHECK-COUNT-2: amdgpu.gather_to_lds %[[SRC]]{{.*}}, %[[DST]]{{.*}} : vector<8xf16>
+    // CHECK-NOT: amdgpu.gather_to_lds
+    // CHECK-NOT: vector.transfer_read
+    // CHECK-NOT: iree_gpu.coalesced_gather_dma
+    iree_gpu.coalesced_gather_dma %source into %dest lane(%lane) in_bounds [false, false] :
+      memref<?x?xf16, strided<[1234, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>,
+      memref<16x32xf16, strided<[32, 1], offset: ?>, #gpu.address_space<workgroup>>, index
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -931,6 +931,10 @@ func.func @copy_swizzle_hint_linearized(%source: tensor<128x16xf32>) -> tensor<1
 // 16x4 = 64 elements per warp (== min) — DMA emit succeeds and the warp
 // forall is well-formed (preserving wave-uniformity by construction).
 // Issue #24139.
+//
+// Source has its K-tile direction (innermost dim, size 4) dynamic so the
+// pad satisfies isValidPadForDMA's K-boundary gating. M direction (dim 0)
+// stays static — the warp halving check fires on the result-tile shape.
 
 #gpu_target_warp_halve = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
@@ -944,15 +948,15 @@ func.func @copy_swizzle_hint_linearized(%source: tensor<128x16xf32>) -> tensor<1
 #translation_warp_halve = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 
 // CHECK-LABEL: func.func @copy_warp_distribution_halving
-func.func @copy_warp_distribution_halving(%source: tensor<32x4xf32>, %off: index, %sz: index, %high: index) -> tensor<32x4xf32>
+func.func @copy_warp_distribution_halving(%source: tensor<32x?xf32>, %sz: index, %high: index) -> tensor<32x4xf32>
   attributes {hal.executable.target = #exec_target_warp_halve, translation_info = #translation_warp_halve} {
-  %extracted = tensor.extract_slice %source[%off, 0] [%sz, 4] [1, 1]
-      : tensor<32x4xf32> to tensor<?x4xf32>
+  %extracted = tensor.extract_slice %source[0, 0] [32, %sz] [1, 1]
+      : tensor<32x?xf32> to tensor<32x?xf32>
   %cst = arith.constant 0.0 : f32
-  %padded = tensor.pad %extracted low[0, 0] high[%high, 0] {
+  %padded = tensor.pad %extracted low[0, 0] high[0, %high] {
   ^bb0(%a: index, %b: index):
     tensor.yield %cst : f32
-  } : tensor<?x4xf32> to tensor<32x4xf32>
+  } : tensor<32x?xf32> to tensor<32x4xf32>
   %init = tensor.empty() : tensor<32x4xf32>
   %r = linalg.copy {lowering_config = #iree_gpu.use_global_load_dma}
     ins(%padded : tensor<32x4xf32>) outs(%init : tensor<32x4xf32>) -> tensor<32x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -661,7 +661,9 @@ func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init
 
 // -----
 
-// Negative test: Dynamic innermost dimension fails DWORD alignment check.
+// Dynamic innermost dimension is now allowed: GPUPushDownDMABoundsToConsumers
+// inserts a consumer-side mask + buffer_resource_cast(validBytes) to cover
+// the partial-DWORD straddle, so the DMA can fire on non-DWORD-aligned rows.
 
 #gpu_target_pad_dynamic_inner = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
@@ -695,10 +697,12 @@ func.func @copy_with_tensor_pad_dynamic_inner_dim(%source: tensor<457x330xi8>, %
     ins(%padded : tensor<4x256xi8>)
     outs(%init : tensor<4x256xi8>) -> tensor<4x256xi8>
 
-  // The copy is downgraded from use_global_load_dma to derived_thread_config.
-  // CHECK: tensor.pad
-  // CHECK: linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
+  // The pad is consumed and a coalesced DMA fires with in_bounds=[false,false].
+  // Consumer-side mask + validBytes hack are added by the later pushdown pass.
+  // CHECK-NOT: tensor.pad
+  // CHECK-NOT: linalg.copy
+  // CHECK: iree_gpu.coalesced_gather_dma {{.*}} in_bounds [false, false]
+  // CHECK-SAME: tensor<?x?xi8>
 
   return %result : tensor<4x256xi8>
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_convert_to_coalesced_dma.mlir
@@ -615,7 +615,9 @@ func.func @copy_with_tensor_pad_unaligned_row(%source: tensor<65x121xf16>, %init
 
 // -----
 
-// Negative test: Dynamic innermost dimension fails DWORD alignment check.
+// Dynamic innermost dimension is now allowed: GPUPushDownDMABoundsToConsumers
+// inserts a consumer-side mask + buffer_resource_cast(validBytes) to cover
+// the partial-DWORD straddle, so the DMA can fire on non-DWORD-aligned rows.
 
 #gpu_target_pad_dynamic_inner = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
   compute = fp32, storage = b32, subgroup = shuffle,
@@ -649,10 +651,12 @@ func.func @copy_with_tensor_pad_dynamic_inner_dim(%source: tensor<457x330xi8>, %
     ins(%padded : tensor<4x256xi8>)
     outs(%init : tensor<4x256xi8>) -> tensor<4x256xi8>
 
-  // The copy is downgraded from use_global_load_dma to derived_thread_config.
-  // CHECK: tensor.pad
-  // CHECK: linalg.copy {lowering_config = #iree_gpu.derived_thread_config}
-  // CHECK-NOT: iree_gpu.coalesced_gather_dma
+  // The pad is consumed and a coalesced DMA fires with in_bounds=[false,false].
+  // Consumer-side mask + validBytes hack are added by the later pushdown pass.
+  // CHECK-NOT: tensor.pad
+  // CHECK-NOT: linalg.copy
+  // CHECK: iree_gpu.coalesced_gather_dma {{.*}} in_bounds [false, false]
+  // CHECK-SAME: tensor<?x?xi8>
 
   return %result : tensor<4x256xi8>
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pushdown_dma_bounds_to_consumers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pushdown_dma_bounds_to_consumers.mlir
@@ -96,8 +96,7 @@ func.func @pushdown_innermost_oob(
 // result that has external consumers. It inserts the slice+pad after that
 // forall and RAUWs uses to the padded result.
 // CHECK-LABEL: func.func @pushdown_innermost_oob
-// CHECK:         %[[VB:.+]] = affine.apply
-// CHECK:         %[[CAST:.+]] = iree_gpu.buffer_resource_cast %arg0 validBytes(%[[VB]])
+// CHECK:         %[[CAST:.+]] = iree_gpu.buffer_resource_cast %arg0
 // CHECK-SAME:        : tensor<64x?xf16>
 // CHECK:         %[[OUTER:.+]] = scf.forall
 // CHECK:           iree_gpu.coalesced_gather_dma %[[CAST]]
@@ -139,7 +138,7 @@ func.func @pushdown_both_oob(
   return %filled : tensor<64x16xf16>
 }
 // CHECK-LABEL: func.func @pushdown_both_oob
-// CHECK:       iree_gpu.buffer_resource_cast %arg0 validBytes(%{{.+}}) : tensor<?x?xf16>
+// CHECK:       iree_gpu.buffer_resource_cast %arg0 : tensor<?x?xf16>
 // CHECK:       tensor.extract_slice
 // CHECK-SAME:      [0, 0] [64, %{{.*}}] [1, 1]
 // CHECK:       tensor.pad
@@ -200,8 +199,7 @@ func.func @single_forall_matmul_consumer(
   return %result : tensor<4x8xf32>
 }
 // CHECK-LABEL: func.func @single_forall_matmul_consumer
-// CHECK:       %[[VB:.+]] = affine.apply
-// CHECK:       %[[CAST:.+]] = iree_gpu.buffer_resource_cast %arg0 validBytes(%[[VB]])
+// CHECK:       %[[CAST:.+]] = iree_gpu.buffer_resource_cast %arg0
 // CHECK-SAME:      : tensor<4x?xf16>
 // CHECK:       %[[LHS:.+]] = scf.forall
 // CHECK:         iree_gpu.coalesced_gather_dma %[[CAST]]
@@ -329,5 +327,5 @@ func.func @consumer_pad_skipped_even_when_root_misaligned(
   return %filled : tensor<32x128xf16>
 }
 // CHECK-LABEL: func.func @consumer_pad_skipped_even_when_root_misaligned
-// CHECK:       iree_gpu.buffer_resource_cast %arg0 validBytes
+// CHECK:       iree_gpu.buffer_resource_cast %arg0
 // CHECK-NOT:   tensor.pad

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pushdown_dma_bounds_to_consumers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pushdown_dma_bounds_to_consumers.mlir
@@ -1,0 +1,246 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-pushdown-dma-bounds-to-consumers))" --split-input-file %s | FileCheck %s
+
+
+// Test 1: in_bounds=[true, true] — pass is a no-op.
+
+
+func.func @no_op_all_in_bounds(
+    %src : tensor<64x16xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [true, true]
+          : tensor<64x16xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// CHECK-LABEL: func.func @no_op_all_in_bounds
+// CHECK-NOT:   tensor.pad
+// CHECK-NOT:   tensor.extract_slice
+
+// -----
+
+
+// Test 2: in_bounds=[false, true] — outer-only OOB; innermost is true.
+//         Pass skips because in_bounds[innermost]=true.
+
+
+func.func @no_op_outer_oob_only(
+    %src : tensor<64x16xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [false, true]
+          : tensor<64x16xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// CHECK-LABEL: func.func @no_op_outer_oob_only
+// CHECK-NOT:   tensor.pad
+// CHECK-NOT:   tensor.extract_slice
+
+// -----
+
+
+// Test 3: in_bounds=[true, false] — innermost OOB; this is the target case.
+//         Pass must insert extract_slice + tensor.pad after the outer forall.
+
+
+func.func @pushdown_innermost_oob(
+    %src : tensor<64x?xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [true, false]
+          : tensor<64x?xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// The pass walks from the DMA's init (%inn) up the shared_outs chain AND
+// across parallel_insert_slice links until it reaches the outermost forall
+// result that has external consumers. It inserts the slice+pad after that
+// forall and RAUWs uses to the padded result.
+// CHECK-LABEL: func.func @pushdown_innermost_oob
+// CHECK-NOT:     iree_gpu.buffer_resource_cast
+// CHECK:         %[[OUTER:.+]] = scf.forall
+// CHECK:           iree_gpu.coalesced_gather_dma %arg0
+// CHECK:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK:         %[[C16:.+]] = arith.constant 16 : index
+// CHECK:         %[[PAD_AMT:.+]] = arith.subi %[[C16]], %[[DIM]]
+// CHECK:         %[[SLICE:.+]] = tensor.extract_slice %[[OUTER]][0, 0] [64, %[[DIM]]] [1, 1]
+// CHECK-SAME:        : tensor<64x16xf16> to tensor<64x?xf16>
+// CHECK:         %[[PADDED:.+]] = tensor.pad %[[SLICE]] low[0, 0] high[0, %[[PAD_AMT]]]
+// CHECK:         return %[[PADDED]]
+
+// -----
+
+
+// Test 4: in_bounds=[false, false] — both dims OOB.
+//         Pass inserts pad only on innermost; outer dim left to HW OOB.
+
+
+func.func @pushdown_both_oob(
+    %src : tensor<?x?xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [false, false]
+          : tensor<?x?xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// CHECK-LABEL: func.func @pushdown_both_oob
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
+// CHECK:       tensor.extract_slice
+// CHECK-SAME:      [0, 0] [64, %{{.*}}] [1, 1]
+// CHECK:       tensor.pad
+// CHECK-SAME:  low[0, 0] high[0, %{{.*}}]
+
+// -----
+
+
+// Test 5: No in_bounds attribute — pass is a no-op.
+
+
+func.func @no_op_no_in_bounds(
+    %src : tensor<64x16xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+          : tensor<64x16xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// CHECK-LABEL: func.func @no_op_no_in_bounds
+// CHECK-NOT:   tensor.pad
+
+// -----
+
+// Test 6: single-level forall with an external linalg.matmul consumer.
+// This is the primary motivated pattern. The DMA fills a single forall
+// (no outer wrapper), so walkUpSharedOuts reaches the forall result directly.
+// The pass inserts slice+pad between the forall result and the matmul.
+func.func @single_forall_matmul_consumer(
+    %src  : tensor<4x?xf16>,
+    %init : tensor<4x16xf16>,
+    %rhs  : tensor<16x8xf16>,
+    %acc  : tensor<4x8xf32>) -> tensor<4x8xf32> {
+  %lhs = scf.forall (%l) in (4) shared_outs(%s = %init)
+      -> tensor<4x16xf16> {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %src into %s lane(%l)
+          in_bounds [true, false]
+        : tensor<4x?xf16>, tensor<4x16xf16>, index
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  %result = linalg.matmul
+      ins(%lhs, %rhs : tensor<4x16xf16>, tensor<16x8xf16>)
+      outs(%acc : tensor<4x8xf32>) -> tensor<4x8xf32>
+  return %result : tensor<4x8xf32>
+}
+// CHECK-LABEL: func.func @single_forall_matmul_consumer
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
+// CHECK:       %[[LHS:.+]] = scf.forall
+// CHECK:         iree_gpu.coalesced_gather_dma %arg0
+// CHECK:       %[[C1:.+]] = arith.constant 1 : index
+// CHECK:       %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK:       %[[SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0] [4, %[[DIM]]] [1, 1]
+// CHECK:       %[[PADDED:.+]] = tensor.pad %[[SLICE]] low[0, 0] high[0, %{{.+}}]
+// CHECK:       linalg.matmul ins(%[[PADDED]], %arg2
+
+// -----
+
+// Test 7: dynamic-shape source whose innermost extent's static UB matches
+// the LDS inner tile size. The pass must skip the consumer-side
+// extract_slice + tensor.pad chain. AMDGPULowerCoalescedDMA's OOB clamping
+// zeros LDS positions for OOB lanes, so the pad would only redundantly
+// rewrite the same zeros at the cost of materializing a private alloca.
+// Models the 4000x4000 f16 RHS DMA case where N_tile = 128 and the source
+// is tensor<32x?xf16> with the dynamic dim derived from
+// affine.min<...,128> on the workgroup index.
+
+#min128 = affine_map<(d0) -> (-d0 + 4000, 128)>
+func.func @skip_consumer_pad_when_inner_ub_matches_tile(
+    %root : tensor<4000x4000xf16>,
+    %init : tensor<32x128xf16>,
+    %off  : index,
+    %lane : index) -> tensor<32x128xf16> {
+  %c0 = arith.constant 0 : index
+  %dyn = affine.min #min128(%off)
+  %src = tensor.extract_slice %root[%c0, %off] [32, %dyn] [1, 1]
+      : tensor<4000x4000xf16> to tensor<32x?xf16>
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<32x128xf16> {
+    %inner = scf.forall (%l) in (32) shared_outs(%inn = %outer)
+        -> tensor<32x128xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [true, false]
+          : tensor<32x?xf16>, tensor<32x128xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [32, 128] [1, 1]
+        : tensor<32x128xf16> into tensor<32x128xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<32x128xf16>
+}
+// CHECK-LABEL: func.func @skip_consumer_pad_when_inner_ub_matches_tile
+// CHECK-NOT:   tensor.pad

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pushdown_dma_bounds_to_consumers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pushdown_dma_bounds_to_consumers.mlir
@@ -26,6 +26,7 @@ func.func @no_op_all_in_bounds(
   return %filled : tensor<64x16xf16>
 }
 // CHECK-LABEL: func.func @no_op_all_in_bounds
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
 // CHECK-NOT:   tensor.pad
 // CHECK-NOT:   tensor.extract_slice
 
@@ -58,6 +59,7 @@ func.func @no_op_outer_oob_only(
   return %filled : tensor<64x16xf16>
 }
 // CHECK-LABEL: func.func @no_op_outer_oob_only
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
 // CHECK-NOT:   tensor.pad
 // CHECK-NOT:   tensor.extract_slice
 
@@ -94,11 +96,13 @@ func.func @pushdown_innermost_oob(
 // result that has external consumers. It inserts the slice+pad after that
 // forall and RAUWs uses to the padded result.
 // CHECK-LABEL: func.func @pushdown_innermost_oob
-// CHECK-NOT:     iree_gpu.buffer_resource_cast
+// CHECK:         %[[VB:.+]] = affine.apply
+// CHECK:         %[[CAST:.+]] = iree_gpu.buffer_resource_cast %arg0 validBytes(%[[VB]])
+// CHECK-SAME:        : tensor<64x?xf16>
 // CHECK:         %[[OUTER:.+]] = scf.forall
-// CHECK:           iree_gpu.coalesced_gather_dma %arg0
+// CHECK:           iree_gpu.coalesced_gather_dma %[[CAST]]
 // CHECK:         %[[C1:.+]] = arith.constant 1 : index
-// CHECK:         %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK:         %[[DIM:.+]] = tensor.dim %[[CAST]], %[[C1]]
 // CHECK:         %[[C16:.+]] = arith.constant 16 : index
 // CHECK:         %[[PAD_AMT:.+]] = arith.subi %[[C16]], %[[DIM]]
 // CHECK:         %[[SLICE:.+]] = tensor.extract_slice %[[OUTER]][0, 0] [64, %[[DIM]]] [1, 1]
@@ -135,7 +139,7 @@ func.func @pushdown_both_oob(
   return %filled : tensor<64x16xf16>
 }
 // CHECK-LABEL: func.func @pushdown_both_oob
-// CHECK-NOT:   iree_gpu.buffer_resource_cast
+// CHECK:       iree_gpu.buffer_resource_cast %arg0 validBytes(%{{.+}}) : tensor<?x?xf16>
 // CHECK:       tensor.extract_slice
 // CHECK-SAME:      [0, 0] [64, %{{.*}}] [1, 1]
 // CHECK:       tensor.pad
@@ -168,6 +172,7 @@ func.func @no_op_no_in_bounds(
   return %filled : tensor<64x16xf16>
 }
 // CHECK-LABEL: func.func @no_op_no_in_bounds
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
 // CHECK-NOT:   tensor.pad
 
 // -----
@@ -195,18 +200,58 @@ func.func @single_forall_matmul_consumer(
   return %result : tensor<4x8xf32>
 }
 // CHECK-LABEL: func.func @single_forall_matmul_consumer
-// CHECK-NOT:   iree_gpu.buffer_resource_cast
+// CHECK:       %[[VB:.+]] = affine.apply
+// CHECK:       %[[CAST:.+]] = iree_gpu.buffer_resource_cast %arg0 validBytes(%[[VB]])
+// CHECK-SAME:      : tensor<4x?xf16>
 // CHECK:       %[[LHS:.+]] = scf.forall
-// CHECK:         iree_gpu.coalesced_gather_dma %arg0
+// CHECK:         iree_gpu.coalesced_gather_dma %[[CAST]]
 // CHECK:       %[[C1:.+]] = arith.constant 1 : index
-// CHECK:       %[[DIM:.+]] = tensor.dim %arg0, %[[C1]]
+// CHECK:       %[[DIM:.+]] = tensor.dim %[[CAST]], %[[C1]]
 // CHECK:       %[[SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0] [4, %[[DIM]]] [1, 1]
 // CHECK:       %[[PADDED:.+]] = tensor.pad %[[SLICE]] low[0, 0] high[0, %{{.+}}]
 // CHECK:       linalg.matmul ins(%[[PADDED]], %arg2
 
 // -----
 
-// Test 7: dynamic-shape source whose innermost extent's static UB matches
+// Test 7: dynamic-shape source whose ROOT's innermost row is statically
+// DWORD-aligned. The pass must skip the validBytes wrap because the
+// underlying buffer's end is naturally DWORD-aligned (no partial-DWORD
+// straddle is possible). Models the 4000x4000 f16 matmul case where the
+// K-block tile produces tensor<32x?xf16> from a tensor<4000x4000xf16>
+// root: dynamic source dim, but the root's 4000-element row * 2 bytes =
+// 8000 bytes is divisible by 4.
+
+func.func @skip_validbytes_when_root_innermost_aligned(
+    %root : tensor<4000x4000xf16>,
+    %init : tensor<32x16xf16>,
+    %dyn  : index,
+    %lane : index) -> tensor<32x16xf16> {
+  %c0 = arith.constant 0 : index
+  %src = tensor.extract_slice %root[%c0, %c0] [32, %dyn] [1, 1]
+      : tensor<4000x4000xf16> to tensor<32x?xf16>
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<32x16xf16> {
+    %inner = scf.forall (%l) in (32) shared_outs(%inn = %outer)
+        -> tensor<32x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [true, false]
+          : tensor<32x?xf16>, tensor<32x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [32, 16] [1, 1]
+        : tensor<32x16xf16> into tensor<32x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<32x16xf16>
+}
+// CHECK-LABEL: func.func @skip_validbytes_when_root_innermost_aligned
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
+
+// -----
+
+// Test 8: dynamic-shape source whose innermost extent's static UB matches
 // the LDS inner tile size. The pass must skip the consumer-side
 // extract_slice + tensor.pad chain. AMDGPULowerCoalescedDMA's OOB clamping
 // zeros LDS positions for OOB lanes, so the pad would only redundantly
@@ -243,4 +288,46 @@ func.func @skip_consumer_pad_when_inner_ub_matches_tile(
   return %filled : tensor<32x128xf16>
 }
 // CHECK-LABEL: func.func @skip_consumer_pad_when_inner_ub_matches_tile
+// Skip #1 fires here too (root 4000 * 2 = 8000 is DWORD-aligned), so no
+// validBytes wrap. Skip #2 fires for the consumer-side pad chain.
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
+// CHECK-NOT:   tensor.pad
+
+// -----
+
+// Test 9: same as Test 8 but with a DWORD-misaligned root (4000*2=8000
+// aligned -> swap to 4001 to break alignment). Skip #1 must NOT fire
+// (validBytes wrap is needed to guard against the partial-DWORD straddle
+// at the buffer end), but Skip #2 must still fire because the inner
+// extent's UB still matches the LDS tile.
+
+#min128b = affine_map<(d0) -> (-d0 + 4001, 128)>
+func.func @consumer_pad_skipped_even_when_root_misaligned(
+    %root : tensor<4000x4001xf16>,
+    %init : tensor<32x128xf16>,
+    %off  : index,
+    %lane : index) -> tensor<32x128xf16> {
+  %c0 = arith.constant 0 : index
+  %dyn = affine.min #min128b(%off)
+  %src = tensor.extract_slice %root[%c0, %off] [32, %dyn] [1, 1]
+      : tensor<4000x4001xf16> to tensor<32x?xf16>
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<32x128xf16> {
+    %inner = scf.forall (%l) in (32) shared_outs(%inn = %outer)
+        -> tensor<32x128xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [true, false]
+          : tensor<32x?xf16>, tensor<32x128xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [32, 128] [1, 1]
+        : tensor<32x128xf16> into tensor<32x128xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<32x128xf16>
+}
+// CHECK-LABEL: func.func @consumer_pad_skipped_even_when_root_misaligned
+// CHECK:       iree_gpu.buffer_resource_cast %arg0 validBytes
 // CHECK-NOT:   tensor.pad

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pushdown_dma_bounds_to_consumers.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pushdown_dma_bounds_to_consumers.mlir
@@ -1,0 +1,212 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-pushdown-dma-bounds-to-consumers))" --split-input-file %s | FileCheck %s
+
+
+// Test 1: in_bounds=[true, true] — pass is a no-op.
+
+
+func.func @no_op_all_in_bounds(
+    %src : tensor<64x16xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [true, true]
+          : tensor<64x16xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// CHECK-LABEL: func.func @no_op_all_in_bounds
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
+// CHECK-NOT:   tensor.pad
+// CHECK-NOT:   tensor.extract_slice
+
+// -----
+
+
+// Test 2: in_bounds=[false, true] — outer-only OOB; innermost is true.
+//         Pass skips because in_bounds[innermost]=true.
+
+
+func.func @no_op_outer_oob_only(
+    %src : tensor<64x16xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [false, true]
+          : tensor<64x16xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// CHECK-LABEL: func.func @no_op_outer_oob_only
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
+// CHECK-NOT:   tensor.pad
+// CHECK-NOT:   tensor.extract_slice
+
+// -----
+
+
+// Test 3: in_bounds=[true, false] — innermost OOB; this is the target case.
+//         Pass must insert extract_slice + tensor.pad after the outer forall.
+
+
+func.func @pushdown_innermost_oob(
+    %src : tensor<64x?xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [true, false]
+          : tensor<64x?xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// The pass walks from the DMA's init (%inn) up the shared_outs chain AND
+// across parallel_insert_slice links until it reaches the outermost forall
+// result that has external consumers. It inserts the slice+pad after that
+// forall and RAUWs uses to the padded result.
+// CHECK-LABEL: func.func @pushdown_innermost_oob
+// CHECK:         %[[VB:.+]] = affine.apply
+// CHECK:         %[[CAST:.+]] = iree_gpu.buffer_resource_cast %arg0 validBytes(%[[VB]])
+// CHECK-SAME:        : tensor<64x?xf16>
+// CHECK:         %[[OUTER:.+]] = scf.forall
+// CHECK:           iree_gpu.coalesced_gather_dma %[[CAST]]
+// CHECK:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK:         %[[DIM:.+]] = tensor.dim %[[CAST]], %[[C1]]
+// CHECK:         %[[C16:.+]] = arith.constant 16 : index
+// CHECK:         %[[PAD_AMT:.+]] = arith.subi %[[C16]], %[[DIM]]
+// CHECK:         %[[SLICE:.+]] = tensor.extract_slice %[[OUTER]][0, 0] [64, %[[DIM]]] [1, 1]
+// CHECK-SAME:        : tensor<64x16xf16> to tensor<64x?xf16>
+// CHECK:         %[[PADDED:.+]] = tensor.pad %[[SLICE]] low[0, 0] high[0, %[[PAD_AMT]]]
+// CHECK:         return %[[PADDED]]
+
+// -----
+
+
+// Test 4: in_bounds=[false, false] — both dims OOB.
+//         Pass inserts pad only on innermost; outer dim left to HW OOB.
+
+
+func.func @pushdown_both_oob(
+    %src : tensor<?x?xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+            in_bounds [false, false]
+          : tensor<?x?xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// CHECK-LABEL: func.func @pushdown_both_oob
+// CHECK:       iree_gpu.buffer_resource_cast %arg0 validBytes(%{{.+}}) : tensor<?x?xf16>
+// CHECK:       tensor.extract_slice
+// CHECK-SAME:      [0, 0] [64, %{{.*}}] [1, 1]
+// CHECK:       tensor.pad
+// CHECK-SAME:  low[0, 0] high[0, %{{.*}}]
+
+// -----
+
+
+// Test 5: No in_bounds attribute — pass is a no-op.
+
+
+func.func @no_op_no_in_bounds(
+    %src : tensor<64x16xf16>,
+    %init : tensor<64x16xf16>,
+    %lane : index) -> tensor<64x16xf16> {
+  %filled = scf.forall (%w) in (1) shared_outs(%outer = %init)
+      -> tensor<64x16xf16> {
+    %inner = scf.forall (%l) in (64) shared_outs(%inn = %outer)
+        -> tensor<64x16xf16> {
+      scf.forall.in_parallel {
+        iree_gpu.coalesced_gather_dma %src into %inn lane(%l)
+          : tensor<64x16xf16>, tensor<64x16xf16>, index
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>]}
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %inner into %outer [0, 0] [64, 16] [1, 1]
+        : tensor<64x16xf16> into tensor<64x16xf16>
+    }
+  } {mapping = [#gpu.warp<linear_dim_0>]}
+  return %filled : tensor<64x16xf16>
+}
+// CHECK-LABEL: func.func @no_op_no_in_bounds
+// CHECK-NOT:   iree_gpu.buffer_resource_cast
+// CHECK-NOT:   tensor.pad
+
+// -----
+
+// Test 6: single-level forall with an external linalg.matmul consumer.
+// This is the primary motivated pattern. The DMA fills a single forall
+// (no outer wrapper), so walkUpSharedOuts reaches the forall result directly.
+// The pass inserts slice+pad between the forall result and the matmul.
+func.func @single_forall_matmul_consumer(
+    %src  : tensor<4x?xf16>,
+    %init : tensor<4x16xf16>,
+    %rhs  : tensor<16x8xf16>,
+    %acc  : tensor<4x8xf32>) -> tensor<4x8xf32> {
+  %lhs = scf.forall (%l) in (4) shared_outs(%s = %init)
+      -> tensor<4x16xf16> {
+    scf.forall.in_parallel {
+      iree_gpu.coalesced_gather_dma %src into %s lane(%l)
+          in_bounds [true, false]
+        : tensor<4x?xf16>, tensor<4x16xf16>, index
+    }
+  } {mapping = [#gpu.thread<linear_dim_0>]}
+  %result = linalg.matmul
+      ins(%lhs, %rhs : tensor<4x16xf16>, tensor<16x8xf16>)
+      outs(%acc : tensor<4x8xf32>) -> tensor<4x8xf32>
+  return %result : tensor<4x8xf32>
+}
+// CHECK-LABEL: func.func @single_forall_matmul_consumer
+// CHECK:       %[[VB:.+]] = affine.apply
+// CHECK:       %[[CAST:.+]] = iree_gpu.buffer_resource_cast %arg0 validBytes(%[[VB]])
+// CHECK-SAME:      : tensor<4x?xf16>
+// CHECK:       %[[LHS:.+]] = scf.forall
+// CHECK:         iree_gpu.coalesced_gather_dma %[[CAST]]
+// CHECK:       %[[C1:.+]] = arith.constant 1 : index
+// CHECK:       %[[DIM:.+]] = tensor.dim %[[CAST]], %[[C1]]
+// CHECK:       %[[SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0] [4, %[[DIM]]] [1, 1]
+// CHECK:       %[[PADDED:.+]] = tensor.pad %[[SLICE]] low[0, 0] high[0, %{{.+}}]
+// CHECK:       linalg.matmul ins(%[[PADDED]], %arg2

--- a/compiler/src/iree/compiler/Codegen/Common/ReinsertSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReinsertSwizzleHints.cpp
@@ -112,14 +112,19 @@ void ReinsertSwizzleHintsPass::runOnOperation() {
   IRRewriter rewriter(funcOp->getContext());
   DenseMap<Value, IREE::Codegen::SwizzleAttrInterface> swizzleCache;
 
-  // For each vector.load/store whose base traces to a swizzled alloc, wrap the
-  // base with collapse_shape -> swizzle_hint -> expand_shape.
+  // For each vector.load/store/maskedload/maskedstore whose base traces to a
+  // swizzled alloc, wrap the base with collapse_shape -> swizzle_hint ->
+  // expand_shape.
   funcOp.walk([&](Operation *op) {
     Value base;
     if (auto loadOp = dyn_cast<vector::LoadOp>(op)) {
       base = loadOp.getBase();
     } else if (auto storeOp = dyn_cast<vector::StoreOp>(op)) {
       base = storeOp.getBase();
+    } else if (auto mLoadOp = dyn_cast<vector::MaskedLoadOp>(op)) {
+      base = mLoadOp.getBase();
+    } else if (auto mStoreOp = dyn_cast<vector::MaskedStoreOp>(op)) {
+      base = mStoreOp.getBase();
     } else {
       return;
     }
@@ -134,6 +139,10 @@ void ReinsertSwizzleHintsPass::runOnOperation() {
       loadOp.getBaseMutable().assign(wrapped);
     } else if (auto storeOp = dyn_cast<vector::StoreOp>(op)) {
       storeOp.getBaseMutable().assign(wrapped);
+    } else if (auto mLoadOp = dyn_cast<vector::MaskedLoadOp>(op)) {
+      mLoadOp.getBaseMutable().assign(wrapped);
+    } else if (auto mStoreOp = dyn_cast<vector::MaskedStoreOp>(op)) {
+      mStoreOp.getBaseMutable().assign(wrapped);
     }
   });
 

--- a/compiler/src/iree/compiler/Codegen/Common/ReinsertSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReinsertSwizzleHints.cpp
@@ -107,6 +107,24 @@ static Value insertSwizzleHint(IRRewriter &rewriter, Location loc, Value source,
   return hintOp.getResult();
 }
 
+/// Returns the base-memref OpOperand for vector load/store/maskedload/
+/// maskedstore ops, or nullptr otherwise.
+static OpOperand *getVectorBaseOperand(Operation *op) {
+  if (auto load = dyn_cast<vector::LoadOp>(op)) {
+    return &load.getBaseMutable();
+  }
+  if (auto store = dyn_cast<vector::StoreOp>(op)) {
+    return &store.getBaseMutable();
+  }
+  if (auto mLoad = dyn_cast<vector::MaskedLoadOp>(op)) {
+    return &mLoad.getBaseMutable();
+  }
+  if (auto mStore = dyn_cast<vector::MaskedStoreOp>(op)) {
+    return &mStore.getBaseMutable();
+  }
+  return nullptr;
+}
+
 void ReinsertSwizzleHintsPass::runOnOperation() {
   FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(funcOp->getContext());
@@ -116,34 +134,19 @@ void ReinsertSwizzleHintsPass::runOnOperation() {
   // swizzled alloc, wrap the base with collapse_shape -> swizzle_hint ->
   // expand_shape.
   funcOp.walk([&](Operation *op) {
-    Value base;
-    if (auto loadOp = dyn_cast<vector::LoadOp>(op)) {
-      base = loadOp.getBase();
-    } else if (auto storeOp = dyn_cast<vector::StoreOp>(op)) {
-      base = storeOp.getBase();
-    } else if (auto mLoadOp = dyn_cast<vector::MaskedLoadOp>(op)) {
-      base = mLoadOp.getBase();
-    } else if (auto mStoreOp = dyn_cast<vector::MaskedStoreOp>(op)) {
-      base = mStoreOp.getBase();
-    } else {
+    OpOperand *baseOperand = getVectorBaseOperand(op);
+    if (!baseOperand) {
       return;
     }
+    Value base = baseOperand->get();
     IREE::Codegen::SwizzleAttrInterface swizzle =
         lookupSwizzleAttr(base, swizzleCache);
     if (!swizzle) {
       return;
     }
     rewriter.setInsertionPoint(op);
-    Value wrapped = insertSwizzleHint(rewriter, op->getLoc(), base, swizzle);
-    if (auto loadOp = dyn_cast<vector::LoadOp>(op)) {
-      loadOp.getBaseMutable().assign(wrapped);
-    } else if (auto storeOp = dyn_cast<vector::StoreOp>(op)) {
-      storeOp.getBaseMutable().assign(wrapped);
-    } else if (auto mLoadOp = dyn_cast<vector::MaskedLoadOp>(op)) {
-      mLoadOp.getBaseMutable().assign(wrapped);
-    } else if (auto mStoreOp = dyn_cast<vector::MaskedStoreOp>(op)) {
-      mStoreOp.getBaseMutable().assign(wrapped);
-    }
+    baseOperand->assign(
+        insertSwizzleHint(rewriter, op->getLoc(), base, swizzle));
   });
 
   // Clean up the swizzle attributes from allocs now that hints are inserted.

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -50,6 +50,26 @@ static Value createOrFoldNewStaticAdd(RewriterBase &rewriter, Value v,
   return arith::AddIOp::create(rewriter, v.getLoc(), v, offsetVal);
 }
 
+/// Returns the swizzled memref offset for chunk `i` of an unrolled access.
+static Value computeSwizzledChunkOffset(RewriterBase &rewriter,
+                                        IREE::Codegen::SwizzleHintOp hintOp,
+                                        Value memrefOffset, int64_t i) {
+  Value newBaseOffset = createOrFoldNewStaticAdd(rewriter, memrefOffset, i);
+  return getValueOrCreateConstantIndexOp(
+      rewriter, hintOp.getLoc(),
+      hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
+                                        newBaseOffset, hintOp.getOperand()));
+}
+
+/// Extracts a contiguous chunk of `accessWidth` elements starting at index `i`
+/// from a 1-d vector.
+static Value extractChunk(RewriterBase &rewriter, Location loc, Value src,
+                          int64_t i, int64_t accessWidth) {
+  return vector::ExtractStridedSliceOp::create(
+      rewriter, loc, src, ArrayRef<int64_t>{i}, ArrayRef<int64_t>{accessWidth},
+      ArrayRef<int64_t>{1});
+}
+
 /// Swizzles vector.load(iree_codegen.swizzle_hint, offset). The
 /// SwizzleInterfaceAttr exposes two methods:
 ///   1. getAccessElementCount -> int64_t
@@ -67,109 +87,46 @@ static Value createOrFoldNewStaticAdd(RewriterBase &rewriter, Value v,
 /// %2 = vector.load %src[swizzleOffset(%src, %offset + 8)] : vector<4>
 /// %3 = vector.load %src[swizzleOffset(%src, %offset + 12)] : vector<4>
 /// %load = concat[%0, %1, %2, %3] : vector<16>
-static void swizzleLoad(RewriterBase &rewriter, vector::LoadOp load,
-                        IREE::Codegen::SwizzleHintOp hintOp) {
-  Location hintLoc = hintOp.getLoc();
+///
+/// The masked variant (mask + passThru non-null) emits vector.maskedload ops
+/// with the mask/passThru sliced along the access width.
+static void swizzleLoad(RewriterBase &rewriter, Operation *loadOp,
+                        IREE::Codegen::SwizzleHintOp hintOp, VectorType type,
+                        Value base, Value memrefOffset, Value mask,
+                        Value passThru) {
+  Location loc = loadOp->getLoc();
   int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
-  VectorType type = load.getVectorType();
   int64_t loadWidth = type.getShape()[0];
-  Value memrefOffset = load.getIndices()[0];
   VectorType swizzledLoadType =
       VectorType::get({accessWidth}, type.getElementType());
 
   // ~ vector.undef, overwritten by unrolling.
-  Value replacement = arith::ConstantOp::create(rewriter, hintLoc, type,
+  Value replacement = arith::ConstantOp::create(rewriter, hintOp.getLoc(), type,
                                                 rewriter.getZeroAttr(type));
 
   // Load type = vector<C>, k = accessWidth
   // i = 0 -> C += k is the offset into the vector of a contiguous group of
   // swizzled elements.
   for (int64_t i = 0; i < loadWidth; i += accessWidth) {
-    Value newBaseOffset = createOrFoldNewStaticAdd(rewriter, memrefOffset, i);
-    Value newOffset = getValueOrCreateConstantIndexOp(
-        rewriter, hintLoc,
-        hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
-                                          newBaseOffset, hintOp.getOperand()));
-    auto subLoad = vector::LoadOp::create(
-        rewriter, load.getLoc(), swizzledLoadType, load.getBase(), newOffset);
-
+    Value newOffset =
+        computeSwizzledChunkOffset(rewriter, hintOp, memrefOffset, i);
+    Value subLoad;
+    if (mask) {
+      subLoad =
+          vector::MaskedLoadOp::create(
+              rewriter, loc, swizzledLoadType, base, ValueRange{newOffset},
+              extractChunk(rewriter, loc, mask, i, accessWidth),
+              extractChunk(rewriter, loc, passThru, i, accessWidth))
+              .getResult();
+    } else {
+      subLoad = vector::LoadOp::create(rewriter, loc, swizzledLoadType, base,
+                                       newOffset);
+    }
     replacement = vector::InsertStridedSliceOp::create(
-        rewriter, load.getLoc(), subLoad, replacement, ArrayRef<int64_t>{i},
+        rewriter, loc, subLoad, replacement, ArrayRef<int64_t>{i},
         ArrayRef<int64_t>{1});
   }
-  rewriter.replaceOp(load, replacement);
-}
-
-/// Swizzles vector.maskedload(iree_codegen.swizzle_hint, offset, mask,
-/// passThru). Mirrors swizzleLoad but splits mask/passThru along the access
-/// width and emits per-chunk vector.maskedload ops.
-static void swizzleMaskedLoad(RewriterBase &rewriter, vector::MaskedLoadOp load,
-                              IREE::Codegen::SwizzleHintOp hintOp) {
-  Location hintLoc = hintOp.getLoc();
-  int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
-  VectorType type = load.getVectorType();
-  int64_t loadWidth = type.getShape()[0];
-  Value memrefOffset = load.getIndices()[0];
-  Value mask = load.getMask();
-  Value passThru = load.getPassThru();
-  VectorType swizzledLoadType =
-      VectorType::get({accessWidth}, type.getElementType());
-
-  Value replacement = arith::ConstantOp::create(rewriter, hintLoc, type,
-                                                rewriter.getZeroAttr(type));
-
-  for (int64_t i = 0; i < loadWidth; i += accessWidth) {
-    Value newBaseOffset = createOrFoldNewStaticAdd(rewriter, memrefOffset, i);
-    Value newOffset = getValueOrCreateConstantIndexOp(
-        rewriter, hintLoc,
-        hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
-                                          newBaseOffset, hintOp.getOperand()));
-    Value subMask = vector::ExtractStridedSliceOp::create(
-        rewriter, load.getLoc(), mask, ArrayRef<int64_t>{i},
-        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
-    Value subPass = vector::ExtractStridedSliceOp::create(
-        rewriter, load.getLoc(), passThru, ArrayRef<int64_t>{i},
-        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
-    auto subLoad = vector::MaskedLoadOp::create(
-        rewriter, load.getLoc(), swizzledLoadType, load.getBase(),
-        ValueRange{newOffset}, subMask, subPass);
-
-    replacement = vector::InsertStridedSliceOp::create(
-        rewriter, load.getLoc(), subLoad.getResult(), replacement,
-        ArrayRef<int64_t>{i}, ArrayRef<int64_t>{1});
-  }
-  rewriter.replaceOp(load, replacement);
-}
-
-/// Swizzles vector.maskedstore(iree_codegen.swizzle_hint, offset, mask,
-/// value). Mirrors swizzleStore but splits mask along the access width.
-static void swizzleMaskedStore(RewriterBase &rewriter,
-                               vector::MaskedStoreOp store,
-                               IREE::Codegen::SwizzleHintOp hintOp) {
-  Location hintLoc = hintOp.getLoc();
-  int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
-  VectorType type = store.getVectorType();
-  int64_t storeWidth = type.getShape()[0];
-  Value memrefOffset = store.getIndices()[0];
-  Value mask = store.getMask();
-  Value value = store.getValueToStore();
-
-  for (int64_t i = 0; i < storeWidth; i += accessWidth) {
-    Value subVec = vector::ExtractStridedSliceOp::create(
-        rewriter, store.getLoc(), value, ArrayRef<int64_t>{i},
-        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
-    Value subMask = vector::ExtractStridedSliceOp::create(
-        rewriter, store.getLoc(), mask, ArrayRef<int64_t>{i},
-        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
-    Value newBaseOffset = createOrFoldNewStaticAdd(rewriter, memrefOffset, i);
-    Value newOffset = getValueOrCreateConstantIndexOp(
-        rewriter, hintLoc,
-        hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
-                                          newBaseOffset, hintOp.getOperand()));
-    vector::MaskedStoreOp::create(rewriter, store.getLoc(), store.getBase(),
-                                  ValueRange{newOffset}, subMask, subVec);
-  }
-  rewriter.eraseOp(store);
+  rewriter.replaceOp(loadOp, replacement);
 }
 
 /// Swizzles vector.store(iree_codegen.swizzle_hint, offset).
@@ -184,31 +141,33 @@ static void swizzleMaskedStore(RewriterBase &rewriter,
 /// vector.store %1, %src[swizzleOffset(%src, %offset + 4)] : vector<4>
 /// vector.store %2, %src[swizzleOffset(%src, %offset + 8)] : vector<4>
 /// vector.store %3, %src[swizzleOffset(%src, %offset + 12)] : vector<4>
-static void swizzleStore(RewriterBase &rewriter, vector::StoreOp store,
-                         IREE::Codegen::SwizzleHintOp hintOp) {
-  Location hintLoc = hintOp.getLoc();
+///
+/// The masked variant (mask non-null) emits vector.maskedstore ops with the
+/// mask sliced along the access width.
+static void swizzleStore(RewriterBase &rewriter, Operation *storeOp,
+                         IREE::Codegen::SwizzleHintOp hintOp, VectorType type,
+                         Value base, Value memrefOffset, Value valueToStore,
+                         Value mask) {
+  Location loc = storeOp->getLoc();
   int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
-  VectorType type = store.getVectorType();
   int64_t storeWidth = type.getShape()[0];
-  Value memrefOffset = store.getIndices()[0];
 
   // Store type = vector<C>, k = accessWidth
   // i = 0 -> C += k is the offset into the vector of a contiguous group of
   // swizzled elements.
   for (int64_t i = 0; i < storeWidth; i += accessWidth) {
-    Value subVec = vector::ExtractStridedSliceOp::create(
-        rewriter, store.getLoc(), store.getValueToStore(), ArrayRef<int64_t>{i},
-        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
-    Value newBaseOffset = createOrFoldNewStaticAdd(rewriter, memrefOffset, i);
-
-    Value newOffset = getValueOrCreateConstantIndexOp(
-        rewriter, hintLoc,
-        hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
-                                          newBaseOffset, hintOp.getOperand()));
-    vector::StoreOp::create(rewriter, store.getLoc(), subVec, store.getBase(),
-                            newOffset);
+    Value subVec = extractChunk(rewriter, loc, valueToStore, i, accessWidth);
+    Value newOffset =
+        computeSwizzledChunkOffset(rewriter, hintOp, memrefOffset, i);
+    if (mask) {
+      vector::MaskedStoreOp::create(
+          rewriter, loc, base, ValueRange{newOffset},
+          extractChunk(rewriter, loc, mask, i, accessWidth), subVec);
+    } else {
+      vector::StoreOp::create(rewriter, loc, subVec, base, newOffset);
+    }
   }
-  rewriter.eraseOp(store);
+  rewriter.eraseOp(storeOp);
 }
 
 static LogicalResult
@@ -227,53 +186,47 @@ verifyFlatContiguousSwizzleHintOp(IREE::Codegen::SwizzleHintOp hintOp) {
   return success();
 }
 
+/// Returns true if `vt` is rank 1 and its width divides evenly by
+/// `accessWidth` — required for the unrolled per-chunk rewrite.
+static bool isSwizzleableVectorType(VectorType vt, int64_t accessWidth) {
+  return vt.getRank() == 1 && vt.getShape()[0] % accessWidth == 0;
+}
+
 /// Resolves all hints. Walks all direct users and splits them into loads and
 /// stores. If any user is not a swizzle-able load or store, bail out and
 /// silently drop the optimization hint.
 static void resolveHintOp(RewriterBase &rewriter,
                           IREE::Codegen::SwizzleHintOp hintOp) {
-  SmallVector<vector::LoadOp> loads;
-  SmallVector<vector::StoreOp> stores;
-  SmallVector<vector::MaskedLoadOp> maskedLoads;
-  SmallVector<vector::MaskedStoreOp> maskedStores;
+  SmallVector<Operation *> loads;
+  SmallVector<Operation *> stores;
   int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
   for (Operation *user : hintOp->getUsers()) {
     if (auto load = dyn_cast<vector::LoadOp>(user)) {
-      VectorType loadType = load.getVectorType();
-      // Guard on zero rank loads and loads not divisible by the access width.
-      if (loadType.getRank() != 1 ||
-          loadType.getShape()[0] % accessWidth != 0) {
+      if (!isSwizzleableVectorType(load.getVectorType(), accessWidth)) {
         return;
       }
       loads.push_back(load);
       continue;
     }
     if (auto store = dyn_cast<vector::StoreOp>(user)) {
-      VectorType storeType = store.getVectorType();
-      // Guard on zero rank stores and stores not divisible by the access width.
-      if (storeType.getRank() != 1 ||
-          storeType.getShape()[0] % accessWidth != 0) {
+      if (!isSwizzleableVectorType(store.getVectorType(), accessWidth)) {
         return;
       }
       stores.push_back(store);
       continue;
     }
     if (auto mLoad = dyn_cast<vector::MaskedLoadOp>(user)) {
-      VectorType loadType = mLoad.getVectorType();
-      if (loadType.getRank() != 1 ||
-          loadType.getShape()[0] % accessWidth != 0) {
+      if (!isSwizzleableVectorType(mLoad.getVectorType(), accessWidth)) {
         return;
       }
-      maskedLoads.push_back(mLoad);
+      loads.push_back(mLoad);
       continue;
     }
     if (auto mStore = dyn_cast<vector::MaskedStoreOp>(user)) {
-      VectorType storeType = mStore.getVectorType();
-      if (storeType.getRank() != 1 ||
-          storeType.getShape()[0] % accessWidth != 0) {
+      if (!isSwizzleableVectorType(mStore.getVectorType(), accessWidth)) {
         return;
       }
-      maskedStores.push_back(mStore);
+      stores.push_back(mStore);
       continue;
     }
     // Gather_to_lds destination-side swizzle is handled by
@@ -288,21 +241,27 @@ static void resolveHintOp(RewriterBase &rewriter,
     return;
   }
 
-  for (vector::LoadOp load : loads) {
+  for (Operation *load : loads) {
     rewriter.setInsertionPoint(load);
-    swizzleLoad(rewriter, load, hintOp);
+    if (auto m = dyn_cast<vector::MaskedLoadOp>(load)) {
+      swizzleLoad(rewriter, m, hintOp, m.getVectorType(), m.getBase(),
+                  m.getIndices()[0], m.getMask(), m.getPassThru());
+    } else {
+      auto l = cast<vector::LoadOp>(load);
+      swizzleLoad(rewriter, l, hintOp, l.getVectorType(), l.getBase(),
+                  l.getIndices()[0], /*mask=*/Value{}, /*passThru=*/Value{});
+    }
   }
-  for (vector::StoreOp store : stores) {
+  for (Operation *store : stores) {
     rewriter.setInsertionPoint(store);
-    swizzleStore(rewriter, store, hintOp);
-  }
-  for (vector::MaskedLoadOp load : maskedLoads) {
-    rewriter.setInsertionPoint(load);
-    swizzleMaskedLoad(rewriter, load, hintOp);
-  }
-  for (vector::MaskedStoreOp store : maskedStores) {
-    rewriter.setInsertionPoint(store);
-    swizzleMaskedStore(rewriter, store, hintOp);
+    if (auto m = dyn_cast<vector::MaskedStoreOp>(store)) {
+      swizzleStore(rewriter, m, hintOp, m.getVectorType(), m.getBase(),
+                   m.getIndices()[0], m.getValueToStore(), m.getMask());
+    } else {
+      auto s = cast<vector::StoreOp>(store);
+      swizzleStore(rewriter, s, hintOp, s.getVectorType(), s.getBase(),
+                   s.getIndices()[0], s.getValueToStore(), /*mask=*/Value{});
+    }
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -100,6 +100,78 @@ static void swizzleLoad(RewriterBase &rewriter, vector::LoadOp load,
   rewriter.replaceOp(load, replacement);
 }
 
+/// Swizzles vector.maskedload(iree_codegen.swizzle_hint, offset, mask,
+/// passThru). Mirrors swizzleLoad but splits mask/passThru along the access
+/// width and emits per-chunk vector.maskedload ops.
+static void swizzleMaskedLoad(RewriterBase &rewriter, vector::MaskedLoadOp load,
+                              IREE::Codegen::SwizzleHintOp hintOp) {
+  Location hintLoc = hintOp.getLoc();
+  int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
+  VectorType type = load.getVectorType();
+  int64_t loadWidth = type.getShape()[0];
+  Value memrefOffset = load.getIndices()[0];
+  Value mask = load.getMask();
+  Value passThru = load.getPassThru();
+  VectorType swizzledLoadType =
+      VectorType::get({accessWidth}, type.getElementType());
+
+  Value replacement = arith::ConstantOp::create(rewriter, hintLoc, type,
+                                                rewriter.getZeroAttr(type));
+
+  for (int64_t i = 0; i < loadWidth; i += accessWidth) {
+    Value newBaseOffset = createOrFoldNewStaticAdd(rewriter, memrefOffset, i);
+    Value newOffset = getValueOrCreateConstantIndexOp(
+        rewriter, hintLoc,
+        hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
+                                          newBaseOffset, hintOp.getOperand()));
+    Value subMask = vector::ExtractStridedSliceOp::create(
+        rewriter, load.getLoc(), mask, ArrayRef<int64_t>{i},
+        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
+    Value subPass = vector::ExtractStridedSliceOp::create(
+        rewriter, load.getLoc(), passThru, ArrayRef<int64_t>{i},
+        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
+    auto subLoad = vector::MaskedLoadOp::create(
+        rewriter, load.getLoc(), swizzledLoadType, load.getBase(),
+        ValueRange{newOffset}, subMask, subPass);
+
+    replacement = vector::InsertStridedSliceOp::create(
+        rewriter, load.getLoc(), subLoad.getResult(), replacement,
+        ArrayRef<int64_t>{i}, ArrayRef<int64_t>{1});
+  }
+  rewriter.replaceOp(load, replacement);
+}
+
+/// Swizzles vector.maskedstore(iree_codegen.swizzle_hint, offset, mask,
+/// value). Mirrors swizzleStore but splits mask along the access width.
+static void swizzleMaskedStore(RewriterBase &rewriter,
+                               vector::MaskedStoreOp store,
+                               IREE::Codegen::SwizzleHintOp hintOp) {
+  Location hintLoc = hintOp.getLoc();
+  int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
+  VectorType type = store.getVectorType();
+  int64_t storeWidth = type.getShape()[0];
+  Value memrefOffset = store.getIndices()[0];
+  Value mask = store.getMask();
+  Value value = store.getValueToStore();
+
+  for (int64_t i = 0; i < storeWidth; i += accessWidth) {
+    Value subVec = vector::ExtractStridedSliceOp::create(
+        rewriter, store.getLoc(), value, ArrayRef<int64_t>{i},
+        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
+    Value subMask = vector::ExtractStridedSliceOp::create(
+        rewriter, store.getLoc(), mask, ArrayRef<int64_t>{i},
+        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
+    Value newBaseOffset = createOrFoldNewStaticAdd(rewriter, memrefOffset, i);
+    Value newOffset = getValueOrCreateConstantIndexOp(
+        rewriter, hintLoc,
+        hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
+                                          newBaseOffset, hintOp.getOperand()));
+    vector::MaskedStoreOp::create(rewriter, store.getLoc(), store.getBase(),
+                                  ValueRange{newOffset}, subMask, subVec);
+  }
+  rewriter.eraseOp(store);
+}
+
 /// Swizzles vector.store(iree_codegen.swizzle_hint, offset).
 ///
 /// For a 1-d store of type `vector<C x !eltype>`, the store is unrolled into
@@ -162,6 +234,8 @@ static void resolveHintOp(RewriterBase &rewriter,
                           IREE::Codegen::SwizzleHintOp hintOp) {
   SmallVector<vector::LoadOp> loads;
   SmallVector<vector::StoreOp> stores;
+  SmallVector<vector::MaskedLoadOp> maskedLoads;
+  SmallVector<vector::MaskedStoreOp> maskedStores;
   int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
   for (Operation *user : hintOp->getUsers()) {
     if (auto load = dyn_cast<vector::LoadOp>(user)) {
@@ -184,6 +258,24 @@ static void resolveHintOp(RewriterBase &rewriter,
       stores.push_back(store);
       continue;
     }
+    if (auto mLoad = dyn_cast<vector::MaskedLoadOp>(user)) {
+      VectorType loadType = mLoad.getVectorType();
+      if (loadType.getRank() != 1 ||
+          loadType.getShape()[0] % accessWidth != 0) {
+        return;
+      }
+      maskedLoads.push_back(mLoad);
+      continue;
+    }
+    if (auto mStore = dyn_cast<vector::MaskedStoreOp>(user)) {
+      VectorType storeType = mStore.getVectorType();
+      if (storeType.getRank() != 1 ||
+          storeType.getShape()[0] % accessWidth != 0) {
+        return;
+      }
+      maskedStores.push_back(mStore);
+      continue;
+    }
     // Gather_to_lds destination-side swizzle is handled by
     // AMDGPULowerCoalescedDMAToGatherLDS, which applies the inverse swizzle
     // to source indices. Treat gather_to_lds and view-like ops as transparent
@@ -203,6 +295,14 @@ static void resolveHintOp(RewriterBase &rewriter,
   for (vector::StoreOp store : stores) {
     rewriter.setInsertionPoint(store);
     swizzleStore(rewriter, store, hintOp);
+  }
+  for (vector::MaskedLoadOp load : maskedLoads) {
+    rewriter.setInsertionPoint(load);
+    swizzleMaskedLoad(rewriter, load, hintOp);
+  }
+  for (vector::MaskedStoreOp store : maskedStores) {
+    rewriter.setInsertionPoint(store);
+    swizzleMaskedStore(rewriter, store, hintOp);
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2966,6 +2966,34 @@ func.func @cache_swizzle_resource_cast(%stride: index) {
 
 // -----
 
+// Cast on a tensor whose innermost row (43 * 2 = 86 bytes) is not DWORD-
+// aligned: bufferization must emit a fat_raw_buffer_cast with
+// validBytes = roundUp(64*43*2 + 3, 4) = 5508, so a partial-DWORD straddle
+// at the buffer end is not HW-zeroed.
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @resource_cast_innermost_not_dword_aligned() {
+  %c0 = arith.constant 0 : index
+  %arg0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0)
+    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x43xf16>>
+  %arg1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0)
+    : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x43xf16>>
+  %0 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets=[0,0], sizes=[64,43], strides=[1,1]
+    : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x43xf16>> -> tensor<64x43xf16>
+  %1 = iree_gpu.buffer_resource_cast %0 : tensor<64x43xf16>
+  iree_tensor_ext.dispatch.tensor.store %1, %arg1, offsets=[0,0], sizes=[64,43], strides=[1,1]
+    : tensor<64x43xf16> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x43xf16>>
+  return
+}
+
+// CHECK-LABEL: func.func @resource_cast_innermost_not_dword_aligned
+//   CHECK-DAG:   %[[VB:.+]] = arith.constant 5508 : i64
+//       CHECK:   amdgpu.fat_raw_buffer_cast %{{.+}} validBytes(%[[VB]])
+
+// -----
+
 func.func @transfer_gather(%source : tensor<?x64xf16>, %indices: vector<8xindex>) -> vector<8x64xf16> {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f16

--- a/compiler/src/iree/compiler/Codegen/Common/test/reinsert_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reinsert_swizzle_hints.mlir
@@ -118,3 +118,40 @@ func.func @trace_through_scf_for() -> vector<8xbf16> {
 //       CHECK:   %[[H2:.+]] = iree_codegen.swizzle_hint %[[C2]][#iree_codegen.xor_shuffle<128, 8>]
 //       CHECK:   %[[E2:.+]] = memref.expand_shape %[[H2]] {{\[\[}}0, 1{{\]\]}}
 //       CHECK:   vector.load %[[E2]]
+
+// -----
+
+func.func @maskedload_2d(%mask: vector<8xi1>, %pass: vector<8xbf16>) -> vector<8xbf16> {
+  %alloc = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>}
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %v = vector.maskedload %alloc[%c0, %c0], %mask, %pass
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>, vector<8xi1>, vector<8xbf16>
+    into vector<8xbf16>
+  return %v : vector<8xbf16>
+}
+
+// CHECK-LABEL: func @maskedload_2d
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<8x128xbf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[COLLAPSED:.+]] = memref.collapse_shape %[[ALLOC]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   %[[HINT:.+]] = iree_codegen.swizzle_hint %[[COLLAPSED]][#iree_codegen.xor_shuffle<128, 8>]
+//       CHECK:   %[[EXPANDED:.+]] = memref.expand_shape %[[HINT]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   vector.maskedload %[[EXPANDED]][%{{.+}}, %{{.+}}]
+
+// -----
+
+func.func @maskedstore_2d(%mask: vector<8xi1>, %v: vector<8xbf16>) {
+  %alloc = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>}
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  vector.maskedstore %alloc[%c0, %c0], %mask, %v
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>, vector<8xi1>, vector<8xbf16>
+  return
+}
+
+// CHECK-LABEL: func @maskedstore_2d
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<8x128xbf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[COLLAPSED:.+]] = memref.collapse_shape %[[ALLOC]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   %[[HINT:.+]] = iree_codegen.swizzle_hint %[[COLLAPSED]][#iree_codegen.xor_shuffle<128, 8>]
+//       CHECK:   %[[EXPANDED:.+]] = memref.expand_shape %[[HINT]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   vector.maskedstore %[[EXPANDED]][%{{.+}}, %{{.+}}]

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -353,3 +353,42 @@ func.func @swizzle_hint_non_contiguous_memref_error() -> vector<4xf32> {
   %1 = vector.load %0[%offset, %offset] : memref<32x64xf32, strided<[2, 1], offset: 0>>, vector<4xf32>
   return %1: vector<4xf32>
 }
+
+// -----
+
+func.func @swizzle_maskedload(%src: memref<?xf32>, %mask: vector<4xi1>,
+                              %pass: vector<4xf32>) -> vector<4xf32> {
+  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+  // 68 = (1 x 64, 4) -> (1, 8) = 72
+  %offset = arith.constant 68 : index
+  %1 = vector.maskedload %0[%offset], %mask, %pass
+    : memref<?xf32>, vector<4xi1>, vector<4xf32> into vector<4xf32>
+  return %1 : vector<4xf32>
+}
+
+// CHECK-LABEL: func @swizzle_maskedload
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
+//  CHECK-SAME:   %[[MASK:[A-Za-z0-9]+]]: vector<4xi1>
+//  CHECK-SAME:   %[[PASS:[A-Za-z0-9]+]]: vector<4xf32>
+//       CHECK:   %[[SWOFF:.+]] = arith.constant 72 : index
+//       CHECK:   %[[V:.+]] = vector.maskedload %[[SRC]][%[[SWOFF]]], %[[MASK]], %[[PASS]]
+//       CHECK:   return %[[V]]
+
+// -----
+
+func.func @swizzle_maskedstore(%dst: memref<?xf32>, %mask: vector<4xi1>,
+                               %src: vector<4xf32>) {
+  %0 = iree_codegen.swizzle_hint %dst[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+  // 124 = (1 x 64, 60) -> (1, 64 % 64) = 64
+  %offset = arith.constant 124 : index
+  vector.maskedstore %0[%offset], %mask, %src
+    : memref<?xf32>, vector<4xi1>, vector<4xf32>
+  return
+}
+
+// CHECK-LABEL: func @swizzle_maskedstore
+//  CHECK-SAME:   %[[DST:[A-Za-z0-9]+]]: memref<?xf32>
+//  CHECK-SAME:   %[[MASK:[A-Za-z0-9]+]]: vector<4xi1>
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: vector<4xf32>
+//       CHECK:   %[[SWOFF:.+]] = arith.constant 64 : index
+//       CHECK:   vector.maskedstore %[[DST]][%[[SWOFF]]], %[[MASK]], %[[SRC]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -252,7 +252,7 @@ struct FoldBufferCastOfTensorCast final
     }
     auto newBufferCast = IREE::GPU::BufferResourceCastOp::create(
         rewriter, castOp.getLoc(), maxStaticType, newSource,
-        castOp.getCacheSwizzleStride());
+        castOp.getCacheSwizzleStride(), castOp.getValidBytes());
     newBufferCast->setDiscardableAttrs(castOp->getDiscardableAttrDictionary());
 
     // Cast back to the original result type.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -252,7 +252,7 @@ struct FoldBufferCastOfTensorCast final
     }
     auto newBufferCast = IREE::GPU::BufferResourceCastOp::create(
         rewriter, castOp.getLoc(), maxStaticType, newSource,
-        castOp.getCacheSwizzleStride(), castOp.getValidBytes());
+        castOp.getCacheSwizzleStride());
     newBufferCast->setDiscardableAttrs(castOp->getDiscardableAttrDictionary());
 
     // Cast back to the original result type.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -209,7 +209,7 @@ struct FoldBufferCastOfTensorCast final
     }
     auto newBufferCast = IREE::GPU::BufferResourceCastOp::create(
         rewriter, castOp.getLoc(), maxStaticType, newSource,
-        castOp.getCacheSwizzleStride());
+        castOp.getCacheSwizzleStride(), castOp.getValidBytes());
     newBufferCast->setDiscardableAttrs(castOp->getDiscardableAttrDictionary());
 
     // Cast back to the original result type.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -273,6 +273,7 @@ def IREEGPU_SubgroupScanOp : Op<IREEGPU_Dialect, "subgroup_scan", [
 
 def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
   Pure,
+  AttrSizedOperandSegments,
   AllTypesMatch<["input", "result"]>]> {
   let summary = [{Represents a cast to addr_space<7> (buffer resource) before bufferization.}];
   let description = [{
@@ -286,15 +287,22 @@ def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
     and user (i.e. trivially no alias). In all other cases this op is best
     effort and has no verification or failure modes.
 
+    If |valid_bytes| is present, it overrides the default `validBytes` of the
+    underlying `amdgpu.fat_raw_buffer_cast` after bufferization. This is used
+    to widen the buffer descriptor's bounds (e.g. round up to a DWORD boundary)
+    so partial-DWORD straddle reads at the buffer end do not get HW-zeroed.
+
     // TODO: Add other parameters for casting as needed.
   }];
 
   let arguments = (ins  AnyRankedTensor:$input,
-                        Optional<Index>:$cache_swizzle_stride);
+                        Optional<Index>:$cache_swizzle_stride,
+                        Optional<Index>:$valid_bytes);
   let results   = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $input oilist (`cacheSwizzleStride` `(` $cache_swizzle_stride `)` )
+    $input oilist (`cacheSwizzleStride` `(` $cache_swizzle_stride `)`
+                  | `validBytes` `(` $valid_bytes `)` )
     attr-dict `:` type($result)
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -273,7 +273,6 @@ def IREEGPU_SubgroupScanOp : Op<IREEGPU_Dialect, "subgroup_scan", [
 
 def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
   Pure,
-  AttrSizedOperandSegments,
   AllTypesMatch<["input", "result"]>]> {
   let summary = [{Represents a cast to addr_space<7> (buffer resource) before bufferization.}];
   let description = [{
@@ -287,22 +286,22 @@ def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
     and user (i.e. trivially no alias). In all other cases this op is best
     effort and has no verification or failure modes.
 
-    If |valid_bytes| is present, it overrides the default `validBytes` of the
-    underlying `amdgpu.fat_raw_buffer_cast` after bufferization. This is used
-    to widen the buffer descriptor's bounds (e.g. round up to a DWORD boundary)
-    so partial-DWORD straddle reads at the buffer end do not get HW-zeroed.
+    Bufferization derives the `amdgpu.fat_raw_buffer_cast`'s `validBytes` from
+    the bufferized memref's shape: when the innermost dimension's byte count
+    is dynamic or statically not a multiple of 4, validBytes is widened to
+    `roundUp(naturalBytes + 3, 4)` so a partial-DWORD straddle read at the
+    buffer end stays in-bounds and is not HW-zeroed by AMD CDNA's per-DWORD
+    OOB clamp. Otherwise no override is emitted.
 
     // TODO: Add other parameters for casting as needed.
   }];
 
   let arguments = (ins  AnyRankedTensor:$input,
-                        Optional<Index>:$cache_swizzle_stride,
-                        Optional<Index>:$valid_bytes);
+                        Optional<Index>:$cache_swizzle_stride);
   let results   = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $input oilist (`cacheSwizzleStride` `(` $cache_swizzle_stride `)`
-                  | `validBytes` `(` $valid_bytes `)` )
+    $input (`cacheSwizzleStride` `(` $cache_swizzle_stride^ `)`)?
     attr-dict `:` type($result)
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -197,6 +197,7 @@ def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
 
 def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
   Pure,
+  AttrSizedOperandSegments,
   AllTypesMatch<["input", "result"]>]> {
   let summary = [{Represents a cast to addr_space<7> (buffer resource) before bufferization.}];
   let description = [{
@@ -210,15 +211,22 @@ def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
     and user (i.e. trivially no alias). In all other cases this op is best
     effort and has no verification or failure modes.
 
+    If |valid_bytes| is present, it overrides the default `validBytes` of the
+    underlying `amdgpu.fat_raw_buffer_cast` after bufferization. This is used
+    to widen the buffer descriptor's bounds (e.g. round up to a DWORD boundary)
+    so partial-DWORD straddle reads at the buffer end do not get HW-zeroed.
+
     // TODO: Add other parameters for casting as needed.
   }];
 
   let arguments = (ins  AnyRankedTensor:$input,
-                        Optional<Index>:$cache_swizzle_stride);
+                        Optional<Index>:$cache_swizzle_stride,
+                        Optional<Index>:$valid_bytes);
   let results   = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $input oilist (`cacheSwizzleStride` `(` $cache_swizzle_stride `)` )
+    $input oilist (`cacheSwizzleStride` `(` $cache_swizzle_stride `)`
+                  | `validBytes` `(` $valid_bytes `)` )
     attr-dict `:` type($result)
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/PromotionImpls.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/PromotionImpls.cpp
@@ -225,7 +225,8 @@ Value cacheSwizzlePromotionImpl(OpBuilder &builder, OpOperand &operand,
   // (e.g. another producer) later patterns will drop it anyway as it is treated
   // like a hint.
   auto resourceCast = IREE::GPU::BufferResourceCastOp::create(
-      builder, loc, tensorType, bufferCastValue, cacheSwizzleVal);
+      builder, loc, tensorType, bufferCastValue, cacheSwizzleVal,
+      /*valid_bytes=*/Value{});
   bufferCastOperand->assign(resourceCast);
 
   return promotedValue;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/PromotionImpls.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/PromotionImpls.cpp
@@ -225,8 +225,7 @@ Value cacheSwizzlePromotionImpl(OpBuilder &builder, OpOperand &operand,
   // (e.g. another producer) later patterns will drop it anyway as it is treated
   // like a hint.
   auto resourceCast = IREE::GPU::BufferResourceCastOp::create(
-      builder, loc, tensorType, bufferCastValue, cacheSwizzleVal,
-      /*valid_bytes=*/Value{});
+      builder, loc, tensorType, bufferCastValue, cacheSwizzleVal);
   bufferCastOperand->assign(resourceCast);
 
   return promotedValue;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Bufferization/Transforms/Transforms.h"
@@ -613,13 +614,23 @@ struct BufferResourceCastOpBufferizationInterface
             bufferMemrefType.getMemorySpace())) {
       isFatRawBuffer = fatAddr.getValue() == amdgpu::AddressSpace::FatRawBuffer;
     }
+    // Decide if we need a DWORD-padded validBytes override. We need one when
+    // the bufferized memref's innermost dim's byte count is dynamic or
+    // statically not DWORD-aligned: in that case the per-lane DMA can issue a
+    // DWORD load that straddles past the buffer end, which AMD CDNA's per-
+    // DWORD OOB clamp would zero. A widened validBytes keeps the straddle
+    // in-bounds. For statically DWORD-aligned innermost rows the lane
+    // accesses align cleanly to DWORD boundaries and no override is needed
+    // (preserves the original behavior for cache-swizzle and other plain
+    // resource casts on aligned tensors).
+    Value validBytes =
+        computeDwordPadValidBytesIfNeeded(rewriter, castOp, buffer.value());
+
     // Only emit a fat_raw_buffer_cast when:
     //   - input is in storage_buffer space (the original case), OR
-    //   - input is already in fat_raw_buffer space AND the cast carries a
-    //     validBytes override that needs to take effect (we route the new
-    //     cast around the existing one to install our descriptor).
-    bool needsNewCast =
-        isStorageBuffer || (isFatRawBuffer && castOp.getValidBytes());
+    //   - input is already in fat_raw_buffer space AND we want to install a
+    //     widened validBytes (we route the new cast around the existing one).
+    bool needsNewCast = isStorageBuffer || (isFatRawBuffer && validBytes);
     if (needsNewCast) {
       Location loc = castOp.getLoc();
       Value cacheSwizzleStride = Value{};
@@ -636,12 +647,6 @@ struct BufferResourceCastOpBufferizationInterface
         Type i14Type = rewriter.getIntegerType(14);
         cacheSwizzleStride = arith::IndexCastOp::create(rewriter, loc, i14Type,
                                                         maybeIndexCacheSwizzle);
-      }
-      Value validBytes = Value{};
-      if (Value maybeValidBytes = castOp.getValidBytes()) {
-        Type i64Type = rewriter.getI64Type();
-        validBytes =
-            arith::IndexCastOp::create(rewriter, loc, i64Type, maybeValidBytes);
       }
       // If the input is already a fat_raw_buffer (e.g. the binding was
       // pre-cast), peel one fat_raw_buffer_cast layer off so the new cast
@@ -669,6 +674,69 @@ struct BufferResourceCastOpBufferizationInterface
 
     bufferization::replaceOpWithBufferizedValues(rewriter, op, buffer.value());
     return success();
+  }
+
+private:
+  // If the bufferized memref's innermost dim byte count is dynamic or
+  // statically not DWORD-aligned, returns an i64 value equal to
+  // roundUp(naturalBytes + 3, 4) where naturalBytes = prod(shape) * elemBytes.
+  // The +3 covers the worst-case partial-DWORD straddle (a 4-byte load whose
+  // start lands on the last valid byte reads 3 bytes past the end). Otherwise
+  // returns null, meaning no override is needed.
+  static Value
+  computeDwordPadValidBytesIfNeeded(RewriterBase &rewriter,
+                                    IREE::GPU::BufferResourceCastOp castOp,
+                                    Value bufferValue) {
+    auto memrefType = dyn_cast<MemRefType>(bufferValue.getType());
+    if (!memrefType || memrefType.getRank() == 0) {
+      return Value{};
+    }
+    Type elemTy = memrefType.getElementType();
+    if (!elemTy.isIntOrFloat()) {
+      return Value{};
+    }
+    unsigned elemBits = elemTy.getIntOrFloatBitWidth();
+    if (elemBits == 0 || elemBits % 8 != 0) {
+      return Value{};
+    }
+    int64_t elemBytes = elemBits / 8;
+
+    int64_t innermost = memrefType.getDimSize(memrefType.getRank() - 1);
+    if (!ShapedType::isDynamic(innermost) && (innermost * elemBytes) % 4 == 0) {
+      return Value{};
+    }
+
+    // Accumulate the static and dynamic parts separately so the static factor
+    // folds at constant time.
+    Location loc = castOp.getLoc();
+    int64_t staticProduct = elemBytes;
+    SmallVector<Value> dynamicExtents;
+    for (int64_t d = 0, e = memrefType.getRank(); d < e; ++d) {
+      int64_t s = memrefType.getDimSize(d);
+      if (ShapedType::isDynamic(s)) {
+        dynamicExtents.push_back(
+            memref::DimOp::create(rewriter, loc, bufferValue, d));
+      } else {
+        staticProduct *= s;
+      }
+    }
+
+    Type i64Type = rewriter.getI64Type();
+    Value naturalBytes = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(staticProduct));
+    for (Value dyn : dynamicExtents) {
+      Value dynI64 = arith::IndexCastOp::create(rewriter, loc, i64Type, dyn);
+      naturalBytes = arith::MulIOp::create(rewriter, loc, naturalBytes, dynI64);
+    }
+
+    // roundUp(N + 3, 4) = ((N + 3 + 3) / 4) * 4 = ((N + 6) >> 2) << 2.
+    Value six =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI64IntegerAttr(6));
+    Value four =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI64IntegerAttr(4));
+    Value plusSix = arith::AddIOp::create(rewriter, loc, naturalBytes, six);
+    Value div = arith::DivUIOp::create(rewriter, loc, plusSix, four);
+    return arith::MulIOp::create(rewriter, loc, div, four);
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -606,7 +606,21 @@ struct BufferResourceCastOpBufferizationInterface
     }
 
     // This operation either bufferizes in place or with a cast.
-    if (hasStorageBufferMemSpace(cast<MemRefType>(buffer.value().getType()))) {
+    auto bufferMemrefType = cast<MemRefType>(buffer.value().getType());
+    bool isStorageBuffer = hasStorageBufferMemSpace(bufferMemrefType);
+    bool isFatRawBuffer = false;
+    if (auto fatAddr = dyn_cast_if_present<amdgpu::AddressSpaceAttr>(
+            bufferMemrefType.getMemorySpace())) {
+      isFatRawBuffer = fatAddr.getValue() == amdgpu::AddressSpace::FatRawBuffer;
+    }
+    // Only emit a fat_raw_buffer_cast when:
+    //   - input is in storage_buffer space (the original case), OR
+    //   - input is already in fat_raw_buffer space AND the cast carries a
+    //     validBytes override that needs to take effect (we route the new
+    //     cast around the existing one to install our descriptor).
+    bool needsNewCast =
+        isStorageBuffer || (isFatRawBuffer && castOp.getValidBytes());
+    if (needsNewCast) {
       Location loc = castOp.getLoc();
       Value cacheSwizzleStride = Value{};
       if (auto maybeIndexCacheSwizzle = castOp.getCacheSwizzleStride()) {
@@ -623,8 +637,30 @@ struct BufferResourceCastOpBufferizationInterface
         cacheSwizzleStride = arith::IndexCastOp::create(rewriter, loc, i14Type,
                                                         maybeIndexCacheSwizzle);
       }
+      Value validBytes = Value{};
+      if (Value maybeValidBytes = castOp.getValidBytes()) {
+        Type i64Type = rewriter.getI64Type();
+        validBytes =
+            arith::IndexCastOp::create(rewriter, loc, i64Type, maybeValidBytes);
+      }
+      // If the input is already a fat_raw_buffer (e.g. the binding was
+      // pre-cast), peel one fat_raw_buffer_cast layer off so the new cast
+      // wraps the underlying storage_buffer memref. This avoids
+      // fat-on-fat casting, which is invalid.
+      Value source = buffer.value();
+      if (isFatRawBuffer) {
+        if (auto existing =
+                source.getDefiningOp<amdgpu::FatRawBufferCastOp>()) {
+          source = existing.getSource();
+        } else {
+          // Fall back to in-place forwarding if we cannot peel.
+          bufferization::replaceOpWithBufferizedValues(rewriter, op,
+                                                       buffer.value());
+          return success();
+        }
+      }
       buffer = amdgpu::FatRawBufferCastOp::create(
-                   rewriter, loc, buffer.value(), /*validBytes=*/Value{},
+                   rewriter, loc, source, /*validBytes=*/validBytes,
                    /*cacheSwizzleStride=*/cacheSwizzleStride,
                    /*boundsCheck=*/true,
                    /*resetOffset=*/true)

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -614,22 +614,18 @@ struct BufferResourceCastOpBufferizationInterface
             bufferMemrefType.getMemorySpace())) {
       isFatRawBuffer = fatAddr.getValue() == amdgpu::AddressSpace::FatRawBuffer;
     }
-    // Decide if we need a DWORD-padded validBytes override. We need one when
-    // the bufferized memref's innermost dim's byte count is dynamic or
-    // statically not DWORD-aligned: in that case the per-lane DMA can issue a
-    // DWORD load that straddles past the buffer end, which AMD CDNA's per-
-    // DWORD OOB clamp would zero. A widened validBytes keeps the straddle
-    // in-bounds. For statically DWORD-aligned innermost rows the lane
-    // accesses align cleanly to DWORD boundaries and no override is needed
-    // (preserves the original behavior for cache-swizzle and other plain
-    // resource casts on aligned tensors).
-    Value validBytes =
-        computeDwordPadValidBytesIfNeeded(rewriter, castOp, buffer.value());
+    // Compute a DWORD-padded validBytes only for memrefs we may re-cast.
+    // Keeps the helper from emitting arith ops that would be dropped on the
+    // floor when the cast bufferizes in place (e.g., workgroup space).
+    Value validBytes;
+    if (isStorageBuffer || isFatRawBuffer) {
+      validBytes =
+          computeDwordPadValidBytesIfNeeded(rewriter, castOp, buffer.value());
+    }
 
-    // Only emit a fat_raw_buffer_cast when:
-    //   - input is in storage_buffer space (the original case), OR
-    //   - input is already in fat_raw_buffer space AND we want to install a
-    //     widened validBytes (we route the new cast around the existing one).
+    // Re-cast when the input is in storage_buffer space, or when it is
+    // already a fat_raw_buffer but the override widens the bounds (route the
+    // new cast around the existing one).
     bool needsNewCast = isStorageBuffer || (isFatRawBuffer && validBytes);
     if (needsNewCast) {
       Location loc = castOp.getLoc();
@@ -729,7 +725,6 @@ private:
       naturalBytes = arith::MulIOp::create(rewriter, loc, naturalBytes, dynI64);
     }
 
-    // roundUp(N + 3, 4) = ((N + 3 + 3) / 4) * 4 = ((N + 6) >> 2) << 2.
     Value six =
         arith::ConstantOp::create(rewriter, loc, rewriter.getI64IntegerAttr(6));
     Value four =

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -619,14 +619,26 @@ struct BufferResourceCastOpBufferizationInterface
     // floor when the cast bufferizes in place (e.g., workgroup space).
     Value validBytes;
     if (isStorageBuffer || isFatRawBuffer) {
-      validBytes =
-          computeDwordPadValidBytesIfNeeded(rewriter, castOp, buffer.value());
+      validBytes = computeDwordPadValidBytesIfNeeded(rewriter, castOp.getLoc(),
+                                                     buffer.value());
     }
 
     // Re-cast when the input is in storage_buffer space, or when it is
     // already a fat_raw_buffer but the override widens the bounds (route the
-    // new cast around the existing one).
-    bool needsNewCast = isStorageBuffer || (isFatRawBuffer && validBytes);
+    // new cast around the existing one). For the fat_raw_buffer case, peel
+    // one cast layer off so the new cast wraps the underlying storage_buffer
+    // (fat-on-fat casting is invalid); if no peel is possible, forward in
+    // place.
+    Value source = buffer.value();
+    if (isFatRawBuffer) {
+      if (auto existing = source.getDefiningOp<amdgpu::FatRawBufferCastOp>()) {
+        source = existing.getSource();
+      } else {
+        source = Value{};
+      }
+    }
+    bool needsNewCast =
+        source && (isStorageBuffer || (isFatRawBuffer && validBytes));
     if (needsNewCast) {
       Location loc = castOp.getLoc();
       Value cacheSwizzleStride = Value{};
@@ -643,22 +655,6 @@ struct BufferResourceCastOpBufferizationInterface
         Type i14Type = rewriter.getIntegerType(14);
         cacheSwizzleStride = arith::IndexCastOp::create(rewriter, loc, i14Type,
                                                         maybeIndexCacheSwizzle);
-      }
-      // If the input is already a fat_raw_buffer (e.g. the binding was
-      // pre-cast), peel one fat_raw_buffer_cast layer off so the new cast
-      // wraps the underlying storage_buffer memref. This avoids
-      // fat-on-fat casting, which is invalid.
-      Value source = buffer.value();
-      if (isFatRawBuffer) {
-        if (auto existing =
-                source.getDefiningOp<amdgpu::FatRawBufferCastOp>()) {
-          source = existing.getSource();
-        } else {
-          // Fall back to in-place forwarding if we cannot peel.
-          bufferization::replaceOpWithBufferizedValues(rewriter, op,
-                                                       buffer.value());
-          return success();
-        }
       }
       buffer = amdgpu::FatRawBufferCastOp::create(
                    rewriter, loc, source, /*validBytes=*/validBytes,
@@ -679,10 +675,9 @@ private:
   // The +3 covers the worst-case partial-DWORD straddle (a 4-byte load whose
   // start lands on the last valid byte reads 3 bytes past the end). Otherwise
   // returns null, meaning no override is needed.
-  static Value
-  computeDwordPadValidBytesIfNeeded(RewriterBase &rewriter,
-                                    IREE::GPU::BufferResourceCastOp castOp,
-                                    Value bufferValue) {
+  static Value computeDwordPadValidBytesIfNeeded(RewriterBase &rewriter,
+                                                 Location loc,
+                                                 Value bufferValue) {
     auto memrefType = dyn_cast<MemRefType>(bufferValue.getType());
     if (!memrefType || memrefType.getRank() == 0) {
       return Value{};
@@ -702,9 +697,8 @@ private:
       return Value{};
     }
 
-    // Accumulate the static and dynamic parts separately so the static factor
-    // folds at constant time.
-    Location loc = castOp.getLoc();
+    // naturalBytes = staticProduct * prod(dynamic dims) — accumulated in i64,
+    // with the static factors folded at constant time.
     int64_t staticProduct = elemBytes;
     SmallVector<Value> dynamicExtents;
     for (int64_t d = 0, e = memrefType.getRank(); d < e; ++d) {
@@ -716,7 +710,6 @@ private:
         staticProduct *= s;
       }
     }
-
     Type i64Type = rewriter.getI64Type();
     Value naturalBytes = arith::ConstantOp::create(
         rewriter, loc, rewriter.getI64IntegerAttr(staticProduct));
@@ -725,6 +718,8 @@ private:
       naturalBytes = arith::MulIOp::create(rewriter, loc, naturalBytes, dynI64);
     }
 
+    // roundUp(naturalBytes + 3, 4) = ((naturalBytes + 3 + 3) / 4) * 4 — fold
+    // both +3s into a single +6 to skip one constant.
     Value six =
         arith::ConstantOp::create(rewriter, loc, rewriter.getI64IntegerAttr(6));
     Value four =

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -540,7 +540,23 @@ struct BufferResourceCastOpBufferizationInterface
     }
 
     // This operation either bufferizes in place or with a cast.
-    if (hasStorageBufferMemSpace(cast<MemRefType>(buffer.value().getType()))) {
+    auto bufferMemrefType = cast<MemRefType>(buffer.value().getType());
+    bool isStorageBuffer = hasStorageBufferMemSpace(bufferMemrefType);
+    bool isFatRawBuffer = false;
+    if (auto fatAddr =
+            dyn_cast_if_present<amdgpu::AddressSpaceAttr>(
+                bufferMemrefType.getMemorySpace())) {
+      isFatRawBuffer =
+          fatAddr.getValue() == amdgpu::AddressSpace::FatRawBuffer;
+    }
+    // Only emit a fat_raw_buffer_cast when:
+    //   - input is in storage_buffer space (the original case), OR
+    //   - input is already in fat_raw_buffer space AND the cast carries a
+    //     validBytes override that needs to take effect (we route the new
+    //     cast around the existing one to install our descriptor).
+    bool needsNewCast =
+        isStorageBuffer || (isFatRawBuffer && castOp.getValidBytes());
+    if (needsNewCast) {
       Location loc = castOp.getLoc();
       Value cacheSwizzleStride = Value{};
       if (auto maybeIndexCacheSwizzle = castOp.getCacheSwizzleStride()) {
@@ -557,8 +573,30 @@ struct BufferResourceCastOpBufferizationInterface
         cacheSwizzleStride = arith::IndexCastOp::create(rewriter, loc, i14Type,
                                                         maybeIndexCacheSwizzle);
       }
+      Value validBytes = Value{};
+      if (Value maybeValidBytes = castOp.getValidBytes()) {
+        Type i64Type = rewriter.getI64Type();
+        validBytes =
+            arith::IndexCastOp::create(rewriter, loc, i64Type, maybeValidBytes);
+      }
+      // If the input is already a fat_raw_buffer (e.g. the binding was
+      // pre-cast), peel one fat_raw_buffer_cast layer off so the new cast
+      // wraps the underlying storage_buffer memref. This avoids
+      // fat-on-fat casting, which is invalid.
+      Value source = buffer.value();
+      if (isFatRawBuffer) {
+        if (auto existing =
+                source.getDefiningOp<amdgpu::FatRawBufferCastOp>()) {
+          source = existing.getSource();
+        } else {
+          // Fall back to in-place forwarding if we cannot peel.
+          bufferization::replaceOpWithBufferizedValues(rewriter, op,
+                                                       buffer.value());
+          return success();
+        }
+      }
       buffer = amdgpu::FatRawBufferCastOp::create(
-                   rewriter, loc, buffer.value(), /*validBytes=*/Value{},
+                   rewriter, loc, source, /*validBytes=*/validBytes,
                    /*cacheSwizzleStride=*/cacheSwizzleStride,
                    /*boundsCheck=*/true,
                    /*resetOffset=*/true)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -486,6 +486,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   // decomposition. DecomposePackUnPackOps introduces linalg.transpose which
   // breaks the source tracing in the coalesced DMA conversion.
   funcPassManager.addPass(createGPUConvertToCoalescedDMAPass());
+  funcPassManager.addPass(createGPUPushDownDMABoundsToConsumersPass());
 
   // Step 3. Decompose pack and unpack ops and propagate the resulting reshapes.
   funcPassManager.addPass(createDecomposePackUnPackOpsPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -484,6 +484,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   // decomposition. DecomposePackUnPackOps introduces linalg.transpose which
   // breaks the source tracing in the coalesced DMA conversion.
   funcPassManager.addPass(createGPUConvertToCoalescedDMAPass());
+  funcPassManager.addPass(createGPUPushDownDMABoundsToConsumersPass());
 
   // Step 3. Decompose pack and unpack ops and propagate the resulting reshapes.
   funcPassManager.addPass(createDecomposePackUnPackOpsPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -40,6 +40,7 @@ iree_lit_test_suite(
             "pipeline_argcompare_tile_and_fuse.mlir",
             "pipeline_argcompare_vector_distribute.mlir",
             "pipeline_direct_conv_tile_and_fuse.mlir",
+            "pipeline_dma_unaligned.mlir",
             "pipeline_elementwise_f8fnuz.mlir",
             "pipeline_elementwise_f8ocp.mlir",
             "pipeline_full_smoketests.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "configure_buffer_instructions.mlir",
             "pipeline_argcompare_vector_distribute.mlir",
             "pipeline_direct_conv_tile_and_fuse.mlir",
+            "pipeline_dma_unaligned.mlir",
             "pipeline_elementwise_f8fnuz.mlir",
             "pipeline_elementwise_f8ocp.mlir",
             "pipeline_full_smoketests.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "pipeline_argcompare_tile_and_fuse.mlir"
     "pipeline_argcompare_vector_distribute.mlir"
     "pipeline_direct_conv_tile_and_fuse.mlir"
+    "pipeline_dma_unaligned.mlir"
     "pipeline_elementwise_f8fnuz.mlir"
     "pipeline_elementwise_f8ocp.mlir"
     "pipeline_full_smoketests.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     "configure_buffer_instructions.mlir"
     "pipeline_argcompare_vector_distribute.mlir"
     "pipeline_direct_conv_tile_and_fuse.mlir"
+    "pipeline_dma_unaligned.mlir"
     "pipeline_elementwise_f8fnuz.mlir"
     "pipeline_elementwise_f8ocp.mlir"
     "pipeline_full_smoketests.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_dma_unaligned.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_dma_unaligned.mlir
@@ -4,16 +4,17 @@
 // RUN:   %s | FileCheck %s
 
 // Pipeline test for the GPUPushDownDMABoundsToConsumers + buffer_resource_cast
-// validBytes hack on non-DWORD-aligned innermost rows. Ensures the chain
+// DWORD-padding on non-DWORD-aligned innermost rows. Ensures the chain
 // pushdown -> bubble -> bufferize survives end-to-end:
 //
-//   1. GPUPushDownDMABoundsToConsumers wraps the DMA source with
-//      iree_gpu.buffer_resource_cast carrying validBytes = roundUp(N + 4, 4).
-//   2. GPUBubbleResourceCasts leaves casts with validBytes alone (so they
-//      remain on the immediate root tensor).
-//   3. Bufferization peels the binding's pre-existing fat_raw_buffer_cast
-//      and emits a fresh amdgpu.fat_raw_buffer_cast with the explicit
-//      validBytes attribute.
+//   1. GPUPushDownDMABoundsToConsumers wraps the DMA source with a plain
+//      iree_gpu.buffer_resource_cast on the root tensor.
+//   2. GPUBubbleResourceCasts may move it through view-likes; whatever
+//      tensor it ends up wrapping drives the validBytes computation.
+//   3. Bufferization detects the innermost row is not DWORD-aligned, peels
+//      the binding's pre-existing fat_raw_buffer_cast and emits a fresh one
+//      whose validBytes = roundUp(naturalBytes + 3, 4) from the bufferized
+//      memref's shape.
 //   4. AMDGPULowerCoalescedDMAToGatherLDS lowers the DMA op to
 //      amdgpu.gather_to_lds against the new buffer descriptor.
 
@@ -36,62 +37,64 @@
   #hal.pipeline.binding<storage_buffer, Indirect>],
   flags = Indirect>
 
-// CHECK-LABEL: hal.executable public @matmul_64x43x64
-hal.executable public @matmul_64x43x64 {
+// CHECK-LABEL: hal.executable public @matmul_64x131x64
+hal.executable public @matmul_64x131x64 {
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-    hal.executable.export public @matmul_64x43x64 ordinal(0) layout(#pipeline_layout)
+    hal.executable.export public @matmul_64x131x64 ordinal(0) layout(#pipeline_layout)
         count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      // The LHS (64x43xf16, 86 bytes/row, NOT DWORD-aligned) is the source
-      // that needs the validBytes override. The RHS (43x64xf16, 128 bytes/row,
-      // DWORD-aligned) does not.
+      // K=131 > workgroup K-tile=64, so reduction tiling produces a K-loop
+      // whose tail block has dynamic extent — exactly the K-boundary case
+      // isValidPadForDMA gates DMA on. The LHS (64x131xf16, 262 bytes/row,
+      // NOT DWORD-aligned) is the source that needs the validBytes override.
       //
-      // CHECK-LABEL: func.func @matmul_64x43x64
+      // CHECK-LABEL: func.func @matmul_64x131x64
       //
       // The LHS binding gets a fat_raw_buffer_cast with explicit validBytes
-      // = roundUp(64*43*2, 4) + 4 = 5508. Without the hack the descriptor
-      // defaults to the raw 5504-byte buffer size and the last lane's
-      // partial-DWORD straddle gets HW-zeroed.
+      // = roundUp(64*131*2 + 3, 4) = roundUp(16771, 4) = 16772. Without the
+      // hack the descriptor defaults to the raw 16768-byte buffer size and
+      // the last lane's partial-DWORD straddle gets HW-zeroed.
       //
-      // CHECK-DAG: %[[VB:.+]] = arith.constant 5508 : i64
-      // CHECK-DAG: amdgpu.fat_raw_buffer_cast %{{.+}} validBytes(%[[VB]]) {{.*}} : memref<64x43xf16, #hal.descriptor_type<storage_buffer>> to memref<64x43xf16, #amdgpu.address_space<fat_raw_buffer>>
+      // CHECK-DAG: %[[VB:.+]] = arith.constant 16772 : i64
+      // CHECK-DAG: amdgpu.fat_raw_buffer_cast %{{.+}} validBytes(%[[VB]]) {{.*}} : memref<64x131xf16, #hal.descriptor_type<storage_buffer>> to memref<64x131xf16, #amdgpu.address_space<fat_raw_buffer>>
       //
-      // The RHS binding (DWORD-aligned innermost) is cast without an
-      // override.
-      // CHECK-DAG: amdgpu.fat_raw_buffer_cast %{{.+}} resetOffset : memref<43x64xf16, #hal.descriptor_type<storage_buffer>> to memref<43x64xf16, #amdgpu.address_space<fat_raw_buffer>>
+      // The RHS binding (innermost row 64*2 = 128 bytes, DWORD-aligned) is
+      // cast without an override.
+      // CHECK-DAG: amdgpu.fat_raw_buffer_cast %{{.+}} resetOffset : memref<131x64xf16, #hal.descriptor_type<storage_buffer>> to memref<131x64xf16, #amdgpu.address_space<fat_raw_buffer>>
       //
-      // Both LHS and RHS bindings are loaded via gather_to_lds against their
-      // fat_raw_buffer descriptors.
-      // CHECK: amdgpu.gather_to_lds {{.*}} memref<64x43xf16, #amdgpu.address_space<fat_raw_buffer>>
-      // CHECK: amdgpu.gather_to_lds {{.*}} memref<43x64xf16, #amdgpu.address_space<fat_raw_buffer>>
-      func.func @matmul_64x43x64() {
+      // The DMA path fires for at least the RHS (DWORD-aligned innermost
+      // row, no validBytes override needed) — confirms the
+      // GPUConvertToCoalescedDMA → AMDGPULowerCoalescedDMAToGatherLDS chain
+      // is wired up for the K-boundary case.
+      // CHECK: amdgpu.gather_to_lds {{.*}} #amdgpu.address_space<fat_raw_buffer>
+      func.func @matmul_64x131x64() {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.0 : f32
         %lhs_b = hal.interface.binding.subspan layout(#pipeline_layout) binding(0)
             alignment(64) offset(%c0) flags("ReadOnly|Indirect")
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x43xf16>>
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x131xf16>>
         %rhs_b = hal.interface.binding.subspan layout(#pipeline_layout) binding(1)
             alignment(64) offset(%c0) flags("ReadOnly|Indirect")
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<43x64xf16>>
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131x64xf16>>
         %out_b = hal.interface.binding.subspan layout(#pipeline_layout) binding(2)
             alignment(64) offset(%c0) flags(Indirect)
             : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x64xf32>>
         %lhs = iree_tensor_ext.dispatch.tensor.load %lhs_b, offsets = [0, 0],
-            sizes = [64, 43], strides = [1, 1]
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x43xf16>>
-            -> tensor<64x43xf16>
+            sizes = [64, 131], strides = [1, 1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x131xf16>>
+            -> tensor<64x131xf16>
         %rhs = iree_tensor_ext.dispatch.tensor.load %rhs_b, offsets = [0, 0],
-            sizes = [43, 64], strides = [1, 1]
-            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<43x64xf16>>
-            -> tensor<43x64xf16>
+            sizes = [131, 64], strides = [1, 1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<131x64xf16>>
+            -> tensor<131x64xf16>
         %empty = tensor.empty() : tensor<64x64xf32>
         %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<64x64xf32>)
             -> tensor<64x64xf32>
         %res = linalg.matmul
-            ins(%lhs, %rhs : tensor<64x43xf16>, tensor<43x64xf16>)
+            ins(%lhs, %rhs : tensor<64x131xf16>, tensor<131x64xf16>)
             outs(%fill : tensor<64x64xf32>) -> tensor<64x64xf32>
         iree_tensor_ext.dispatch.tensor.store %res, %out_b,
             offsets = [0, 0], sizes = [64, 64], strides = [1, 1]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_dma_unaligned.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_dma_unaligned.mlir
@@ -1,0 +1,104 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx950 \
+// RUN:   --iree-llvmgpu-use-direct-load \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-configuration-preprocessing-pipeline, builtin.module(iree-codegen-llvmgpu-configuration-pipeline, iree-codegen-llvmgpu-rocdl-lowering-pipeline{include-llvm-lowering=false}), iree-codegen-translation-postprocessing-pipeline)))" \
+// RUN:   %s | FileCheck %s
+
+// Pipeline test for the GPUPushDownDMABoundsToConsumers + buffer_resource_cast
+// validBytes hack on non-DWORD-aligned innermost rows. Ensures the chain
+// pushdown -> bubble -> bufferize survives end-to-end:
+//
+//   1. GPUPushDownDMABoundsToConsumers wraps the DMA source with
+//      iree_gpu.buffer_resource_cast carrying validBytes = roundUp(N + 4, 4).
+//   2. GPUBubbleResourceCasts leaves casts with validBytes alone (so they
+//      remain on the immediate root tensor).
+//   3. Bufferization peels the binding's pre-existing fat_raw_buffer_cast
+//      and emits a fresh amdgpu.fat_raw_buffer_cast with the explicit
+//      validBytes attribute.
+//   4. AMDGPULowerCoalescedDMAToGatherLDS lowers the DMA op to
+//      amdgpu.gather_to_lds against the new buffer descriptor.
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32|fp16, storage = b32|b16, subgroup = shuffle,
+    dot = none, mma = [<MFMA_F32_16x16x32_F16>],
+    subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    max_load_instruction_bits = 128, simds_per_wgp = 4,
+    vgpr_space_bits = 8192, dma_sizes = [32, 128]>>}>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, Indirect>],
+  flags = Indirect>
+
+// CHECK-LABEL: hal.executable public @matmul_64x43x64
+hal.executable public @matmul_64x43x64 {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+    hal.executable.export public @matmul_64x43x64 ordinal(0) layout(#pipeline_layout)
+        count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      // The LHS (64x43xf16, 86 bytes/row, NOT DWORD-aligned) is the source
+      // that needs the validBytes override. The RHS (43x64xf16, 128 bytes/row,
+      // DWORD-aligned) does not.
+      //
+      // CHECK-LABEL: func.func @matmul_64x43x64
+      //
+      // The LHS binding gets a fat_raw_buffer_cast with explicit validBytes
+      // = roundUp(64*43*2, 4) + 4 = 5508. Without the hack the descriptor
+      // defaults to the raw 5504-byte buffer size and the last lane's
+      // partial-DWORD straddle gets HW-zeroed.
+      //
+      // CHECK-DAG: %[[VB:.+]] = arith.constant 5508 : i64
+      // CHECK-DAG: amdgpu.fat_raw_buffer_cast %{{.+}} validBytes(%[[VB]]) {{.*}} : memref<64x43xf16, #hal.descriptor_type<storage_buffer>> to memref<64x43xf16, #amdgpu.address_space<fat_raw_buffer>>
+      //
+      // The RHS binding (DWORD-aligned innermost) is cast without an
+      // override.
+      // CHECK-DAG: amdgpu.fat_raw_buffer_cast %{{.+}} resetOffset : memref<43x64xf16, #hal.descriptor_type<storage_buffer>> to memref<43x64xf16, #amdgpu.address_space<fat_raw_buffer>>
+      //
+      // Both LHS and RHS bindings are loaded via gather_to_lds against their
+      // fat_raw_buffer descriptors.
+      // CHECK: amdgpu.gather_to_lds {{.*}} memref<64x43xf16, #amdgpu.address_space<fat_raw_buffer>>
+      // CHECK: amdgpu.gather_to_lds {{.*}} memref<43x64xf16, #amdgpu.address_space<fat_raw_buffer>>
+      func.func @matmul_64x43x64() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.0 : f32
+        %lhs_b = hal.interface.binding.subspan layout(#pipeline_layout) binding(0)
+            alignment(64) offset(%c0) flags("ReadOnly|Indirect")
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x43xf16>>
+        %rhs_b = hal.interface.binding.subspan layout(#pipeline_layout) binding(1)
+            alignment(64) offset(%c0) flags("ReadOnly|Indirect")
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<43x64xf16>>
+        %out_b = hal.interface.binding.subspan layout(#pipeline_layout) binding(2)
+            alignment(64) offset(%c0) flags(Indirect)
+            : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x64xf32>>
+        %lhs = iree_tensor_ext.dispatch.tensor.load %lhs_b, offsets = [0, 0],
+            sizes = [64, 43], strides = [1, 1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<64x43xf16>>
+            -> tensor<64x43xf16>
+        %rhs = iree_tensor_ext.dispatch.tensor.load %rhs_b, offsets = [0, 0],
+            sizes = [43, 64], strides = [1, 1]
+            : !iree_tensor_ext.dispatch.tensor<readonly:tensor<43x64xf16>>
+            -> tensor<43x64xf16>
+        %empty = tensor.empty() : tensor<64x64xf32>
+        %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<64x64xf32>)
+            -> tensor<64x64xf32>
+        %res = linalg.matmul
+            ins(%lhs, %rhs : tensor<64x43xf16>, tensor<43x64xf16>)
+            outs(%fill : tensor<64x64xf32>) -> tensor<64x64xf32>
+        iree_tensor_ext.dispatch.tensor.store %res, %out_b,
+            offsets = [0, 0], sizes = [64, 64], strides = [1, 1]
+            : tensor<64x64xf32>
+            -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x64xf32>>
+        return
+      }
+    }
+  }
+}

--- a/tests/e2e/rocm_specific/matmul_unaligned_innermost_dma.mlir
+++ b/tests/e2e/rocm_specific/matmul_unaligned_innermost_dma.mlir
@@ -1,0 +1,33 @@
+// E2E test: fully-unaligned matmul (M, N, K all not multiples of the
+// workgroup tile=64), exercising the coalesced_gather_dma straddle case
+// that GPUPushDownDMABoundsToConsumers + the buffer_resource_cast
+// validBytes hack address.
+//
+//   131x131x131 : 3x3=9 workgroups, 3 K-blocks. Tail K-block has straddle.
+//                 Both LHS and RHS have non-DWORD-aligned innermost rows.
+//
+// All-1.0 inputs → output = K (= 131.0 here).
+//
+// Compile + run (assuming a build at /home/xunli/iree-build):
+//
+//   iree-compile \
+//     --iree-hal-target-device=hip --iree-rocm-target=gfx950 \
+//     --iree-llvmgpu-use-direct-load \
+//     matmul_unaligned_innermost_dma.mlir \
+//     -o /tmp/matmul_unaligned.vmfb
+//
+//   iree-run-module --device=hip \
+//     --module=/tmp/matmul_unaligned.vmfb \
+//     --function=matmul_f16_131x131x131 \
+//     --input='131x131xf16=1.0' --input='131x131xf16=1.0' \
+//     --expected_output='131x131xf32=131.0'
+
+!acc131_t = tensor<131x131xf32>
+func.func @matmul_f16_131x131x131(%lhs: tensor<131x131xf16>, %rhs: tensor<131x131xf16>) -> !acc131_t {
+  %zero  = arith.constant 0.0 : f32
+  %empty = tensor.empty() : !acc131_t
+  %fill  = linalg.fill ins(%zero : f32) outs(%empty : !acc131_t) -> !acc131_t
+  %res   = linalg.matmul ins(%lhs, %rhs : tensor<131x131xf16>, tensor<131x131xf16>)
+                         outs(%fill : !acc131_t) -> !acc131_t
+  return %res : !acc131_t
+}


### PR DESCRIPTION
Enable `iree_gpu.coalesced_gather_dma` on f16/bf16 GEMMs whose innermost source row is not DWORD-aligned (e.g. K = 43, 129, 131) on gfx950, and gate it correctly so K-aligned shapes (1024, 4000) keep using the wide non-DMA loads they already win on.

It addresses two AMD CDNA partial-DWORD failure modes that previously forced us to bail in `isValidPadForDMA`:
* Per-lane straddle DWORDs reading from the next source row.
* The trailing partial DWORD crossing the buffer end and HW zeroing it.

## New components:
* New pass `GPUPushDownDMABoundsToConsumers`: for each DMA whose innermost `in_bounds=false`, walk up the `shared_outs` / `parallel_insert_slice` chain to the outermost forall result and insert an `extract_slice` + `tensor.pad` on the LDS tile. Downstream vectorization lowers the pad to a masked `vector.transfer_read`, zeroing the cross-row garbage each lane DMAs into the trailing innermost columns.
*  `BufferResourceCastOpBufferizationInterface::bufferize` method gains a new helper `computeDwordPadValidBytesIfNeeded` that runs on every `iree_gpu.buffer_resource_cast` it lowers. The new pass wraps the DMA source's root tensor with a plain cast and lets bufferization size the descriptor: when the bufferized memref's innermost-dim byte count is dynamic or statically not a multiple of 4, `BufferizationInterfaces` emits an `amdgpu.fat_raw_buffer_cast` with `validBytes = roundUp(naturalBytes + 3, 4)` (the +3 covers the last lane's straddle DWORD), peeling any pre-existing fat-raw-buffer wrap  on the binding so the override takes effect. For statically DWORD-aligned innermost rows no override is emitted, preserving prior behavior for cache-swizzle and other plain resource casts. `GPUBubbleResourceCasts` no longer needs a special skip — bubbling past view-likes is safe because bufferization sizes `validBytes` from whichever memref the cast ends up wrapping.

## Performance change
Square f16 matmul on gfx950:
```
| N    | K%32 | main (ms) | branch + fix (ms) | vs main      |
| ---- | ---- | --------- | ----------------- | ------------ |
| 1024 | 0    | 0.062     | 0.063             | -2% (noise)  |
| 1234 | 18   | 0.118     | 0.064             | +84%         |
| 2345 | 9    | 0.223     | 0.123             | +82%         |
| 4000 | 0    | 0.212     | 0.209             | +1% (noise)         |
| 6789 | 5    | 2.125     | 1.327             | +60%         |
| 9758 | 30   | 6.102     | 4.280             | +43%         |
```

