### PR TITLE
[LLVMGPU] Add TileAndFuse fallback for iree_linalg_ext.arg_compare

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_greedily_distribute_to_threads.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_greedily_distribute_to_threads.mlir
@@ -158,3 +158,36 @@ func.func @multiple_use_tilable_op(%3: tensor<64x256xf32>, %4: tensor<64x256xf32
 //       CHECK:       tensor.parallel_insert_slice %[[T]]
 //       CHECK:   mapping = [#gpu.thread<linear_dim_1>, #gpu.thread<linear_dim_0>]
 //       CHECK:   return %[[ADD_DIST]], %[[T_DIST]]
+
+// -----
+
+// Regression: `getVectorTileSizesFromLoopRanges` previously underflowed on
+// rank-0 ops via `loopRanges[rank - 1]`; they should be left untiled instead.
+func.func @rank0_fill_no_crash(%input: tensor<5xf32>) -> (tensor<f32>, tensor<i32>)
+    attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 1, 1] subgroup_size = 64>
+    } {
+  %cstf = arith.constant 0.0 : f32
+  %csti = arith.constant 0 : i32
+  %ev = tensor.empty() : tensor<f32>
+  %ei = tensor.empty() : tensor<i32>
+  %fv = linalg.fill ins(%cstf : f32) outs(%ev : tensor<f32>) -> tensor<f32>
+  %fi = linalg.fill ins(%csti : i32) outs(%ei : tensor<i32>) -> tensor<i32>
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%input : tensor<5xf32>)
+    outs(%fv, %fi : tensor<f32>, tensor<i32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<f32>, tensor<i32>
+  return %0#0, %0#1 : tensor<f32>, tensor<i32>
+}
+
+// CHECK-LABEL: func.func @rank0_fill_no_crash
+//   CHECK-NOT:   scf.forall
+//       CHECK:   linalg.fill {{.*}} -> tensor<f32>
+//       CHECK:   linalg.fill {{.*}} -> tensor<i32>
+//       CHECK:   iree_linalg_ext.arg_compare
+//  CHECK-SAME:     dimension(0)
+//  CHECK-SAME:     ins({{.*}}: tensor<5xf32>)

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -212,6 +212,9 @@ void GenericVectorizationPass::runOnOperation() {
     if (!vectorizeMapStore && isa<IREE::LinalgExt::MapStoreOp>(operation)) {
       return;
     }
+    if (!vectorizeArgCompare && isa<IREE::LinalgExt::ArgCompareOp>(operation)) {
+      return;
+    }
     candidates.push_back(op);
   });
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -647,7 +647,9 @@ def GenericVectorizationPass :
             /*default=*/"2147483647",
            "Max vector size allowed to avoid creating large vectors.">,
     Option<"vectorizeMapStore", "vectorize-map-store", "bool", /*default=*/"false",
-      "Enable vectorization of iree_linalg_ext.map_store operations via VectorizableOpInterface.">
+      "Enable vectorization of iree_linalg_ext.map_store operations via VectorizableOpInterface.">,
+    Option<"vectorizeArgCompare", "vectorize-arg-compare", "bool", /*default=*/"true",
+      "Enable vectorization of iree_linalg_ext.arg_compare operations via VectorizableOpInterface.">
   ];
   let dependentDialects = [
     "::mlir::arith::ArithDialect"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -649,7 +649,10 @@ def GenericVectorizationPass :
     Option<"vectorizeMapStore", "vectorize-map-store", "bool", /*default=*/"false",
       "Enable vectorization of iree_linalg_ext.map_store operations via VectorizableOpInterface.">,
     Option<"vectorizeArgCompare", "vectorize-arg-compare", "bool", /*default=*/"true",
-      "Enable vectorization of iree_linalg_ext.arg_compare operations via VectorizableOpInterface.">
+      "Vectorize iree_linalg_ext.arg_compare. Disable for pipelines without a "
+      "lowering for iree_vector_ext.arg_compare. "
+      "TODO(#24365): remove once a generic vector lowering for "
+      "iree_vector_ext.arg_compare exists.">
   ];
   let dependentDialects = [
     "::mlir::arith::ArithDialect"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -50,6 +50,12 @@ static SmallVector<int64_t> getVectorTileSizesFromLoopRanges(
     ArrayRef<int64_t> loopRanges, int64_t numThreads, int64_t vectorSize,
     bool allowMultiDimCollapse = true,
     std::optional<int64_t> vectorizableDim = std::nullopt) {
+  // Rank-0 ops (e.g., a `linalg.fill` seeding a scalar tensor) have no loop
+  // dimension to vectorize across; return an empty tile-size list so callers
+  // can skip the op rather than indexing `loopRanges[-1]`.
+  if (loopRanges.empty()) {
+    return {};
+  }
   int64_t rank = loopRanges.size();
   int64_t targetDim = vectorizableDim.has_value() ? *vectorizableDim : rank - 1;
   int64_t targetRange = loopRanges[targetDim];

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -2075,6 +2075,92 @@ LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
                             workgroupSize, subgroupSize));
 }
 
+//====---------------------------------------------------------------------===//
+// ArgCompare Pipeline Configuration
+//====---------------------------------------------------------------------===//
+
+LogicalResult setArgCompareConfig(IREE::GPU::TargetAttr target,
+                                  mlir::FunctionOpInterface entryPoint,
+                                  Operation *op) {
+  assert(isa<IREE::LinalgExt::ArgCompareOp>(op) &&
+         "expected linalg_ext.arg_compare op");
+  auto argCompareOp = cast<IREE::LinalgExt::ArgCompareOp>(op);
+  MLIRContext *context = op->getContext();
+  Builder b(context);
+
+  const int64_t subgroupSize = target.getPreferredSubgroupSize();
+  auto interfaceOp = cast<PartitionableLoopsInterface>(*op);
+  SmallVector<unsigned> partitionedLoops =
+      interfaceOp.getPartitionableLoops(std::nullopt);
+
+  auto createLoweringConfig = [&](ArrayRef<int64_t> workgroupSizes,
+                                  ArrayRef<int64_t> threadSizes) {
+    NamedAttribute attrs[2] = {{"workgroup", b.getI64ArrayAttr(workgroupSizes)},
+                               {"thread", b.getI64ArrayAttr(threadSizes)}};
+    auto configDict = b.getDictionaryAttr(attrs);
+    return IREE::GPU::LoweringConfigAttr::get(context, configDict);
+  };
+
+  // No parallel dims (e.g. rank-1 input reducing to a scalar) means there is
+  // nothing for the TileAndFuse pipeline to distribute across threads, and the
+  // resulting `tile = [0]` config trips downstream tiling passes. Bail out and
+  // let the dispatcher fall through to `setRootDefaultConfig`.
+  if (partitionedLoops.empty()) {
+    return failure();
+  }
+
+  // arg_compare's iteration domain has one loop per input dim; the single
+  // reduction dim is `getDimension()` and the rest are parallel.
+  int64_t numLoops = argCompareOp.getInputRank();
+
+  // Starting point pending tuning data: two warps per workgroup mirrors
+  // setSortConfig and gives reasonable occupancy without over-subscribing
+  // for the small parallel iteration spaces typical of arg_compare fallbacks.
+  std::array<int64_t, 3> workgroupSize = {2 * subgroupSize, 1, 1};
+  SmallVector<int64_t> workgroupTileSizes(numLoops, 1);
+  SmallVector<int64_t> threadTileSizes(numLoops, 1);
+
+  // Set non-parallel loops (the single reduction dim) to zero tile size so
+  // each thread runs the full reduction on its parallel slice.
+  llvm::DenseSet<unsigned> partitionedLoopsSet(llvm::from_range,
+                                               partitionedLoops);
+  for (int64_t depth : llvm::seq<int64_t>(0, numLoops)) {
+    if (!partitionedLoopsSet.contains(depth)) {
+      workgroupTileSizes[depth] = 0;
+      threadTileSizes[depth] = 0;
+    }
+  }
+
+  // Pack as many parallel-dim iterations as possible into the workgroup tile
+  // (innermost dim first), matching the setSortConfig packing strategy.
+  ArrayRef<int64_t> loopBounds = argCompareOp.getInputType().getShape();
+  int64_t residualWorkgroupSize = workgroupSize[0];
+  for (int64_t depth = numLoops - 1; depth >= 0; --depth) {
+    if (!partitionedLoopsSet.contains(depth)) {
+      continue;
+    }
+    if (ShapedType::isDynamic(loopBounds[depth])) {
+      continue;
+    }
+    if (residualWorkgroupSize % loopBounds[depth] == 0) {
+      workgroupTileSizes[depth] = loopBounds[depth];
+      residualWorkgroupSize /= loopBounds[depth];
+      continue;
+    }
+    if (loopBounds[depth] % residualWorkgroupSize == 0) {
+      workgroupTileSizes[depth] = residualWorkgroupSize;
+      break;
+    }
+  }
+
+  IREE::GPU::LoweringConfigAttr loweringConfig =
+      createLoweringConfig(workgroupTileSizes, threadTileSizes);
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPoint, op, loweringConfig,
+      getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                            workgroupSize, subgroupSize));
+}
+
 //===----------------------------------------------------------------------===//
 // Lowering Config Attributes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -2082,8 +2082,6 @@ LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
 LogicalResult setArgCompareConfig(IREE::GPU::TargetAttr target,
                                   mlir::FunctionOpInterface entryPoint,
                                   Operation *op) {
-  assert(isa<IREE::LinalgExt::ArgCompareOp>(op) &&
-         "expected linalg_ext.arg_compare op");
   auto argCompareOp = cast<IREE::LinalgExt::ArgCompareOp>(op);
   MLIRContext *context = op->getContext();
   Builder b(context);
@@ -2097,8 +2095,8 @@ LogicalResult setArgCompareConfig(IREE::GPU::TargetAttr target,
                                   ArrayRef<int64_t> threadSizes) {
     NamedAttribute attrs[2] = {{"workgroup", b.getI64ArrayAttr(workgroupSizes)},
                                {"thread", b.getI64ArrayAttr(threadSizes)}};
-    auto configDict = b.getDictionaryAttr(attrs);
-    return IREE::GPU::LoweringConfigAttr::get(context, configDict);
+    return IREE::GPU::LoweringConfigAttr::get(context,
+                                              b.getDictionaryAttr(attrs));
   };
 
   // No parallel dims (e.g. rank-1 input reducing to a scalar) means there is

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -2100,14 +2100,20 @@ LogicalResult setArgCompareConfig(IREE::GPU::TargetAttr target,
   };
 
   // No parallel dims (e.g. rank-1 input reducing to a scalar) means there is
-  // nothing to distribute across threads. Emitting a `[0]`-length tile config
-  // for a rank-0 result trips downstream passes (GPUGreedilyDistributeToThreads
-  // crashes on rank-0 iteration targets when fused with `linalg.fill`).
-  // Bail out and let the dispatcher fall through to setRootDefaultConfig; for
-  // rank-1 reducing to a scalar the race in the default pipeline is benign
-  // because every thread computes the same value.
+  // nothing to distribute across threads. Emit a degenerate single-thread
+  // TileAndFuse config instead of bailing: the per-loop tile size is 0 for
+  // every reduction loop, so a single thread walks the full reduction once
+  // without racing.
   if (partitionedLoops.empty()) {
-    return failure();
+    int64_t numLoops = argCompareOp.getInputRank();
+    SmallVector<int64_t> zeroTileSizes(numLoops, 0);
+    IREE::GPU::LoweringConfigAttr loweringConfig =
+        createLoweringConfig(zeroTileSizes, zeroTileSizes);
+    std::array<int64_t, 3> singleThread = {1, 1, 1};
+    return setOpConfigAndEntryPointFnTranslation(
+        entryPoint, op, loweringConfig,
+        getGPUTranslationInfo(op->getContext(), LoweringPipeline::TileAndFuse,
+                              singleThread, subgroupSize));
   }
 
   // arg_compare's iteration domain has one loop per input dim; the single

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -2102,9 +2102,12 @@ LogicalResult setArgCompareConfig(IREE::GPU::TargetAttr target,
   };
 
   // No parallel dims (e.g. rank-1 input reducing to a scalar) means there is
-  // nothing for the TileAndFuse pipeline to distribute across threads, and the
-  // resulting `tile = [0]` config trips downstream tiling passes. Bail out and
-  // let the dispatcher fall through to `setRootDefaultConfig`.
+  // nothing to distribute across threads. Emitting a `[0]`-length tile config
+  // for a rank-0 result trips downstream passes (GPUGreedilyDistributeToThreads
+  // crashes on rank-0 iteration targets when fused with `linalg.fill`).
+  // Bail out and let the dispatcher fall through to setRootDefaultConfig; for
+  // rank-1 reducing to a scalar the race in the default pipeline is benign
+  // because every thread computes the same value.
   if (partitionedLoops.empty()) {
     return failure();
   }
@@ -2151,6 +2154,18 @@ LogicalResult setArgCompareConfig(IREE::GPU::TargetAttr target,
       workgroupTileSizes[depth] = residualWorkgroupSize;
       break;
     }
+  }
+
+  // If the parallel iterations actually packed into the workgroup tile fit in
+  // a single subgroup, drop to one warp so we don't launch idle threads.
+  int64_t cumulativeWorkgroupTile = 1;
+  for (int64_t depth : llvm::seq<int64_t>(0, numLoops)) {
+    if (partitionedLoopsSet.contains(depth) && workgroupTileSizes[depth] > 0) {
+      cumulativeWorkgroupTile *= workgroupTileSizes[depth];
+    }
+  }
+  if (cumulativeWorkgroupTile <= subgroupSize) {
+    workgroupSize[0] = subgroupSize;
   }
 
   IREE::GPU::LoweringConfigAttr loweringConfig =

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -60,6 +60,14 @@ LogicalResult setSortConfig(IREE::GPU::TargetAttr target,
                             mlir::FunctionOpInterface entryPoint,
                             Operation *op);
 
+/// Helper for setting tile sizes for arg_compare. Targets the TileAndFuse
+/// pipeline so the parallel iteration space is distributed across threads via
+/// `scf.forall` + `GPUDistributeForall`, while the reduction dimension stays
+/// untiled (each thread runs the deterministic scan on its own slice).
+LogicalResult setArgCompareConfig(IREE::GPU::TargetAttr target,
+                                  mlir::FunctionOpInterface entryPoint,
+                                  Operation *op);
+
 /// Helper for setting up a memory bound reduction configuration, focusing
 /// on getting peak global memory bandwidth. Supports linalg::LinalgOp and
 /// LinalgExt::ArgCompareOp.

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -279,6 +279,9 @@ def IREEVectorExt_YieldOp : IREEVectorExt_PureOp<"yield", [
 // LinalgExt-style ops.
 //===----------------------------------------------------------------------===//
 
+// TODO(#24365): the only lowering for this op today is via the nested-layout
+// distribution patterns owned by the VectorDistribute pipeline. Add a generic
+// lowering (e.g. via vector.* ops) so CPU and other GPU backends can use it.
 def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
   Pure,
   AttrSizedOperandSegments,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2486,6 +2486,10 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
                 target, entryPointFn, argCompareOp.getOperation()))) {
           return success();
         }
+        if (succeeded(IREE::GPU::setArgCompareConfig(
+                target, entryPointFn, argCompareOp.getOperation()))) {
+          return success();
+        }
         return setRootDefaultConfig(target, entryPointFn, computeOp);
       })
       .Case<IREE::LinalgExt::WinogradInputTransformOp,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -578,9 +578,10 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   // `iree_vector_ext.arg_compare` only has a lowering through the nested-layout
   // distribution patterns owned by the VectorDistribute pipeline. Ops routed
   // to TileAndFuse (small reductions, f64) need the scalar-loop lowering from
-  // `LinalgExtToLoops` instead. This gate is intentionally narrow and should
-  // be removed once a TileAndFuse-compatible lowering for
-  // `iree_vector_ext.arg_compare` exists.
+  // `LinalgExtToLoops` instead. This gate is intentionally narrow.
+  // TODO(https://github.com/iree-org/iree/issues/24309): Remove this option
+  // once a TileAndFuse-compatible lowering for `iree_vector_ext.arg_compare`
+  // exists.
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false,
                             /*enableMasking=*/true,
                             /*foldIdentitySlices=*/true,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -272,7 +272,8 @@ static void tileAndBufferize(OpPassManager &funcPassManager) {
 static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
                                       bool vectorizeCopies, bool enableMasking,
                                       bool foldIdentitySlices,
-                                      bool decomposeMasks) {
+                                      bool decomposeMasks,
+                                      bool vectorizeArgCompare) {
   funcPassManager.addPass(createDecomposeConvolutionToLowerDimOpsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -286,6 +287,7 @@ static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
   options.foldCastIntoContract = true;
   options.enableVectorMasking = enableMasking;
   options.vectorizeMapStore = true;
+  options.vectorizeArgCompare = vectorizeArgCompare;
   funcPassManager.addPass(createGenericVectorizationPass(options));
   // Im2col decomposition runs after vectorization so that im2col ops get
   // direct vectorization via VectorizableOpInterface when possible. Any
@@ -326,7 +328,8 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager) {
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/true,
                             /*enableMasking=*/false,
                             /*foldIdentitySlices=*/false,
-                            /*decomposeMasks=*/false);
+                            /*decomposeMasks=*/false,
+                            /*vectorizeArgCompare=*/true);
 
   // tensor to memref
   addBufferizePasses(funcPassManager);
@@ -571,10 +574,18 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createGPUCombineValueSemanticBarriersPass());
 
   // Step 6. Vectorize.
+  // Skip vectorization of `iree_linalg_ext.arg_compare` here: the resulting
+  // `iree_vector_ext.arg_compare` only has a lowering through the nested-layout
+  // distribution patterns owned by the VectorDistribute pipeline. Ops routed
+  // to TileAndFuse (small reductions, f64) need the scalar-loop lowering from
+  // `LinalgExtToLoops` instead. This gate is intentionally narrow and should
+  // be removed once a TileAndFuse-compatible lowering for
+  // `iree_vector_ext.arg_compare` exists.
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false,
                             /*enableMasking=*/true,
                             /*foldIdentitySlices=*/true,
-                            /*decomposeMasks=*/false);
+                            /*decomposeMasks=*/false,
+                            /*vectorizeArgCompare=*/false);
   funcPassManager.addPass(createCleanupBufferAllocViewPass());
   funcPassManager.addPass(createGPUCombineValueSemanticBarriersPass());
 
@@ -659,7 +670,8 @@ void addGPUWinogradVectorizePassPipeline(OpPassManager &funcPassManager) {
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/true,
                             /*enableMasking=*/false,
                             /*foldIdentitySlices=*/false,
-                            /*decomposeMasks=*/false);
+                            /*decomposeMasks=*/false,
+                            /*vectorizeArgCompare=*/true);
 
   // tensor to memref
   addBufferizePasses(funcPassManager);
@@ -822,7 +834,8 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/true,
                             /*enableMasking=*/true,
                             /*foldIdentitySlices=*/false,
-                            /*decomposeMasks=*/true);
+                            /*decomposeMasks=*/true,
+                            /*vectorizeArgCompare=*/true);
 
   // Allocate tensors for copies to shared memory.
   funcPassManager.addPass(createGPUVectorAllocPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -579,9 +579,8 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   // distribution patterns owned by the VectorDistribute pipeline. Ops routed
   // to TileAndFuse (small reductions, f64) need the scalar-loop lowering from
   // `LinalgExtToLoops` instead. This gate is intentionally narrow.
-  // TODO(https://github.com/iree-org/iree/issues/24309): Remove this option
-  // once a TileAndFuse-compatible lowering for `iree_vector_ext.arg_compare`
-  // exists.
+  // TODO(#24365): Remove this option once a generic vector lowering for
+  // `iree_vector_ext.arg_compare` exists.
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false,
                             /*enableMasking=*/true,
                             /*foldIdentitySlices=*/true,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
@@ -294,3 +294,33 @@ func.func @argcompare_f64_fallback(
 // CHECK:         iree_linalg_ext.arg_compare
 // CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [{{[0-9]+}}, 0],
 // CHECK-SAME:        workgroup = [{{[0-9]+}}, 0]}>
+
+// -----
+
+// Rank-1 input reducing to a scalar: the only iteration loop is the reduction
+// dim, so there are no parallel loops to distribute across threads.
+// setReductionConfig rejects (reduction size 5 below subgroup), and
+// setArgCompareConfig emits a degenerate single-thread TileAndFuse config
+// (workgroup_size = [1, 1, 1], tile = [0]) so the lone thread runs the full
+// scan once.
+
+func.func @argcompare_1d_rank_to_scalar_f32(
+    %input: tensor<5xf32>,
+    %out_val: tensor<f32>,
+    %out_idx: tensor<i32>) -> (tensor<f32>, tensor<i32>) {
+  %0:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%input : tensor<5xf32>)
+    outs(%out_val, %out_idx : tensor<f32>, tensor<i32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<f32>, tensor<i32>
+  return %0#0, %0#1 : tensor<f32>, tensor<i32>
+}
+
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
+// CHECK-SAME:    workgroup_size = [1, 1, 1] subgroup_size = 64
+// CHECK-LABEL: func.func @argcompare_1d_rank_to_scalar_f32
+// CHECK:         iree_linalg_ext.arg_compare
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [0], workgroup = [0]}>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
@@ -213,6 +213,88 @@ func.func @argcompare_argmin() {
 
 // -----
 
+// Reduction size 2 is smaller than the subgroup size, so setReductionConfig
+// rejects this op and it falls through to setArgCompareConfig (TileAndFuse).
+// This is the canonical small-reduction case that motivated routing
+// arg_compare through TileAndFuse.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_small_reduction_f32() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x3x4xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xi64>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 3, 4], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x3x4xf32>> -> tensor<2x3x4xf32>
+  %4 = tensor.empty() : tensor<3x4xf32>
+  %5 = tensor.empty() : tensor<3x4xi64>
+  %6:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%3 : tensor<2x3x4xf32>)
+    outs(%4, %5 : tensor<3x4xf32>, tensor<3x4xi64>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<3x4xf32>, tensor<3x4xi64>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0, 0], sizes = [3, 4], strides = [1, 1] : tensor<3x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xf32>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0, 0], sizes = [3, 4], strides = [1, 1] : tensor<3x4xi64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xi64>>
+  return
+}
+
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
+// CHECK-SAME:    workgroup_size = [{{[0-9]+}}, 1, 1] subgroup_size = 64
+// CHECK-LABEL: func.func @argcompare_small_reduction_f32
+// CHECK:         iree_linalg_ext.arg_compare
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [0,
+// CHECK-SAME:        workgroup = [0,
+
+// -----
+
+// Reduction size 100 is not a multiple of any subgroup size choice
+// (32 or 64), so setReductionConfig rejects this op even though the
+// element type (f32) is supported. It falls through to
+// setArgCompareConfig (TileAndFuse).
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_unaligned_reduction_f32() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x100xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 100], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x100xf32>> -> tensor<8x100xf32>
+  %4 = tensor.empty() : tensor<8xf32>
+  %5 = tensor.empty() : tensor<8xi32>
+  %6:2 = iree_linalg_ext.arg_compare
+    dimension(1)
+    ins(%3 : tensor<8x100xf32>)
+    outs(%4, %5 : tensor<8xf32>, tensor<8xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<8xf32>, tensor<8xi32>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf32>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0], sizes = [8], strides = [1] : tensor<8xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
+  return
+}
+
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
+// CHECK-SAME:    workgroup_size = [{{[0-9]+}}, 1, 1] subgroup_size = 64
+// CHECK-LABEL: func.func @argcompare_unaligned_reduction_f32
+// CHECK:         iree_linalg_ext.arg_compare
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [{{[0-9]+}}, 0],
+// CHECK-SAME:        workgroup = [{{[0-9]+}}, 0]}>
+
+// -----
+
 // f64 (64-bit) is not supported by vector distribution, falls back to default.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -242,5 +324,9 @@ func.func @argcompare_f64_fallback() {
   return
 }
 
-// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Distribute>
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
+// CHECK-SAME:    workgroup_size = [{{[0-9]+}}, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @argcompare_f64_fallback
+// CHECK:         iree_linalg_ext.arg_compare
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [{{[0-9]+}}, 0],
+// CHECK-SAME:        workgroup = [{{[0-9]+}}, 0]}>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
@@ -218,31 +218,19 @@ func.func @argcompare_argmin() {
 // This is the canonical small-reduction case that motivated routing
 // arg_compare through TileAndFuse.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @argcompare_small_reduction_f32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x3x4xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xi64>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 3, 4], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x3x4xf32>> -> tensor<2x3x4xf32>
-  %4 = tensor.empty() : tensor<3x4xf32>
-  %5 = tensor.empty() : tensor<3x4xi64>
-  %6:2 = iree_linalg_ext.arg_compare
+func.func @argcompare_small_reduction_f32(
+    %input: tensor<2x3x4xf32>,
+    %out_val: tensor<3x4xf32>,
+    %out_idx: tensor<3x4xi64>) -> (tensor<3x4xf32>, tensor<3x4xi64>) {
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(0)
-    ins(%3 : tensor<2x3x4xf32>)
-    outs(%4, %5 : tensor<3x4xf32>, tensor<3x4xi64>) {
+    ins(%input : tensor<2x3x4xf32>)
+    outs(%out_val, %out_idx : tensor<3x4xf32>, tensor<3x4xi64>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
       iree_linalg_ext.yield %cmp : i1
   } -> tensor<3x4xf32>, tensor<3x4xi64>
-  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0, 0], sizes = [3, 4], strides = [1, 1] : tensor<3x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xf32>>
-  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0, 0], sizes = [3, 4], strides = [1, 1] : tensor<3x4xi64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xi64>>
-  return
+  return %0#0, %0#1 : tensor<3x4xf32>, tensor<3x4xi64>
 }
 
 // CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
@@ -259,31 +247,19 @@ func.func @argcompare_small_reduction_f32() {
 // element type (f32) is supported. It falls through to
 // setArgCompareConfig (TileAndFuse).
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @argcompare_unaligned_reduction_f32() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x100xf32>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf32>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 100], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x100xf32>> -> tensor<8x100xf32>
-  %4 = tensor.empty() : tensor<8xf32>
-  %5 = tensor.empty() : tensor<8xi32>
-  %6:2 = iree_linalg_ext.arg_compare
+func.func @argcompare_unaligned_reduction_f32(
+    %input: tensor<8x100xf32>,
+    %out_val: tensor<8xf32>,
+    %out_idx: tensor<8xi32>) -> (tensor<8xf32>, tensor<8xi32>) {
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
-    ins(%3 : tensor<8x100xf32>)
-    outs(%4, %5 : tensor<8xf32>, tensor<8xi32>) {
+    ins(%input : tensor<8x100xf32>)
+    outs(%out_val, %out_idx : tensor<8xf32>, tensor<8xi32>) {
     ^bb0(%a: f32, %b: f32):
       %cmp = arith.cmpf ogt, %a, %b : f32
       iree_linalg_ext.yield %cmp : i1
   } -> tensor<8xf32>, tensor<8xi32>
-  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf32>>
-  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0], sizes = [8], strides = [1] : tensor<8xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
-  return
+  return %0#0, %0#1 : tensor<8xf32>, tensor<8xi32>
 }
 
 // CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
@@ -297,31 +273,19 @@ func.func @argcompare_unaligned_reduction_f32() {
 
 // f64 (64-bit) is not supported by vector distribution, falls back to default.
 
-#pipeline_layout = #hal.pipeline.layout<bindings = [
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>,
-  #hal.pipeline.binding<storage_buffer>
-]>
-
-func.func @argcompare_f64_fallback() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x256xf64>>
-  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf64>>
-  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
-  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x256xf64>> -> tensor<8x256xf64>
-  %4 = tensor.empty() : tensor<8xf64>
-  %5 = tensor.empty() : tensor<8xi32>
-  %6:2 = iree_linalg_ext.arg_compare
+func.func @argcompare_f64_fallback(
+    %input: tensor<8x256xf64>,
+    %out_val: tensor<8xf64>,
+    %out_idx: tensor<8xi32>) -> (tensor<8xf64>, tensor<8xi32>) {
+  %0:2 = iree_linalg_ext.arg_compare
     dimension(1)
-    ins(%3 : tensor<8x256xf64>)
-    outs(%4, %5 : tensor<8xf64>, tensor<8xi32>) {
+    ins(%input : tensor<8x256xf64>)
+    outs(%out_val, %out_idx : tensor<8xf64>, tensor<8xi32>) {
     ^bb0(%a: f64, %b: f64):
       %cmp = arith.cmpf ogt, %a, %b : f64
       iree_linalg_ext.yield %cmp : i1
   } -> tensor<8xf64>, tensor<8xi32>
-  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf64>>
-  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0], sizes = [8], strides = [1] : tensor<8xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
-  return
+  return %0#0, %0#1 : tensor<8xf64>, tensor<8xi32>
 }
 
 // CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
@@ -234,11 +234,10 @@ func.func @argcompare_small_reduction_f32(
 }
 
 // CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
-// CHECK-SAME:    workgroup_size = [{{[0-9]+}}, 1, 1] subgroup_size = 64
+// CHECK-SAME:    workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @argcompare_small_reduction_f32
 // CHECK:         iree_linalg_ext.arg_compare
-// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [0,
-// CHECK-SAME:        workgroup = [0,
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [0, 1, 1], workgroup = [0, 1, 4]}>
 
 // -----
 
@@ -263,11 +262,10 @@ func.func @argcompare_unaligned_reduction_f32(
 }
 
 // CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
-// CHECK-SAME:    workgroup_size = [{{[0-9]+}}, 1, 1] subgroup_size = 64
+// CHECK-SAME:    workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @argcompare_unaligned_reduction_f32
 // CHECK:         iree_linalg_ext.arg_compare
-// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [{{[0-9]+}}, 0],
-// CHECK-SAME:        workgroup = [{{[0-9]+}}, 0]}>
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [1, 0], workgroup = [8, 0]}>
 
 // -----
 
@@ -289,11 +287,10 @@ func.func @argcompare_f64_fallback(
 }
 
 // CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse>
-// CHECK-SAME:    workgroup_size = [{{[0-9]+}}, 1, 1] subgroup_size = 64
+// CHECK-SAME:    workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @argcompare_f64_fallback
 // CHECK:         iree_linalg_ext.arg_compare
-// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [{{[0-9]+}}, 0],
-// CHECK-SAME:        workgroup = [{{[0-9]+}}, 0]}>
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [1, 0], workgroup = [8, 0]}>
 
 // -----
 


### PR DESCRIPTION
This PR is a short-term fix: send arg_compare ops unsupported by the `VectorDistribute `pipeline to `TileAndFuse`
- adds a `setArgCompareConfig` lowering-config function that routes                                                                                                                           `iree_linalg_ext.arg_compare` ops to the `LLVMGPUTileAndFuse` pipeline when `setReductionConfig` (the VectorDistribute path) rejects them.  
- gates `iree_linalg_ext.arg_compare` vectorization in the `TileAndFuse` pipeline only, while the resulting  `iree_vector_ext.arg_compare` only has a lowering through the nested-layout distribution patterns owned by the VectorDistribute pipeline. 

Issue: #24309 
Assisted-by:  [Claude Code](https://claude.ai/code)                                                                                                                                                                                                                                                                                                                                                                                             