### PR TITLE
[Codegen][CPU] Fix transposed-intrinsic narrow-N inner_tiled lowering.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
@@ -250,6 +250,80 @@ func.func @unset_encoding_matmul_RESULT_inner_tiled_avx512(%arg0: tensor<127x255
 
 // -----
 
+// Narrow-N (`transposed_intrinsic = true`): with `iteration_sizes = [_, 8, _]`
+// the cost model picks the M↔N-swapped orientation of
+// MMA_X86_AVX512_1x16x1_F32_F32 (16x1x1 lane layout) over the natural 1x16x1
+// — the static N=8 caps natural usefulOps to 8, while the transposed
+// orientation fully utilizes its M=16 lanes. Unrolling lands on
+// (intrinsics_m=2, intrinsics_n=8), giving M_inner=32, N_inner=8.
+//
+// The accumulator swizzle is then stored in (N, M) physical order, so
+// materialize-encoding swaps the ACC pack's *inner* tile to (N_inner=8,
+// M_inner=32) and routes its inner_dims_pos to [1, 0]. LHS (M, K) and
+// RHS (N, K) packs keep their natural inner order — only the ACC swap is
+// needed. Without that surgical (ACC-only, inner-only) swap, the
+// inner_tiled verifier rejects the materialized op.
+
+#map_t = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map_t1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map_t2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding_t_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_t, #map_t1, #map_t2], iteration_sizes = [127, 8, ?]>
+#encoding_t_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_t, #map_t1, #map_t2], iteration_sizes = [127, 8, ?]>
+#encoding_t_res = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_t, #map_t1, #map_t2], iteration_sizes = [127, 8, ?]>
+func.func @set_encoding_LHS_inner_tiled_avx512_narrow_n(%arg0: tensor<127x255xf32>, %k: index) -> tensor<127x255xf32, #encoding_t_lhs> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<127x255xf32> -> tensor<127x255xf32, #encoding_t_lhs>
+  return %0 : tensor<127x255xf32, #encoding_t_lhs>
+}
+func.func @set_encoding_RHS_inner_tiled_avx512_narrow_n(%arg0: tensor<127x255xf32>, %k: index) -> tensor<127x255xf32, #encoding_t_rhs> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k} : tensor<127x255xf32> -> tensor<127x255xf32, #encoding_t_rhs>
+  return %0 : tensor<127x255xf32, #encoding_t_rhs>
+}
+func.func @unset_encoding_RESULT_inner_tiled_avx512_narrow_n(%arg0: tensor<127x255xf32, #encoding_t_res>, %k: index) -> tensor<127x255xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%k} : tensor<127x255xf32, #encoding_t_res> -> tensor<127x255xf32>
+  return %0 : tensor<127x255xf32>
+}
+// LHS pack: natural (M, K) inner order, M_inner = intrinsicM * intrinsics_m
+// = 16 * 2 = 32, K_inner = 1.
+// CHECK-LABEL: func @set_encoding_LHS_inner_tiled_avx512_narrow_n(
+//  CHECK-SAME:   %[[INPUT_T_L:[a-zA-Z0-9]+]]: tensor<127x255xf32>
+//       CHECK:   %[[EMPTY_T_L:.+]] = tensor.empty() : tensor<4x255x32x1xf32>
+//       CHECK:   %[[PACK_T_L:.+]] = linalg.pack %[[INPUT_T_L]]
+//  CHECK-SAME:     outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 1]
+//  CHECK-SAME:     into %[[EMPTY_T_L]] : tensor<127x255xf32> -> tensor<4x255x32x1xf32>
+//       CHECK:   return %[[PACK_T_L]] : tensor<4x255x32x1xf32>
+
+// RHS pack: natural (N, K) inner order, N_inner = intrinsicN * intrinsics_n
+// = 1 * 8 = 8, K_inner = 1.
+// CHECK-LABEL: func @set_encoding_RHS_inner_tiled_avx512_narrow_n(
+//  CHECK-SAME:   %[[INPUT_T_R:[a-zA-Z0-9]+]]: tensor<127x255xf32>
+//       CHECK:   %[[EMPTY_T_R:.+]] = tensor.empty() : tensor<32x127x8x1xf32>
+//       CHECK:   %[[PACK_T_R:.+]] = linalg.pack %[[INPUT_T_R]]
+//  CHECK-SAME:     outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 1]
+//  CHECK-SAME:     into %[[EMPTY_T_R]] : tensor<127x255xf32> -> tensor<32x127x8x1xf32>
+//       CHECK:   return %[[PACK_T_R]] : tensor<32x127x8x1xf32>
+
+// ACC unpack: outer dims still iterate as (M_outer, N_outer) per the
+// inner_tiled op's indexing maps (outer_dims_perm = [0, 1]) — only the
+// inner tile is swapped. inner_dims_pos = [1, 0] points at (N, M) and
+// inner_tiles = [8, 32] gives N_inner = 8, M_inner = 32, i.e. the ACC
+// is stored in physical (N, M) order. The packed input shape is
+// tensor<4x32x8x32xf32> = (M_outer=4, N_outer=32, N_inner=8, M_inner=32).
+// CHECK-LABEL: func @unset_encoding_RESULT_inner_tiled_avx512_narrow_n(
+//  CHECK-SAME:   %[[PACKED_T:[a-zA-Z0-9]+]]: tensor<4x32x8x32xf32>
+//       CHECK:   %[[EMPTY_T_U:.+]] = tensor.empty() : tensor<127x255xf32>
+//       CHECK:   %[[UNPACK_T:.+]] = linalg.unpack %[[PACKED_T]]
+//  CHECK-SAME:     outer_dims_perm = [0, 1] inner_dims_pos = [1, 0] inner_tiles = [8, 32]
+//  CHECK-SAME:     into %[[EMPTY_T_U]] : tensor<4x32x8x32xf32> -> tensor<127x255xf32>
+//       CHECK:   return %[[UNPACK_T]]
+
+// -----
+
 // It tests with bindings and checks that the reshape ops are folded into bindings.
 
 #executable_target_xyz = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -635,17 +635,16 @@ DataTiledMMAAttr::getDistributionWorkerCount(OpBuilder &builder, Location loc,
 // Lowers a MMAIntrinsic to a llvm.call_intrinsic op, plus any necessary
 // additional ops (potentially broadcasting or widening LHS/RHS or creating an
 // add op if the intrinsic isn't already adding the accumulator).
-//
-// Currently assumes that if one of LHS or RHS needs to be broadcasted, then it
-// musst be LHS. This corresponds to the fact that transposed intrinsics are not
-// currently handled by the caller, which is just a temporary limitation.
 static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
                                        MMAIntrinsic intrinsic, Value lhs,
                                        Value rhs, Value acc) {
-  // Replicate LHS (M=1, K elements) across RHS's N lanes so both have the
-  // intrinsic's flat lane width. Going through a (N, K) 2-D form keeps the
-  // K-pair contiguous; a final shape_cast collapses to the flat 1-D vector
-  // the LLVM intrinsic expects. All x86 LLVM intrinsics we target here
+  // Replicate the narrower of LHS/RHS across the wider operand's lanes so
+  // both have the intrinsic's flat lane width. In the natural orientation
+  // that's the LHS (M=1, K elements) broadcast across the N lanes of the
+  // RHS; under `transposed_intrinsic` the roles swap and the RHS is the
+  // narrower one. Going through a (lanes, K) 2-D form keeps the K-pair
+  // contiguous; a final shape_cast collapses to the flat 1-D vector the
+  // LLVM intrinsic expects. All x86 LLVM intrinsics we target here
   // (AVX-512 FMA, VNNI vpdpwssd, BF16 dpbf16ps, integer pmaddwd) take same-
   // width vector operands — there is no narrow-input variant. The ISA-level
   // `{1toN}` broadcast-from-memory form is recovered later by the x86
@@ -659,11 +658,15 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   auto lhsType = cast<VectorType>(lhs.getType());
   auto rhsType = cast<VectorType>(rhs.getType());
   if (lhsType.getNumElements() != rhsType.getNumElements()) {
-    int64_t replicate = rhsType.getNumElements() / lhsType.getNumElements();
-    auto bcastType = VectorType::get({replicate, lhsType.getNumElements()},
-                                     lhsType.getElementType());
-    Value bcast = vector::BroadcastOp::create(builder, loc, bcastType, lhs);
-    lhs = vector::ShapeCastOp::create(builder, loc, rhsType, bcast);
+    bool lhsIsNarrow = lhsType.getNumElements() < rhsType.getNumElements();
+    Value &narrow = lhsIsNarrow ? lhs : rhs;
+    VectorType narrowType = lhsIsNarrow ? lhsType : rhsType;
+    VectorType wideType = lhsIsNarrow ? rhsType : lhsType;
+    int64_t replicate = wideType.getNumElements() / narrowType.getNumElements();
+    auto bcastType = VectorType::get({replicate, narrowType.getNumElements()},
+                                     narrowType.getElementType());
+    Value bcast = vector::BroadcastOp::create(builder, loc, bcastType, narrow);
+    narrow = vector::ShapeCastOp::create(builder, loc, wideType, bcast);
   }
 
   // Sign-/float-extend a vector to a wider element type. Used by the
@@ -729,14 +732,6 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
 LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
     OpBuilder &builder, Location loc, ValueRange inputs, ValueRange outputs,
     SmallVectorImpl<Value> &results) const {
-  // TODO: handle `transposed_intrinsic`. When set, LHS and RHS swap roles
-  // (narrow-N case), and the broadcast in `createCpuMmaIntrinsicCall` would
-  // need to broadcast whichever operand is narrower rather than always LHS.
-  // Bail for now so we don't silently produce wrong code.
-  if (getTransposedIntrinsic()) {
-    return failure();
-  }
-
   SmallVector<VectorType> regTypes;
   getDistributedTileTypes(regTypes);
   if (inputs.size() != 2 || outputs.size() != 1 ||
@@ -754,7 +749,8 @@ LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
       builder, loc, getSwizzle(*this, /*operandIdx=*/0),
       getSwizzle(*this, /*operandIdx=*/1), getSwizzle(*this, /*operandIdx=*/2),
       getIntrinsicsM(), getIntrinsicsN(), getIntrinsicsK(), inputs, outputs,
-      emitIntrinsic, results);
+      emitIntrinsic, results,
+      /*accCrossIntrinsicTransposed=*/getTransposedIntrinsic());
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -118,3 +118,72 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   arith.extsi {{.*}} : vector<32xi8> to vector<32xi16>
 //       CHECK:   %[[DOT:.+]] = llvm.call_intrinsic "llvm.x86.avx512.pmaddw.d.512"({{.*}}) : (vector<32xi16>, vector<32xi16>) -> vector<16xi32>
 //       CHECK:   arith.addi {{.*}}, %[[DOT]] : vector<16xi32>
+
+// -----
+
+// AVX-512 1×16×1 f32 used with `transposed_intrinsic = true` and
+// asymmetric unrolling intrinsics_m=2, intrinsics_n=4. With the M↔N roles
+// swapped, the LHS becomes the 16-wide side and the RHS the 1-wide side
+// (each per-intrinsic LHS slice is vector<16xf32>, each per-intrinsic RHS
+// slice is vector<1xf32>). Two correctness invariants the lowering must
+// respect:
+//
+//   1. Broadcast direction (fix from `createCpuMmaIntrinsicCall`): the
+//      broadcast widens the *narrower* side to the wider side's width, so
+//      under `transposed_intrinsic` the RHS gets broadcast 1→16, not the
+//      LHS. Without the fix, the lowering tries to replicate the 16-wide
+//      LHS to 1-wide RHS and hits replicate=0.
+//
+//   2. ACC index in the unroll loop (fix from
+//      `buildDataTiledMMAUnderlyingOperations`): the ACC swizzle expands
+//      cross-intrinsic factors as (intrinsicsN, intrinsicsM) under
+//      `transposed_intrinsic`, so `distributeMmaFragmentToIntrinsics`
+//      walks ACC pieces in (n_idx, m_idx) row-major. The FMA loop iterates
+//      (mu, nu) and must therefore index ACC at `nu * intrinsicsM + mu`
+//      (= `nu * 2 + mu` here), giving the interleaved sequence
+//      0, 2, 4, 6, 1, 3, 5, 7. Without the fix the sequential
+//      `mu * intrinsicsN + nu` indexing miswires ACC chunks to (mu, nu)
+//      pairs and produces miscompares.
+
+#contraction_accesses_t = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_avx512_1x16x1_f32_transposed(
+    %lhs: vector<32x1xf32>, %rhs: vector<4x1xf32>, %acc: vector<4x32xf32>)
+    -> vector<4x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_t,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 2, intrinsics_n = 4, transposed_intrinsic = true>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<32x1xf32>, vector<4x1xf32> into vector<4x32xf32>
+  return %0 : vector<4x32xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_avx512_1x16x1_f32_transposed
+//       CHECK:   %[[ACC_T:.+]]:8 = util.hoistable_conversion "data_tiled_acc_distribute"
+// Broadcast widens the 1-wide RHS slice to 16, not the 16-wide LHS.
+//       CHECK:   vector.broadcast {{.*}} : vector<1xf32> to vector<16x1xf32>
+// 8 FMA calls in (mu, nu) row-major over (intrinsicsM=2, intrinsicsN=4),
+// indexing ACC at `nu * intrinsicsM + mu`: 0, 2, 4, 6, 1, 3, 5, 7.
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}, {{.*}}, %[[ACC_T]]#0)
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}, {{.*}}, %[[ACC_T]]#2)
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}, {{.*}}, %[[ACC_T]]#4)
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}, {{.*}}, %[[ACC_T]]#6)
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}, {{.*}}, %[[ACC_T]]#1)
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}, {{.*}}, %[[ACC_T]]#3)
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}, {{.*}}, %[[ACC_T]]#5)
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}, {{.*}}, %[[ACC_T]]#7)

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.cpp
@@ -96,8 +96,8 @@ LogicalResult buildDataTiledMMAUnderlyingOperations(
     const TileSwizzle &rhsSwizzle, const TileSwizzle &accSwizzle,
     int64_t intrinsicsM, int64_t intrinsicsN, int64_t intrinsicsK,
     ValueRange inputs, ValueRange outputs,
-    DataTiledMMAIntrinsicEmitter emitIntrinsic,
-    SmallVectorImpl<Value> &results) {
+    DataTiledMMAIntrinsicEmitter emitIntrinsic, SmallVectorImpl<Value> &results,
+    bool accCrossIntrinsicTransposed) {
   if (inputs.size() != 2 || outputs.size() != 1) {
     return failure();
   }
@@ -126,13 +126,21 @@ LogicalResult buildDataTiledMMAUnderlyingOperations(
       });
   SmallVector<Value> intrinsicsAcc(distributeAccOp.getResults());
 
-  // Loop over the unroll_{m,n,k} dimensions to emit per-intrinsic ops.
+  // Loop over the unroll_{m,n,k} dimensions to emit per-intrinsic ops. The
+  // ACC index follows the swizzle's cross-intrinsic ordering: normally
+  // (intrinsicsM, intrinsicsN) → idx = mu * intrinsicsN + nu, but under CPU's
+  // `transposed_intrinsic` the ACC swizzle stores them as (intrinsicsN,
+  // intrinsicsM) so the index becomes nu * intrinsicsM + mu.
+  auto accIndex = [&](int64_t mu, int64_t nu) -> int64_t {
+    return accCrossIntrinsicTransposed ? nu * intrinsicsM + mu
+                                       : mu * intrinsicsN + nu;
+  };
   for (int64_t mu = 0; mu < intrinsicsM; ++mu) {
     for (int64_t nu = 0; nu < intrinsicsN; ++nu) {
       for (int64_t ku = 0; ku < intrinsicsK; ++ku) {
         Value lhsPiece = intrinsicsLhs[mu * intrinsicsK + ku];
         Value rhsPiece = intrinsicsRhs[nu * intrinsicsK + ku];
-        Value &acc = intrinsicsAcc[mu * intrinsicsN + nu];
+        Value &acc = intrinsicsAcc[accIndex(mu, nu)];
         Value newAcc = emitIntrinsic(builder, loc, lhsPiece, rhsPiece, acc);
         if (!newAcc) {
           return failure();

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.h
@@ -87,14 +87,17 @@ using DataTiledMMAIntrinsicEmitter = llvm::function_ref<Value(
 /// `inputs` are LHS and RHS in that order. `outputs[0]` is the accumulator.
 /// Operand vector ranks may be either the swizzle's full expanded form (GPU)
 /// or the 2-D (outer × inner) collapsed form (CPU); the helper reshapes as
-/// needed.
+/// needed. `accCrossIntrinsicTransposed` reflects whether the ACC swizzle's
+/// cross-intrinsic dims are stored as (intrinsicsN, intrinsicsM) instead of
+/// (intrinsicsM, intrinsicsN) — set by CPU's `transposed_intrinsic` flag and
+/// always false for GPU.
 LogicalResult buildDataTiledMMAUnderlyingOperations(
     OpBuilder &builder, Location loc, const TileSwizzle &lhsSwizzle,
     const TileSwizzle &rhsSwizzle, const TileSwizzle &accSwizzle,
     int64_t intrinsicsM, int64_t intrinsicsN, int64_t intrinsicsK,
     ValueRange inputs, ValueRange outputs,
-    DataTiledMMAIntrinsicEmitter emitIntrinsic,
-    SmallVectorImpl<Value> &results);
+    DataTiledMMAIntrinsicEmitter emitIntrinsic, SmallVectorImpl<Value> &results,
+    bool accCrossIntrinsicTransposed = false);
 
 } // namespace mlir::iree_compiler::IREE::Codegen
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -1109,9 +1109,21 @@ private:
 
   /// Intrinsic-first path for `iree_codegen.inner_tiled`: pick a
   /// `DataTiledMMAAttr` (same decision the lowering will make) and derive the
-  /// packed-layout tile shape from it. No narrow-N transpose: unlike the
-  /// legacy mmt4d path, the inner_tiled lowering handles narrow dims natively
-  /// via `intrinsics_m` / `intrinsics_n`.
+  /// packed-layout tile shape from it. The narrow-dim case is handled natively
+  /// via `intrinsics_m` / `intrinsics_n` (no narrow-N→narrow-M *matmul-level*
+  /// transpose like the legacy mmt4d path) — but when the cost model picks
+  /// `transposed_intrinsic = true` (intrinsic with M/N roles swapped), the
+  /// ACC swizzle stores its inner tile in (N, M) physical order, so the ACC
+  /// pack info must swap its (M, N) inner tile to (N, M) to match. Only the
+  /// inner part of the ACC pack is affected — the outer dims still iterate as
+  /// (M_outer, N_outer) per the inner_tiled op's indexing maps, so we leave
+  /// `outerDimsPerm` alone (unlike the legacy mmt4d narrow-N path, which
+  /// swaps the matmul-level M and N globally and therefore swaps the outer
+  /// dims too). LHS (M, K) and RHS (N, K) keep their physical layout — only
+  /// the ACC needs the swap. Without this, the `InnerTiledOp` verifier
+  /// rejects the materialized op with "operand #2 inner tile
+  /// 'tensor<M_pack x N_pack>' is incompatible with expected MMA tile type
+  /// 'vector<N x M>'".
   static MaterializeEncodingInfo getInnerTiledEncodingInfo(
       MLIRContext *ctx, IREE::Encoding::EncodingAttr encoding,
       const linalg::ContractionDimensions &cDims, DictionaryAttr config) {
@@ -1131,6 +1143,19 @@ private:
         getScalableTileFlags(cDims, encoding, config);
     if (succeeded(scalableFlags)) {
       info.scalableTiles = std::move(scalableFlags);
+    }
+    if (mma.getTransposedIntrinsic() &&
+        encoding.getOperandIndex().getValue() ==
+            IREE::Encoding::MATMUL_RESULT &&
+        info.innerTileSizes.size() >= 2) {
+      auto transposeInner = [](auto &a) {
+        std::swap(a[a.size() - 2], a[a.size() - 1]);
+      };
+      transposeInner(info.innerDimsPos);
+      transposeInner(info.innerTileSizes);
+      if (info.scalableTiles) {
+        transposeInner(info.scalableTiles.value());
+      }
     }
     return info;
   }


### PR DESCRIPTION
Three correctness bugs surface together when the cost model picks `transposed_intrinsic = true` (narrow-N matmuls). The first two stop compilation; the third is a runtime miscompare. They are intentionally fixed in one commit so the e2e test suite can advance to the full `default` shape set without an intermediate commit that compiles but returns wrong results.

1. Materialize-encoding swapped the inner tile of *every* operand. Only the ACC swizzle is stored in physical (N, M) order — LHS (M, K) and RHS (N, K) keep their layout. Previously `transposeInPlace` was called for all three encodings, which corrupted LHS/RHS and made the inner_tiled verifier reject the materialized op with iteration- bound mismatches. Restrict the swap to the ACC encoding, and only swap the *inner* part (innerDimsPos / innerTileSizes) — the outer dims still iterate as (M_outer, N_outer) per the inner_tiled op's indexing maps, unlike the legacy mmt4d narrow-N path which globally remaps M↔N including outer dims.

2. `createCpuMmaIntrinsicCall` always broadcast the LHS to the RHS's width, assuming the LHS is the smaller side (M=1 vs N>1). Under `transposed_intrinsic` the RHS is the narrow side, so the assumption flipped and the broadcast aborted with `replicate = 0` when computing the bcast vector type. Detect which side is narrower and broadcast it; the AVX-family intrinsics this path emits (FMA, packed i16/bf16 pairwise dot) are all symmetric in their LHS/RHS args, so the call-site argument order is unchanged.

3. Under `transposed_intrinsic` the ACC swizzle expands its cross-intrinsic factors as (intrinsicsN, intrinsicsM) rather than (intrinsicsM, intrinsicsN), since the ACC tile is stored in physical (N, M) order. `distributeMmaFragmentToIntrinsics` walks the swizzle in row-major order, so the per-intrinsic ACC pieces land in the list at index `nu * intrinsicsM + mu` for the transposed ACC versus `mu * intrinsicsN + nu` for the regular one. The shared lowering loop hardcoded the regular indexing, lining up new ACC values with the wrong (mu, nu) chunk and producing miscompares (e.g. AVX2 1x8x1 with intrinsicsM=2, intrinsicsN=4 on the small/15x37x7 case). Plumb a `accCrossIntrinsicTransposed` flag through `buildDataTiledMMAUnderlyingOperations` (default false for GPU) and have CPU's `DataTiledMMAAttr::buildUnderlyingOperations` forward `getTransposedIntrinsic()`.

With the three fixes, the e2e matmul inner_tiled test suite passes the full `default` shape set across generic/AVX2/AVX-512/AVX-512-VNNI/ AVX-512-BF16 variants for every supported type combination.

Progress towards #24323