### PR TITLE
[GPU] Add user defined constraints in XorShuffleAttr

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -913,13 +913,25 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   if (useDirectLoad) {
     Attribute lhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
     Attribute rhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
+    // Build a DMA compatibility constraint: the swizzle access width (in bits)
+    // must be at least as wide as the narrowest supported DMA load.
+    DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes();
+    int64_t elemBits = 0;
+    auto dmaConstraint = [&](XorShuffleParams params) -> LogicalResult {
+      if (!dmaSizesAttr || dmaSizesAttr.empty()) {
+        return failure();
+      }
+      int64_t minDmaBits = *llvm::min_element(dmaSizesAttr.asArrayRef());
+      int64_t accessBits = params.accessElems * elemBits;
+      return accessBits >= minDmaBits ? success() : failure();
+    };
     // Apply XOR swizzle for BF16 DMA operands whose reduction dim is
     // innermost (contiguous reads) to avoid LDS bank conflicts.
     // TODO(#24255): Fix untuned swizzle logic for DMA.
     if (!transposedLhs) {
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
-          /*skipUntunedFallback=*/true);
+          /*skipUntunedFallback=*/false, dmaConstraint);
       if (succeeded(lhsSwizzleAttr)) {
         lhsAttr = *lhsSwizzleAttr;
       }
@@ -927,7 +939,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     if (transposedRhs) {
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,
-          /*skipUntunedFallback=*/true);
+          /*skipUntunedFallback=*/false, dmaConstraint);
       if (succeeded(rhsSwizzleAttr)) {
         rhsAttr = *rhsSwizzleAttr;
       }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -917,8 +917,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // innermost (contiguous reads) to avoid LDS bank conflicts.
     // TODO(#24255): Fix untuned swizzle logic for DMA.
     if (!transposedLhs) {
-      auto dmaConstraintFn = makeDmaConstraintFn(target,
-          lhsElemType.getIntOrFloatBitWidth());
+      auto dmaConstraintFn =
+          makeDmaConstraintFn(target, lhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
           /*skipUntunedFallback=*/false, dmaConstraintFn);
@@ -927,8 +927,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
       }
     }
     if (transposedRhs) {
-      auto dmaConstraintFn = makeDmaConstraintFn(target,
-          rhsElemType.getIntOrFloatBitWidth());
+      auto dmaConstraintFn =
+          makeDmaConstraintFn(target, rhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,
           /*skipUntunedFallback=*/false, dmaConstraintFn);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -879,21 +879,35 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   if (useDirectLoad) {
     Attribute lhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
     Attribute rhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
+    // Build a DMA compatibility constraint: the swizzle access width (in bits)
+    // must be at least as wide as the narrowest supported DMA load.
+    DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes();
+    int64_t elemBits = 0;
+    auto dmaConstraint = [&](XorShuffleParams params) -> LogicalResult {
+      if (!dmaSizesAttr || dmaSizesAttr.empty()) {
+        return failure();
+      }
+      int64_t minDmaBits = *llvm::min_element(dmaSizesAttr.asArrayRef());
+      int64_t accessBits = params.accessElems * elemBits;
+      return accessBits >= minDmaBits ? success() : failure();
+    };
     // Apply XOR swizzle for BF16 DMA operands whose reduction dim is
     // innermost (contiguous reads) to avoid LDS bank conflicts.
     // TODO(#24255): Fix untuned swizzle logic for DMA.
     if (lhsElemType.isBF16() && !transposedLhs) {
+      elemBits = lhsElemType.getIntOrFloatBitWidth();
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
-          /*skipUntunedFallback=*/true);
+          /*skipUntunedFallback=*/false, dmaConstraint);
       if (succeeded(lhsSwizzleAttr)) {
         lhsAttr = *lhsSwizzleAttr;
       }
     }
     if (rhsElemType.isBF16() && transposedRhs) {
+      elemBits = rhsElemType.getIntOrFloatBitWidth();
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,
-          /*skipUntunedFallback=*/true);
+          /*skipUntunedFallback=*/false, dmaConstraint);
       if (succeeded(rhsSwizzleAttr)) {
         rhsAttr = *rhsSwizzleAttr;
       }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -921,7 +921,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
           target, lhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
-          /*skipUntunedFallback=*/false, dmaConstraintFn);
+          /*skipUntunedFallback=*/true, dmaConstraintFn);
       if (succeeded(lhsSwizzleAttr)) {
         lhsAttr = *lhsSwizzleAttr;
       }
@@ -931,7 +931,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
           target, rhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,
-          /*skipUntunedFallback=*/false, dmaConstraintFn);
+          /*skipUntunedFallback=*/true, dmaConstraintFn);
       if (succeeded(rhsSwizzleAttr)) {
         rhsAttr = *rhsSwizzleAttr;
       }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -917,8 +917,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // innermost (contiguous reads) to avoid LDS bank conflicts.
     // TODO(#24255): Fix untuned swizzle logic for DMA.
     if (!transposedLhs) {
-      auto dmaConstraintFn =
-          makeDmaConstraintFn(target, lhsElemType.getIntOrFloatBitWidth());
+      auto dmaConstraintFn = makeDmaConstraintForXorShuffleFn(
+          target, lhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
           /*skipUntunedFallback=*/false, dmaConstraintFn);
@@ -927,8 +927,8 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
       }
     }
     if (transposedRhs) {
-      auto dmaConstraintFn =
-          makeDmaConstraintFn(target, rhsElemType.getIntOrFloatBitWidth());
+      auto dmaConstraintFn = makeDmaConstraintForXorShuffleFn(
+          target, rhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,
           /*skipUntunedFallback=*/false, dmaConstraintFn);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -917,7 +917,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // innermost (contiguous reads) to avoid LDS bank conflicts.
     // TODO(#24255): Fix untuned swizzle logic for DMA.
     if (!transposedLhs) {
-      auto dmaConstraintFn = makeDmaConstraintForXorShuffleFn(
+      auto dmaConstraintFn = makeDmaConstraintFnForXorShuffle(
           target, lhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
@@ -927,7 +927,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
       }
     }
     if (transposedRhs) {
-      auto dmaConstraintFn = makeDmaConstraintForXorShuffleFn(
+      auto dmaConstraintFn = makeDmaConstraintFnForXorShuffle(
           target, rhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -913,33 +913,25 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
   if (useDirectLoad) {
     Attribute lhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
     Attribute rhsAttr = IREE::GPU::UseGlobalLoadDMAAttr::get(context);
-    // Build a DMA compatibility constraint: the swizzle access width (in bits)
-    // must be at least as wide as the narrowest supported DMA load.
-    DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes();
-    int64_t elemBits = 0;
-    auto dmaConstraint = [&](XorShuffleParams params) -> LogicalResult {
-      if (!dmaSizesAttr || dmaSizesAttr.empty()) {
-        return failure();
-      }
-      int64_t minDmaBits = *llvm::min_element(dmaSizesAttr.asArrayRef());
-      int64_t accessBits = params.accessElems * elemBits;
-      return accessBits >= minDmaBits ? success() : failure();
-    };
     // Apply XOR swizzle for BF16 DMA operands whose reduction dim is
     // innermost (contiguous reads) to avoid LDS bank conflicts.
     // TODO(#24255): Fix untuned swizzle logic for DMA.
     if (!transposedLhs) {
+      auto dmaConstraintFn = makeDmaConstraintFn(target,
+          lhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
-          /*skipUntunedFallback=*/false, dmaConstraint);
+          /*skipUntunedFallback=*/false, dmaConstraintFn);
       if (succeeded(lhsSwizzleAttr)) {
         lhsAttr = *lhsSwizzleAttr;
       }
     }
     if (transposedRhs) {
+      auto dmaConstraintFn = makeDmaConstraintFn(target,
+          rhsElemType.getIntOrFloatBitWidth());
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,
-          /*skipUntunedFallback=*/false, dmaConstraint);
+          /*skipUntunedFallback=*/false, dmaConstraintFn);
       if (succeeded(rhsSwizzleAttr)) {
         rhsAttr = *rhsSwizzleAttr;
       }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -1007,6 +1007,18 @@ getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
                                             swizzleAttr);
 }
 
+std::function<LogicalResult(XorShuffleParams)> makeDmaConstraintFn(IREE::GPU::TargetAttr target, int64_t elemBits) {
+  return [target, elemBits](XorShuffleParams params) -> LogicalResult {
+    DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes();
+    if (!dmaSizesAttr || dmaSizesAttr.empty()) {
+      return failure();
+    }
+    int64_t minDmaBits = *llvm::min_element(dmaSizesAttr.asArrayRef());
+    int64_t accessBits = params.accessElems * elemBits;
+    return accessBits >= minDmaBits ? success() : failure();
+  };
+}
+
 //===----------------------------------------------------------------------===//
 // getMmaNativeVectorSize
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -997,8 +997,8 @@ getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
   if (failed(xorShuffleParams)) {
     return failure();
   }
-  int64_t effectiverowElems = xorShuffleParams->rowElems;
-  int64_t numAccessElems = xorShuffleParams->accessElems;
+  int64_t effectiverowElems = xorShuffleParams.value().rowElems;
+  int64_t numAccessElems = xorShuffleParams.value().accessElems;
   auto swizzleAttr = IREE::Codegen::XORShuffleAttr::get(
       context, effectiverowElems, numAccessElems,
       /*row_stride=*/int64_t(0),
@@ -1008,7 +1008,7 @@ getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
 }
 
 std::function<LogicalResult(XorShuffleParams)>
-makeDmaConstraintForXorShuffleFn(IREE::GPU::TargetAttr target,
+makeDmaConstraintFnForXorShuffle(IREE::GPU::TargetAttr target,
                                  int64_t elemBits) {
   return [target, elemBits](XorShuffleParams params) -> LogicalResult {
     DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes();

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -1008,7 +1008,8 @@ getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
 }
 
 std::function<LogicalResult(XorShuffleParams)>
-makeDmaConstraintFn(IREE::GPU::TargetAttr target, int64_t elemBits) {
+makeDmaConstraintForXorShuffleFn(IREE::GPU::TargetAttr target,
+                                 int64_t elemBits) {
   return [target, elemBits](XorShuffleParams params) -> LogicalResult {
     DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes();
     if (!dmaSizesAttr || dmaSizesAttr.empty()) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -834,19 +834,25 @@ static FailureOr<XorShuffleParams> getXorShuffleParamsForGfx950(
 
 /// Validate the XOR shuffle parameters for the given intrinsic and operand
 /// index. If the parameters produce an XOR Shuffle that is not valid, return
-/// failure. Else, return the swizzle parameters.
-static FailureOr<XorShuffleParams>
-validateXorShuffle(FailureOr<XorShuffleParams> swizzle,
-                   IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                   int operandIndex) {
+/// failure. An optional constraint function provides additional validation
+/// (e.g., DMA compatibility).
+static FailureOr<XorShuffleParams> validateXorShuffle(
+    FailureOr<XorShuffleParams> swizzle,
+    IREE::Codegen::InnerTileDescAttrInterface intrinsic, int operandIndex,
+    function_ref<LogicalResult(XorShuffleParams)> constraint = nullptr) {
+  if (failed(swizzle)) {
+    return failure();
+  }
   FailureOr<int64_t> maybeTotalTileElems =
       getTotalTileElems(intrinsic, operandIndex);
   if (failed(maybeTotalTileElems)) {
     return failure();
   }
-  int64_t totalTileElems = *maybeTotalTileElems;
   if (!isXORShuffleValid(swizzle->rowElems, swizzle->accessElems,
-                         totalTileElems)) {
+                         *maybeTotalTileElems)) {
+    return failure();
+  }
+  if (constraint && failed(constraint(*swizzle))) {
     return failure();
   }
   return swizzle;
@@ -915,8 +921,7 @@ FailureOr<XorShuffleParams> getXorShuffleParamsForTunedChipset(
     return failure();
   }
   if (*maybeChipset == amdgpu::Chipset(9, 5, 0)) {
-    return validateXorShuffle(getXorShuffleParamsForGfx950(target, intrinsic),
-                              intrinsic, operandIndex);
+    return getXorShuffleParamsForGfx950(target, intrinsic);
   }
   return failure();
 }
@@ -958,23 +963,24 @@ FailureOr<XorShuffleParams> getXorShuffleParamsForUntunedChipset(
 
   // Ensure row width is at least access width (minimum 1 column).
   effectiverowElems = std::max(effectiverowElems, numAccessElems);
-  return validateXorShuffle(XorShuffleParams({/*rowElems=*/effectiverowElems,
-                                              /*accessElems=*/numAccessElems}),
-                            intrinsic, operandIndex);
+  return XorShuffleParams({/*rowElems=*/effectiverowElems,
+                           /*accessElems=*/numAccessElems});
 }
 
 FailureOr<XorShuffleParams>
 getXorShuffleParams(IREE::GPU::TargetAttr target,
                     IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                     ArrayRef<int64_t> reductionTileSizes, int operandIndex,
-                    bool skipUntunedFallback) {
-  FailureOr<XorShuffleParams> xorShuffleAttr =
+                    bool skipUntunedFallback,
+                    function_ref<LogicalResult(XorShuffleParams)> constraint) {
+  FailureOr<XorShuffleParams> xorShuffleParams =
       getXorShuffleParamsForTunedChipset(target, intrinsic, operandIndex);
-  if (failed(xorShuffleAttr) && !skipUntunedFallback) {
-    xorShuffleAttr = getXorShuffleParamsForUntunedChipset(
+  if (failed(xorShuffleParams) && !skipUntunedFallback) {
+    xorShuffleParams = getXorShuffleParamsForUntunedChipset(
         target, intrinsic, reductionTileSizes, operandIndex);
   }
-  return xorShuffleAttr;
+  return validateXorShuffle(xorShuffleParams, intrinsic, operandIndex,
+                            constraint);
 }
 // NOLINTEND(misc-use-internal-linkage)
 
@@ -983,14 +989,16 @@ getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
                   IREE::GPU::TargetAttr target,
                   IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                   ArrayRef<int64_t> reductionTileSizes, int operandIndex,
-                  bool skipUntunedFallback) {
-  FailureOr<XorShuffleParams> xorShuffleParams = getXorShuffleParams(
-      target, intrinsic, reductionTileSizes, operandIndex, skipUntunedFallback);
+                  bool skipUntunedFallback,
+                  function_ref<LogicalResult(XorShuffleParams)> constraint) {
+  FailureOr<XorShuffleParams> xorShuffleParams =
+      getXorShuffleParams(target, intrinsic, reductionTileSizes, operandIndex,
+                          skipUntunedFallback, constraint);
   if (failed(xorShuffleParams)) {
     return failure();
   }
-  int64_t effectiverowElems = xorShuffleParams.value().rowElems;
-  int64_t numAccessElems = xorShuffleParams.value().accessElems;
+  int64_t effectiverowElems = xorShuffleParams->rowElems;
+  int64_t numAccessElems = xorShuffleParams->accessElems;
   auto swizzleAttr = IREE::Codegen::XORShuffleAttr::get(
       context, effectiverowElems, numAccessElems,
       /*row_stride=*/int64_t(0),

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -832,19 +832,25 @@ static FailureOr<XorShuffleParams> getXorShuffleParamsForGfx950(
 
 /// Validate the XOR shuffle parameters for the given intrinsic and operand
 /// index. If the parameters produce an XOR Shuffle that is not valid, return
-/// failure. Else, return the swizzle parameters.
-static FailureOr<XorShuffleParams>
-validateXorShuffle(FailureOr<XorShuffleParams> swizzle,
-                   IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                   int operandIndex) {
+/// failure. An optional constraint function provides additional validation
+/// (e.g., DMA compatibility).
+static FailureOr<XorShuffleParams> validateXorShuffle(
+    FailureOr<XorShuffleParams> swizzle,
+    IREE::Codegen::InnerTileDescAttrInterface intrinsic, int operandIndex,
+    function_ref<LogicalResult(XorShuffleParams)> constraint = nullptr) {
+  if (failed(swizzle)) {
+    return failure();
+  }
   FailureOr<int64_t> maybeTotalTileElems =
       getTotalTileElems(intrinsic, operandIndex);
   if (failed(maybeTotalTileElems)) {
     return failure();
   }
-  int64_t totalTileElems = *maybeTotalTileElems;
   if (!isXORShuffleValid(swizzle->rowElems, swizzle->accessElems,
-                         totalTileElems)) {
+                         *maybeTotalTileElems)) {
+    return failure();
+  }
+  if (constraint && failed(constraint(*swizzle))) {
     return failure();
   }
   return swizzle;
@@ -913,8 +919,7 @@ FailureOr<XorShuffleParams> getXorShuffleParamsForTunedChipset(
     return failure();
   }
   if (*maybeChipset == amdgpu::Chipset(9, 5, 0)) {
-    return validateXorShuffle(getXorShuffleParamsForGfx950(target, intrinsic),
-                              intrinsic, operandIndex);
+    return getXorShuffleParamsForGfx950(target, intrinsic);
   }
   return failure();
 }
@@ -956,23 +961,24 @@ FailureOr<XorShuffleParams> getXorShuffleParamsForUntunedChipset(
 
   // Ensure row width is at least access width (minimum 1 column).
   effectiverowElems = std::max(effectiverowElems, numAccessElems);
-  return validateXorShuffle(XorShuffleParams({/*rowElems=*/effectiverowElems,
-                                              /*accessElems=*/numAccessElems}),
-                            intrinsic, operandIndex);
+  return XorShuffleParams({/*rowElems=*/effectiverowElems,
+                           /*accessElems=*/numAccessElems});
 }
 
 FailureOr<XorShuffleParams>
 getXorShuffleParams(IREE::GPU::TargetAttr target,
                     IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                     ArrayRef<int64_t> reductionTileSizes, int operandIndex,
-                    bool skipUntunedFallback) {
-  FailureOr<XorShuffleParams> xorShuffleAttr =
+                    bool skipUntunedFallback,
+                    function_ref<LogicalResult(XorShuffleParams)> constraint) {
+  FailureOr<XorShuffleParams> xorShuffleParams =
       getXorShuffleParamsForTunedChipset(target, intrinsic, operandIndex);
-  if (failed(xorShuffleAttr) && !skipUntunedFallback) {
-    xorShuffleAttr = getXorShuffleParamsForUntunedChipset(
+  if (failed(xorShuffleParams) && !skipUntunedFallback) {
+    xorShuffleParams = getXorShuffleParamsForUntunedChipset(
         target, intrinsic, reductionTileSizes, operandIndex);
   }
-  return xorShuffleAttr;
+  return validateXorShuffle(xorShuffleParams, intrinsic, operandIndex,
+                            constraint);
 }
 // NOLINTEND(misc-use-internal-linkage)
 
@@ -981,14 +987,16 @@ getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
                   IREE::GPU::TargetAttr target,
                   IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                   ArrayRef<int64_t> reductionTileSizes, int operandIndex,
-                  bool skipUntunedFallback) {
-  FailureOr<XorShuffleParams> xorShuffleParams = getXorShuffleParams(
-      target, intrinsic, reductionTileSizes, operandIndex, skipUntunedFallback);
+                  bool skipUntunedFallback,
+                  function_ref<LogicalResult(XorShuffleParams)> constraint) {
+  FailureOr<XorShuffleParams> xorShuffleParams =
+      getXorShuffleParams(target, intrinsic, reductionTileSizes, operandIndex,
+                          skipUntunedFallback, constraint);
   if (failed(xorShuffleParams)) {
     return failure();
   }
-  int64_t effectiverowElems = xorShuffleParams.value().rowElems;
-  int64_t numAccessElems = xorShuffleParams.value().accessElems;
+  int64_t effectiverowElems = xorShuffleParams->rowElems;
+  int64_t numAccessElems = xorShuffleParams->accessElems;
   auto swizzleAttr = IREE::Codegen::XORShuffleAttr::get(
       context, effectiverowElems, numAccessElems,
       /*row_stride=*/int64_t(0),

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -1007,7 +1007,8 @@ getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
                                             swizzleAttr);
 }
 
-std::function<LogicalResult(XorShuffleParams)> makeDmaConstraintFn(IREE::GPU::TargetAttr target, int64_t elemBits) {
+std::function<LogicalResult(XorShuffleParams)>
+makeDmaConstraintFn(IREE::GPU::TargetAttr target, int64_t elemBits) {
   return [target, elemBits](XorShuffleParams params) -> LogicalResult {
     DenseI64ArrayAttr dmaSizesAttr = target.getWgp().getDmaSizes();
     if (!dmaSizesAttr || dmaSizesAttr.empty()) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -309,8 +309,8 @@ Value applyInverseXorSwizzleToDMASourceOffset(
 /// parameters based on the DMA sizes available in the target.
 /// The swizzle access width (in bits) must be at least as wide as the
 /// narrowest supported DMA load.
-std::function<LogicalResult(XorShuffleParams)> makeDmaConstraintFn(
-    IREE::GPU::TargetAttr target, int64_t elemBits);
+std::function<LogicalResult(XorShuffleParams)>
+makeDmaConstraintFn(IREE::GPU::TargetAttr target, int64_t elemBits);
 
 //===----------------------------------------------------------------------===//
 // GPU CodeGen op filter

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -310,7 +310,7 @@ Value applyInverseXorSwizzleToDMASourceOffset(
 /// The swizzle access width (in bits) must be at least as wide as the
 /// narrowest supported DMA load.
 std::function<LogicalResult(XorShuffleParams)>
-makeDmaConstraintFn(IREE::GPU::TargetAttr target, int64_t elemBits);
+makeDmaConstraintForXorShuffle(IREE::GPU::TargetAttr target, int64_t elemBits);
 
 //===----------------------------------------------------------------------===//
 // GPU CodeGen op filter

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -268,20 +268,22 @@ FailureOr<XorShuffleParams> getXorShuffleParamsForUntunedChipset(
 /// computed by calculating the K tile size and LDS bank width. Note this
 /// generic heuristic for untuned cases is not guaranteed to be optimal for all
 /// targets and intrinsics.
-FailureOr<XorShuffleParams>
-getXorShuffleParams(IREE::GPU::TargetAttr target,
-                    IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                    ArrayRef<int64_t> reductionTileSizes, int operandIndex,
-                    bool skipUntunedFallback = false);
+FailureOr<XorShuffleParams> getXorShuffleParams(
+    IREE::GPU::TargetAttr target,
+    IREE::Codegen::InnerTileDescAttrInterface intrinsic,
+    ArrayRef<int64_t> reductionTileSizes, int operandIndex,
+    bool skipUntunedFallback = false,
+    function_ref<LogicalResult(XorShuffleParams)> constraint = nullptr);
 
 /// Returns the XOR shuffle attribute for the given target, intrinsic, and
 /// operand index.
-FailureOr<Attribute>
-getXorShuffleAttr(MLIRContext *context, Attribute baseConfigAttr,
-                  IREE::GPU::TargetAttr target,
-                  IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                  ArrayRef<int64_t> reductionTileSizes, int operandIndex,
-                  bool skipUntunedFallback = false);
+FailureOr<Attribute> getXorShuffleAttr(
+  MLIRContext *context, Attribute baseConfigAttr,
+  IREE::GPU::TargetAttr target,
+  IREE::Codegen::InnerTileDescAttrInterface intrinsic,
+  ArrayRef<int64_t> reductionTileSizes, int operandIndex,
+  bool skipUntunedFallback = false,
+  function_ref<LogicalResult(XorShuffleParams)> constraint = nullptr);
 
 /// Apply inverse XOR swizzle to a sub-tile-local source offset so that the
 /// DMA write-side permutation matches the read-side (ResolveSwizzleHints).

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -305,6 +305,13 @@ Value applyInverseXorSwizzleToDMASourceOffset(
     OpBuilder &builder, Location loc, Value srcLinearOffset,
     IREE::Codegen::XORShuffleAttr swizzle, Value dest);
 
+/// When using direct-load, this function is used to constrain the XOR shuffle
+/// parameters based on the DMA sizes available in the target.
+/// The swizzle access width (in bits) must be at least as wide as the
+/// narrowest supported DMA load.
+std::function<LogicalResult(XorShuffleParams)> makeDmaConstraintFn(
+    IREE::GPU::TargetAttr target, int64_t elemBits);
+
 //===----------------------------------------------------------------------===//
 // GPU CodeGen op filter
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -310,7 +310,8 @@ Value applyInverseXorSwizzleToDMASourceOffset(
 /// The swizzle access width (in bits) must be at least as wide as the
 /// narrowest supported DMA load.
 std::function<LogicalResult(XorShuffleParams)>
-makeDmaConstraintForXorShuffle(IREE::GPU::TargetAttr target, int64_t elemBits);
+makeDmaConstraintFnForXorShuffle(IREE::GPU::TargetAttr target,
+                                 int64_t elemBits);
 
 //===----------------------------------------------------------------------===//
 // GPU CodeGen op filter

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -278,12 +278,12 @@ FailureOr<XorShuffleParams> getXorShuffleParams(
 /// Returns the XOR shuffle attribute for the given target, intrinsic, and
 /// operand index.
 FailureOr<Attribute> getXorShuffleAttr(
-  MLIRContext *context, Attribute baseConfigAttr,
-  IREE::GPU::TargetAttr target,
-  IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-  ArrayRef<int64_t> reductionTileSizes, int operandIndex,
-  bool skipUntunedFallback = false,
-  function_ref<LogicalResult(XorShuffleParams)> constraint = nullptr);
+    MLIRContext *context, Attribute baseConfigAttr,
+    IREE::GPU::TargetAttr target,
+    IREE::Codegen::InnerTileDescAttrInterface intrinsic,
+    ArrayRef<int64_t> reductionTileSizes, int operandIndex,
+    bool skipUntunedFallback = false,
+    function_ref<LogicalResult(XorShuffleParams)> constraint = nullptr);
 
 /// Apply inverse XOR swizzle to a sub-tile-local source offset so that the
 /// DMA write-side permutation matches the read-side (ResolveSwizzleHints).


### PR DESCRIPTION
When `useDirectLoad` is set and we opt-in to DMA, there are contiguity constraints that the XOR shuffle must respect when choosing its parameters. Prior to this change, the heuristic was unaware of these constraints. In this change, we introduce a new argument to the `getXorShuffleAttr` function that takes as input a constraint function that is used to validate generated shuffle parameters to ensure they meet whatever requirements the function encodes. If the result of the constraint function indicates an invalid shuffle, no shuffle is returned.  In the case of `useDirectLoad` we introduce the `makeDmaConstraintFnForXorShuffle`.