### PR TITLE
[Codegen] Canonicalize transfer_{read,write} vector<1xT>

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPU1DVectorCanonicalizations.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPU1DVectorCanonicalizations.cpp
@@ -76,6 +76,49 @@ struct FoldI1SelectToBroadcast final : OpRewritePattern<arith::SelectOp> {
   }
 };
 
+/// Canonicalize a rank-1 single-element vector transfer op so that its
+/// permutation map is the minor identity.
+///
+/// When the vector type is `vector<1xT>`, the permutation map is irrelevant
+/// to which element is accessed: the single vector lane has iteration offset 0,
+/// so the element is always at `memref[indices...]` regardless of which
+/// memref/tensor dimension the map points at. Replacing the map with minor
+/// identity unblocks lowering to vector.load / vector.store.
+template <typename TransferOp>
+struct CanonicalizeSize1TransferMap final : OpRewritePattern<TransferOp> {
+  using OpRewritePattern<TransferOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(TransferOp op,
+                                PatternRewriter &rewriter) const override {
+    VectorType vecType = op.getVectorType();
+    if (vecType.getRank() != 1 || vecType.getShape()[0] != 1) {
+      return failure();
+    }
+
+    AffineMap map = op.getPermutationMap();
+    if (map.isMinorIdentity()) {
+      return failure();
+    }
+
+    int64_t srcRank = op.getShapedType().getRank();
+    AffineMap minorIdentity =
+        AffineMap::getMinorIdentityMap(srcRank, 1, rewriter.getContext());
+
+    if constexpr (std::is_same_v<TransferOp, vector::TransferReadOp>) {
+      rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
+          op, vecType, op.getBase(), op.getIndices(),
+          AffineMapAttr::get(minorIdentity), op.getPadding(), op.getMask(),
+          op.getInBoundsAttr());
+    } else {
+      rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
+          op, op.getVector(), op.getBase(), op.getIndices(),
+          AffineMapAttr::get(minorIdentity), op.getMask(),
+          op.getInBoundsAttr());
+    }
+    return success();
+  }
+};
+
 struct LLVMGPU1DVectorCanonicalizationsPass final
     : impl::LLVMGPU1DVectorCanonicalizationsPassBase<
           LLVMGPU1DVectorCanonicalizationsPass> {
@@ -88,6 +131,8 @@ struct LLVMGPU1DVectorCanonicalizationsPass final
     vector::BroadcastOp::getCanonicalizationPatterns(patterns, ctx);
     arith::SelectOp::getCanonicalizationPatterns(patterns, ctx);
     patterns.add<FoldI1SelectToBroadcast>(ctx);
+    patterns.add<CanonicalizeSize1TransferMap<vector::TransferReadOp>,
+                 CanonicalizeSize1TransferMap<vector::TransferWriteOp>>(ctx);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/1d_vector_canonicalization.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/1d_vector_canonicalization.mlir
@@ -1,0 +1,101 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmgpu-1d-vector-canonicalizations))" \
+// RUN:   --split-input-file %s | FileCheck %s
+
+// transfer_read with vector<1xf32> and non-minor-identity map: canonicalize
+// the permutation map to minor identity.
+//   (d0, d1) -> (d0) becomes (d0, d1) -> (d1)
+func.func @canonicalize_transfer_read_size1_map(%m: memref<4x3xf32>, %i: index, %j: index, %pad: f32) -> vector<1xf32> {
+  %v = vector.transfer_read %m[%i, %j], %pad {in_bounds = [true], permutation_map = affine_map<(d0, d1) -> (d0)>} : memref<4x3xf32>, vector<1xf32>
+  return %v : vector<1xf32>
+}
+// CHECK-LABEL: func.func @canonicalize_transfer_read_size1_map
+//  CHECK-SAME:   (%[[M:.+]]: memref<4x3xf32>, %[[I:.+]]: index, %[[J:.+]]: index, %[[PAD:.+]]: f32)
+//       CHECK:   %[[V:.+]] = vector.transfer_read %[[M]][%[[I]], %[[J]]], %[[PAD]]
+//  CHECK-SAME:     {in_bounds = [true]}
+//  CHECK-SAME:     : memref<4x3xf32>, vector<1xf32>
+//   CHECK-NOT:     permutation_map
+//       CHECK:   return %[[V]]
+
+// -----
+
+// transfer_write with vector<1xf32> and non-minor-identity map: canonicalize.
+func.func @canonicalize_transfer_write_size1_map(%v: vector<1xf32>, %m: memref<4x3xf32>, %i: index, %j: index) {
+  vector.transfer_write %v, %m[%i, %j] {in_bounds = [true], permutation_map = affine_map<(d0, d1) -> (d0)>} : vector<1xf32>, memref<4x3xf32>
+  return
+}
+// CHECK-LABEL: func.func @canonicalize_transfer_write_size1_map
+//  CHECK-SAME:   (%[[V:.+]]: vector<1xf32>, %[[M:.+]]: memref<4x3xf32>, %[[I:.+]]: index, %[[J:.+]]: index)
+//       CHECK:   vector.transfer_write %[[V]], %[[M]][%[[I]], %[[J]]]
+//  CHECK-SAME:     {in_bounds = [true]}
+//  CHECK-SAME:     : vector<1xf32>, memref<4x3xf32>
+//   CHECK-NOT:     permutation_map
+
+// -----
+
+// Rank-3 memref: (d0, d1, d2) -> (d0) becomes (d0, d1, d2) -> (d2).
+func.func @canonicalize_transfer_read_size1_rank3(%m: memref<4x3x2xf32>, %i: index, %j: index, %k: index, %pad: f32) -> vector<1xf32> {
+  %v = vector.transfer_read %m[%i, %j, %k], %pad {in_bounds = [true], permutation_map = affine_map<(d0, d1, d2) -> (d0)>} : memref<4x3x2xf32>, vector<1xf32>
+  return %v : vector<1xf32>
+}
+// CHECK-LABEL: func.func @canonicalize_transfer_read_size1_rank3
+//       CHECK:   vector.transfer_read
+//   CHECK-NOT:     permutation_map
+//  CHECK-SAME:     : memref<4x3x2xf32>, vector<1xf32>
+
+// -----
+
+// Middle dimension map: (d0, d1, d2) -> (d1) becomes (d0, d1, d2) -> (d2).
+func.func @canonicalize_transfer_read_size1_middle_dim(%m: memref<4x3x2xf32>, %i: index, %j: index, %k: index, %pad: f32) -> vector<1xf32> {
+  %v = vector.transfer_read %m[%i, %j, %k], %pad {in_bounds = [true], permutation_map = affine_map<(d0, d1, d2) -> (d1)>} : memref<4x3x2xf32>, vector<1xf32>
+  return %v : vector<1xf32>
+}
+// CHECK-LABEL: func.func @canonicalize_transfer_read_size1_middle_dim
+//       CHECK:   vector.transfer_read
+//   CHECK-NOT:     permutation_map
+//  CHECK-SAME:     : memref<4x3x2xf32>, vector<1xf32>
+
+// -----
+
+// Negative: already minor identity — should not be modified.
+func.func @negative_already_minor_identity(%m: memref<4x3xf32>, %i: index, %j: index, %pad: f32) -> vector<1xf32> {
+  %v = vector.transfer_read %m[%i, %j], %pad {in_bounds = [true], permutation_map = affine_map<(d0, d1) -> (d1)>} : memref<4x3xf32>, vector<1xf32>
+  return %v : vector<1xf32>
+}
+// CHECK-LABEL: func.func @negative_already_minor_identity
+//       CHECK:   vector.transfer_read
+//   CHECK-NOT:     permutation_map
+//  CHECK-SAME:     : memref<4x3xf32>, vector<1xf32>
+
+// -----
+
+// Negative: vector<4xf32> (size != 1) — should not be modified.
+func.func @negative_size_not_one(%m: memref<4x3xf32>, %i: index, %j: index, %pad: f32) -> vector<4xf32> {
+  %v = vector.transfer_read %m[%i, %j], %pad {in_bounds = [true], permutation_map = affine_map<(d0, d1) -> (d0)>} : memref<4x3xf32>, vector<4xf32>
+  return %v : vector<4xf32>
+}
+// CHECK-LABEL: func.func @negative_size_not_one
+//       CHECK:   vector.transfer_read
+//  CHECK-SAME:     permutation_map
+//  CHECK-SAME:     : memref<4x3xf32>, vector<4xf32>
+
+// -----
+
+// Negative: rank-0 vector<f32> — should not be modified.
+func.func @negative_rank0(%m: memref<4xf32>, %i: index, %pad: f32) -> vector<f32> {
+  %v = vector.transfer_read %m[%i], %pad : memref<4xf32>, vector<f32>
+  return %v : vector<f32>
+}
+// CHECK-LABEL: func.func @negative_rank0
+//       CHECK:   vector.transfer_read
+//  CHECK-SAME:     : memref<4xf32>, vector<f32>
+
+// -----
+
+// Negative: rank-2 vector — should not be modified.
+func.func @negative_rank2(%m: memref<4x3xf32>, %i: index, %j: index, %pad: f32) -> vector<2x4xf32> {
+  %v = vector.transfer_read %m[%i, %j], %pad {in_bounds = [true, true]} : memref<4x3xf32>, vector<2x4xf32>
+  return %v : vector<2x4xf32>
+}
+// CHECK-LABEL: func.func @negative_rank2
+//       CHECK:   vector.transfer_read
+//  CHECK-SAME:     : memref<4x3xf32>, vector<2x4xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
+            "1d_vector_canonicalization.mlir",
             "amdgpu_emulate_narrow_type.mlir",
             "assign_constant_ordinals.mlir",
             "cast_address_space_function.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "1d_vector_canonicalization.mlir"
     "amdgpu_emulate_narrow_type.mlir"
     "assign_constant_ordinals.mlir"
     "cast_address_space_function.mlir"


### PR DESCRIPTION
vector.transfer_read and vector.transfer_writes's permutation maps are irrelevant with vector<1xT>. This pattern unblocks lowering to vector.load and vector.store.

Assisted-By: Claude Opus 4.6