### PR TITLE
[VectorExt] Change `to_layout` `shared_memory_conversion`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/DecomposeHorizontallyFusedGemms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/DecomposeHorizontallyFusedGemms.cpp
@@ -86,16 +86,31 @@ getModifiedLoweringConfigForDecomposedGemmOp(
     return origAttr;
   }
 
-  llvm::SmallDenseSet<int64_t> promotedOperandsSet(
-      promotedOperandsList->begin(), promotedOperandsList->end());
-  SmallVector<int64_t> newPromotedOperands;
+  std::optional<ArrayRef<Attribute>> promotionTypes =
+      IREE::GPU::getPromotionTypesList(origAttr);
+
+  llvm::SmallDenseMap<int64_t, int64_t> keptOperandToNewOperand;
   for (auto [index, origOperandNum] : llvm::enumerate(keptOperands)) {
-    if (promotedOperandsSet.contains(origOperandNum)) {
-      newPromotedOperands.push_back(index);
+    keptOperandToNewOperand[origOperandNum] = index;
+  }
+
+  SmallVector<int64_t> newPromotedOperands;
+  SmallVector<Attribute> newPromotionTypes;
+  for (auto [index, promotedOperand] : llvm::enumerate(*promotedOperandsList)) {
+    auto newOperand = keptOperandToNewOperand.find(promotedOperand);
+    if (newOperand != keptOperandToNewOperand.end()) {
+      newPromotedOperands.push_back(newOperand->second);
+      if (promotionTypes) {
+        newPromotionTypes.push_back((*promotionTypes)[index]);
+      }
     }
   }
+  std::optional<ArrayRef<Attribute>> newPromotionTypesRef = std::nullopt;
+  if (!newPromotionTypes.empty()) {
+    newPromotionTypesRef = newPromotionTypes;
+  }
   return setPromotedOperandsList(rewriter.getContext(), origAttr,
-                                 newPromotedOperands);
+                                 newPromotedOperands, newPromotionTypesRef);
 }
 
 static LogicalResult

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -162,12 +162,6 @@ struct GPUPromoteMatmulOperandsPass final
 
       std::optional<ArrayRef<Attribute>> maybePromotionTypes =
           getPromotionTypesList(loweringConfig);
-      if (maybePromotionTypes &&
-          maybePromotionTypes->size() != promotedOperands->size()) {
-        op->emitOpError(
-            "promoted operand and promotion types lists size mismatch");
-        return WalkResult::interrupt();
-      }
 
       Attribute derived =
           IREE::GPU::DerivedThreadConfigAttr::get(op->getContext());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
@@ -85,6 +86,13 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
 
   OpBuilder builder(funcOp);
   for (IREE::VectorExt::ToLayoutOp op : opsToPromote) {
+    if (!llvm::isa<IREE::GPU::PromotionAttr>(
+            op.getSharedMemoryConversionAttr())) {
+      op.emitOpError("shared_memory_conversion attribute must implement "
+                     "IREE::GPU::PromotionAttr");
+      return failure();
+    }
+
     // HACK: Until proper barrier placement is handled later we have to
     // synchronize explicitly in this pass.
 
@@ -114,7 +122,7 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
 
     // Remove the shared_memory_conversion attribute from the to_layout
     // operation.
-    op.setSharedMemoryConversion(false);
+    op.removeSharedMemoryConversionAttr();
   }
   return success();
 }
@@ -145,7 +153,8 @@ struct GPUVectorAllocPass final
       auto outputLayout = layouts.lookup(op.getResult());
       if (inputLayout && outputLayout &&
           inputLayout.needsSharedMemoryForConversion(outputLayout)) {
-        op.setSharedMemoryConversion(true);
+        op.setSharedMemoryConversionAttr(
+            IREE::GPU::DerivedThreadConfigAttr::get(op.getContext()));
       }
     });
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-vector-alloc))" | FileCheck %s
+// RUN: iree-opt %s --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-vector-alloc))" | FileCheck %s
 
 #layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
@@ -12,7 +12,7 @@
 >
 
 func.func @test(%vector: vector<16x16xf16>) -> vector<16x16xf16> {
-  %out = iree_vector_ext.to_layout %vector to layout(#layout) {shared_memory_conversion} : vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %vector to layout(#layout) {shared_memory_conversion = #iree_gpu.derived_thread_config} : vector<16x16xf16>
   return %out : vector<16x16xf16>
 }
 
@@ -24,3 +24,22 @@ func.func @test(%vector: vector<16x16xf16>) -> vector<16x16xf16> {
 //         CHECK:    %[[BAR:.+]]   = iree_gpu.value_barrier %[[WRITE]]
 //         CHECK:    %[[READ:.+]]  = vector.transfer_read %[[BAR]]
 //         CHECK:    %[[OUT:.+]]   = iree_vector_ext.to_layout %[[READ]]
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [4, 1],
+
+  subgroup_strides = [1, 1],
+  thread_strides   = [0, 0]
+>
+
+func.func @invalid_shared_memory_conversion_attr(%vector: vector<16x16xf16>) -> vector<16x16xf16> {
+  // expected-error @+1 {{shared_memory_conversion attribute must implement IREE::GPU::PromotionAttr}}
+  %out = iree_vector_ext.to_layout %vector to layout(#layout) {shared_memory_conversion = "invalid"} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -123,7 +123,7 @@ setPromotedOperandsList(MLIRContext *context,
   std::optional<SmallVector<int64_t>> currPromotedOperandsList =
       getPromotedOperandList(currAttr);
   if (currPromotedOperandsList &&
-      currPromotedOperandsList.value() == operands) {
+      currPromotedOperandsList.value() == operands && !promotionTypes) {
     return currAttr;
   }
 
@@ -133,6 +133,8 @@ setPromotedOperandsList(MLIRContext *context,
 
   if (promotionTypes) {
     attributes.set(kPromotionTypesName, b.getArrayAttr(promotionTypes.value()));
+  } else {
+    attributes.erase(kPromotionTypesName);
   }
   return IREE::GPU::LoweringConfigAttr::get(context,
                                             attributes.getDictionary(context));

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -100,6 +100,43 @@ getPromotionTypesList(LoweringConfigAttr config) {
   return array.getValue();
 }
 
+LogicalResult
+verifyPromotedOperandsList(function_ref<InFlightDiagnostic()> emitError,
+                           DictionaryAttr attributes) {
+  Attribute promotionTypesAttr = attributes.get(kPromotionTypesName);
+  if (!promotionTypesAttr) {
+    return success();
+  }
+  auto promotionTypes = dyn_cast<ArrayAttr>(promotionTypesAttr);
+  if (!promotionTypes) {
+    return emitError() << "promotion_types must be an array";
+  }
+
+  auto promotedOperandsAttr = attributes.getAs<ArrayAttr>(kPromoteOperandsName);
+  if (!promotedOperandsAttr) {
+    return emitError()
+           << "promotion_types requires promote_operands to be specified";
+  }
+
+  std::optional<SmallVector<int64_t>> promotedOperands =
+      getIntegerVector(promotedOperandsAttr);
+  if (!promotedOperands) {
+    return emitError() << "promote_operands must be an array of integers";
+  }
+
+  if (promotionTypes.size() != promotedOperands->size()) {
+    return emitError()
+           << "promote_operands and promotion_types must have the same length";
+  }
+
+  if (!llvm::all_of(promotionTypes.getValue(), llvm::IsaPred<PromotionAttr>)) {
+    return emitError() << "promotion_types elements must implement "
+                          "IREE::GPU::PromotionAttr";
+  }
+
+  return success();
+}
+
 void appendPromotedOperandsList(MLIRContext *context,
                                 SmallVectorImpl<NamedAttribute> &attrs,
                                 ArrayRef<int64_t> operands,
@@ -112,6 +149,15 @@ void appendPromotedOperandsList(MLIRContext *context,
     attrs.emplace_back(kPromotionTypesName, b.getArrayAttr(promotionTypes));
   }
 }
+
+static bool arePromotionTypesEqual(std::optional<ArrayRef<Attribute>> lhs,
+                                   std::optional<ArrayRef<Attribute>> rhs) {
+  if (lhs.has_value() != rhs.has_value()) {
+    return false;
+  }
+  return !lhs || lhs->equals(*rhs);
+}
+
 IREE::GPU::LoweringConfigAttr
 setPromotedOperandsList(MLIRContext *context,
                         IREE::GPU::LoweringConfigAttr currAttr,
@@ -122,8 +168,11 @@ setPromotedOperandsList(MLIRContext *context,
   NamedAttrList attributes(currAttributes);
   std::optional<SmallVector<int64_t>> currPromotedOperandsList =
       getPromotedOperandList(currAttr);
+  std::optional<ArrayRef<Attribute>> currPromotionTypes =
+      getPromotionTypesList(currAttr);
   if (currPromotedOperandsList &&
-      currPromotedOperandsList.value() == operands && !promotionTypes) {
+      currPromotedOperandsList.value() == operands &&
+      arePromotionTypesEqual(currPromotionTypes, promotionTypes)) {
     return currAttr;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -43,6 +43,11 @@ getPromotedOperandList(LoweringConfigAttr config);
 /// Helper to retrieve a list of operand promotion types.
 std::optional<ArrayRef<Attribute>>
 getPromotionTypesList(LoweringConfigAttr config);
+/// Verifies that any configured operand promotion types match the promoted
+/// operands list.
+LogicalResult
+verifyPromotedOperandsList(function_ref<InFlightDiagnostic()> emitError,
+                           DictionaryAttr attributes);
 /// Append to `attrs` an `ArrayAttr` for `promotedOperands`.
 /// The `promotionTypes` is an optional list of Attributes
 /// describing how to promote each individual operand.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
@@ -49,6 +50,9 @@
 #define DEBUG_TYPE "iree-gpu-attrs"
 
 namespace mlir::iree_compiler::IREE::GPU {
+
+constexpr StringLiteral kPromoteOperandsName = "promote_operands";
+constexpr StringLiteral kPromotionTypesName = "promotion_types";
 
 // HoistableConversionOp tag constants — definitions live in
 // `Codegen/Utils/MMAUtils.h` so paired tags (which match by string) can't
@@ -2829,6 +2833,39 @@ static SmallVector<int64_t> getTileSizes(DictionaryAttr config,
 
 SmallVector<int64_t> LoweringConfigAttr::getWorkgroupTileSizes() const {
   return getTileSizes(getAttributes(), GPU::TilingLevel::Workgroup);
+}
+
+LogicalResult
+LoweringConfigAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                           DictionaryAttr attributes) {
+  auto promotionTypes = attributes.getAs<ArrayAttr>(kPromotionTypesName);
+  if (!promotionTypes) {
+    return success();
+  }
+
+  auto promotedOperandsAttr = attributes.getAs<ArrayAttr>(kPromoteOperandsName);
+  if (!promotedOperandsAttr) {
+    return emitError()
+           << "promotion_types requires promote_operands to be specified";
+  }
+
+  SmallVector<int64_t> promotedOperands =
+      getIntegerVector(promotedOperandsAttr);
+  if (promotedOperands.size() != promotedOperandsAttr.size()) {
+    return emitError() << "promote_operands must be an array of integers";
+  }
+
+  if (promotionTypes.size() != promotedOperands.size()) {
+    return emitError()
+           << "promote_operands and promotion_types must have the same length";
+  }
+
+  if (!llvm::all_of(promotionTypes.getValue(), llvm::IsaPred<PromotionAttr>)) {
+    return emitError() << "promotion_types elements must implement "
+                          "IREE::GPU::PromotionAttr";
+  }
+
+  return success();
 }
 
 SmallVector<int64_t>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
@@ -50,9 +51,6 @@
 #define DEBUG_TYPE "iree-gpu-attrs"
 
 namespace mlir::iree_compiler::IREE::GPU {
-
-constexpr StringLiteral kPromoteOperandsName = "promote_operands";
-constexpr StringLiteral kPromotionTypesName = "promotion_types";
 
 // HoistableConversionOp tag constants — definitions live in
 // `Codegen/Utils/MMAUtils.h` so paired tags (which match by string) can't
@@ -2838,38 +2836,7 @@ SmallVector<int64_t> LoweringConfigAttr::getWorkgroupTileSizes() const {
 LogicalResult
 LoweringConfigAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                            DictionaryAttr attributes) {
-  Attribute promotionTypesAttr = attributes.get(kPromotionTypesName);
-  if (!promotionTypesAttr) {
-    return success();
-  }
-  auto promotionTypes = dyn_cast<ArrayAttr>(promotionTypesAttr);
-  if (!promotionTypes) {
-    return emitError() << "promotion_types must be an array";
-  }
-
-  auto promotedOperandsAttr = attributes.getAs<ArrayAttr>(kPromoteOperandsName);
-  if (!promotedOperandsAttr) {
-    return emitError()
-           << "promotion_types requires promote_operands to be specified";
-  }
-
-  SmallVector<int64_t> promotedOperands =
-      getIntegerVector(promotedOperandsAttr);
-  if (promotedOperands.size() != promotedOperandsAttr.size()) {
-    return emitError() << "promote_operands must be an array of integers";
-  }
-
-  if (promotionTypes.size() != promotedOperands.size()) {
-    return emitError()
-           << "promote_operands and promotion_types must have the same length";
-  }
-
-  if (!llvm::all_of(promotionTypes.getValue(), llvm::IsaPred<PromotionAttr>)) {
-    return emitError() << "promotion_types elements must implement "
-                          "IREE::GPU::PromotionAttr";
-  }
-
-  return success();
+  return verifyPromotedOperandsList(emitError, attributes);
 }
 
 SmallVector<int64_t>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -2838,9 +2838,13 @@ SmallVector<int64_t> LoweringConfigAttr::getWorkgroupTileSizes() const {
 LogicalResult
 LoweringConfigAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                            DictionaryAttr attributes) {
-  auto promotionTypes = attributes.getAs<ArrayAttr>(kPromotionTypesName);
-  if (!promotionTypes) {
+  Attribute promotionTypesAttr = attributes.get(kPromotionTypesName);
+  if (!promotionTypesAttr) {
     return success();
+  }
+  auto promotionTypes = dyn_cast<ArrayAttr>(promotionTypesAttr);
+  if (!promotionTypes) {
+    return emitError() << "promotion_types must be an array";
   }
 
   auto promotedOperandsAttr = attributes.getAs<ArrayAttr>(kPromoteOperandsName);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -33,6 +33,7 @@ def IREEGPU_LoweringConfigAttr :
         "getWorkgroupReorderingStrategy"
     ]>
     ]> {
+  let genVerifyDecl = 1;
   let mnemonic = "lowering_config";
   let summary = [{Drive lowering of an operation for gpu compilation.}];
   let description = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -24,6 +24,14 @@ func.func @lowering_config_invalid_promotion_type() attributes {
 
 // -----
 
+func.func @lowering_config_invalid_promotion_types_attr() attributes {
+    // expected-error @+1 {{promotion_types must be an array}}
+    lowering_config = #iree_gpu.lowering_config<{promote_operands = [0], promotion_types = "invalid"}>} {
+  return
+}
+
+// -----
+
 func.func @mma_inner_tiled_invalid_num_inputs(%lhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
   // expected-error @+1 {{number of inputs (1) doesn't match expected number from kind (2)}}
   %0 = iree_codegen.inner_tiled ins(%lhs) outs(%acc) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/invalid.mlir
@@ -1,5 +1,29 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics %s
 
+func.func @lowering_config_missing_promote_operands() attributes {
+    // expected-error @+1 {{promotion_types requires promote_operands to be specified}}
+    lowering_config = #iree_gpu.lowering_config<{promotion_types = [#iree_gpu.derived_thread_config]}>} {
+  return
+}
+
+// -----
+
+func.func @lowering_config_mismatched_promotion_types() attributes {
+    // expected-error @+1 {{promote_operands and promotion_types must have the same length}}
+    lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1], promotion_types = [#iree_gpu.derived_thread_config]}>} {
+  return
+}
+
+// -----
+
+func.func @lowering_config_invalid_promotion_type() attributes {
+    // expected-error @+1 {{promotion_types elements must implement IREE::GPU::PromotionAttr}}
+    lowering_config = #iree_gpu.lowering_config<{promote_operands = [0], promotion_types = ["invalid"]}>} {
+  return
+}
+
+// -----
+
 func.func @mma_inner_tiled_invalid_num_inputs(%lhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
   // expected-error @+1 {{number of inputs (1) doesn't match expected number from kind (2)}}
   %0 = iree_codegen.inner_tiled ins(%lhs) outs(%acc) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -335,6 +335,15 @@ module {
 //  CHECK-SAME:   lowering_config = #iree_gpu.lowering_config<{thread = [0, 4], workgroup = [16, 16]}>
 
 module {
+  func.func @test_lowering_config_promotion_types() attributes {
+      lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1], promotion_types = [#iree_gpu.derived_thread_config, #iree_gpu.use_global_load_dma]}>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_lowering_config_promotion_types
+//  CHECK-SAME:   lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1], promotion_types = [#iree_gpu.derived_thread_config, #iree_gpu.use_global_load_dma]}>
+
+module {
   func.func @test_lowering_config_reordering() attributes {
       lowering_config = #iree_gpu.lowering_config<{workgroup = [256, 256], workgroup_reordering_strategy = #iree_gpu.conditional_transpose<8, 38>}>} {
     return

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -41,12 +41,13 @@ def IREEVectorExt_ToLayoutOp : IREEVectorExt_PureOp<"to_layout", [
     transforms the value to have that layout.
 
     If the "shared_memory_conversion" attribute is set, then this layout
-    change has to be materialized through shared memory.
+    change has to be materialized through shared memory. GPU codegen expects
+    the attribute value to implement the IREE::GPU::PromotionAttr interface.
   }];
   let arguments = (ins
     AnyShaped:$input,
     VectorLayoutInterface:$layout,
-    DefaultValuedAttr<UnitAttr, "false">:$shared_memory_conversion
+    OptionalAttr<AnyAttr>:$shared_memory_conversion
   );
   let results = (outs
     AnyShaped:$output
@@ -54,12 +55,9 @@ def IREEVectorExt_ToLayoutOp : IREEVectorExt_PureOp<"to_layout", [
   let builders = [
     OpBuilder<(ins "Value":$input,
                    "VectorLayoutInterface":$layout,
-                   CArg<"bool", "false">:$shared_memory_conversion), [{
-      UnitAttr defaultSharedMemoryConversion;
-      if (shared_memory_conversion) {
-        defaultSharedMemoryConversion = UnitAttr::get(input.getContext());
-      }
-      build($_builder, $_state, input.getType(), input, layout, defaultSharedMemoryConversion);
+                   CArg<"Attribute", "{}">:$shared_memory_conversion), [{
+      build($_builder, $_state, input.getType(), input, layout,
+            shared_memory_conversion);
     }]>,
   ];
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
@@ -14,6 +14,16 @@ func.func @specify_inline_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 
 // -----
 
+func.func @specify_shared_memory_conversion(%lhs: vector<32x32xf16>) -> vector<32x32xf16> {
+  %0 = iree_vector_ext.to_layout %lhs to layout(#iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [2, 4], outer_tile = [4, 1], thread_tile = [4, 2], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [1, 4]>) {shared_memory_conversion = #iree_gpu.derived_thread_config} : vector<32x32xf16>
+  return %0 : vector<32x32xf16>
+}
+
+// CHECK-LABEL: func.func @specify_shared_memory_conversion
+// CHECK:      iree_vector_ext.to_layout {{.*}} to layout({{.*}}) {shared_memory_conversion = #iree_gpu.derived_thread_config}
+
+// -----
+
 #nested_0 = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
   batch_tile = [2, 4],

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
@@ -61,7 +61,7 @@ struct DropToLayoutUnitDims final
     Value rankReducedValue = rankReducingExtract.value();
     auto newToLayoutOp = IREE::VectorExt::ToLayoutOp::create(
         rewriter, loc, rankReducedValue.getType(), rankReducedValue, newLayout,
-        toLayoutOp.getSharedMemoryConversion());
+        toLayoutOp.getSharedMemoryConversionAttr());
 
     // Expand to preserve output shape using insert_slice.
     Value dest = tensor::EmptyOp::create(

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -427,7 +427,7 @@ struct ToLayoutOpVectorizationModel
     // Create the toLayout operation but with vector types instead.
     auto newLayoutOp = IREE::VectorExt::ToLayoutOp::create(
         rewriter, loc, readOp, toLayoutOp.getLayout(),
-        toLayoutOp.getSharedMemoryConversion());
+        toLayoutOp.getSharedMemoryConversionAttr());
     // Create the write back to a tensor.
     ShapedType tensorTy = toLayoutOp.getType();
     auto resType =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -80,6 +80,15 @@ static llvm::cl::opt<bool> clGPUEnableReductionVectorDistribution(
         "enable the usage of the reduction vector distribution pipeline"),
     llvm::cl::init(true));
 
+static void appendPromotedOperandsListWithDerivedThread(
+    MLIRContext *context, SmallVectorImpl<NamedAttribute> &attrs,
+    ArrayRef<int64_t> operands) {
+  SmallVector<Attribute> promotionTypes(
+      operands.size(), IREE::GPU::DerivedThreadConfigAttr::get(context));
+  IREE::GPU::appendPromotedOperandsList(context, attrs, operands,
+                                        promotionTypes);
+}
+
 static llvm::cl::opt<bool> clGPUUseTileAndFuseConvolution(
     "iree-codegen-llvmgpu-use-tile-and-fuse-convolution",
     llvm::cl::desc(
@@ -692,7 +701,7 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
       NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
   auto promotedOperands =
       llvm::to_vector(llvm::seq<int64_t>(op.getNumDpsInputs()));
-  IREE::GPU::appendPromotedOperandsList(context, attrs, promotedOperands);
+  appendPromotedOperandsListWithDerivedThread(context, attrs, promotedOperands);
   IREE::GPU::setMmaKind(context, attrs, schedule->mmaKind);
   IREE::GPU::Basis subgroupBasis = {
       SmallVector<int64_t>(op.getNumLoops(), 1),
@@ -978,7 +987,7 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   SmallVector<NamedAttribute, 2> attrs = {
       NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
       NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
-  IREE::GPU::appendPromotedOperandsList(context, attrs, {0, 1, 2});
+  appendPromotedOperandsListWithDerivedThread(context, attrs, {0, 1, 2});
 
   // Check if transposing both intrinsics eliminates the layout conflict
   // between QK output and PV LHS input.
@@ -1015,14 +1024,14 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   SmallVector<NamedAttribute, 2> pvConfig;
 
   // Configuring for qk matmul.
-  IREE::GPU::appendPromotedOperandsList(context, qkConfig, {0, 1});
+  appendPromotedOperandsListWithDerivedThread(context, qkConfig, {0, 1});
   IREE::GPU::setMmaKind(context, qkConfig,
                         getIntrinsic(qkSchedule.mmaKind, useColMajor));
   IREE::GPU::setBasis(context, qkConfig, IREE::GPU::TilingLevel::Subgroup,
                       projectBasis(subgroupBasis, opInfo.getNDims()));
 
   // Configuring for pv matmul.
-  IREE::GPU::appendPromotedOperandsList(context, pvConfig, {1});
+  appendPromotedOperandsListWithDerivedThread(context, pvConfig, {1});
   IREE::GPU::setMmaKind(context, pvConfig,
                         getIntrinsic(pvSchedule.mmaKind, useColMajor));
   IREE::GPU::setBasis(context, pvConfig, IREE::GPU::TilingLevel::Subgroup,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -33,8 +33,8 @@ using IREE::VectorExt::VectorLayoutInterface;
 
 namespace {
 
-static SmallVector<bool> getPromotedOperands(Operation *op) {
-  SmallVector<bool> promotedOperands(op->getNumOperands(), false);
+static SmallVector<Attribute> getPromotedOperandAttrs(Operation *op) {
+  SmallVector<Attribute> promotedOperands(op->getNumOperands());
 
   auto config = getLoweringConfig<IREE::GPU::LoweringConfigAttr>(op);
   if (!config) {
@@ -47,8 +47,20 @@ static SmallVector<bool> getPromotedOperands(Operation *op) {
     return promotedOperands;
   }
 
-  for (int64_t operand : promoteConfig.value()) {
-    promotedOperands[operand] = true;
+  std::optional<ArrayRef<Attribute>> maybePromotionTypes =
+      getPromotionTypesList(config);
+
+  Attribute defaultPromotion =
+      IREE::GPU::DerivedThreadConfigAttr::get(op->getContext());
+  for (auto [index, operand] : llvm::enumerate(promoteConfig.value())) {
+    assert(operand >= 0 &&
+           operand < static_cast<int64_t>(op->getNumOperands()) &&
+           "promoted operand index out of bounds");
+    Attribute promotion =
+        maybePromotionTypes ? (*maybePromotionTypes)[index] : defaultPromotion;
+    assert(llvm::isa<IREE::GPU::PromotionAttr>(promotion) &&
+           "promotion types must implement promotion attr interface");
+    promotedOperands[operand] = promotion;
   }
 
   return promotedOperands;
@@ -300,8 +312,8 @@ SmallVector<int64_t> getIterationSpaceBounds(IndexingMapOpInterface candidate) {
 
 static LogicalResult
 setContractionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
-                     SmallVector<bool> promotedOperands, RewriterBase &rewriter,
-                     linalg::LinalgOp contract) {
+                     ArrayRef<Attribute> promotedOperands,
+                     RewriterBase &rewriter, linalg::LinalgOp contract) {
   // This function should have only be called on a contraction op.
   assert(linalg::isaContractionOpInterface(contract) &&
          "cannot set contraction anchor on non contraction op");
@@ -330,15 +342,15 @@ setContractionAnchor(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
   // TODO: This is a hack until layout analysis is improved. The layout analysis
   // should decide where to put these shared memory conversions.
   if (promotedOperands[0]) {
-    layoutedLhs.setSharedMemoryConversion(true);
+    layoutedLhs.setSharedMemoryConversionAttr(promotedOperands[0]);
   }
 
   if (promotedOperands[1]) {
-    layoutedRhs.setSharedMemoryConversion(true);
+    layoutedRhs.setSharedMemoryConversionAttr(promotedOperands[1]);
   }
 
   if (promotedOperands[2]) {
-    layoutedAcc.setSharedMemoryConversion(true);
+    layoutedAcc.setSharedMemoryConversionAttr(promotedOperands[2]);
   }
 
   contract->setOperand(0, layoutedLhs.getResult());
@@ -439,7 +451,7 @@ static LogicalResult setIntrinsicLoweringConfigLayout(
     IREE::GPU::LoweringConfigAttr config, linalg::LinalgOp candidate,
     ArrayRef<int64_t> workgroupSize, RewriterBase &rewriter) {
 
-  SmallVector<bool> promotedOperands = getPromotedOperands(candidate);
+  SmallVector<Attribute> promotedOperands = getPromotedOperandAttrs(candidate);
   IREE::Codegen::InnerTileDescAttrInterface intrinsic = getIntrinsic(candidate);
 
   if (linalg::isaContractionOpInterface(candidate)) {
@@ -498,8 +510,8 @@ static LogicalResult setGPULoweringConfigLayout(
       context, subgroupSizes, batchTile, outerTile, threadSizes,
       elementTile.value(), subgroupStrides, threadStrides);
 
-  SmallVector<bool> promotedOperands =
-      getPromotedOperands(candidate.getOperation());
+  SmallVector<Attribute> promotedOperands =
+      getPromotedOperandAttrs(candidate.getOperation());
 
   rewriter.setInsertionPoint(candidate.getOperation());
   for (OpOperand &operand : candidate->getOpOperands()) {
@@ -508,8 +520,10 @@ static LogicalResult setGPULoweringConfigLayout(
     auto toLayout =
         ToLayoutOp::create(rewriter, loc, operand.get(), operandLayout);
     // Set shared memory promotion if requested.
-    toLayout.setSharedMemoryConversion(
-        promotedOperands[operand.getOperandNumber()]);
+    if (promotedOperands[operand.getOperandNumber()]) {
+      toLayout.setSharedMemoryConversionAttr(
+          promotedOperands[operand.getOperandNumber()]);
+    }
     operand.set(toLayout);
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
@@ -477,6 +477,8 @@ func.func @contraction_ceildiv_batch(%lhs: tensor<1x1x63xf16>,
   indexing_maps = #maps_block,
   iterator_types = ["parallel", "parallel", "parallel", "reduction"],
   lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x4x2B_F16>,
+                                              promote_operands = [0, 1],
+                                              promotion_types = [#iree_gpu.derived_thread_config, #iree_gpu.use_global_load_dma],
                                               subgroup_basis = [[1, 1, 1, 1], [0, 1, 2, 3]]}>
 }
 
@@ -504,8 +506,8 @@ func.func @batch_matmul_block_intrinsic(%lhs: tensor<4x32x4xf16>,
 
 // CHECK-LABEL: func.func @batch_matmul_block_intrinsic
 
-// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED]])
-// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED1]])
+// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED]]) {shared_memory_conversion = #iree_gpu.derived_thread_config}
+// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED1]]) {shared_memory_conversion = #iree_gpu.use_global_load_dma}
 // CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED2]])
 // CHECK: linalg.generic
 // CHECK-SAME: ins(%[[LHS]], %[[RHS]]


### PR DESCRIPTION
Change how `shared_memory_conversion` is represented on the `to_layout` operation. So far, a unit attribute was used to simply turn shared memory conversion on/off. Now, the `shared_memory_conversion` takes an attribute, which allows us to attach for example the GPU promotion type (e.g. `use_global_load_dma`) to the operation. 

The motivation is to use this additional information in analyses such as https://github.com/iree-org/iree/pull/24227 as part of https://github.com/iree-org/iree/issues/23782. 

The representation is `AnyAttr` to (a) avoid a dependency from `VectorExt` on `IREEGPU` and (b) to allow other pipelines to use the attribute differently.

The PR also adds some verification to the `LoweringConfigAttr` to avoid having to repeatedly check that the list of promoted operands and promotion types has the same length.

Assisted-by: Codex