### PR TITLE
[HAL] Add executable global lookup buffers

### DIFF
--- a/runtime/src/iree/hal/cts/core/executable_test.cc
+++ b/runtime/src/iree/hal/cts/core/executable_test.cc
@@ -11,6 +11,7 @@
 namespace iree::hal::cts {
 
 using iree::testing::status::StatusIs;
+using ::testing::AnyOf;
 
 class ExecutableTest : public CtsTestBase<> {
  protected:
@@ -135,6 +136,16 @@ TEST_P(ExecutableTest, LookupExportByName) {
   IREE_ASSERT_OK(iree_hal_executable_lookup_export_by_name(
       executable_, IREE_SV("export0"), &ordinal));
   EXPECT_EQ(ordinal, 0);
+}
+
+TEST_P(ExecutableTest, LookupGlobalByNameNotFoundOrUnsupported) {
+  iree_hal_buffer_t* buffer = nullptr;
+  EXPECT_THAT(Status(iree_hal_executable_lookup_global_by_name(
+                  executable_, IREE_SV("NOT_FOUND"),
+                  IREE_HAL_QUEUE_AFFINITY_ANY, &buffer)),
+              AnyOf(StatusIs(StatusCode::kNotFound),
+                    StatusIs(StatusCode::kUnimplemented)));
+  EXPECT_EQ(buffer, nullptr);
 }
 
 CTS_REGISTER_EXECUTABLE_TEST_SUITE(ExecutableTest);

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -7,6 +7,7 @@
 #include "iree/hal/drivers/amdgpu/executable.h"
 
 #include "iree/base/internal/debugging.h"
+#include "iree/hal/drivers/amdgpu/buffer.h"
 #include "iree/hal/drivers/amdgpu/queue_affinity.h"
 #include "iree/hal/drivers/amdgpu/util/code_object_target.h"
 #include "iree/hal/drivers/amdgpu/util/hsaco_metadata.h"
@@ -803,7 +804,7 @@ static iree_status_t iree_hal_amdgpu_executable_get_symbol_by_cstring(
     const iree_hal_amdgpu_libhsa_t* libhsa, hsa_executable_t executable,
     const char* symbol_name, hsa_agent_t device_agent,
     hsa_executable_symbol_t* out_symbol) {
-  // NOTE: AMDGPU kernel symbols must include the `.kd` suffix.
+  // Kernel callers pass the `.kd` suffix; globals use their source symbol name.
   return iree_hsa_executable_get_symbol_by_name(
       IREE_LIBHSA(libhsa), executable, symbol_name, &device_agent, out_symbol);
 }
@@ -826,6 +827,29 @@ static iree_status_t iree_hal_amdgpu_executable_get_raw_hsaco_symbol_by_name(
 
   // AMDGPU MessagePack strings are length-delimited and not NUL-terminated.
   // Copy only at the HSA API boundary so ROCR can use its internal symbol map.
+  char* symbol_name_storage = (char*)iree_alloca(symbol_name.size + 1);
+  memcpy(symbol_name_storage, symbol_name.data, symbol_name.size);
+  symbol_name_storage[symbol_name.size] = 0;
+  return iree_hal_amdgpu_executable_get_symbol_by_cstring(
+      libhsa, executable, symbol_name_storage, device_agent, out_symbol);
+}
+
+static iree_status_t iree_hal_amdgpu_executable_get_global_symbol_by_name(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_executable_t executable,
+    iree_string_view_t symbol_name, hsa_agent_t device_agent,
+    hsa_executable_symbol_t* out_symbol) {
+  if (iree_string_view_is_empty(symbol_name)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable global name is empty");
+  }
+  if (symbol_name.size > IREE_HAL_AMDGPU_MAX_STACK_SYMBOL_NAME_LENGTH) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
+        (int)symbol_name.size, symbol_name.data,
+        IREE_HAL_AMDGPU_MAX_STACK_SYMBOL_NAME_LENGTH);
+  }
+
   char* symbol_name_storage = (char*)iree_alloca(symbol_name.size + 1);
   memcpy(symbol_name_storage, symbol_name.data, symbol_name.size);
   symbol_name_storage[symbol_name.size] = 0;
@@ -1088,6 +1112,9 @@ typedef struct iree_hal_amdgpu_executable_t {
   // executable.
   const iree_hal_amdgpu_libhsa_t* libhsa;
 
+  // Borrowed HAL device used for global-buffer placement metadata.
+  iree_hal_device_t* device;
+
   // Loaded HSA executable with a code object for each device.
   hsa_executable_t handle;
 
@@ -1115,12 +1142,16 @@ typedef struct iree_hal_amdgpu_executable_t {
 
   // Queue affinity this executable was loaded for after normalization.
   iree_hal_queue_affinity_t queue_affinity;
+  // Queue-affinity domain used to resolve per-device globals.
+  iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain;
   // Bitmask of physical GPU device ordinals with loaded code objects.
   uint64_t loaded_physical_device_mask;
   // Number of loaded physical GPU devices in |loaded_physical_device_mask|.
   iree_host_size_t loaded_physical_device_count;
   // Total number of GPU devices in the topology used for per-device tables.
   iree_host_size_t device_count;
+  // HSA GPU agents indexed by physical device ordinal.
+  hsa_agent_t* device_agents /*[device_count]*/;
   // Table of kernel args stored in device memory, one copy per device.
   // Selected devices have an entire `kernel_count` set of args; unselected
   // devices remain NULL and fail lookup.
@@ -1166,7 +1197,7 @@ static iree_string_view_t iree_hal_amdgpu_executable_export_reflection_name(
 }
 
 static iree_status_t iree_hal_amdgpu_executable_allocate(
-    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_device_t* device, const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology,
     const iree_hal_amdgpu_queue_affinity_physical_device_set_t*
         physical_devices,
@@ -1202,6 +1233,7 @@ static iree_status_t iree_hal_amdgpu_executable_allocate(
   iree_host_size_t export_parameter_name_storage_offset = 0;
   iree_host_size_t host_kernel_args_offset = 0;
   iree_host_size_t host_dispatch_descriptors_offset = 0;
+  iree_host_size_t device_agents_offset = 0;
   IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
       sizeof(iree_hal_amdgpu_executable_t), &total_size,
       IREE_STRUCT_FIELD_FAM(
@@ -1222,7 +1254,9 @@ static iree_status_t iree_hal_amdgpu_executable_allocate(
                         &host_kernel_args_offset),
       IREE_STRUCT_FIELD(dispatch_descriptor_count,
                         iree_hal_amdgpu_executable_dispatch_descriptor_t,
-                        &host_dispatch_descriptors_offset)));
+                        &host_dispatch_descriptors_offset),
+      IREE_STRUCT_FIELD(topology->gpu_agent_count, hsa_agent_t,
+                        &device_agents_offset)));
 
   iree_hal_amdgpu_executable_t* executable = NULL;
   IREE_RETURN_IF_ERROR(
@@ -1232,6 +1266,7 @@ static iree_status_t iree_hal_amdgpu_executable_allocate(
                                &executable->resource);
   executable->host_allocator = host_allocator;
   executable->libhsa = libhsa;
+  executable->device = device;
   executable->kernel_count = export_count;
   uint8_t* executable_storage = (uint8_t*)executable;
   executable->export_infos =
@@ -1250,7 +1285,16 @@ static iree_status_t iree_hal_amdgpu_executable_allocate(
   executable->host_dispatch_descriptors =
       (iree_hal_amdgpu_executable_dispatch_descriptor_t*)(executable_storage +
                                                           host_dispatch_descriptors_offset);
+  executable->device_agents =
+      (hsa_agent_t*)(executable_storage + device_agents_offset);
+  memcpy(executable->device_agents, topology->gpu_agents,
+         topology->gpu_agent_count * sizeof(executable->device_agents[0]));
   executable->queue_affinity = physical_devices->queue_affinity;
+  executable->queue_affinity_domain = (iree_hal_amdgpu_queue_affinity_domain_t){
+      .supported_affinity = physical_devices->queue_affinity,
+      .physical_device_count = topology->gpu_agent_count,
+      .queue_count_per_physical_device = topology->gpu_agent_queue_count,
+  };
   executable->loaded_physical_device_mask =
       physical_devices->physical_device_mask;
   executable->loaded_physical_device_count =
@@ -1790,7 +1834,7 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
 }
 
 static iree_status_t iree_hal_amdgpu_executable_create_from_flatbuffer(
-    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_device_t* device, const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology,
     const iree_hal_amdgpu_queue_affinity_physical_device_set_t*
         physical_devices,
@@ -1843,7 +1887,7 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_flatbuffer(
   char* export_parameter_name_storage = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_executable_allocate(
-        libhsa, topology, physical_devices, export_count,
+        device, libhsa, topology, physical_devices, export_count,
         export_name_storage_size, export_parameter_count,
         export_parameter_name_storage_size, host_allocator,
         &export_name_storage, &export_parameter_name_storage, &executable);
@@ -1925,7 +1969,7 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_flatbuffer(
 }
 
 static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
-    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_device_t* device, const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology,
     const iree_hal_amdgpu_queue_affinity_physical_device_set_t*
         physical_devices,
@@ -1954,7 +1998,7 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
   char* export_parameter_name_storage = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_executable_allocate(
-        libhsa, topology, physical_devices, hsaco_metadata.kernel_count,
+        device, libhsa, topology, physical_devices, hsaco_metadata.kernel_count,
         export_name_storage_size, export_parameter_count,
         export_parameter_name_storage_size, host_allocator,
         &export_name_storage, &export_parameter_name_storage, &executable);
@@ -2030,7 +2074,7 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
 }
 
 iree_status_t iree_hal_amdgpu_executable_create(
-    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_device_t* device, const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology,
     const iree_hal_executable_params_t* executable_params,
     iree_hal_amdgpu_profile_metadata_registry_t* profile_metadata,
@@ -2085,11 +2129,11 @@ iree_status_t iree_hal_amdgpu_executable_create(
   if (iree_hal_amdgpu_executable_data_is_wrapped_flatbuffer(
           executable_params->executable_data)) {
     status = iree_hal_amdgpu_executable_create_from_flatbuffer(
-        libhsa, topology, &physical_devices, executable_params, &limits,
+        device, libhsa, topology, &physical_devices, executable_params, &limits,
         any_device_agent, profile_metadata, host_allocator, out_executable);
   } else {
     status = iree_hal_amdgpu_executable_create_from_raw_hsaco(
-        libhsa, topology, &physical_devices, executable_params, &limits,
+        device, libhsa, topology, &physical_devices, executable_params, &limits,
         any_device_agent, profile_metadata, host_allocator, out_executable);
   }
   if (!iree_status_is_ok(status)) {
@@ -2289,10 +2333,82 @@ static iree_status_t iree_hal_amdgpu_executable_lookup_export_by_name(
                           (int)name.size, name.data);
 }
 
+static void iree_hal_amdgpu_executable_global_buffer_release(
+    void* user_data, iree_hal_buffer_t* buffer) {
+  (void)buffer;
+  iree_hal_executable_release((iree_hal_executable_t*)user_data);
+}
+
+static iree_status_t iree_hal_amdgpu_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_amdgpu_executable_t* executable =
+      iree_hal_amdgpu_executable_cast(base_executable);
+  *out_buffer = NULL;
+
+  iree_hal_queue_affinity_t requested_queue_affinity = queue_affinity;
+  if (iree_hal_queue_affinity_is_empty(requested_queue_affinity)) {
+    requested_queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
+  }
+
+  iree_hal_queue_affinity_t selected_queue_affinity = 0;
+  iree_host_size_t physical_device_ordinal = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_queue_affinity_normalize_for_physical_device(
+          executable->queue_affinity_domain, requested_queue_affinity,
+          &selected_queue_affinity, &physical_device_ordinal));
+
+  hsa_executable_symbol_t symbol = {0};
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_get_global_symbol_by_name(
+      executable->libhsa, executable->handle, name,
+      executable->device_agents[physical_device_ordinal], &symbol));
+
+  hsa_symbol_kind_t symbol_kind = HSA_SYMBOL_KIND_KERNEL;
+  IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
+      IREE_LIBHSA(executable->libhsa), symbol, HSA_EXECUTABLE_SYMBOL_INFO_TYPE,
+      &symbol_kind));
+  if (symbol_kind != HSA_SYMBOL_KIND_VARIABLE) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "executable global `%.*s` not found",
+                            (int)name.size, name.data);
+  }
+
+  uint64_t variable_address = 0;
+  IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
+      IREE_LIBHSA(executable->libhsa), symbol,
+      HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_ADDRESS, &variable_address));
+  uint32_t variable_size = 0;
+  IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
+      IREE_LIBHSA(executable->libhsa), symbol,
+      HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_SIZE, &variable_size));
+
+  iree_hal_buffer_placement_t placement = {
+      .device = executable->device,
+      .queue_affinity = selected_queue_affinity,
+      .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
+  };
+  iree_hal_buffer_release_callback_t release_callback = {
+      .fn = iree_hal_amdgpu_executable_global_buffer_release,
+      .user_data = base_executable,
+  };
+  iree_hal_executable_retain(base_executable);
+  iree_status_t status = iree_hal_amdgpu_buffer_create(
+      executable->libhsa, placement, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
+      IREE_HAL_BUFFER_USAGE_DEFAULT, variable_size, variable_size,
+      (void*)(uintptr_t)variable_address, release_callback,
+      executable->host_allocator, out_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_executable_release(base_executable);
+  }
+  return status;
+}
+
 static const iree_hal_executable_vtable_t iree_hal_amdgpu_executable_vtable = {
     .destroy = iree_hal_amdgpu_executable_destroy,
     .export_count = iree_hal_amdgpu_executable_export_count,
     .export_info = iree_hal_amdgpu_executable_export_info,
     .export_parameters = iree_hal_amdgpu_executable_export_parameters,
     .lookup_export_by_name = iree_hal_amdgpu_executable_lookup_export_by_name,
+    .lookup_global_by_name = iree_hal_amdgpu_executable_lookup_global_by_name,
 };

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.h
@@ -110,7 +110,7 @@ iree_status_t iree_hal_amdgpu_executable_infer_format(
 // may begin after executable preparation, so this cold-path metadata is always
 // durable instead of being gated on an active profiling session.
 iree_status_t iree_hal_amdgpu_executable_create(
-    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_device_t* device, const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology,
     const iree_hal_executable_params_t* executable_params,
     iree_hal_amdgpu_profile_metadata_registry_t* profile_metadata,

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_cache.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_cache.c
@@ -18,6 +18,8 @@ typedef struct iree_hal_amdgpu_executable_cache_t {
   iree_hal_resource_t resource;
   // Host allocator used for cache lifetime.
   iree_allocator_t host_allocator;
+  // Borrowed HAL device used for global-buffer placement metadata.
+  iree_hal_device_t* device;
   // Borrowed HSA API table used for executable loading.
   const iree_hal_amdgpu_libhsa_t* libhsa;
   // Borrowed topology describing the physical devices to load onto.
@@ -36,7 +38,7 @@ iree_hal_amdgpu_executable_cache_cast(iree_hal_executable_cache_t* base_value) {
 }
 
 iree_status_t iree_hal_amdgpu_executable_cache_create(
-    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_device_t* device, const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology,
     iree_hal_amdgpu_profile_metadata_registry_t* profile_metadata,
     iree_string_view_t identifier, iree_allocator_t host_allocator,
@@ -61,6 +63,7 @@ iree_status_t iree_hal_amdgpu_executable_cache_create(
   iree_hal_resource_initialize(&iree_hal_amdgpu_executable_cache_vtable,
                                &executable_cache->resource);
   executable_cache->host_allocator = host_allocator;
+  executable_cache->device = device;
   executable_cache->libhsa = libhsa;
   executable_cache->topology = topology;
   executable_cache->profile_metadata = profile_metadata;
@@ -124,7 +127,8 @@ static iree_status_t iree_hal_amdgpu_executable_cache_prepare_executable(
   iree_hal_amdgpu_executable_cache_t* executable_cache =
       iree_hal_amdgpu_executable_cache_cast(base_executable_cache);
   return iree_hal_amdgpu_executable_create(
-      executable_cache->libhsa, executable_cache->topology, executable_params,
+      executable_cache->device, executable_cache->libhsa,
+      executable_cache->topology, executable_params,
       executable_cache->profile_metadata, executable_cache->host_allocator,
       out_executable);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_cache.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_cache.h
@@ -29,7 +29,7 @@ typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
 // Exact code-object image bytes and loader load ranges are retained in profile
 // metadata for every prepared executable.
 iree_status_t iree_hal_amdgpu_executable_cache_create(
-    const iree_hal_amdgpu_libhsa_t* libhsa,
+    iree_hal_device_t* device, const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology,
     iree_hal_amdgpu_profile_metadata_registry_t* profile_metadata,
     iree_string_view_t identifier, iree_allocator_t host_allocator,

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -2113,9 +2113,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_executable_cache(
   iree_hal_amdgpu_logical_device_t* logical_device =
       iree_hal_amdgpu_logical_device_cast(base_device);
   return iree_hal_amdgpu_executable_cache_create(
-      &logical_device->system->libhsa, &logical_device->system->topology,
-      &logical_device->profile_metadata, identifier,
-      iree_hal_device_host_allocator(base_device), out_executable_cache);
+      base_device, &logical_device->system->libhsa,
+      &logical_device->system->topology, &logical_device->profile_metadata,
+      identifier, iree_hal_device_host_allocator(base_device),
+      out_executable_cache);
 }
 
 static iree_status_t iree_hal_amdgpu_logical_device_import_file(

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -986,8 +986,8 @@ static iree_status_t iree_hal_cuda_device_create_executable_cache(
     iree_hal_executable_cache_t** out_executable_cache) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   return iree_hal_cuda_nop_executable_cache_create(
-      identifier, device->cuda_symbols, device->cu_device,
-      device->host_allocator, out_executable_cache);
+      base_device, identifier, device->cuda_symbols, device->cu_device,
+      device->cu_context, device->host_allocator, out_executable_cache);
 }
 
 static iree_status_t iree_hal_cuda_device_import_file(

--- a/runtime/src/iree/hal/drivers/cuda/cuda_dynamic_symbol_table.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_dynamic_symbol_table.h
@@ -69,6 +69,8 @@ IREE_CU_PFN_DECL(cuMemAllocFromPoolAsync, CUdeviceptr*, size_t, CUmemoryPool,
                  CUstream)
 IREE_CU_PFN_DECL(cuMemFreeAsync, CUdeviceptr dptr, CUstream hStream)
 IREE_CU_PFN_DECL(cuModuleGetFunction, CUfunction*, CUmodule, const char*)
+IREE_CU_PFN_DECL(cuModuleGetGlobal, CUdeviceptr*, size_t*, CUmodule,
+                 const char*)
 IREE_CU_PFN_DECL(cuModuleLoadDataEx, CUmodule*, const void*, unsigned int,
                  CUjit_option*, void**)
 IREE_CU_PFN_DECL(cuModuleUnload, CUmodule)

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -9,6 +9,7 @@
 #include <stddef.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/drivers/cuda/cuda_buffer.h"
 #include "iree/hal/drivers/cuda/cuda_dynamic_symbols.h"
 #include "iree/hal/drivers/cuda/cuda_status_util.h"
 #include "iree/hal/utils/executable_debug_info.h"
@@ -25,16 +26,25 @@ typedef struct iree_hal_cuda_native_executable_t {
   // Abstract resource used for injecting reference counting and vtable;
   // must be at offset 0.
   iree_hal_resource_t resource;
+  // Host allocator used for executable lifetime.
   iree_allocator_t host_allocator;
 
+  // Borrowed HAL device used for buffer placement metadata.
+  iree_hal_device_t* device;
+  // Borrowed CUDA dynamic symbols used for module and global lookup.
   const iree_hal_cuda_dynamic_symbols_t* symbols;
 
-  // Loaded CUDA modules.
+  // CUDA context owning the executable modules.
+  CUcontext cu_context;
+
+  // Number of loaded CUDA modules.
   iree_host_size_t module_count;
+  // Loaded CUDA modules.
   CUmodule* modules;
 
-  // Exported kernels referencing the loaded modules.
+  // Number of exported kernels referencing the loaded modules.
   iree_host_size_t export_count;
+  // Exported kernels referencing the loaded modules.
   iree_hal_cuda_kernel_params_t exports[];
 } iree_hal_cuda_native_executable_t;
 
@@ -238,7 +248,8 @@ static iree_status_t iree_hal_cuda_native_executable_flatbuffer_verify(
 }
 
 iree_status_t iree_hal_cuda_native_executable_create(
-    const iree_hal_cuda_dynamic_symbols_t* symbols, CUdevice device,
+    iree_hal_device_t* device, const iree_hal_cuda_dynamic_symbols_t* symbols,
+    CUdevice cu_device, CUcontext cu_context,
     const iree_hal_executable_params_t* executable_params,
     iree_allocator_t host_allocator, iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(executable_params);
@@ -250,7 +261,7 @@ iree_status_t iree_hal_cuda_native_executable_create(
   // TODO: move to the executable cache to avoid repeated queries.
   iree_hal_cuda_limits_t limits = {0};
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_cuda_query_limits(symbols, device, &limits));
+      z0, iree_hal_cuda_query_limits(symbols, cu_device, &limits));
 
   // Read and strip the flatbuffer header prefix.
   iree_const_byte_span_t executable_flatbuffer = iree_const_byte_span_empty();
@@ -300,7 +311,9 @@ iree_status_t iree_hal_cuda_native_executable_create(
   iree_hal_resource_initialize(&iree_hal_cuda_native_executable_vtable,
                                &executable->resource);
   executable->host_allocator = host_allocator;
+  executable->device = device;
   executable->symbols = symbols;
+  executable->cu_context = cu_context;
   executable->module_count = module_count;
   executable->modules =
       (CUmodule*)((uint8_t*)executable + sizeof(*executable) +
@@ -513,6 +526,87 @@ static iree_status_t iree_hal_cuda_native_executable_lookup_export_by_name(
                           "reflection not implemented");
 }
 
+#define IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH \
+  ((iree_host_size_t)(4 * 1024))
+
+static void iree_hal_cuda_native_executable_global_buffer_release(
+    void* user_data, iree_hal_buffer_t* buffer) {
+  (void)buffer;
+  iree_hal_executable_release((iree_hal_executable_t*)user_data);
+}
+
+static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_cuda_native_executable_t* executable =
+      iree_hal_cuda_native_executable_cast(base_executable);
+  *out_buffer = NULL;
+
+  if (iree_string_view_is_empty(name)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable global name is empty");
+  }
+  if (name.size > IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
+        (int)name.size, name.data, IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH);
+  }
+
+  IREE_RETURN_IF_ERROR(
+      IREE_CURESULT_TO_STATUS(executable->symbols,
+                              cuCtxSetCurrent(executable->cu_context)),
+      "setting CUDA context for executable global lookup");
+
+  char* global_name = (char*)iree_alloca(name.size + 1);
+  memcpy(global_name, name.data, name.size);
+  global_name[name.size] = 0;
+
+  CUresult terminal_result = CUDA_ERROR_NOT_FOUND;
+  CUdeviceptr global_device_ptr = 0;
+  size_t global_size = 0;
+  for (iree_host_size_t module_ordinal = 0;
+       module_ordinal < executable->module_count; ++module_ordinal) {
+    terminal_result = executable->symbols->cuModuleGetGlobal(
+        &global_device_ptr, &global_size, executable->modules[module_ordinal],
+        global_name);
+    if (terminal_result == CUDA_SUCCESS) break;
+    if (terminal_result != CUDA_ERROR_NOT_FOUND) {
+      return iree_hal_cuda_result_to_status(
+          executable->symbols, terminal_result, __FILE__, __LINE__);
+    }
+  }
+  if (terminal_result != CUDA_SUCCESS) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "executable global `%.*s` not found",
+                            (int)name.size, name.data);
+  }
+
+  iree_hal_buffer_placement_t placement = {
+      .device = executable->device,
+      .queue_affinity = iree_hal_queue_affinity_is_empty(queue_affinity)
+                            ? IREE_HAL_QUEUE_AFFINITY_ANY
+                            : queue_affinity,
+      .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
+  };
+  iree_hal_buffer_release_callback_t release_callback = {
+      .fn = iree_hal_cuda_native_executable_global_buffer_release,
+      .user_data = base_executable,
+  };
+  iree_hal_executable_retain(base_executable);
+  iree_status_t status = iree_hal_cuda_buffer_wrap(
+      placement, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
+      IREE_HAL_BUFFER_USAGE_DEFAULT, global_size, /*byte_offset=*/0,
+      global_size, IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL, global_device_ptr,
+      /*host_ptr=*/NULL, release_callback, executable->host_allocator,
+      out_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_executable_release(base_executable);
+  }
+  return status;
+}
+
 static const iree_hal_executable_vtable_t
     iree_hal_cuda_native_executable_vtable = {
         .destroy = iree_hal_cuda_native_executable_destroy,
@@ -521,4 +615,6 @@ static const iree_hal_executable_vtable_t
         .export_parameters = iree_hal_cuda_native_executable_export_parameters,
         .lookup_export_by_name =
             iree_hal_cuda_native_executable_lookup_export_by_name,
+        .lookup_global_by_name =
+            iree_hal_cuda_native_executable_lookup_global_by_name,
 };

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.h
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.h
@@ -56,7 +56,8 @@ iree_status_t iree_hal_cuda_native_executable_infer_format(
 // Creates an IREE executable from a CUDA PTX module. The module may contain
 // several kernels that can be extracted along with the associated block size.
 iree_status_t iree_hal_cuda_native_executable_create(
-    const iree_hal_cuda_dynamic_symbols_t* symbols, CUdevice device,
+    iree_hal_device_t* device, const iree_hal_cuda_dynamic_symbols_t* symbols,
+    CUdevice cu_device, CUcontext cu_context,
     const iree_hal_executable_params_t* executable_params,
     iree_allocator_t host_allocator, iree_hal_executable_t** out_executable);
 

--- a/runtime/src/iree/hal/drivers/cuda/nop_executable_cache.c
+++ b/runtime/src/iree/hal/drivers/cuda/nop_executable_cache.c
@@ -18,11 +18,18 @@ typedef struct iree_hal_cuda_nop_executable_cache_t {
   // must be at offset 0.
   iree_hal_resource_t resource;
 
+  // Host allocator used for executable cache lifetime.
   iree_allocator_t host_allocator;
 
+  // Borrowed HAL device used for buffer placement metadata.
+  iree_hal_device_t* device;
+  // Borrowed CUDA dynamic symbols used for executable loading.
   const iree_hal_cuda_dynamic_symbols_t* symbols;
 
-  CUdevice device;
+  // CUDA device owning the executable modules.
+  CUdevice cu_device;
+  // CUDA context owning the executable modules.
+  CUcontext cu_context;
 } iree_hal_cuda_nop_executable_cache_t;
 
 static const iree_hal_executable_cache_vtable_t
@@ -36,9 +43,9 @@ iree_hal_cuda_nop_executable_cache_cast(
 }
 
 iree_status_t iree_hal_cuda_nop_executable_cache_create(
-    iree_string_view_t identifier,
-    const iree_hal_cuda_dynamic_symbols_t* symbols, CUdevice device,
-    iree_allocator_t host_allocator,
+    iree_hal_device_t* device, iree_string_view_t identifier,
+    const iree_hal_cuda_dynamic_symbols_t* symbols, CUdevice cu_device,
+    CUcontext cu_context, iree_allocator_t host_allocator,
     iree_hal_executable_cache_t** out_executable_cache) {
   IREE_ASSERT_ARGUMENT(out_executable_cache);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -52,8 +59,10 @@ iree_status_t iree_hal_cuda_nop_executable_cache_create(
   iree_hal_resource_initialize(&iree_hal_cuda_nop_executable_cache_vtable,
                                &executable_cache->resource);
   executable_cache->host_allocator = host_allocator;
-  executable_cache->symbols = symbols;
   executable_cache->device = device;
+  executable_cache->symbols = symbols;
+  executable_cache->cu_device = cu_device;
+  executable_cache->cu_context = cu_context;
 
   *out_executable_cache = (iree_hal_executable_cache_t*)executable_cache;
 
@@ -102,8 +111,9 @@ static iree_status_t iree_hal_cuda_nop_executable_cache_prepare_executable(
   iree_hal_cuda_nop_executable_cache_t* executable_cache =
       iree_hal_cuda_nop_executable_cache_cast(base_executable_cache);
   return iree_hal_cuda_native_executable_create(
-      executable_cache->symbols, executable_cache->device, executable_params,
-      executable_cache->host_allocator, out_executable);
+      executable_cache->device, executable_cache->symbols,
+      executable_cache->cu_device, executable_cache->cu_context,
+      executable_params, executable_cache->host_allocator, out_executable);
 }
 
 static const iree_hal_executable_cache_vtable_t

--- a/runtime/src/iree/hal/drivers/cuda/nop_executable_cache.h
+++ b/runtime/src/iree/hal/drivers/cuda/nop_executable_cache.h
@@ -20,9 +20,9 @@ extern "C" {
 // This is useful to isolate pipeline caching behavior and verify compilation
 // behavior.
 iree_status_t iree_hal_cuda_nop_executable_cache_create(
-    iree_string_view_t identifier,
-    const iree_hal_cuda_dynamic_symbols_t* symbols, CUdevice device,
-    iree_allocator_t host_allocator,
+    iree_hal_device_t* device, iree_string_view_t identifier,
+    const iree_hal_cuda_dynamic_symbols_t* symbols, CUdevice cu_device,
+    CUcontext cu_context, iree_allocator_t host_allocator,
     iree_hal_executable_cache_t** out_executable_cache);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
@@ -108,6 +108,8 @@ IREE_HAL_HIP_REQUIRED_PFN_DECL(hipMemsetD32Async, void*, int, size_t,
                                hipStream_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipModuleGetFunction, hipFunction_t*,
                                hipModule_t, const char*)
+IREE_HAL_HIP_REQUIRED_PFN_DECL(hipModuleGetGlobal, hipDeviceptr_t*, size_t*,
+                               hipModule_t, const char*)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipModuleLaunchKernel, hipFunction_t,
                                unsigned int, unsigned int, unsigned int,
                                unsigned int, unsigned int, unsigned int,

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -1076,7 +1076,7 @@ static iree_status_t iree_hal_hip_device_create_executable_cache(
     contexts[i] = device->devices[i].hip_context;
   }
   return iree_hal_hip_nop_executable_cache_create(
-      identifier, device->hip_symbols,
+      base_device, identifier, device->hip_symbols,
       iree_hal_hip_device_make_topology(device), device->host_allocator,
       out_executable_cache);
 }

--- a/runtime/src/iree/hal/drivers/hip/native_executable.c
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.c
@@ -10,7 +10,9 @@
 
 #include "iree/base/api.h"
 #include "iree/base/internal/math.h"
+#include "iree/hal/drivers/hip/context_util.h"
 #include "iree/hal/drivers/hip/dynamic_symbols.h"
+#include "iree/hal/drivers/hip/hip_buffer.h"
 #include "iree/hal/drivers/hip/status_util.h"
 #include "iree/hal/utils/executable_debug_info.h"
 #include "iree/hal/utils/executable_header.h"
@@ -23,12 +25,17 @@
 #include "iree/schemas/hip_executable_def_verifier.h"
 
 typedef struct iree_hal_hip_native_executable_per_device_data_t {
-  // Loaded HIP modules.
+  // HIP context owning all modules in this per-device table.
+  hipCtx_t hip_context;
+
+  // Number of loaded HIP modules.
   iree_host_size_t module_count;
+  // Loaded HIP modules.
   hipModule_t* modules;
 
-  // Exported kernels referencing the loaded modules.
+  // Number of exported kernels referencing the loaded modules.
   iree_host_size_t export_count;
+  // Exported kernels referencing the loaded modules.
   iree_hal_hip_kernel_params_t exports[];
 } iree_hal_hip_native_executable_per_device_data_t;
 
@@ -36,11 +43,17 @@ typedef struct iree_hal_hip_native_executable_t {
   // Abstract resource used for injecting reference counting and vtable;
   // must be at offset 0.
   iree_hal_resource_t resource;
+  // Host allocator used for executable lifetime.
   iree_allocator_t host_allocator;
 
+  // Borrowed HAL device used for buffer placement metadata.
+  iree_hal_device_t* device;
+  // Borrowed HIP dynamic symbols used for module and global lookup.
   const iree_hal_hip_dynamic_symbols_t* symbols;
 
+  // Number of HIP devices this executable was loaded onto.
   iree_host_size_t num_devices;
+  // Per-device module and export tables.
   iree_hal_hip_native_executable_per_device_data_t* per_device_data[];
 } iree_hal_hip_native_executable_t;
 
@@ -255,7 +268,7 @@ static iree_status_t iree_hal_hip_function_attributes_verify(
 }
 
 iree_status_t iree_hal_hip_native_executable_create(
-    const iree_hal_hip_dynamic_symbols_t* symbols,
+    iree_hal_device_t* device, const iree_hal_hip_dynamic_symbols_t* symbols,
     iree_hal_hip_device_topology_t topology,
     const iree_hal_executable_params_t* executable_params,
     iree_allocator_t host_allocator, iree_hal_executable_t** out_executable) {
@@ -332,6 +345,7 @@ iree_status_t iree_hal_hip_native_executable_create(
   iree_hal_resource_initialize(&iree_hal_hip_native_executable_vtable,
                                &executable->resource);
   executable->host_allocator = host_allocator;
+  executable->device = device;
   executable->symbols = symbols;
   executable->num_devices = topology.count;
   const iree_host_size_t per_device_data_size =
@@ -367,6 +381,7 @@ iree_status_t iree_hal_hip_native_executable_create(
     iree_hal_hip_native_executable_per_device_data_t* per_device_data =
         executable->per_device_data[j];
 
+    per_device_data->hip_context = topology.devices[j].hip_context;
     per_device_data->module_count = module_count;
     per_device_data->modules =
         (hipModule_t*)((uint8_t*)per_device_data + sizeof(*per_device_data) +
@@ -603,6 +618,128 @@ static iree_status_t iree_hal_hip_native_executable_lookup_export_by_name(
                           "reflection not implemented");
 }
 
+#define IREE_HAL_HIP_MAX_STACK_GLOBAL_NAME_LENGTH ((iree_host_size_t)(4 * 1024))
+
+static bool iree_hal_hip_native_executable_is_global_not_found(
+    hipError_t result) {
+  return result == hipErrorNotFound ||
+         result == hipErrorSharedObjectSymbolNotFound;
+}
+
+static iree_status_t iree_hal_hip_native_executable_select_global_device(
+    const iree_hal_hip_native_executable_t* executable,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_host_size_t* out_device_ordinal,
+    iree_hal_queue_affinity_t* out_queue_affinity) {
+  *out_device_ordinal = 0;
+  *out_queue_affinity = 0;
+
+  iree_hal_queue_affinity_t available_affinity =
+      executable->num_devices == IREE_HAL_MAX_QUEUES
+          ? IREE_HAL_QUEUE_AFFINITY_ANY
+          : (((iree_hal_queue_affinity_t)1) << executable->num_devices) - 1;
+  iree_hal_queue_affinity_t selected_affinity = queue_affinity;
+  if (iree_hal_queue_affinity_is_empty(selected_affinity) ||
+      iree_hal_queue_affinity_is_any(selected_affinity)) {
+    selected_affinity = available_affinity;
+  } else {
+    iree_hal_queue_affinity_and_into(selected_affinity, available_affinity);
+  }
+  if (iree_hal_queue_affinity_is_empty(selected_affinity)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "global lookup queue affinity 0x%" PRIx64
+                            " does not select a loaded HIP device",
+                            queue_affinity);
+  }
+
+  iree_host_size_t device_ordinal =
+      iree_hal_queue_affinity_find_first_set(selected_affinity);
+  *out_device_ordinal = device_ordinal;
+  *out_queue_affinity = ((iree_hal_queue_affinity_t)1) << device_ordinal;
+  return iree_ok_status();
+}
+
+static void iree_hal_hip_native_executable_global_buffer_release(
+    void* user_data, iree_hal_buffer_t* buffer) {
+  (void)buffer;
+  iree_hal_executable_release((iree_hal_executable_t*)user_data);
+}
+
+static iree_status_t iree_hal_hip_native_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_hip_native_executable_t* executable =
+      iree_hal_hip_native_executable_cast(base_executable);
+  *out_buffer = NULL;
+
+  if (iree_string_view_is_empty(name)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable global name is empty");
+  }
+  if (name.size > IREE_HAL_HIP_MAX_STACK_GLOBAL_NAME_LENGTH) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
+        (int)name.size, name.data, IREE_HAL_HIP_MAX_STACK_GLOBAL_NAME_LENGTH);
+  }
+
+  iree_host_size_t device_ordinal = 0;
+  iree_hal_queue_affinity_t selected_queue_affinity = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_select_global_device(
+      executable, queue_affinity, &device_ordinal, &selected_queue_affinity));
+
+  const iree_hal_hip_native_executable_per_device_data_t* per_device_data =
+      executable->per_device_data[device_ordinal];
+  IREE_RETURN_IF_ERROR(iree_hal_hip_set_context(executable->symbols,
+                                                per_device_data->hip_context),
+                       "setting HIP context for executable global lookup");
+
+  char* global_name = (char*)iree_alloca(name.size + 1);
+  memcpy(global_name, name.data, name.size);
+  global_name[name.size] = 0;
+
+  hipError_t terminal_result = hipErrorNotFound;
+  hipDeviceptr_t global_device_ptr = 0;
+  size_t global_size = 0;
+  for (iree_host_size_t module_ordinal = 0;
+       module_ordinal < per_device_data->module_count; ++module_ordinal) {
+    terminal_result = executable->symbols->hipModuleGetGlobal(
+        &global_device_ptr, &global_size,
+        per_device_data->modules[module_ordinal], global_name);
+    if (terminal_result == hipSuccess) break;
+    if (!iree_hal_hip_native_executable_is_global_not_found(terminal_result)) {
+      return IREE_HIP_RESULT_TO_STATUS(executable->symbols, terminal_result);
+    }
+  }
+  if (terminal_result != hipSuccess) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "executable global `%.*s` not found",
+                            (int)name.size, name.data);
+  }
+
+  iree_hal_buffer_placement_t placement = {
+      .device = executable->device,
+      .queue_affinity = selected_queue_affinity,
+      .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
+  };
+  iree_hal_buffer_release_callback_t release_callback = {
+      .fn = iree_hal_hip_native_executable_global_buffer_release,
+      .user_data = base_executable,
+  };
+  iree_hal_executable_retain(base_executable);
+  iree_status_t status = iree_hal_hip_buffer_wrap(
+      placement, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
+      IREE_HAL_BUFFER_USAGE_DEFAULT, global_size, /*byte_offset=*/0,
+      global_size, IREE_HAL_HIP_BUFFER_TYPE_EXTERNAL, global_device_ptr,
+      /*host_ptr=*/NULL, release_callback, executable->host_allocator,
+      out_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_executable_release(base_executable);
+  }
+  return status;
+}
+
 static const iree_hal_executable_vtable_t
     iree_hal_hip_native_executable_vtable = {
         .destroy = iree_hal_hip_native_executable_destroy,
@@ -611,4 +748,6 @@ static const iree_hal_executable_vtable_t
         .export_parameters = iree_hal_hip_native_executable_export_parameters,
         .lookup_export_by_name =
             iree_hal_hip_native_executable_lookup_export_by_name,
+        .lookup_global_by_name =
+            iree_hal_hip_native_executable_lookup_global_by_name,
 };

--- a/runtime/src/iree/hal/drivers/hip/native_executable.h
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.h
@@ -52,7 +52,7 @@ iree_status_t iree_hal_hip_native_executable_infer_format(
 // Creates an IREE executable from a HSACO module. The module may contain
 // several kernels that can be extracted along with the associated block size.
 iree_status_t iree_hal_hip_native_executable_create(
-    const iree_hal_hip_dynamic_symbols_t* symbols,
+    iree_hal_device_t* device, const iree_hal_hip_dynamic_symbols_t* symbols,
     iree_hal_hip_device_topology_t topology,
     const iree_hal_executable_params_t* executable_params,
     iree_allocator_t host_allocator, iree_hal_executable_t** out_executable);

--- a/runtime/src/iree/hal/drivers/hip/nop_executable_cache.c
+++ b/runtime/src/iree/hal/drivers/hip/nop_executable_cache.c
@@ -18,9 +18,14 @@ typedef struct iree_hal_hip_nop_executable_cache_t {
   // must be at offset 0.
   iree_hal_resource_t resource;
 
+  // Host allocator used for executable cache lifetime.
   iree_allocator_t host_allocator;
 
+  // Borrowed HAL device used for buffer placement metadata.
+  iree_hal_device_t* device;
+  // Borrowed HIP dynamic symbols used for executable loading.
   const iree_hal_hip_dynamic_symbols_t* symbols;
+  // Borrowed HIP device topology used for per-device module loading.
   iree_hal_hip_device_topology_t topology;
 } iree_hal_hip_nop_executable_cache_t;
 
@@ -35,7 +40,7 @@ iree_hal_hip_nop_executable_cache_cast(
 }
 
 iree_status_t iree_hal_hip_nop_executable_cache_create(
-    iree_string_view_t identifier,
+    iree_hal_device_t* device, iree_string_view_t identifier,
     const iree_hal_hip_dynamic_symbols_t* symbols,
     iree_hal_hip_device_topology_t topology, iree_allocator_t host_allocator,
     iree_hal_executable_cache_t** out_executable_cache) {
@@ -52,6 +57,7 @@ iree_status_t iree_hal_hip_nop_executable_cache_create(
   iree_hal_resource_initialize(&iree_hal_hip_nop_executable_cache_vtable,
                                &executable_cache->resource);
   executable_cache->host_allocator = host_allocator;
+  executable_cache->device = device;
   executable_cache->symbols = symbols;
 
   executable_cache->topology = topology;
@@ -103,7 +109,8 @@ static iree_status_t iree_hal_hip_nop_executable_cache_prepare_executable(
   iree_hal_hip_nop_executable_cache_t* executable_cache =
       iree_hal_hip_nop_executable_cache_cast(base_executable_cache);
   return iree_hal_hip_native_executable_create(
-      executable_cache->symbols, executable_cache->topology, executable_params,
+      executable_cache->device, executable_cache->symbols,
+      executable_cache->topology, executable_params,
       executable_cache->host_allocator, out_executable);
 }
 

--- a/runtime/src/iree/hal/drivers/hip/nop_executable_cache.h
+++ b/runtime/src/iree/hal/drivers/hip/nop_executable_cache.h
@@ -17,7 +17,7 @@
 // This is useful to isolate pipeline caching behavior and verify compilation
 // behavior.
 iree_status_t iree_hal_hip_nop_executable_cache_create(
-    iree_string_view_t identifier,
+    iree_hal_device_t* device, iree_string_view_t identifier,
     const iree_hal_hip_dynamic_symbols_t* symbols,
     iree_hal_hip_device_topology_t topology, iree_allocator_t host_allocator,
     iree_hal_executable_cache_t** out_executable_cache);

--- a/runtime/src/iree/hal/drivers/metal/executable.m
+++ b/runtime/src/iree/hal/drivers/metal/executable.m
@@ -551,6 +551,17 @@ static iree_status_t iree_hal_metal_executable_lookup_export_by_name(
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "reflection not implemented");
 }
 
+static iree_status_t iree_hal_metal_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_metal_executable_t* executable = iree_hal_metal_executable_cast(base_executable);
+  (void)executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "global lookup not implemented");
+}
+
 static iree_status_t iree_hal_metal_executable_export_parameters(
     iree_hal_executable_t* base_executable, iree_hal_executable_export_ordinal_t export_ordinal,
     iree_host_size_t capacity, iree_hal_executable_export_parameter_t* out_parameters) {
@@ -566,4 +577,5 @@ static const iree_hal_executable_vtable_t iree_hal_metal_executable_vtable = {
     .export_info = iree_hal_metal_executable_export_info,
     .export_parameters = iree_hal_metal_executable_export_parameters,
     .lookup_export_by_name = iree_hal_metal_executable_lookup_export_by_name,
+    .lookup_global_by_name = iree_hal_metal_executable_lookup_global_by_name,
 };

--- a/runtime/src/iree/hal/drivers/null/executable.c
+++ b/runtime/src/iree/hal/drivers/null/executable.c
@@ -130,10 +130,24 @@ static iree_status_t iree_hal_null_executable_lookup_export_by_name(
                           "reflection not implemented");
 }
 
+static iree_status_t iree_hal_null_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_null_executable_t* executable =
+      iree_hal_null_executable_cast(base_executable);
+  (void)executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "global lookup not implemented");
+}
+
 static const iree_hal_executable_vtable_t iree_hal_null_executable_vtable = {
     .destroy = iree_hal_null_executable_destroy,
     .export_count = iree_hal_null_executable_export_count,
     .export_info = iree_hal_null_executable_export_info,
     .export_parameters = iree_hal_null_executable_export_parameters,
     .lookup_export_by_name = iree_hal_null_executable_lookup_export_by_name,
+    .lookup_global_by_name = iree_hal_null_executable_lookup_global_by_name,
 };

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable.cc
@@ -1098,6 +1098,19 @@ static iree_status_t iree_hal_vulkan_native_executable_lookup_export_by_name(
                           "reflection not implemented");
 }
 
+static iree_status_t iree_hal_vulkan_native_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_vulkan_native_executable_t* executable =
+      iree_hal_vulkan_native_executable_cast(base_executable);
+  (void)executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "global lookup not implemented");
+}
+
 namespace {
 const iree_hal_executable_vtable_t iree_hal_vulkan_native_executable_vtable = {
     /*.destroy=*/iree_hal_vulkan_native_executable_destroy,
@@ -1106,5 +1119,7 @@ const iree_hal_executable_vtable_t iree_hal_vulkan_native_executable_vtable = {
     /*.export_parameters=*/iree_hal_vulkan_native_executable_export_parameters,
     /*.lookup_export_by_name=*/
     iree_hal_vulkan_native_executable_lookup_export_by_name,
+    /*.lookup_global_by_name=*/
+    iree_hal_vulkan_native_executable_lookup_global_by_name,
 };
 }  // namespace

--- a/runtime/src/iree/hal/executable.c
+++ b/runtime/src/iree/hal/executable.c
@@ -58,3 +58,16 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_export_by_name(
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_global_by_name(
+    iree_hal_executable_t* executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_buffer = NULL;
+  iree_status_t status = _VTABLE_DISPATCH(executable, lookup_global_by_name)(
+      executable, name, queue_affinity, out_buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/runtime/src/iree/hal/executable.h
+++ b/runtime/src/iree/hal/executable.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/queue.h"
 #include "iree/hal/resource.h"
 
 #ifdef __cplusplus
@@ -18,6 +19,7 @@ extern "C" {
 #endif  // __cplusplus
 
 typedef struct iree_hal_device_t iree_hal_device_t;
+typedef struct iree_hal_buffer_t iree_hal_buffer_t;
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_t
@@ -154,6 +156,21 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_export_by_name(
     iree_hal_executable_t* executable, iree_string_view_t name,
     iree_hal_executable_export_ordinal_t* out_export_ordinal);
 
+// Finds the executable global variable with the given |name| and returns a
+// device buffer aliasing its storage.
+//
+// |queue_affinity| selects the device instance for per-device globals. Empty or
+// any affinities select an implementation-defined valid device instance. The
+// returned buffer retains the executable storage it aliases and must be
+// released by the caller.
+//
+// Returns IREE_STATUS_NOT_FOUND when no such global variable exists and
+// IREE_STATUS_UNIMPLEMENTED when the executable format or backend cannot expose
+// globals.
+IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_global_by_name(
+    iree_hal_executable_t* executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer);
+
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_t implementation details
 //===----------------------------------------------------------------------===//
@@ -178,6 +195,10 @@ typedef struct iree_hal_executable_vtable_t {
   iree_status_t(IREE_API_PTR* lookup_export_by_name)(
       iree_hal_executable_t* executable, iree_string_view_t name,
       iree_hal_executable_export_ordinal_t* out_export_ordinal);
+
+  iree_status_t(IREE_API_PTR* lookup_global_by_name)(
+      iree_hal_executable_t* executable, iree_string_view_t name,
+      iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer);
 } iree_hal_executable_vtable_t;
 IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_executable_vtable_t);
 

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -260,6 +260,17 @@ static iree_status_t iree_hal_elf_executable_lookup_export_by_name(
       executable->library.v0, name, out_export_ordinal);
 }
 
+static iree_status_t iree_hal_elf_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "local executable global lookup not implemented");
+}
+
 static const iree_hal_local_executable_vtable_t iree_hal_elf_executable_vtable =
     {
         .base =
@@ -270,6 +281,8 @@ static const iree_hal_local_executable_vtable_t iree_hal_elf_executable_vtable =
                 .export_parameters = iree_hal_elf_executable_export_parameters,
                 .lookup_export_by_name =
                     iree_hal_elf_executable_lookup_export_by_name,
+                .lookup_global_by_name =
+                    iree_hal_elf_executable_lookup_global_by_name,
             },
         .issue_call = iree_hal_elf_executable_issue_call,
 };

--- a/runtime/src/iree/hal/local/loaders/static_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/static_library_loader.c
@@ -195,6 +195,17 @@ static iree_status_t iree_hal_static_executable_lookup_export_by_name(
       executable->library.v0, name, out_export_ordinal);
 }
 
+static iree_status_t iree_hal_static_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "local executable global lookup not implemented");
+}
+
 static const iree_hal_local_executable_vtable_t
     iree_hal_static_executable_vtable = {
         .base =
@@ -206,6 +217,8 @@ static const iree_hal_local_executable_vtable_t
                     iree_hal_static_executable_export_parameters,
                 .lookup_export_by_name =
                     iree_hal_static_executable_lookup_export_by_name,
+                .lookup_global_by_name =
+                    iree_hal_static_executable_lookup_global_by_name,
             },
         .issue_call = iree_hal_static_executable_issue_call,
 };

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -373,6 +373,17 @@ static iree_status_t iree_hal_system_executable_lookup_export_by_name(
       executable->library.v0, name, out_export_ordinal);
 }
 
+static iree_status_t iree_hal_system_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "local executable global lookup not implemented");
+}
+
 static const iree_hal_local_executable_vtable_t
     iree_hal_system_executable_vtable = {
         .base =
@@ -384,6 +395,8 @@ static const iree_hal_local_executable_vtable_t
                     iree_hal_system_executable_export_parameters,
                 .lookup_export_by_name =
                     iree_hal_system_executable_lookup_export_by_name,
+                .lookup_global_by_name =
+                    iree_hal_system_executable_lookup_global_by_name,
             },
         .issue_call = iree_hal_system_executable_issue_call,
 };

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -641,6 +641,17 @@ static iree_status_t iree_hal_vmvx_executable_lookup_export_by_name(
       (int)name.size, name.data);
 }
 
+static iree_status_t iree_hal_vmvx_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "VMVX executable global lookup not implemented");
+}
+
 static const iree_hal_local_executable_vtable_t
     iree_hal_vmvx_executable_vtable = {
         .base =
@@ -651,6 +662,8 @@ static const iree_hal_local_executable_vtable_t
                 .export_parameters = iree_hal_vmvx_executable_export_parameters,
                 .lookup_export_by_name =
                     iree_hal_vmvx_executable_lookup_export_by_name,
+                .lookup_global_by_name =
+                    iree_hal_vmvx_executable_lookup_global_by_name,
             },
         .issue_call = iree_hal_vmvx_executable_issue_call,
 };

--- a/runtime/src/iree/hal/replay/recorder_executable.c
+++ b/runtime/src/iree/hal/replay/recorder_executable.c
@@ -189,6 +189,20 @@ static iree_status_t iree_hal_replay_recorder_executable_lookup_export_by_name(
                                                 name, out_export_ordinal));
 }
 
+static iree_status_t iree_hal_replay_recorder_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_replay_recorder_executable_t* executable =
+      iree_hal_replay_recorder_executable_cast(base_executable);
+  (void)executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(
+      IREE_STATUS_UNIMPLEMENTED,
+      "replay recording of executable global lookup is not implemented");
+}
+
 //===----------------------------------------------------------------------===//
 // iree_hal_replay_recorder_executable_cache_t
 //===----------------------------------------------------------------------===//
@@ -571,6 +585,8 @@ static const iree_hal_executable_vtable_t
             iree_hal_replay_recorder_executable_export_parameters,
         .lookup_export_by_name =
             iree_hal_replay_recorder_executable_lookup_export_by_name,
+        .lookup_global_by_name =
+            iree_hal_replay_recorder_executable_lookup_global_by_name,
 };
 
 static const iree_hal_executable_cache_vtable_t

--- a/runtime/src/iree/hal/testing/mock_device.c
+++ b/runtime/src/iree/hal/testing/mock_device.c
@@ -170,12 +170,23 @@ static iree_status_t iree_hal_mock_executable_lookup_export_by_name(
   return iree_make_status(IREE_STATUS_NOT_FOUND);
 }
 
+static iree_status_t iree_hal_mock_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)name;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
 static const iree_hal_executable_vtable_t iree_hal_mock_executable_vtable = {
     .destroy = iree_hal_mock_executable_destroy,
     .export_count = iree_hal_mock_executable_export_count,
     .export_info = iree_hal_mock_executable_export_info,
     .export_parameters = iree_hal_mock_executable_export_parameters,
     .lookup_export_by_name = iree_hal_mock_executable_lookup_export_by_name,
+    .lookup_global_by_name = iree_hal_mock_executable_lookup_global_by_name,
 };
 
 typedef struct iree_hal_mock_executable_cache_t {


### PR DESCRIPTION
Introduces iree_hal_executable_lookup_global_by_name as the public HAL API for resolving executable-owned globals. The API returns a normal iree_hal_buffer_t so callers can use existing queue copies, mapping checks, and command-buffer bindings instead of reaching around HAL with raw device pointers.

AMDGPU resolves HSA variable symbols for the selected queue-affinity device and wraps the variable address as non-owning executable-backed storage. HIP and CUDA use their module global lookup APIs and wrap external device pointers with the same lifetime rule. Returned buffers retain the executable until the buffer is released.

All executable vtables now implement the hook explicitly. Backends without global support fail with UNIMPLEMENTED, and replay recording fails loudly rather than returning an unrecorded buffer object.

(cherry pick from #24049 with CUDA + AMDGPU support as well as HIP)