### PR TITLE
[Codegen] Limit async scope in pipelining

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -1095,14 +1095,6 @@ static void insertAsyncDrainBefore(RewriterBase &rewriter, Location loc,
 /// Converts direct pre-existing gather_to_lds ops before the pipelined loop to
 /// async mode and inserts explicit waits that preserve their original
 /// synchronous behavior.
-///
-/// Pre-loop async groups must be fully drained before the pipelining prologue
-/// starts. Otherwise, the loop body's wait.asyncmark N would count unrelated
-/// pre-loop groups and no longer correspond to the intended N-stage pipeline.
-///
-/// This only handles direct gather_to_lds ops in the parent block. Recursively
-/// converting nested pre-loop gathers would require placing marks and waits
-/// inside those nested regions according to their local control flow.
 static void insertPreLoopAsyncMarkers(RewriterBase &rewriter, Location loc,
                                       Block::iterator preLoopStart,
                                       Block::iterator preLoopEnd) {
@@ -1324,11 +1316,17 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
     return forOp;
   }
 
+  Operation *opBeforeLoop = nullptr;
   if (mode == PipelineMode::AsyncCopy) {
     // Apply multi-buffering: numStages buffers for N-stage pipelining.
     if (failed(multiBufferLDSAllocations(forOp, /*numBuffers=*/numStages))) {
       return failure();
     }
+    // Record the operation before the original loop. After pipelining, the next
+    // operation after this marker is the start of the generated prologue. Ops
+    // before that boundary are pre-existing parent-block ops and are explicitly
+    // drained separately from the pipelined async groups.
+    opBeforeLoop = forOp->getPrevNode();
   }
 
   // Re-run classification on the (potentially multi-buffered) IR to capture
@@ -1363,15 +1361,6 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
   LLVM_DEBUG(dumpSchedule(finalSchedule, opToCluster));
 
   scf::PipeliningOption options = buildPipeliningOption(finalSchedule);
-
-  Operation *opBeforeLoop = nullptr;
-  if (mode == PipelineMode::AsyncCopy) {
-    // Record the operation before the original loop. After pipelining, the next
-    // operation after this marker is the start of the generated prologue. Ops
-    // before that boundary are pre-existing parent-block ops and are explicitly
-    // drained separately from the pipelined async groups.
-    opBeforeLoop = forOp->getPrevNode();
-  }
 
   FailureOr<scf::ForOp> newForOpOr = invokePipelineForLoop(forOp, options);
   if (failed(newForOpOr)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -1075,11 +1075,17 @@ static Operation *findLastGatherToLDS(Block::iterator begin,
   return nullptr;
 }
 
-/// Sets the async flag on all gather_to_lds ops in the parent block so they
+/// Sets the async flag on gather_to_lds ops in the given block range so they
 /// lower to rocdl.load.async.to.lds instead of rocdl.load.to.lds.
-static void enableAsyncOnGatherOps(Block *parentBlock) {
-  parentBlock->walk(
-      [](amdgpu::GatherToLDSOp gatherOp) { gatherOp.setAsync(true); });
+/// Only affects ops between prologueStart and the end of the block, plus ops
+/// inside the loop body. This avoids making pre-existing gather ops (e.g., Q
+/// loads consumed before the loop) async, which would be incorrect since those
+/// ops lack corresponding asyncmark/wait.asyncmark synchronization.
+static void enableAsyncOnGatherOps(Block *parentBlock,
+                                   Block::iterator prologueStart) {
+  for (auto it = prologueStart; it != parentBlock->end(); ++it) {
+    it->walk([](amdgpu::GatherToLDSOp gatherOp) { gatherOp.setAsync(true); });
+  }
 }
 
 /// Inserts asyncmark ops in the prologue to delineate DMA groups.
@@ -1088,11 +1094,11 @@ static void enableAsyncOnGatherOps(Block *parentBlock) {
 /// Each iteration group gets one asyncmark after its last gather_to_lds.
 /// Groups are identified by evenly dividing the total prologue gather ops.
 static void insertPrologueAsyncMarks(RewriterBase &rewriter, Location loc,
-                                     Block *parentBlock,
+                                     Block::iterator prologueStart,
                                      Block::iterator loopStart,
                                      unsigned numStages) {
   SmallVector<Operation *> prologueGathers;
-  for (auto it = parentBlock->begin(); it != loopStart; ++it) {
+  for (auto it = prologueStart; it != loopStart; ++it) {
     if (isa<amdgpu::GatherToLDSOp>(&*it)) {
       prologueGathers.push_back(&*it);
     } else if (it->getNumRegions() > 0 && containsNestedGatherToLDS(&*it)) {
@@ -1175,15 +1181,15 @@ static void insertEpilogueAsyncWait(RewriterBase &rewriter, Location loc,
 /// new DMA group we wait until only (N-1) groups are in flight, ensuring the
 /// oldest group's data is ready for reading.
 static void insertExplicitAsyncMarkers(RewriterBase &rewriter,
-                                       scf::ForOp newForOp,
-                                       unsigned numStages) {
+                                       scf::ForOp newForOp, unsigned numStages,
+                                       Block::iterator prologueStart) {
   Block *parentBlock = newForOp->getBlock();
   Location loc = newForOp.getLoc();
   int16_t waitCount = static_cast<int16_t>(numStages - 1);
 
-  enableAsyncOnGatherOps(parentBlock);
-  insertPrologueAsyncMarks(rewriter, loc, parentBlock, newForOp->getIterator(),
-                           numStages);
+  enableAsyncOnGatherOps(parentBlock, prologueStart);
+  insertPrologueAsyncMarks(rewriter, loc, prologueStart,
+                           newForOp->getIterator(), numStages);
   insertLoopBodyAsyncMarkers(rewriter, loc, newForOp, waitCount);
   insertEpilogueAsyncWait(rewriter, loc, std::next(newForOp->getIterator()),
                           parentBlock->end());
@@ -1318,6 +1324,20 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
 
   scf::PipeliningOption options = buildPipeliningOption(finalSchedule);
 
+  // Record the position of the original loop before pipelining. The pipelining
+  // transformation inserts prologue ops before the loop and epilogue ops after.
+  // Any gather_to_lds ops that existed before the loop in the parent block
+  // (e.g., Q loads in attention) are not part of the pipeline and must not be
+  // converted to async mode.
+  Block *parentBlock = forOp->getBlock();
+  Block::iterator preLoopMarker = forOp->getIterator();
+  bool noOpsBeforeLoop = (preLoopMarker == parentBlock->begin());
+  if (!noOpsBeforeLoop) {
+    // Decrement to point to the operation before the loop that is going to be
+    // transform, otherwise the marker would be invalidated.
+    --preLoopMarker;
+  }
+
   FailureOr<scf::ForOp> newForOpOr = invokePipelineForLoop(forOp, options);
   if (failed(newForOpOr)) {
     return failure();
@@ -1334,7 +1354,11 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
   // allowing DMA writes to a new buffer slot to overlap with ds_reads from the
   // previous slot.
   if (mode == PipelineMode::AsyncCopy) {
-    insertExplicitAsyncMarkers(rewriter, newForOp, numStages);
+    // Compute the start of the pipelining prologue, skipping any pre-existing
+    // ops that were before the original loop.
+    Block::iterator prologueStart =
+        noOpsBeforeLoop ? parentBlock->begin() : std::next(preLoopMarker);
+    insertExplicitAsyncMarkers(rewriter, newForOp, numStages, prologueStart);
   }
 
   return newForOp;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/ROCDLPrefetchSharedMemoryCopy.cpp
@@ -1075,16 +1075,55 @@ static Operation *findLastGatherToLDS(Block::iterator begin,
   return nullptr;
 }
 
-/// Sets the async flag on gather_to_lds ops in the given block range so they
+/// Sets the async flag on gather_to_lds ops from `begin` to `end` so they
 /// lower to rocdl.load.async.to.lds instead of rocdl.load.to.lds.
-/// Only affects ops between prologueStart and the end of the block, plus ops
-/// inside the loop body. This avoids making pre-existing gather ops (e.g., Q
-/// loads consumed before the loop) async, which would be incorrect since those
-/// ops lack corresponding asyncmark/wait.asyncmark synchronization.
-static void enableAsyncOnGatherOps(Block *parentBlock,
-                                   Block::iterator prologueStart) {
-  for (auto it = prologueStart; it != parentBlock->end(); ++it) {
+static void enableAsyncOnGatherOps(Block::iterator begin, Block::iterator end) {
+  for (auto it = begin; it != end; ++it) {
     it->walk([](amdgpu::GatherToLDSOp gatherOp) { gatherOp.setAsync(true); });
+  }
+}
+
+/// Inserts an asyncmark/wait.asyncmark 0 pair before `insertPt`.
+static void insertAsyncDrainBefore(RewriterBase &rewriter, Location loc,
+                                   Operation *insertPt) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(insertPt);
+  ROCDL::AsyncmarkOp::create(rewriter, loc);
+  ROCDL::WaitAsyncmarkOp::create(rewriter, loc, rewriter.getI16IntegerAttr(0));
+}
+
+/// Converts direct pre-existing gather_to_lds ops before the pipelined loop to
+/// async mode and inserts explicit waits that preserve their original
+/// synchronous behavior.
+///
+/// Pre-loop async groups must be fully drained before the pipelining prologue
+/// starts. Otherwise, the loop body's wait.asyncmark N would count unrelated
+/// pre-loop groups and no longer correspond to the intended N-stage pipeline.
+///
+/// This only handles direct gather_to_lds ops in the parent block. Recursively
+/// converting nested pre-loop gathers would require placing marks and waits
+/// inside those nested regions according to their local control flow.
+static void insertPreLoopAsyncMarkers(RewriterBase &rewriter, Location loc,
+                                      Block::iterator preLoopStart,
+                                      Block::iterator preLoopEnd) {
+  bool hasPendingAsyncGather = false;
+  for (auto it = preLoopStart; it != preLoopEnd;) {
+    Operation *op = &*it++;
+
+    if (hasPendingAsyncGather &&
+        (isa<gpu::BarrierOp>(op) || hasNestedSharedRead(op))) {
+      insertAsyncDrainBefore(rewriter, loc, op);
+      hasPendingAsyncGather = false;
+    }
+
+    if (auto gatherOp = dyn_cast<amdgpu::GatherToLDSOp>(op)) {
+      gatherOp.setAsync(true);
+      hasPendingAsyncGather = true;
+    }
+  }
+
+  if (hasPendingAsyncGather) {
+    insertAsyncDrainBefore(rewriter, loc, &*preLoopEnd);
   }
 }
 
@@ -1187,7 +1226,8 @@ static void insertExplicitAsyncMarkers(RewriterBase &rewriter,
   Location loc = newForOp.getLoc();
   int16_t waitCount = static_cast<int16_t>(numStages - 1);
 
-  enableAsyncOnGatherOps(parentBlock, prologueStart);
+  insertPreLoopAsyncMarkers(rewriter, loc, parentBlock->begin(), prologueStart);
+  enableAsyncOnGatherOps(prologueStart, parentBlock->end());
   insertPrologueAsyncMarks(rewriter, loc, prologueStart,
                            newForOp->getIterator(), numStages);
   insertLoopBodyAsyncMarkers(rewriter, loc, newForOp, waitCount);
@@ -1324,18 +1364,13 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
 
   scf::PipeliningOption options = buildPipeliningOption(finalSchedule);
 
-  // Record the position of the original loop before pipelining. The pipelining
-  // transformation inserts prologue ops before the loop and epilogue ops after.
-  // Any gather_to_lds ops that existed before the loop in the parent block
-  // (e.g., Q loads in attention) are not part of the pipeline and must not be
-  // converted to async mode.
-  Block *parentBlock = forOp->getBlock();
-  Block::iterator preLoopMarker = forOp->getIterator();
-  bool noOpsBeforeLoop = (preLoopMarker == parentBlock->begin());
-  if (!noOpsBeforeLoop) {
-    // Decrement to point to the operation before the loop that is going to be
-    // transform, otherwise the marker would be invalidated.
-    --preLoopMarker;
+  Operation *opBeforeLoop = nullptr;
+  if (mode == PipelineMode::AsyncCopy) {
+    // Record the operation before the original loop. After pipelining, the next
+    // operation after this marker is the start of the generated prologue. Ops
+    // before that boundary are pre-existing parent-block ops and are explicitly
+    // drained separately from the pipelined async groups.
+    opBeforeLoop = forOp->getPrevNode();
   }
 
   FailureOr<scf::ForOp> newForOpOr = invokePipelineForLoop(forOp, options);
@@ -1356,8 +1391,9 @@ FailureOr<scf::ForOp> prefetchSharedMemoryCopy(RewriterBase &rewriter,
   if (mode == PipelineMode::AsyncCopy) {
     // Compute the start of the pipelining prologue, skipping any pre-existing
     // ops that were before the original loop.
-    Block::iterator prologueStart =
-        noOpsBeforeLoop ? parentBlock->begin() : std::next(preLoopMarker);
+    Block::iterator prologueStart = opBeforeLoop
+                                        ? std::next(opBeforeLoop->getIterator())
+                                        : newForOp->getBlock()->begin();
     insertExplicitAsyncMarkers(rewriter, newForOp, numStages, prologueStart);
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -799,3 +799,45 @@ func.func @gather_to_lds_with_swizzle_attr(
   vector.transfer_write %result, %output[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
   return
 }
+
+// -----
+
+// Test that gather_to_lds ops before the loop (e.g., Q loads in attention) are
+// NOT converted to async. Only the pipelined loop's gather ops should be async.
+// CHECK-LABEL: @gather_to_lds_pre_loop_stays_sync
+func.func @gather_to_lds_pre_loop_stays_sync(
+    %A_global: memref<128x128xf32>,
+    %B_global: memref<128x128xf32>,
+    %C_global: memref<128xf32>) {
+  %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+
+  %Q_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+  %K_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+
+  // Pre-loop gather_to_lds (e.g., loading Q) - must stay synchronous (no async).
+  // CHECK: amdgpu.gather_to_lds %{{.*}}[%{{.*}}, %{{.*}}], %{{.*}}[%{{.*}}] : vector<1xf32>
+  amdgpu.gather_to_lds %A_global[%c0, %c0], %Q_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+
+  // Barrier + read Q from LDS before the loop, mirroring the real attention
+  // pattern where Q is loaded, synchronized, and consumed before K/V pipelining.
+  gpu.barrier
+  %q_val = vector.transfer_read %Q_lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+
+  // Pipelined loop with gather_to_lds - these should be async.
+  // CHECK: amdgpu.gather_to_lds async
+  // CHECK: rocdl.asyncmark
+  // CHECK: scf.for
+  %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %q_val) -> (vector<1xf32>) {
+    amdgpu.gather_to_lds %B_global[%c0, %k], %K_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+    %k_val = vector.transfer_read %K_lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    %prod = arith.mulf %k_val, %acc : vector<1xf32>
+    scf.yield %prod : vector<1xf32>
+  }
+
+  vector.transfer_write %result, %C_global[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -803,13 +803,62 @@ func.func @gather_to_lds_with_swizzle_attr(
 // -----
 
 // Test that gather_to_lds ops before the loop (e.g., Q loads in attention) are
-// NOT converted to async. Only the pipelined loop's gather ops should be async.
-// CHECK-LABEL: @gather_to_lds_pre_loop_stays_sync
-func.func @gather_to_lds_pre_loop_stays_sync(
+// converted to async with explicit synchronization. This is intentionally two
+// pre-loop gathers to verify that they are grouped and drained before use.
+// CHECK-LABEL: @gather_to_lds_pre_loop_gets_explicit_wait
+func.func @gather_to_lds_pre_loop_gets_explicit_wait(
     %A_global: memref<128x128xf32>,
     %B_global: memref<128x128xf32>,
     %C_global: memref<128xf32>) {
-  %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+
+  %Q_lds = memref.alloc() : memref<2xf32, #gpu.address_space<workgroup>>
+  %K_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+
+  // Pre-loop gather_to_lds ops (e.g., loading Q) - async with explicit drain.
+  // CHECK: amdgpu.gather_to_lds async
+  amdgpu.gather_to_lds %A_global[%c0, %c0], %Q_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<2xf32, #gpu.address_space<workgroup>>
+  // CHECK: amdgpu.gather_to_lds async
+  amdgpu.gather_to_lds %A_global[%c0, %c1], %Q_lds[%c1] : vector<1xf32>, memref<128x128xf32>, memref<2xf32, #gpu.address_space<workgroup>>
+  // CHECK: rocdl.asyncmark
+  // CHECK: rocdl.wait.asyncmark 0
+  // CHECK: gpu.barrier
+  // CHECK: vector.transfer_read
+
+  // Barrier + read Q from LDS before the loop, mirroring the real attention
+  // pattern where Q is loaded, synchronized, and consumed before K/V pipelining.
+  gpu.barrier
+  %q_val = vector.transfer_read %Q_lds[%c0], %cst_0 : memref<2xf32, #gpu.address_space<workgroup>>, vector<2xf32>
+
+  // Pipelined loop with gather_to_lds - these should be async.
+  // CHECK: amdgpu.gather_to_lds async
+  // CHECK: rocdl.asyncmark
+  // CHECK: scf.for
+  %result = scf.for %k = %c0 to %c128 step %c1 iter_args(%acc = %q_val) -> (vector<2xf32>) {
+    amdgpu.gather_to_lds %B_global[%c0, %k], %K_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+    %k_val = vector.transfer_read %K_lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    %k_splat = vector.broadcast %k_val : vector<1xf32> to vector<2xf32>
+    %prod = arith.mulf %k_splat, %acc : vector<2xf32>
+    scf.yield %prod : vector<2xf32>
+  }
+
+  vector.transfer_write %result, %C_global[%c0] {in_bounds = [true]} : vector<2xf32>, memref<128xf32>
+  return
+}
+
+// -----
+
+// Test that the pre-loop async drain is inserted before the first barrier even
+// when the shared read is not immediately adjacent to that barrier.
+// CHECK-LABEL: @gather_to_lds_pre_loop_wait_before_non_adjacent_read
+func.func @gather_to_lds_pre_loop_wait_before_non_adjacent_read(
+    %A_global: memref<128x128xf32>,
+    %B_global: memref<128x128xf32>,
+    %C_global: memref<128xf32>,
+    %offset: index) {
   %cst_0 = arith.constant 0.000000e+00 : f32
   %c128 = arith.constant 128 : index
   %c1 = arith.constant 1 : index
@@ -818,16 +867,17 @@ func.func @gather_to_lds_pre_loop_stays_sync(
   %Q_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
   %K_lds = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
 
-  // Pre-loop gather_to_lds (e.g., loading Q) - must stay synchronous (no async).
-  // CHECK: amdgpu.gather_to_lds %{{.*}}[%{{.*}}, %{{.*}}], %{{.*}}[%{{.*}}] : vector<1xf32>
+  // CHECK: amdgpu.gather_to_lds async
   amdgpu.gather_to_lds %A_global[%c0, %c0], %Q_lds[%c0] : vector<1xf32>, memref<128x128xf32>, memref<1xf32, #gpu.address_space<workgroup>>
-
-  // Barrier + read Q from LDS before the loop, mirroring the real attention
-  // pattern where Q is loaded, synchronized, and consumed before K/V pipelining.
+  // CHECK: rocdl.asyncmark
+  // CHECK: rocdl.wait.asyncmark 0
+  // CHECK: gpu.barrier
+  // CHECK: arith.addi
+  // CHECK: vector.transfer_read
   gpu.barrier
+  %write_idx = arith.addi %offset, %c1 : index
   %q_val = vector.transfer_read %Q_lds[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
 
-  // Pipelined loop with gather_to_lds - these should be async.
   // CHECK: amdgpu.gather_to_lds async
   // CHECK: rocdl.asyncmark
   // CHECK: scf.for
@@ -838,6 +888,6 @@ func.func @gather_to_lds_pre_loop_stays_sync(
     scf.yield %prod : vector<1xf32>
   }
 
-  vector.transfer_write %result, %C_global[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+  vector.transfer_write %result, %C_global[%write_idx] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
   return
 }


### PR DESCRIPTION
Currently, the pipelining assumes that all `amdgpu.gather_to_lds` operations are part of the loop that is being pipelined and marks them as async, with waits inserted in the pipelined loop.

This assumption was fine for the workloads so far, but with work underway to enable pipelining for attention, this no longer holds, as the load of e.g. the `Q` matrix can be outside of the loop. Operations outside the loop can also be marked async, but that requires inserting marks and waits before the loop.

This PR fixes this by recording a marker in the block before the loop and later on inserting marks and waits for async operations before the marker.

This is part of https://github.com/iree-org/iree/issues/23782.

Assisted-by: Claude Code and Codex