### PR TITLE
[Codegen][CPU] Eliminate HoistableConversionOps after lowering inner_…

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerInnerTiled.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerInnerTiled.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -38,6 +39,16 @@ struct LLVMCPULowerInnerTiledPass final
     //     transparently.
     IREE::Codegen::populateLowerInnerTiledPatterns(patterns);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      return signalPassFailure();
+    }
+
+    // The lowering patterns above wrap the per-intrinsic ACC distribute and
+    // reassemble in `IREE::Util::HoistableConversionOp` pairs (tagged with
+    // `kDataTiledAcc{Distribute,Reassemble}` etc.) so that the conversion can
+    // sink/hoist out of any reduction loop wrapping it. Cancel the surviving
+    // pairs in this function — anything that didn't get hoisted out becomes a
+    // trivial round-trip and folds away here.
+    if (failed(IREE::Util::eliminateHoistableConversions(getOperation()))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_inner_tiled.mlir
@@ -5,8 +5,10 @@
 // GenericVectorization via the VectorizableOpInterface external model):
 //   1. drop the (now-unit) iter domain,
 //   2. lower the iter-free vector inner_tiled to llvm.call_intrinsic.
-// On a single-tile AVX-512 1x16x1 f32 matmul the end result is one
-// `llvm.fma.v16f32` call.
+// It then calls `IREE::Util::eliminateHoistableConversions` to cancel the
+// conversion pairs the lowering patterns leave around the ACC.
+// On a single-tile AVX-512 1x16x1 f32 matmul, the end result is one
+// `llvm.fma.v16f32` call with no surviving `util.hoistable_conversion`s.
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
@@ -29,4 +31,5 @@ func.func @lower_avx512_1x16x1_f32(
 
 // CHECK-LABEL: func @lower_avx512_1x16x1_f32
 //   CHECK-NOT:   iree_codegen.inner_tiled
+//   CHECK-NOT:   util.hoistable_conversion
 //       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}) : (vector<16xf32>, vector<16xf32>, vector<16xf32>) -> vector<16xf32>


### PR DESCRIPTION
The CPU `LowerInnerTiledPattern` and `DropInnerTiledUnitDimsPattern`
both wrap the per-intrinsic ACC distribute/reassemble in
`IREE::Util::HoistableConversionOp` pairs (tagged
`kDataTiledAcc{Distribute,Reassemble}`, `kDropUnitDims`/`kAddUnitDims`)
so the conversions can sink/hoist out of any reduction loop wrapping
the intrinsic.

Anything that didn't get hoisted out is a trivial round-trip; calling
`IREE::Util::eliminateHoistableConversions` on the function at the end
of the pass cancels the surviving pairs. GPU does the same in its
`LowerIREEGPUOpsPass`.

Strengthens the `lower_inner_tiled` lit test with a `CHECK-NOT:
util.hoistable_conversion` so the elimination is verified.

Progress towards https://github.com/iree-org/iree/issues/24323