### PR TITLE
[ABI] Tighten validation around iree.abi.output storage args

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -611,7 +611,23 @@ createExportWrapperFunc(IREE::ABI::InvocationModel invocationModel,
                            << "; must be a !hal.buffer";
       return {};
     }
-    resultStorages[outputAttr.getInt()] = storageArg;
+    int64_t resultIndex = outputAttr.getInt();
+    if (resultIndex < 0 ||
+        resultIndex >= static_cast<int64_t>(resultStorages.size())) {
+      exportOp.emitError() << "iree.abi.output on argument " << i
+                           << " refers to result " << resultIndex
+                           << " but the function has only "
+                           << resultStorages.size() << " results";
+      return {};
+    }
+    if (resultStorages[resultIndex]) {
+      exportOp.emitError()
+          << "result " << resultIndex
+          << " has multiple iree.abi.output storage arguments; only one is "
+             "permitted";
+      return {};
+    }
+    resultStorages[resultIndex] = storageArg;
   }
 
   // Find the transient storage buffer if provided.

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
             "convert_streamable_ops.mlir",
             "wrap_entry_points.mlir",
             "wrap_entry_points_coarse_fences.mlir",
+            "wrap_entry_points_invalid.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "convert_streamable_ops.mlir"
     "wrap_entry_points.mlir"
     "wrap_entry_points_coarse_fences.mlir"
+    "wrap_entry_points_invalid.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points_invalid.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points_invalid.mlir
@@ -1,0 +1,22 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-abi-wrap-entry-points{invocation-model=sync})' --split-input-file --verify-diagnostics %s
+
+// expected-error @+1 {{iree.abi.output on argument 1 refers to result 5 but the function has only 1 results}}
+util.func public @outputIndexOutOfRange(
+    %arg0: tensor<4xf32>,
+    %ret0: !hal.buffer {iree.abi.output = 5 : index}
+) -> tensor<4xf32> {
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}
+
+// -----
+
+// expected-error @+1 {{result 0 has multiple iree.abi.output storage arguments; only one is permitted}}
+util.func public @outputDuplicateStorage(
+    %arg0: tensor<4xf32>,
+    %ret0a: !hal.buffer {iree.abi.output = 0 : index},
+    %ret0b: !hal.buffer {iree.abi.output = 0 : index}
+) -> tensor<4xf32> {
+  %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
+  util.return %0 : tensor<4xf32>
+}


### PR DESCRIPTION
This PR adds a few compile-time checks to handle `iree.abi.output` better :-

1. Adds a bounds check on `iree.abi.output` against the function's actual result count.
2. Multiple `iree.abi.output` storage arguments targeting the same result index overwrote the previous one, resulting in mis-binding of the buffers at runtime with no diagnostic. This PR fixes that as well.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>
