### PR TITLE
[test][nfc] Add regression tests about strided vector.gather back.

### DIFF
--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -91,6 +91,22 @@ iree_check_single_backend_test_suite(
     target_backend = "llvm-cpu",
 )
 
+# TODO(24342): Merge the test suite into the main e2e reverse coverage in
+# tests/e2e/stablehlo_ops/reverse.mlir once the RISC-V vector miscompile of
+# fused slice + reverse is fixed.
+iree_check_single_backend_test_suite(
+    name = "check_regression_xla_reverse_after_slice_llvm-cpu",
+    srcs = [
+        "xla_reverse_after_slice.mlir",
+    ],
+    compiler_flags = ["--iree-llvmcpu-target-cpu=generic"],
+    driver = "local-task",
+    tags = [
+        "noriscv",
+    ],
+    target_backend = "llvm-cpu",
+)
+
 iree_check_single_backend_test_suite(
     name = "check_regression_tosa_llvm-cpu",
     srcs = [

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -86,6 +86,21 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
+    check_regression_xla_reverse_after_slice_llvm-cpu
+  SRCS
+    "xla_reverse_after_slice.mlir"
+  TARGET_BACKEND
+    "llvm-cpu"
+  DRIVER
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-target-cpu=generic"
+  LABELS
+    "noriscv"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
     check_regression_tosa_llvm-cpu
   SRCS
     "linalg_quantized_matmul_vs_linalg_matmul.mlir"

--- a/tests/e2e/regression/xla_reverse_after_slice.mlir
+++ b/tests/e2e/regression/xla_reverse_after_slice.mlir
@@ -1,0 +1,26 @@
+// Regression test for https://github.com/iree-org/iree/issues/24342.
+//
+// It fails on risc-v only because it does not apply the upstream pattern that
+// recovers the logical indices of a `vector.gather` op.
+// See https://github.com/iree-org/iree/commit/25dcacfcbcd4ec91260920d7296ad558aa03ef84
+func.func @xla_reverse_after_slice() {
+  %t1 = util.unfoldable_constant dense<[
+      [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]],
+      [[9.0, 10.0], [11.0, 12.0], [13.0, 14.0], [15.0, 16.0]]
+  ]> : tensor<2x4x2xf32>
+  %sliced = "stablehlo.slice"(%t1) {
+      start_indices = array<i64: 0, 1, 0>,
+      limit_indices = array<i64: 2, 3, 2>,
+      strides = array<i64: 1, 1, 1>
+  } : (tensor<2x4x2xf32>) -> tensor<2x2x2xf32>
+  %reversed = "stablehlo.reverse"(%sliced) {dimensions = array<i64: 1>}
+      : (tensor<2x2x2xf32>) -> tensor<2x2x2xf32>
+  check.expect_almost_eq_const(
+      %reversed,
+      dense<[
+          [[5.0, 6.0], [3.0, 4.0]],
+          [[13.0, 14.0], [11.0, 12.0]]
+      ]> : tensor<2x2x2xf32>
+  ) : tensor<2x2x2xf32>
+  return
+}

--- a/tests/e2e/stablehlo_ops/reverse.mlir
+++ b/tests/e2e/stablehlo_ops/reverse.mlir
@@ -20,30 +20,3 @@ func.func @xla_reverse() {
   ) : tensor<2x3xf32>
   return
 }
-
-// Regression test for https://github.com/iree-org/iree/issues/23637.
-//
-// TODO(24342): re-enable once the RISC-V vector miscompile is fixed. When the fused
-// slice + reverse `linalg.generic` is collapsed to a 1-D iteration space,
-// RISC-V vector codegen produces wrong values.
-//
-// func.func @xla_reverse_after_slice() {
-//   %t1 = util.unfoldable_constant dense<[
-//       [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]],
-//       [[9.0, 10.0], [11.0, 12.0], [13.0, 14.0], [15.0, 16.0]]
-//   ]> : tensor<2x4x2xf32>
-//   %sliced = "stablehlo.slice"(%t1) {
-//       start_indices = array<i64: 0, 1, 0>,
-//       limit_indices = array<i64: 2, 3, 2>,
-//       strides = array<i64: 1, 1, 1>
-//   } : (tensor<2x4x2xf32>) -> tensor<2x2x2xf32>
-//   %reversed = "stablehlo.reverse"(%sliced) {dimensions = array<i64: 1>} : (tensor<2x2x2xf32>) -> tensor<2x2x2xf32>
-//   check.expect_almost_eq_const(
-//       %reversed,
-//       dense<[
-//           [[5.0, 6.0], [3.0, 4.0]],
-//           [[13.0, 14.0], [11.0, 12.0]]
-//       ]> : tensor<2x2x2xf32>
-//   ) : tensor<2x2x2xf32>
-//   return
-// }


### PR DESCRIPTION
It was failing on RISC-V because it explicitly exlcudes the lowering (which contains the proper fix) in https://github.com/iree-org/iree/commit/25dcacfcbcd4ec91260920d7296ad558aa03ef84

It seems like it is converted to `llvm.*.gather` ops and relies on LLVM backend to pick the corresponding instruction. This basically bypasses the vector level optimization in MLIR which is not fixable in IREE.

Related issue: https://github.com/iree-org/iree/issues/24342