### PR TITLE
[HAL] Preserve tensor import effects when folding

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -49,6 +49,11 @@ struct ElideUnusedOp : OpRewritePattern<Op> {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult TensorImportOp::fold(FoldAdaptor operands) {
+  // Wait fences and consumes carry availability/ownership effects for the
+  // imported tensor value. Folding through them would drop those effects.
+  if (getWaitFence() || getConsume()) {
+    return {};
+  }
   // Cannot fold if there is a byte offset — the import is a subview.
   if (getByteOffset()) {
     return {};
@@ -189,6 +194,11 @@ void TensorImportOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 OpFoldResult TensorExportOp::fold(FoldAdaptor operands) {
   if (auto importOp = getSource().getDefiningOp<TensorImportOp>()) {
+    // Wait fences and consumes carry availability/ownership effects for the
+    // imported tensor value. Folding through them would drop those effects.
+    if (importOp.getWaitFence() || importOp.getConsume()) {
+      return {};
+    }
     // Cannot fold through an import with byte_offset — it's a subview.
     if (importOp.getByteOffset()) {
       return {};

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_folding.mlir
@@ -12,6 +12,66 @@ util.func public @foldTensorImportExport(%arg0: !hal.buffer_view) -> !hal.buffer
 
 // -----
 
+// Import wait fences must not be folded away.
+
+// CHECK-LABEL: @noFoldTensorImportExportWithWait
+// CHECK-SAME: (%[[ARG0:.+]]: !hal.buffer_view, %[[WAIT:.+]]: !hal.fence)
+util.func public @noFoldTensorImportExportWithWait(%arg0: !hal.buffer_view, %wait: !hal.fence) -> !hal.buffer_view {
+  // CHECK: %[[IMPORT:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[ARG0]] : !hal.buffer_view -> tensor<5xi32>
+  %0 = hal.tensor.import wait(%wait) => %arg0 : !hal.buffer_view -> tensor<5xi32>
+  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %[[IMPORT]] : tensor<5xi32> -> !hal.buffer_view
+  %1 = hal.tensor.export %0 : tensor<5xi32> -> !hal.buffer_view
+  // CHECK: util.return %[[EXPORT]] : !hal.buffer_view
+  util.return %1 : !hal.buffer_view
+}
+
+// -----
+
+// Import consumes must not be folded away.
+
+// CHECK-LABEL: @noFoldTensorImportExportWithConsume
+// CHECK-SAME: (%[[ARG0:.+]]: !hal.buffer_view)
+util.func public @noFoldTensorImportExportWithConsume(%arg0: !hal.buffer_view) -> !hal.buffer_view {
+  // CHECK: %[[IMPORT:.+]] = hal.tensor.import consume %[[ARG0]] : !hal.buffer_view -> tensor<5xi32>
+  %0 = hal.tensor.import consume %arg0 : !hal.buffer_view -> tensor<5xi32>
+  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %[[IMPORT]] : tensor<5xi32> -> !hal.buffer_view
+  %1 = hal.tensor.export %0 : tensor<5xi32> -> !hal.buffer_view
+  // CHECK: util.return %[[EXPORT]] : !hal.buffer_view
+  util.return %1 : !hal.buffer_view
+}
+
+// -----
+
+// Import wait fences must not be folded away from export/import pairs.
+
+// CHECK-LABEL: @noFoldTensorExportImportWithWait
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<5xi32>, %[[WAIT:.+]]: !hal.fence)
+util.func public @noFoldTensorExportImportWithWait(%arg0: tensor<5xi32>, %wait: !hal.fence) -> tensor<5xi32> {
+  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %[[ARG0]] : tensor<5xi32> -> !hal.buffer_view
+  %0 = hal.tensor.export %arg0 : tensor<5xi32> -> !hal.buffer_view
+  // CHECK: %[[IMPORT:.+]] = hal.tensor.import wait(%[[WAIT]]) => %[[EXPORT]] : !hal.buffer_view -> tensor<5xi32>
+  %1 = hal.tensor.import wait(%wait) => %0 : !hal.buffer_view -> tensor<5xi32>
+  // CHECK: util.return %[[IMPORT]] : tensor<5xi32>
+  util.return %1 : tensor<5xi32>
+}
+
+// -----
+
+// Import consumes must not be folded away from export/import pairs.
+
+// CHECK-LABEL: @noFoldTensorExportImportWithConsume
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<5xi32>)
+util.func public @noFoldTensorExportImportWithConsume(%arg0: tensor<5xi32>) -> tensor<5xi32> {
+  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %[[ARG0]] : tensor<5xi32> -> !hal.buffer_view
+  %0 = hal.tensor.export %arg0 : tensor<5xi32> -> !hal.buffer_view
+  // CHECK: %[[IMPORT:.+]] = hal.tensor.import consume %[[EXPORT]] : !hal.buffer_view -> tensor<5xi32>
+  %1 = hal.tensor.import consume %0 : !hal.buffer_view -> tensor<5xi32>
+  // CHECK: util.return %[[IMPORT]] : tensor<5xi32>
+  util.return %1 : tensor<5xi32>
+}
+
+// -----
+
 // Import with byte_offset must not fold — the import is a subview.
 
 // CHECK-LABEL: @noFoldTensorImportExportWithOffset


### PR DESCRIPTION
HAL tensor imports carry optional wait fences and consume markers that are part of the availability and ownership contract for the imported tensor. Folding through an import/export pair erased that contract, allowing an async wrapper that returns an imported buffer view unchanged to discard the wait fence and signal its output fence immediately.

Keep the fold only for imports with no sequencing or ownership effects. Imports with wait_fence, consume, or byte offsets remain explicit so later conversion can materialize the required timepoint await or ownership transfer instead of reducing the wrapper to an immediate host-side fence signal.

Add canonicalization coverage for both import-to-export and export-to-import pairs so the plain effect-free fold remains available while sequenced imports are preserved.

Found while triaging #24324.