### PR TITLE
[Stream] Fix build break: PropertyRef → OpaqueProperties after MLIR revert

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -3863,7 +3863,7 @@ void AsyncParameterWriteOp::getAsyncAccessRanges(
 
 LogicalResult AsyncParameterGatherOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, PropertyRef properties, RegionRange regions,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   // The result type matches the target operand type.
   AsyncParameterGatherOpAdaptor adaptor(operands, attributes, properties,
@@ -3929,7 +3929,7 @@ void AsyncParameterGatherOp::getAsyncAccessRanges(
 
 LogicalResult AsyncParameterScatterOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, PropertyRef properties, RegionRange regions,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   // The result type matches the source operand type.
   AsyncParameterScatterOpAdaptor adaptor(operands, attributes, properties,


### PR DESCRIPTION
MLIR commit 7fce7631a098 renamed `OpaqueProperties` to `PropertyRef` across the codebase. MLIR commit b31e232c29ae then reverted that rename back to `OpaqueProperties`, updating dialect files within llvm-project, but `StreamOps.cpp` in IREE was not reverted accordingly.

This fixes the two affected `inferReturnTypes` signatures in `AsyncParameterGatherOp` and `AsyncParameterScatterOp`.

---

**Note:** CI may show a pre-existing build failure in `compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp`
(`vector::createWriteOrMaskedWrite` missing) that is unrelated to this PR and reproducible on `upstream/main` without this change.

Assisted-by: Claude (Anthropic)