### PR TITLE
 [VectorDistribute] Preserve vector.contract semantics during distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/DistributionPatterns.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Utils/Indexing.h"
 #include "iree/compiler/Utils/Permutation.h"
@@ -133,7 +134,7 @@ getElementVectorTileShape(NestedLayoutAttr vectorLayout) {
 static VectorValue getDeinterleavedPackedForm(PatternRewriter &rewriter,
                                               VectorValue val,
                                               NestedLayoutAttr layout) {
-  Location loc = val.getDefiningOp()->getLoc();
+  Location loc = val.getLoc();
   SmallVector<int64_t> interleavedPackedShape(layout.getRank() * 3, 0);
   for (int64_t undistributedDim : llvm::seq<int64_t>(layout.getRank())) {
     SmallVector<int64_t> packedShapePerDim =
@@ -158,6 +159,9 @@ static VectorValue getDeinterleavedPackedForm(PatternRewriter &rewriter,
       perm.push_back(tileGroupIdx * layout.getRank() + undistributedDim);
     }
   }
+  if (perm.empty()) {
+    return interleavedPackedShaped;
+  }
   return vector::TransposeOp::create(rewriter, loc, interleavedPackedShaped,
                                      perm);
 }
@@ -167,18 +171,21 @@ static VectorValue getDeinterleavedPackedForm(PatternRewriter &rewriter,
 static VectorValue getDeinterleavedUnpackedForm(PatternRewriter &rewriter,
                                                 VectorValue val,
                                                 NestedLayoutAttr layout) {
-  Location loc = val.getDefiningOp()->getLoc();
+  Location loc = val.getLoc();
   VectorValue deinterleavedPacked =
       getDeinterleavedPackedForm(rewriter, val, layout);
-  ArrayRef<int64_t> deinterleavedPackedShape =
-      deinterleavedPacked.getType().getShape();
+  ArrayRef<int64_t> packedShape = deinterleavedPacked.getType().getShape();
   SmallVector<int64_t> unpackedShape;
-  unpackedShape.reserve(layout.getRank() * 3);
+  unpackedShape.reserve(layout.getRank());
   for (int64_t unDistrDim : llvm::seq<int64_t>(layout.getRank())) {
-    int64_t collapsedDimLen = deinterleavedPackedShape[unDistrDim * 3 + 0] *
-                              deinterleavedPackedShape[unDistrDim * 3 + 1] *
-                              deinterleavedPackedShape[unDistrDim * 3 + 2];
-    unpackedShape.push_back(collapsedDimLen);
+    int64_t unpackedDim = layout.getBatchTile()[unDistrDim] *
+                          layout.getOuterTile()[unDistrDim] *
+                          layout.getElementTile()[unDistrDim];
+    assert(unpackedDim == packedShape[unDistrDim * 3] *
+                              packedShape[unDistrDim * 3 + 1] *
+                              packedShape[unDistrDim * 3 + 2] &&
+           "packed B/O/E shape must match nested layout tile product");
+    unpackedShape.push_back(unpackedDim);
   }
   VectorType unpackedType = VectorType::get(
       unpackedShape, deinterleavedPacked.getType().getElementType());
@@ -191,7 +198,7 @@ static VectorValue getDeinterleavedUnpackedForm(PatternRewriter &rewriter,
 static VectorValue getInterleavedPackedForm(PatternRewriter &rewriter,
                                             VectorValue val,
                                             NestedLayoutAttr layout) {
-  Location loc = val.getDefiningOp()->getLoc();
+  Location loc = val.getLoc();
   SmallVector<int64_t> nonInterleavedPackedShape;
   nonInterleavedPackedShape.reserve(layout.getRank() * 3);
   for (int64_t undistributedDim : llvm::seq<int64_t>(layout.getRank())) {
@@ -212,6 +219,9 @@ static VectorValue getInterleavedPackedForm(PatternRewriter &rewriter,
     for (int64_t undistributedDim : llvm::seq<int64_t>(layout.getRank())) {
       perm.push_back(tileGroupIdx + 3 * undistributedDim);
     }
+  }
+  if (perm.empty()) {
+    return nonInterleavedPackedShaped;
   }
   return vector::TransposeOp::create(rewriter, loc, nonInterleavedPackedShaped,
                                      perm);
@@ -259,6 +269,8 @@ static VectorValue getSlicedPermutedValue(PatternRewriter &rewriter,
 /// but with projecting out the indexed/sliced dimensions from the result.
 static VectorValue projectVector(RewriterBase &rewriter, Location loc,
                                  VectorValue val, AffineMap projectionMap) {
+  assert(projectionMap.isProjectedPermutation() &&
+         "expected a projected permutation map");
   SmallVector<int64_t> remainingDims;
   auto allDims =
       llvm::to_vector(llvm::seq<int64_t>(projectionMap.getNumDims()));
@@ -2245,8 +2257,7 @@ private:
 /// the resulting vector is interpreted in undistributed domain. The said
 /// undistributed vector is a partial reduction when contraction has been
 /// performed only thread locally. Therefore, a to-be-distributed
-/// vector.multi_reduce
-////is added to complete the contraction.
+/// vector.multi_reduction is added to complete the contraction.
 struct DistributeContract final
     : MaskedOpDistributionPattern<vector::ContractionOp> {
   using MaskedOpDistributionPattern::MaskedOpDistributionPattern;
@@ -2266,6 +2277,7 @@ struct DistributeContract final
     if (failed(maybeOpInfo)) {
       return rewriter.notifyMatchFailure(contractOp, "not a contraction");
     }
+    const VectorContractOpInfo &opInfo = maybeOpInfo.value();
     // If mmaAttr exists, defer the lowering to use MMA.
     // Notify failure if the "iree.gpu.mma" intrinsic attribute is present.
     auto mmaAttr =
@@ -2286,8 +2298,13 @@ struct DistributeContract final
           contractOp, "missing nested layout for contraction rhs");
     }
     NestedLayoutAttr resLayout;
-    if (auto contractRes = dyn_cast<VectorValue>(contractOp.getResult())) {
-      resLayout = dyn_cast<NestedLayoutAttr>(signature[contractRes]);
+    auto resVector = dyn_cast<VectorValue>(contractOp.getResult());
+    if (resVector) {
+      resLayout = dyn_cast<NestedLayoutAttr>(signature[resVector]);
+      if (!resLayout) {
+        return rewriter.notifyMatchFailure(
+            contractOp, "missing nested layout for contraction result");
+      }
     } else {
       // Create a zero-d layout because we
       // are going to add reduction dims
@@ -2296,104 +2313,193 @@ struct DistributeContract final
           contractOp.getContext(), ArrayRef<int64_t>{}, {}, {}, {}, {}, {}, {});
     }
 
-    Value disLhs = getDistributed(rewriter, contractOp.getLhs(), lhsLayout);
-    Value disRhs = getDistributed(rewriter, contractOp.getRhs(), rhsLayout);
-
-    VectorValue mask = nullptr;
+    NestedLayoutAttr maskLayoutAttr;
     if (maskOp) {
-      auto maskLayout = dyn_cast_if_present<NestedLayoutAttr>(
+      maskLayoutAttr = dyn_cast_if_present<NestedLayoutAttr>(
           maskSignature.value()[maskOp.getMask()]);
-      if (!maskLayout) {
+      if (!maskLayoutAttr) {
         return rewriter.notifyMatchFailure(maskOp,
                                            "expected nested layout attr");
       }
-      mask = getDistributed(rewriter, maskOp.getMask(), maskLayout);
+    }
+
+    SmallVector<AffineMap> indexingMaps = contractOp.getIndexingMapsArray();
+    if (lhsLayout.getRank() != opInfo.getARank() ||
+        rhsLayout.getRank() != opInfo.getBRank()) {
+      return rewriter.notifyMatchFailure(
+          contractOp, "nested layout rank does not match contraction maps");
+    }
+
+    MLIRContext *ctx = contractOp.getContext();
+    AffineMap lhsMap = indexingMaps[0];
+    AffineMap rhsMap = indexingMaps[1];
+    auto hasMatchingDimLayout = [](NestedLayoutAttr lhsLayout, int64_t lhsDim,
+                                   NestedLayoutAttr rhsLayout, int64_t rhsDim) {
+      return lhsLayout.getSubgroupTile()[lhsDim] ==
+                 rhsLayout.getSubgroupTile()[rhsDim] &&
+             lhsLayout.getBatchTile()[lhsDim] ==
+                 rhsLayout.getBatchTile()[rhsDim] &&
+             lhsLayout.getOuterTile()[lhsDim] ==
+                 rhsLayout.getOuterTile()[rhsDim] &&
+             lhsLayout.getThreadTile()[lhsDim] ==
+                 rhsLayout.getThreadTile()[rhsDim] &&
+             lhsLayout.getElementTile()[lhsDim] ==
+                 rhsLayout.getElementTile()[rhsDim] &&
+             lhsLayout.getSubgroupStrides()[lhsDim] ==
+                 rhsLayout.getSubgroupStrides()[rhsDim] &&
+             lhsLayout.getThreadStrides()[lhsDim] ==
+                 rhsLayout.getThreadStrides()[rhsDim];
+    };
+    if (resVector) {
+      auto resType = cast<VectorType>(resVector.getType());
+      SmallVector<int64_t> resUndistributedShape =
+          resLayout.getUndistributedShape();
+      if (resLayout.getRank() != opInfo.getCRank() ||
+          !llvm::equal(resUndistributedShape, resType.getShape())) {
+        return rewriter.notifyMatchFailure(
+            contractOp, "result layout does not match contraction result");
+      }
+    }
+    if (maskOp) {
+      // Mask projection uses getDimPosition on operand map results. Keep the
+      // unmasked path aligned with VectorContractOpInfo, which allows constant
+      // zero results for broadcast-style maps.
+      if (!lhsMap.isProjectedPermutation() ||
+          !rhsMap.isProjectedPermutation()) {
+        return rewriter.notifyMatchFailure(
+            maskOp,
+            "masked contraction requires projected permutation operand maps");
+      }
+      if (maskLayoutAttr.getRank() !=
+          static_cast<int64_t>(contractOp.getIteratorTypes().size())) {
+        return rewriter.notifyMatchFailure(
+            maskOp, "mask layout rank does not match contraction iterators");
+      }
+      auto hasMatchingMaskLayout = [&](AffineMap operandMap,
+                                       NestedLayoutAttr operandLayout) {
+        for (int64_t resultIdx :
+             llvm::seq<int64_t>(operandMap.getNumResults())) {
+          int64_t iterSpacePos = operandMap.getDimPosition(resultIdx);
+          if (!hasMatchingDimLayout(maskLayoutAttr, iterSpacePos, operandLayout,
+                                    resultIdx)) {
+            return false;
+          }
+        }
+        return true;
+      };
+      if (!hasMatchingMaskLayout(lhsMap, lhsLayout) ||
+          !hasMatchingMaskLayout(rhsMap, rhsLayout)) {
+        return rewriter.notifyMatchFailure(
+            maskOp, "mask layout does not match contraction operand layouts");
+      }
+    }
+    SmallVector<int64_t> reductionLhsPositions;
+    for (auto [index, iteratorType] :
+         llvm::enumerate(contractOp.getIteratorTypes())) {
+      if (!vector::isReductionIterator(iteratorType)) {
+        continue;
+      }
+      AffineExpr reductionExpr = getAffineDimExpr(index, ctx);
+      auto lhsResultPos = lhsMap.getResultPosition(reductionExpr);
+      auto rhsResultPos = rhsMap.getResultPosition(reductionExpr);
+      if (!lhsResultPos || !rhsResultPos) {
+        return rewriter.notifyMatchFailure(
+            contractOp, "reduction iterators must appear in lhs and rhs maps");
+      }
+
+      int64_t redLhsIdx = *lhsResultPos;
+      int64_t redRhsIdx = *rhsResultPos;
+      if (!hasMatchingDimLayout(lhsLayout, redLhsIdx, rhsLayout, redRhsIdx)) {
+        return rewriter.notifyMatchFailure(
+            contractOp, "lhs/rhs reduction iterator layouts do not match");
+      }
+      reductionLhsPositions.push_back(redLhsIdx);
+    }
+
+    VectorValue localLhs = getDeinterleavedUnpackedForm(
+        rewriter, getDistributed(rewriter, contractOp.getLhs(), lhsLayout),
+        lhsLayout);
+    VectorValue localRhs = getDeinterleavedUnpackedForm(
+        rewriter, getDistributed(rewriter, contractOp.getRhs(), rhsLayout),
+        rhsLayout);
+    assert(
+        cast<VectorType>(localLhs.getType()).getRank() == opInfo.getARank() &&
+        cast<VectorType>(localRhs.getType()).getRank() == opInfo.getBRank() &&
+        "nested layout unpack must match contraction indexing maps");
+
+    VectorValue mask = nullptr;
+    if (maskOp) {
+      mask = getDistributed(rewriter, maskOp.getMask(), maskLayoutAttr);
       Value passThruLhs = getCombiningIdentityValue(
-          loc, rewriter, contractOp.getKind(), disLhs.getType());
+          loc, rewriter, contractOp.getKind(), localLhs.getType());
       Value passThruRhs = getCombiningIdentityValue(
-          loc, rewriter, contractOp.getKind(), disRhs.getType());
+          loc, rewriter, contractOp.getKind(), localRhs.getType());
 
       VectorValue deInterleavedMask =
-          getDeinterleavedUnpackedForm(rewriter, mask, maskLayout);
+          getDeinterleavedUnpackedForm(rewriter, mask, maskLayoutAttr);
       VectorValue maskLhs = projectVector(rewriter, loc, deInterleavedMask,
                                           contractOp.getIndexingMapsArray()[0]);
-      VectorValue interleavedMaskLhs =
-          getInterleavedPackedForm(rewriter, maskLhs, lhsLayout);
 
       VectorValue maskRhs = projectVector(rewriter, loc, deInterleavedMask,
                                           contractOp.getIndexingMapsArray()[1]);
-      VectorValue interleavedMaskRhs =
-          getInterleavedPackedForm(rewriter, maskRhs, rhsLayout);
 
-      disLhs = cast<VectorValue>(arith::SelectOp::create(rewriter, loc,
-                                                         interleavedMaskLhs,
-                                                         disLhs, passThruLhs)
-                                     .getResult());
-      disRhs = cast<VectorValue>(arith::SelectOp::create(rewriter, loc,
-                                                         interleavedMaskRhs,
-                                                         disRhs, passThruRhs)
-                                     .getResult());
+      localLhs = cast<VectorValue>(
+          arith::SelectOp::create(rewriter, loc, maskLhs, localLhs, passThruLhs)
+              .getResult());
+      localRhs = cast<VectorValue>(
+          arith::SelectOp::create(rewriter, loc, maskRhs, localRhs, passThruRhs)
+              .getResult());
     }
 
     Value acc = contractOp.getAcc();
-    Value res = contractOp.getResult();
     auto accVector = dyn_cast<VectorValue>(acc);
-    auto resVector = dyn_cast<VectorValue>(res);
-    Value disAcc;
-    if (accVector) {
-      disAcc = getDistributed(rewriter, accVector, signature[accVector]);
-    } else {
-      disAcc = contractOp.getAcc();
-    }
 
     Type accElemTy = getElementTypeOrSelf(acc.getType());
 
-    MLIRContext *ctx = contractOp.getContext();
-
     // Step 1: local contraction
-    Value localInit = getCombiningIdentityValue(
-        loc, rewriter, contractOp.getKind(), disAcc.getType());
-    Value localContract = doDistributedContraction(
-        rewriter, loc, ctx, contractOp, disLhs, disRhs, localInit);
-
-    // TODO: As per current upstream lowering implementations, there is no point
-    // in doing this because it does a select much later in a finer granularity
-    // rather than supporting predication. Moreover, since we are doing a select
-    // to cater reductions across the distribution, we can choose not to mask
-    // the op post-distribution.
-
-    VectorValue localContractValue;
+    Type localInitType = acc.getType();
     if (accVector) {
-      localContractValue = dyn_cast<VectorValue>(localContract);
+      SmallVector<int64_t> localResultShape;
+      localResultShape.reserve(resLayout.getRank());
+      for (int64_t unDistrDim : llvm::seq<int64_t>(resLayout.getRank())) {
+        localResultShape.push_back(resLayout.getBatchTile()[unDistrDim] *
+                                   resLayout.getOuterTile()[unDistrDim] *
+                                   resLayout.getElementTile()[unDistrDim]);
+      }
+      localInitType = VectorType::get(localResultShape, accElemTy);
+    }
+    Value localInit = getCombiningIdentityValue(
+        loc, rewriter, contractOp.getKind(), localInitType);
+    Value localContract = doDistributedContraction(
+        rewriter, loc, contractOp, localLhs, localRhs, localInit);
+
+    VectorValue packedLocalContractValue;
+    if (accVector) {
+      VectorValue localContractValue = dyn_cast<VectorValue>(localContract);
+      packedLocalContractValue =
+          getInterleavedPackedForm(rewriter, localContractValue, resLayout);
     } else {
       VectorType vecType = VectorType::get(ArrayRef{int64_t(1)}, accElemTy);
-      localContractValue =
+      packedLocalContractValue =
           vector::BroadcastOp::create(rewriter, loc, vecType, localContract);
     }
 
-    assert(localContractValue && "result should have been a vector");
+    assert(packedLocalContractValue && "result should have been a vector");
 
     // Identify the reduction dimension and apply it for subgroup reduction.
-    auto lhsMap = contractOp.getIndexingMapsArray()[0];
     SmallVector<int64_t> reductionSubGroupTile;
     SmallVector<int64_t> reductionSubGroupStrides;
     SmallVector<int64_t> reductionThreadTile;
     SmallVector<int64_t> reductionThreadStrides;
     SmallVector<int64_t> partialReductionDims;
-    for (auto [index, iteratorType] :
-         llvm::enumerate(contractOp.getIteratorTypes())) {
-      if (vector::isReductionIterator(iteratorType)) {
-        int64_t redLhsIdx =
-            *(lhsMap.getResultPosition(getAffineDimExpr(index, ctx)));
-        partialReductionDims.push_back(resLayout.getRank() +
-                                       reductionSubGroupTile.size());
-        reductionSubGroupTile.push_back(lhsLayout.getSubgroupTile()[redLhsIdx]);
-        reductionSubGroupStrides.push_back(
-            lhsLayout.getSubgroupStrides()[redLhsIdx]);
-        reductionThreadTile.push_back(lhsLayout.getThreadTile()[redLhsIdx]);
-        reductionThreadStrides.push_back(
-            lhsLayout.getThreadStrides()[redLhsIdx]);
-      }
+    for (int64_t redLhsIdx : reductionLhsPositions) {
+      partialReductionDims.push_back(resLayout.getRank() +
+                                     reductionSubGroupTile.size());
+      reductionSubGroupTile.push_back(lhsLayout.getSubgroupTile()[redLhsIdx]);
+      reductionSubGroupStrides.push_back(
+          lhsLayout.getSubgroupStrides()[redLhsIdx]);
+      reductionThreadTile.push_back(lhsLayout.getThreadTile()[redLhsIdx]);
+      reductionThreadStrides.push_back(lhsLayout.getThreadStrides()[redLhsIdx]);
     }
     SmallVector<int64_t> unitBroadcastTile(reductionThreadTile.size(), 1);
 
@@ -2415,12 +2521,12 @@ struct DistributeContract final
 
     VectorType partialReducedDistributedType =
         VectorType::get(reductionLayout.getDistributedShape(),
-                        localContractValue.getType().getElementType());
+                        packedLocalContractValue.getType().getElementType());
     Value shapeCasted = vector::ShapeCastOp::create(
-        rewriter, loc, partialReducedDistributedType, localContractValue);
+        rewriter, loc, partialReducedDistributedType, packedLocalContractValue);
     VectorType unDistributedType =
         VectorType::get(reductionLayout.getUndistributedShape(),
-                        localContractValue.getType().getElementType());
+                        packedLocalContractValue.getType().getElementType());
     Value undistrLocalReduced = IREE::VectorExt::ToSIMDOp::create(
         rewriter, loc, unDistributedType, shapeCasted);
 
@@ -2442,50 +2548,12 @@ struct DistributeContract final
 
   vector::ContractionOp
   doDistributedContraction(RewriterBase &rewriter, Location loc,
-                           MLIRContext *ctx, vector::ContractionOp contractOp,
-                           Value lhs, Value rhs, Value acc) const {
-    SmallVector<AffineMap> maps = contractOp.getIndexingMapsArray();
-    ArrayRef<Attribute> iteratorTypes =
-        contractOp.getIteratorTypes().getValue();
-
-    // Given that the distribution format is <BATCH x OUTER x ELEMENT>,
-    // the iterations and affine maps need to be replicated three times.
-
-    SmallVector<Attribute> newIterators;
-    // Replicate the iterators for local vector.contract
-    for (int i = 0; i < 3; ++i) {
-      newIterators.append(iteratorTypes.begin(), iteratorTypes.end());
-    }
-
-    // Replicate the affine maps for local vector.contract
-    SmallVector<AffineMap> newMaps;
-    for (AffineMap map : maps) {
-      int64_t numDims = map.getNumDims();
-      int64_t numResults = map.getNumResults();
-      SmallVector<AffineExpr> exprs;
-      for (int i = 0; i < 3; ++i) {
-        AffineMap shiftedMap = map.shiftDims(i * numDims);
-        for (int j = 0; j < numResults; ++j) {
-          exprs.push_back(shiftedMap.getResult(j));
-        }
-      }
-      AffineMap newMap =
-          AffineMap::get(/*dimCount=*/3 * numDims,
-                         /*symbolCount=*/map.getNumSymbols(), exprs, ctx);
-      newMaps.push_back(newMap);
-    }
-
-    Value localInit = getCombiningIdentityValue(
-        loc, rewriter, contractOp.getKind(), acc.getType());
-
-    auto localContractOp = vector::ContractionOp::create(
-        rewriter, loc, lhs, rhs, localInit,
-        rewriter.getAffineMapArrayAttr(newMaps),
-        rewriter.getArrayAttr(newIterators), contractOp.getKind());
-    localContractOp->setDiscardableAttrs(
-        contractOp->getDiscardableAttrDictionary());
-
-    return localContractOp;
+                           vector::ContractionOp contractOp, Value lhs,
+                           Value rhs, Value acc) const {
+    return vector::ContractionOp::create(
+        rewriter, loc, lhs, rhs, acc, contractOp.getIndexingMaps(),
+        contractOp.getIteratorTypes(), contractOp.getKind(),
+        contractOp.getFastmath());
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -174,17 +174,18 @@ static VectorValue getDeinterleavedUnpackedForm(PatternRewriter &rewriter,
   Location loc = val.getLoc();
   VectorValue deinterleavedPacked =
       getDeinterleavedPackedForm(rewriter, val, layout);
-  ArrayRef<int64_t> packedShape = deinterleavedPacked.getType().getShape();
   SmallVector<int64_t> unpackedShape;
   unpackedShape.reserve(layout.getRank());
   for (int64_t unDistrDim : llvm::seq<int64_t>(layout.getRank())) {
     int64_t unpackedDim = layout.getBatchTile()[unDistrDim] *
                           layout.getOuterTile()[unDistrDim] *
                           layout.getElementTile()[unDistrDim];
-    assert(unpackedDim == packedShape[unDistrDim * 3] *
-                              packedShape[unDistrDim * 3 + 1] *
-                              packedShape[unDistrDim * 3 + 2] &&
-           "packed B/O/E shape must match nested layout tile product");
+    assert(
+        unpackedDim ==
+            deinterleavedPacked.getType().getShape()[unDistrDim * 3] *
+                deinterleavedPacked.getType().getShape()[unDistrDim * 3 + 1] *
+                deinterleavedPacked.getType().getShape()[unDistrDim * 3 + 2] &&
+        "packed B/O/E shape must match nested layout tile product");
     unpackedShape.push_back(unpackedDim);
   }
   VectorType unpackedType = VectorType::get(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -180,12 +180,6 @@ static VectorValue getDeinterleavedUnpackedForm(PatternRewriter &rewriter,
     int64_t unpackedDim = layout.getBatchTile()[unDistrDim] *
                           layout.getOuterTile()[unDistrDim] *
                           layout.getElementTile()[unDistrDim];
-    assert(
-        unpackedDim ==
-            deinterleavedPacked.getType().getShape()[unDistrDim * 3] *
-                deinterleavedPacked.getType().getShape()[unDistrDim * 3 + 1] *
-                deinterleavedPacked.getType().getShape()[unDistrDim * 3 + 2] &&
-        "packed B/O/E shape must match nested layout tile product");
     unpackedShape.push_back(unpackedDim);
   }
   VectorType unpackedType = VectorType::get(
@@ -270,8 +264,6 @@ static VectorValue getSlicedPermutedValue(PatternRewriter &rewriter,
 /// but with projecting out the indexed/sliced dimensions from the result.
 static VectorValue projectVector(RewriterBase &rewriter, Location loc,
                                  VectorValue val, AffineMap projectionMap) {
-  assert(projectionMap.isProjectedPermutation() &&
-         "expected a projected permutation map");
   SmallVector<int64_t> remainingDims;
   auto allDims =
       llvm::to_vector(llvm::seq<int64_t>(projectionMap.getNumDims()));
@@ -2423,10 +2415,6 @@ struct DistributeContract final
     VectorValue localRhs = getDeinterleavedUnpackedForm(
         rewriter, getDistributed(rewriter, contractOp.getRhs(), rhsLayout),
         rhsLayout);
-    assert(
-        cast<VectorType>(localLhs.getType()).getRank() == opInfo.getARank() &&
-        cast<VectorType>(localRhs.getType()).getRank() == opInfo.getBRank() &&
-        "nested layout unpack must match contraction indexing maps");
 
     VectorValue mask = nullptr;
     if (maskOp) {
@@ -2476,7 +2464,7 @@ struct DistributeContract final
 
     VectorValue packedLocalContractValue;
     if (accVector) {
-      VectorValue localContractValue = dyn_cast<VectorValue>(localContract);
+      VectorValue localContractValue = cast<VectorValue>(localContract);
       packedLocalContractValue =
           getInterleavedPackedForm(rewriter, localContractValue, resLayout);
     } else {
@@ -2484,8 +2472,6 @@ struct DistributeContract final
       packedLocalContractValue =
           vector::BroadcastOp::create(rewriter, loc, vecType, localContract);
     }
-
-    assert(packedLocalContractValue && "result should have been a vector");
 
     // Identify the reduction dimension and apply it for subgroup reduction.
     SmallVector<int64_t> reductionSubGroupTile;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1060,8 +1060,8 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @contraction_32x32_alldims
-// Local contraction
-// CHECK: vector.contract {{.*}} vector<2x2x1x1x1x4xf32>, vector<2x2x1x1x1x4xf32> into f32
+// Local contraction keeps original iterator types and indexing maps.
+// CHECK: vector.contract {indexing_maps = [#map, #map, #map1], iterator_types = ["reduction", "reduction"], kind = #vector.kind<maxnumf>} {{.*}} : vector<2x8xf32>, vector<2x8xf32> into f32
 // Global reduction
 // CHECK: gpu.subgroup_reduce maxnumf %{{.*}} cluster(size = 16) : (f32) -> f32
 // CHECK-NEXT: gpu.subgroup_reduce maxnumf %{{.*}} cluster(size = 4, stride = 16) : (f32) -> f32
@@ -1128,7 +1128,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[C:.*]] = arith.extf %[[B]]
 // CHECK-NEXT: %[[D:.*]] = vector.extract %[[ARG0]][]
 // Local contraction
-// CHECK: vector.contract {{.*}} vector<2x2x1x1x1x4xf32>, vector<2x2x1x1x1x4xf32> into f32
+// CHECK: vector.contract {{.*}} vector<2x8xf32>, vector<2x8xf32> into f32
 // Global reduction
 // CHECK: gpu.subgroup_reduce maxnumf %{{.*}} cluster(size = 16) : (f32) -> f32
 // CHECK-NEXT: gpu.subgroup_reduce maxnumf %{{.*}} cluster(size = 4, stride = 16) : (f32) -> f32
@@ -1199,8 +1199,9 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @contraction_dim1
-// Local contraction
-// CHECK: vector.contract {{.*}} vector<2x2x1x1x1x4xf32>, vector<2x1x4xf32> into vector<2x1x1xf32>
+// Local contraction keeps parallel/reduction semantics from the maps.
+// CHECK: vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "reduction"], kind = #vector.kind<maxnumf>} {{.*}} : vector<2x8xf32>, vector<8xf32> into vector<2xf32>
+// CHECK: vector.shape_cast %{{.*}} : vector<2xf32> to vector<2x1x1xf32>
 // Global reduction
 // CHECK: vector.extract %{{.*}}[0, 0, 0]
 // CHECK-NEXT: gpu.subgroup_reduce maxnumf %{{.*}} cluster(size = 4, stride = 16) : (f32) -> f32

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -295,18 +295,14 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // CHECK-LABEL: func @masked_read_write_contract
 
-// CHECK-DAG: %[[RED_IDENTITY_LHS:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x2xf16>
-// CHECK-DAG: %[[RED_IDENTITY_RHS:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x2x2xf16>
+// Identities for predicated local logical operands (flat ranks match indexing maps).
+// CHECK-DAG: %[[RED_IDENTITY_LHS:.+]] = arith.constant dense<0.000000e+00> : vector<2xf16>
+// CHECK-DAG: %[[RED_IDENTITY_RHS:.+]] = arith.constant dense<0.000000e+00> : vector<2x2xf16>
 
-// Note this this transposed to match the second indexing map
 // CHECK-DAG: %[[MASK_LHS:.+]] = vector.create_mask %[[LHSUB:.+]] : vector<2xi1>
 // CHECK-DAG: %[[MASK_OP:.+]] = vector.create_mask %[[OPUB0:.+]], %[[LHSUB]] : vector<2x2xi1>
 
-// Note MASK_OP_1D is equivalent to MASK_LHS.
-// Currently, it does not fold away.
 // CHECK-DAG: %[[MASK_OP_1D:.+]] = vector.extract %[[MASK_OP]][0] : vector<2xi1> from vector<2x2xi1>
-// CHECK-DAG: %[[MASK_OP_1D_PACKED:.+]] = vector.shape_cast %[[MASK_OP_1D]] : vector<2xi1> to vector<1x1x2xi1>
-// CHECK-DAG: %[[MASK_OP_PACKED:.+]] = vector.shape_cast %[[MASK_OP]] : vector<2x2xi1> to vector<1x1x1x1x2x2xi1>
 // CHECK-DAG: %[[MASK_OUT:.+]] = vector.create_mask {{.*}} : vector<2xi1>
 
 // CHECK-DAG: %[[LHS_READ:.+]] = vector.transfer_read %arg0{{.*}} %[[MASK_LHS]] {in_bounds = [true]} : memref<?xf16>, vector<2xf16>
@@ -314,10 +310,13 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-DAG: %[[RHS_READ:.+]] = vector.transfer_read %arg1{{.*}} %[[MASK_OP]] {in_bounds = [true, true]} : memref<?x?xf16>, vector<2x2xf16>
 // CHECK-DAG: %[[RHS:.+]] = vector.insert_strided_slice %[[RHS_READ]]
 
-// CHECK-DAG: %[[LHS_SELECT:.+]] = arith.select %[[MASK_OP_1D_PACKED]], %[[LHS]], %[[RED_IDENTITY_LHS]] : vector<1x1x2xi1>, vector<1x1x2xf16>
-// CHECK-DAG: %[[RHS_SELECT:.+]] = arith.select %[[MASK_OP_PACKED]], %[[RHS]], %[[RED_IDENTITY_RHS]] : vector<1x1x1x1x2x2xi1>, vector<1x1x1x1x2x2xf16>
+// CHECK-DAG: %[[LHS_FLAT:.+]] = vector.shape_cast %[[LHS]] : vector<1x1x2xf16> to vector<2xf16>
+// CHECK-DAG: %[[RHS_FLAT:.+]] = vector.shape_cast %[[RHS]] : vector<1x1x1x1x2x2xf16> to vector<2x2xf16>
 
-// CHECK: vector.contract {{.*}} %[[LHS_SELECT]], %[[RHS_SELECT]]
+// CHECK-DAG: %[[LHS_SELECT:.+]] = arith.select %[[MASK_OP_1D]], %[[LHS_FLAT]], %[[RED_IDENTITY_LHS]] : vector<2xi1>, vector<2xf16>
+// CHECK-DAG: %[[RHS_SELECT:.+]] = arith.select %[[MASK_OP]], %[[RHS_FLAT]], %[[RED_IDENTITY_RHS]] : vector<2x2xi1>, vector<2x2xf16>
+
+// CHECK: vector.contract {indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d1)>], iterator_types = ["reduction", "parallel"], kind = #vector.kind<add>} %[[LHS_SELECT]], %[[RHS_SELECT]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -493,8 +493,8 @@ struct LLVMGPUVectorLoweringPass final
           contractLoweringPatterns, options.vectorContractLowering);
       contractLoweringPatterns.add<PromoteContractOperands>(
           funcOp->getContext());
-      contractLoweringPatterns.add<ContractToChainFMA>(funcOp->getContext(),
-                                                       PatternBenefit(2));
+      // contractLoweringPatterns.add<ContractToChainFMA>(funcOp->getContext(),
+      //                                                  PatternBenefit(2));
       vector::populateVectorGatherLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorMaskOpLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorShapeCastLoweringPatterns(contractLoweringPatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -493,8 +493,8 @@ struct LLVMGPUVectorLoweringPass final
           contractLoweringPatterns, options.vectorContractLowering);
       contractLoweringPatterns.add<PromoteContractOperands>(
           funcOp->getContext());
-      // contractLoweringPatterns.add<ContractToChainFMA>(funcOp->getContext(),
-      //                                                  PatternBenefit(2));
+      contractLoweringPatterns.add<ContractToChainFMA>(funcOp->getContext(),
+                                                       PatternBenefit(2));
       vector::populateVectorGatherLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorMaskOpLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorShapeCastLoweringPatterns(contractLoweringPatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -41,8 +41,9 @@ func.func @matvec_fp16() attributes {hal.executable.target = #executable_target_
 //     CHECK-LABEL: func.func @matvec_fp16
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c128
 //          CHECK:      %[[OUT:.+]] = vector.contract
-//     CHECK-SAME:      vector<1x1x1x1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1x1x1x1xf16>
-//          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
+//     CHECK-SAME:      vector<1x8xf16>, vector<1x8xf16> into vector<1x1xf16>
+//          CHECK:      vector.shape_cast %[[OUT]] : vector<1x1xf16> to vector<1x1x1x1x1x1xf16>
+//          CHECK:      %[[SCALAR:.+]] = vector.extract %{{.*}}
 //          CHECK:      gpu.subgroup_reduce add %[[SCALAR]]
 
 //          CHECK:      scf.yield
@@ -90,8 +91,9 @@ func.func @matvec_fp16_parallel_subgroup() attributes {hal.executable.target = #
 //     CHECK-LABEL: func.func @matvec_fp16_parallel_subgroup
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c512
 //          CHECK:      %[[OUT:.+]] = vector.contract
-//     CHECK-SAME:      vector<1x1x1x1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1x1x1x1xf16>
-//          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
+//     CHECK-SAME:      vector<1x8xf16>, vector<1x8xf16> into vector<1x1xf16>
+//          CHECK:      vector.shape_cast %[[OUT]] : vector<1x1xf16> to vector<1x1x1x1x1x1xf16>
+//          CHECK:      %[[SCALAR:.+]] = vector.extract %{{.*}}
 //          CHECK:      gpu.subgroup_reduce add %[[SCALAR]]
 
 //          CHECK:      scf.yield
@@ -143,8 +145,9 @@ func.func @matvec_fp16_promote_rhs() attributes {hal.executable.target = #execut
 //          CHECK:      %[[RHS_SHARED_READ:.+]] = vector.transfer_read %alloc
 //          CHECK:      %[[RHS_INSERT:.+]] = vector.insert_strided_slice %[[RHS_SHARED_READ]]
 //          CHECK:      %[[OUT:.+]] = vector.contract
-//     CHECK-SAME:      %{{.*}}, %[[RHS_INSERT]], %{{.*}} : vector<1x1x1x1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1x1x1x1xf16>
-//          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
+//     CHECK-SAME:      vector<1x8xf16>, vector<1x8xf16> into vector<1x1xf16>
+//          CHECK:      vector.shape_cast %[[OUT]] : vector<1x1xf16> to vector<1x1x1x1x1x1xf16>
+//          CHECK:      %[[SCALAR:.+]] = vector.extract %{{.*}}
 //          CHECK:      gpu.subgroup_reduce add %[[SCALAR]]
 
 //          CHECK:      scf.yield
@@ -224,7 +227,8 @@ func.func @attention_20x1x64x4096x64() attributes {hal.executable.target = #exec
 // CHECK:         scf.for %{{.*}} = %c0 to %c4096 step %c128
 // QK Matmul
 // CHECK:           vector.contract
-// CHECK-SAME:      vector<1x1x1x1x1x1x1x1x32xf16>, vector<1x1x1x1x1x1x1x4x32xf16> into vector<1x1x1x1x1x1x1x1x4xf32>
+// CHECK-SAME:      vector<1x1x32xf16>, vector<1x4x32xf16> into vector<1x1x4xf32>
+// CHECK-NEXT:      vector.shape_cast %{{.*}} : vector<1x1x4xf32> to vector<1x1x1x1x1x1x1x1x4xf32>
 // CHECK-COUNT-4:   gpu.subgroup_reduce add
 
 // QK Max
@@ -313,7 +317,8 @@ func.func @attention_20x1x64x4096x64() attributes {hal.executable.target = #exec
 // CHECK:         scf.for %{{.*}} = %c0 to %c4096 step %c128
 // QK Matmul
 // CHECK:           vector.contract
-// CHECK-SAME:      vector<1x1x1x1x1x1x1x1x32xf16>, vector<1x1x1x1x1x1x1x4x32xf16> into vector<1x1x1x1x1x1x1x4x1xf32>
+// CHECK-SAME:      vector<1x1x32xf16>, vector<1x4x32xf16> into vector<1x4x1xf32>
+// CHECK-NEXT:      vector.shape_cast %{{.*}} : vector<1x4x1xf32> to vector<1x1x1x1x1x1x1x4x1xf32>
 // CHECK-COUNT-4:   gpu.subgroup_reduce add
 
 // No subgroup reduction in the loop other than QK reductions
@@ -369,8 +374,9 @@ func.func @matvec_fp16_subgroup_reduction() attributes {hal.executable.target = 
 //     CHECK-LABEL: func.func @matvec_fp16_subgroup_reduction
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c128
 //          CHECK:      %[[OUT:.+]] = vector.contract
-//     CHECK-SAME:      vector<1x1x1x1x1x4xf16>, vector<1x1x1x1x1x4xf16> into vector<1x1x1x1x1x1xf16>
-//          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
+//     CHECK-SAME:      vector<1x4xf16>, vector<1x4xf16> into vector<1x1xf16>
+//          CHECK:      vector.shape_cast %[[OUT]] : vector<1x1xf16> to vector<1x1x1x1x1x1xf16>
+//          CHECK:      %[[SCALAR:.+]] = vector.extract %{{.*}}
 //          CHECK:      gpu.subgroup_reduce add %[[SCALAR]]
 //          CHECK:        gpu.barrier memfence [#gpu.address_space<workgroup>]
                        /// Second round of reduction i.e., across subgroups.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -415,4 +415,5 @@ func.func @i4_dequant_matvec() attributes {hal.executable.target = #executable_t
 //         CHECK:     arith.uitofp %{{.*}} : vector<1x1x1x1x1x1x1x1x4xi4> to vector<1x1x1x1x1x1x1x1x4xf16>
 //         CHECK:     arith.subf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>
 //         CHECK:     arith.mulf %{{.*}}, %{{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>
-//         CHECK:     vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>, vector<1x1x1x1x1x1x1x1x1x1x1x4xf16> into vector<1x1x1x1x1x1x1x1x1xf16>
+//         CHECK:     vector.contract {{.*}} : vector<1x1x4xf16>, vector<1x1x1x4xf16> into vector<1x1x1xf16>
+//    CHECK-NEXT:     vector.shape_cast %{{.*}} : vector<1x1x1xf16> to vector<1x1x1x1x1x1x1x1x1xf16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -111,7 +111,8 @@ func.func @i4_dequant_matvec() attributes {hal.executable.target = #executable_t
 //         RDNA3:   %{{.*}} = arith.uitofp %{{.*}} : vector<4x1x1x1x1x1x1x1x4xi4> to vector<4x1x1x1x1x1x1x1x4xf16>
 //         RDNA3:   %{{.*}} = arith.subf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x4xf16>
 //         RDNA3:   %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : vector<4x1x1x1x1x1x1x1x4xf16>
-//         RDNA3:   vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x4xf16>, vector<4x1x1x1x1x1x1x1x1x1x1x4xf16> into vector<4x1x1x1x1x1x1x1x1xf16>
+//         RDNA3:   vector.contract {{.*}} : vector<1x1x4xf16>, vector<4x1x1x4xf16> into vector<4x1x1xf16>
+//    RDNA3-NEXT:   vector.shape_cast %{{.*}} : vector<4x1x1xf16> to vector<4x1x1x1x1x1x1x1x1xf16>
 
 //         RDNA3:   vector.shape_cast %{{.*}} : vector<4x1x1x1x1x1x1x1x1xf16> to vector<4x1x1xf16>
 
@@ -199,7 +200,8 @@ func.func @matvec_fp16() attributes {hal.executable.target = #executable_target_
 //      CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
 //      CHECK-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1x8x1x1x1x1x1x1x1xf16>
 //          CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C512]] step %[[C64]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<1x8x1x1x1x1x1x1x1xf16>)
-//          CHECK:     vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x8xf16>, vector<8x1x1x1x1x1x1x1x8xf16> into vector<1x8x1x1x1x1x1x1x1xf16>
+//          CHECK:     vector.contract {{.*}} : vector<1x1x8xf16>, vector<8x1x8xf16> into vector<1x8x1xf16>
+//     CHECK-NEXT:     vector.shape_cast %{{.*}} : vector<1x8x1xf16> to vector<1x8x1x1x1x1x1x1x1xf16>
 
 //          CHECK: vector.shape_cast %{{.*}} : vector<1x8x1x1x1x1x1x1x1xf16> to vector<1x8x1x1x1x1xf16>
 
@@ -240,7 +242,8 @@ func.func @matvec_fp16() attributes {hal.executable.target = #executable_target_
 //      RDNA3-DAG:   %[[C32:.+]] = arith.constant 32 : index
 //      RDNA3-DAG:   %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<1x4x1x1x1x1x1x1x1xf16>
 //          RDNA3:   scf.for %{{.+}} = %[[C0]] to %[[C512]] step %[[C32]] iter_args(%[[ARG:.+]] = %[[CST]]) -> (vector<1x4x1x1x1x1x1x1x1xf16>)
-//          RDNA3:     vector.contract {{.*}} : vector<1x1x1x1x1x1x1x1x8xf16>, vector<4x1x1x1x1x1x1x1x8xf16> into vector<1x4x1x1x1x1x1x1x1xf16>
+//          RDNA3:     vector.contract {{.*}} : vector<1x1x8xf16>, vector<4x1x8xf16> into vector<1x4x1xf16>
+//     RDNA3-NEXT:     vector.shape_cast %{{.*}} : vector<1x4x1xf16> to vector<1x4x1x1x1x1x1x1x1xf16>
 
 //          RDNA3: vector.shape_cast %{{.*}} : vector<1x4x1x1x1x1x1x1x1xf16> to vector<1x4x1x1x1x1xf16>
 


### PR DESCRIPTION
Given a `vector.contract` off the MMA path, like 

```
%17 = vector.contract {
        indexing_maps = [
          affine_map<(d0, d1, d2) -> (d1, d2)>,
          affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
          affine_map<(d0, d1, d2) -> (d0, d1)>
        ],
        iterator_types = ["parallel", "parallel", "reduction"],
        kind = #vector.kind<add>
      } %14, %15, %16
      : vector<352x8xf16>,
        vector<64x352x8xf16>
        into vector<64x352xf32>

```

We currently distribute this like:

```
%1006 = vector.shape_cast %1005
  : vector<64x1x1x1x1x8xf16>
    to vector<64x1x1x1x1x1x1x1x8xf16>

%1007 = vector.contract {
          indexing_maps = [
            affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8)
                         -> (d1, d2, d4, d5, d7, d8)>,
            affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8)
                         -> (d0, d1, d2, d3, d4, d5, d6, d7, d8)>,
            affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8)
                         -> (d0, d1, d3, d4, d6, d7)>
          ],
          iterator_types = [
            "parallel", "parallel", "reduction",
            "parallel", "parallel", "reduction",
            "parallel", "parallel", "reduction"
          ],
          kind = #vector.kind<add>
        } %747, %1006, %cst_4
        : vector<1x1x1x1x1x8xf16>,
          vector<64x1x1x1x1x1x1x1x8xf16>
          into vector<64x1x1x1x1x1xf32>

%1008 = vector.shape_cast %1007
  : vector<64x1x1x1x1x1xf32>
    to vector<64x1x1x1x1x1x1x1x1xf32>

%1009 = vector.multi_reduction <add>, %1008, %cst_4 [2, 5, 8]
  : vector<64x1x1x1x1x1x1x1x1xf32>
    to vector<64x1x1x1x1x1xf32>
```

Which is semantically correct, but upstream `populateVectorContractLoweringPatterns` sees several iterators signifying the distributed semantics wrt `<batch, outer, element>`. Thus we could fail to match better lowering patterns than we’d like and would instead fall back on the generic lowering pattern.

With this patch, we take the distributed operands feeding into the `vector.contract` and convert them from the nested layout form into the shape of the original `vector.contract`

For example:

```
vector<2x2x1x1x1x4xf32> -> vector<2x8xf32>
vector<2x1x4xf32>       -> vector<8xf32>
```

The result is packed back into the distributed nested layout form before further use immediately following `vector.contract`; so we preserve surrounding semantics while allowing upstream patterns to match the original semantics of `vector.contract` when viable. 

The motivating sequence would now lower to:

```
%1005 = vector.shape_cast %746
  : vector<1x1x8xf16>
    to vector<1x8xf16>

%1006 = vector.shape_cast %1004
  : vector<64x1x1x1x1x8xf16>
    to vector<64x1x8xf16>

%1007 = vector.contract {
          indexing_maps = [
            affine_map<(d0, d1, d2) -> (d1, d2)>,
            affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
            affine_map<(d0, d1, d2) -> (d0, d1)>
          ],
          iterator_types = ["parallel", "parallel", "reduction"],
          kind = #vector.kind<add>
        } %1005, %1006, %cst_1
        : vector<1x8xf16>,
          vector<64x1x8xf16>
          into vector<64x1xf32>

%1008 = vector.shape_cast %1007
  : vector<64x1xf32>
    to vector<64x1x1x1x1x1x1x1x1xf32>

%1009 = vector.multi_reduction <add>, %1008, %cst_5 [2, 5, 8]
  : vector<64x1x1x1x1x1x1x1x1xf32>
    to vector<64x1x1x1x1x1xf32>
```

Contributes towards #24297

Assisted with: Cursor 