### PR TITLE
[HAL][local_task] Release retained resources before signaling completion.

### DIFF
--- a/runtime/src/iree/hal/cts/queue/queue_dispatch_test.cc
+++ b/runtime/src/iree/hal/cts/queue/queue_dispatch_test.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <numeric>
 #include <vector>
 
@@ -391,6 +392,116 @@ TEST_P(QueueDispatchTest, DispatchProfileFilterCanSkipDirectDispatchEvents) {
   EXPECT_EQ(0, sink.dispatch_event_count);
   EXPECT_TRUE(sink.dispatch_events.empty());
   EXPECT_FALSE(sink.write_after_end);
+}
+
+// Release callback that flips a flag the first time it is invoked.
+// Used below to detect when the HAL buffer's last ref has been dropped.
+static void FlagReleaseCallback(void* user_data,
+                                iree_hal_buffer_t* /*buffer*/) {
+  *static_cast<bool*>(user_data) = true;
+}
+
+// Verifies that by the time a dispatch's signal semaphore is observed, the
+// queue has already released its retained refs to the binding-table buffers.
+//
+// Otherwise a thread waiting on the signal could race past the wait and tear
+// down dependent objects (e.g. a VM context whose modules' rodata is bound
+// here), only to abort because the queue still holds those refs. We hit this
+// in practice with iree-run-mlir on local-task + vmvx: see the fix in
+// runtime/src/iree/hal/drivers/local_task/task_queue.c that releases the
+// op->resource_set before signaling.
+//
+// The window between "worker signals" and "worker drops its retained refs"
+// is microseconds, so a single iteration is unreliable: usually the worker
+// finishes both before the test thread wakes up. We loop the dispatch many
+// times so the test deterministically catches the bug if the ordering is
+// wrong.
+TEST_P(QueueDispatchTest, BindingBuffersReleasedBeforeSignalIsObserved) {
+  iree_hal_buffer_params_t input_params = {};
+  input_params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL_FOR_DEVICE;
+  input_params.access = IREE_HAL_MEMORY_ACCESS_ALL;
+  input_params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE_READ |
+                       IREE_HAL_BUFFER_USAGE_TRANSFER |
+                       IREE_HAL_BUFFER_USAGE_MAPPING;
+  constexpr iree_device_size_t kInputBytes = 4 * sizeof(uint32_t);
+  iree_device_size_t compat_size = kInputBytes;
+  iree_hal_buffer_params_t compat_params = input_params;
+  if (!iree_all_bits_set(iree_hal_allocator_query_buffer_compatibility(
+                             iree_hal_device_allocator(device_), input_params,
+                             kInputBytes, &compat_params, &compat_size),
+                         IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE)) {
+    GTEST_SKIP() << "Allocator does not support importing host allocations";
+  }
+
+  constexpr int kIterations = 10000;
+  for (int iter = 0; iter < kIterations; ++iter) {
+    SCOPED_TRACE(::testing::Message() << "iteration " << iter);
+
+    // Build the input buffer as an imported host allocation so we can attach
+    // a release callback that fires when the HAL buffer's last ref is
+    // dropped.
+    void* host_ptr = nullptr;
+    IREE_ASSERT_OK(iree_allocator_malloc_aligned(
+        iree_allocator_system(), kInputBytes, /*min_alignment=*/64,
+        /*offset=*/0, &host_ptr));
+    std::vector<uint32_t> input_data = {1, 2, 3, 4};
+    std::memcpy(host_ptr, input_data.data(), kInputBytes);
+
+    bool input_released = false;
+    iree_hal_buffer_release_callback_t release_callback = {};
+    release_callback.fn = FlagReleaseCallback;
+    release_callback.user_data = &input_released;
+
+    iree_hal_external_buffer_t ext = {};
+    ext.type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION;
+    ext.size = kInputBytes;
+    ext.handle.host_allocation.ptr = host_ptr;
+
+    iree_hal_buffer_t* input_buffer = nullptr;
+    IREE_ASSERT_OK(iree_hal_allocator_import_buffer(
+        iree_hal_device_allocator(device_), input_params, &ext,
+        release_callback, &input_buffer));
+    ASSERT_NE(nullptr, input_buffer);
+
+    Ref<iree_hal_buffer_t> output_buffer;
+    IREE_ASSERT_OK(CreateFilledDeviceBuffer(4 * sizeof(uint32_t), uint32_t{99},
+                                            output_buffer.out()));
+
+    iree_hal_buffer_ref_t binding_refs[2];
+    MakeScaleAndOffsetBindings(input_buffer, output_buffer.get(), binding_refs);
+    iree_hal_buffer_ref_list_t bindings = {
+        /*.count=*/IREE_ARRAYSIZE(binding_refs),
+        /*.values=*/binding_refs,
+    };
+
+    const uint32_t constant_data[] = {3, 10};
+    iree_const_byte_span_t constants =
+        iree_make_const_byte_span(constant_data, sizeof(constant_data));
+
+    SemaphoreList empty_wait;
+    SemaphoreList dispatch_signal(device_, {0}, {1});
+    IREE_ASSERT_OK(iree_hal_device_queue_dispatch(
+        device_, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, dispatch_signal,
+        executable_, /*export_ordinal=*/0,
+        iree_hal_make_static_dispatch_config(1, 1, 1), constants, bindings,
+        IREE_HAL_DISPATCH_FLAG_NONE));
+    IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
+        dispatch_signal, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
+
+    // The signal has fired. If the queue has already released its retained
+    // ref on `input_buffer` (correct ordering), our drop below is the last
+    // release and the callback fires synchronously. If the queue still holds
+    // its ref (the regression), the callback does not fire on our drop and
+    // we catch the bug.
+    iree_hal_buffer_release(input_buffer);
+    input_buffer = nullptr;
+    ASSERT_TRUE(input_released)
+        << "queue still held a binding-buffer ref after signaling completion; "
+           "this is the regression in iree_hal_task_queue_op_complete that "
+           "caused intermittent rodata-refcount aborts during VM teardown";
+
+    iree_allocator_free_aligned(iree_allocator_system(), host_ptr);
+  }
 }
 
 // Zero-workgroup dispatches are no-ops that still participate in semaphore

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -692,10 +692,29 @@ static void iree_hal_task_queue_op_advance_frontier(
                                       operation->axis, epoch);
 }
 
+// Releases the resource_set retained for the duration of the operation.
+// Must be called before signaling the operation's signal semaphores so that
+// any thread waiting on the signal observes the resource refs already
+// dropped: otherwise a waiter can race ahead and tear down dependent objects
+// (e.g. a VM context whose modules' rodata is bound here) while the
+// resource_set is still alive, causing a refcount-still-held abort during
+// teardown of those dependent objects.
+static void iree_hal_task_queue_op_release_retained_resources(
+    iree_hal_task_queue_op_t* operation) {
+  if (operation->resource_set) {
+    iree_hal_resource_set_free(operation->resource_set);
+    operation->resource_set = NULL;
+  }
+}
+
 static void iree_hal_task_queue_op_complete_with_epoch(
     iree_hal_task_queue_op_t* operation, uint64_t epoch) {
   iree_status_t status = iree_hal_task_queue_op_unmap_binding_mappings(
       operation, iree_ok_status());
+  // Release the retained resources before signaling so that waiters observing
+  // completion cannot race ahead and tear down dependent objects while we
+  // still hold refs to command buffers / binding-table buffers.
+  iree_hal_task_queue_op_release_retained_resources(operation);
   if (iree_status_is_ok(status)) {
     status = iree_hal_semaphore_list_signal(operation->signal_semaphores,
                                             /*frontier=*/NULL);
@@ -715,6 +734,10 @@ static void iree_hal_task_queue_op_complete(
     iree_hal_task_queue_op_t* operation) {
   iree_status_t status = iree_hal_task_queue_op_unmap_binding_mappings(
       operation, iree_ok_status());
+  // Release the retained resources before signaling so that waiters observing
+  // completion cannot race ahead and tear down dependent objects while we
+  // still hold refs to command buffers / binding-table buffers.
+  iree_hal_task_queue_op_release_retained_resources(operation);
   if (iree_status_is_ok(status)) {
     // Signal all semaphores to their new values.
     status = iree_hal_semaphore_list_signal(operation->signal_semaphores,


### PR DESCRIPTION
Note: This PR (including the description below) is entirely generated by AI (Claude).

Fixes #24331.

`iree_hal_task_queue_op_complete` (and its with-epoch sibling) signaled the operation's signal semaphores *before* freeing the operation's resource set. The resource set retains the command buffer and all binding-table buffers for the duration of the dispatch — so any thread waiting on the signal could observe completion while the worker still held those refs.

In practice this caused intermittent aborts under
`iree-run-mlir --iree-hal-target-device=local --iree-hal-local-target-device-backends=vmvx` during context teardown:

```
  iree_abort                          base/assert.h:26
  iree_vm_buffer_deinitialize         vm/buffer.c:79     // counter == 2
  iree_vm_bytecode_module_destroy     vm/bytecode/module.c:171
  iree_vm_module_release              vm/module.c:238
  iree_vm_context_release_modules     vm/context.c:337
  iree_vm_context_destroy             vm/context.c:482
```

The race chain:

```
  worker:
             op_complete: signal_semaphores  // wakes waiter
             op_complete: ... op_destroy: resource_set_free  // releases refs
  waiter:
             fence.await returns (semaphore signaled)
             vm finishes, iree_vm_invoke returns
             iree_vm_context_release → free_state on HAL module
             iree_vm_module_release on bytecode module
             iree_vm_buffer_deinitialize sees rodata refcount > 1 (worker
                                       hasn't reached resource_set_free yet)
             abort.
```

ThreadSanitizer never flagged this as a data race because every refcount access goes through `iree_atomic_*` and is properly synchronized at the memory-model level. The bug is at a higher abstraction level: a missing happens-before edge between *"owning thread releases its retained resources"* and *"consumer thread observes completion"*.

The fix is mechanical: drop the resource set before publishing the signal in both `op_complete` and `op_complete_with_epoch`. `op_destroy` already guards against a NULL `resource_set`, so the existing teardown path handles the now-already-freed case as a no-op.

Adds a CTS regression test `QueueDispatchTest.BindingBuffersReleasedBeforeSignalIsObserved` that imports a host buffer with a release callback, dispatches with it as a binding, waits on the signal, drops the visible ref, and asserts that the release callback fired synchronously — i.e. the queue had already let go of its retained ref. The test loops 10000 iterations because the race window is microseconds; with the bug present the assertion fires deterministically (observed at iteration ~9429 on local_task+vmvx, TSan build), with the fix in place all iterations pass.