### PR TITLE
[DT] Improving DT heuristic for choosing tiling config

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_for_iree_ops.mlir
@@ -463,7 +463,7 @@ func.func @matmul_lowering_f32f32f32_gfx942() attributes {
       -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
   return
 }
-//   CHECK-DAG: #[[$MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 128)>
+//   CHECK-DAG: #[[$MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 256)>
 //   CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
 //   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 //   CHECK-DAG: #[[$MAP3:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
@@ -476,23 +476,23 @@ func.func @matmul_lowering_f32f32f32_gfx942() attributes {
 //   CHECK-DAG:   %[[TILED_M:.+]] = affine.apply #[[$MAP0]]()[%[[M]]]
 //   CHECK-DAG:   %[[TILED_K:.+]] = affine.apply #[[$MAP1]]()[%[[K]]]
 //       CHECK:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x2x4x4x16x4xf32>>{%[[TILED_M]], %[[TILED_K]]}
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x16x4x16x4xf32>>{%[[TILED_M]], %[[TILED_K]]}
 //       CHECK:   %[[TILED_N:.+]] = affine.apply #[[$MAP0]]()[%[[N]]]
 //       CHECK:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x2x4x4x16x4xf32>>{%[[TILED_N]], %[[TILED_K]]}
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x8x2x4x16x4xf32>>{%[[TILED_N]], %[[TILED_K]]}
 //       CHECK:   %[[OUTS_BINDING:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x2x2x4x4x4x16x4xf32>>{%[[TILED_M]], %[[TILED_N]]}
+//  CHECK-SAME:       !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x8x16x2x4x16x4xf32>>{%[[TILED_M]], %[[TILED_N]]}
 //       CHECK:   %[[LHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[LHS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_K]], 2, 4, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_K]], 16, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1]
 //       CHECK:   %[[RHS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[RHS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_N]], %[[TILED_K]], 2, 4, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_N]], %[[TILED_K]], 8, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1]
 //       CHECK:   %[[OUTS:.+]] = iree_tensor_ext.dispatch.tensor.load %[[OUTS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 2, 2, 4, 4, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 8, 16, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1]
 //       CHECK:   %[[GEMM:.+]] = iree_codegen.inner_tiled
 //  CHECK-SAME:       ins(%[[LHS]], %[[RHS]])
 //  CHECK-SAME:       outs(%[[OUTS]])
 //       CHECK:   iree_tensor_ext.dispatch.tensor.store %[[GEMM]], %[[OUTS_BINDING]]
-//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 2, 2, 4, 4, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1, 1]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0, 0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 8, 16, 2, 4, 16, 4], strides = [1, 1, 1, 1, 1, 1, 1, 1]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1100.mlir
@@ -23,13 +23,13 @@ func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_WMMAR3_F32_16x16x16_F16(
-// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x2x2x1x16x16xf16>, %[[RHS:.+]]: tensor<?x?x2x2x1x16x16xf16>
-// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x2x2x2x2x8x2x16xf32>
-// CHECK-SAME: ) -> tensor<?x?x2x2x2x2x8x2x16xf32>
+// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x2x4x1x16x16xf16>, %[[RHS:.+]]: tensor<?x?x4x2x1x16x16xf16>
+// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x2x4x4x2x8x2x16xf32>
+// CHECK-SAME: ) -> tensor<?x?x2x4x4x2x8x2x16xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = WMMAR3_F32_16x16x16_F16, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = WMMAR3_F32_16x16x16_F16, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 4, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx908.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx908.mlir
@@ -24,11 +24,12 @@ func.func @matmul_lowering_MFMA_i32_16x16x16_i8(
 // CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-LABEL: func.func @matmul_lowering_MFMA_i32_16x16x16_i8(
-// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x4x4x16x4x4xi8>, %[[RHS:.+]]: tensor<?x?x4x2x4x16x4x4xi8>
-// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x4x4x2x4x16x4xi32>
-// CHECK-SAME: ) -> tensor<?x?x4x4x2x4x16x4xi32>
+// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x8x4x16x4x4xi8>, %[[RHS:.+]]: tensor<?x?x8x2x4x16x4x4xi8>
+// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x8x8x2x4x16x4xi32>
+// CHECK-SAME: ) -> tensor<?x?x8x8x2x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[$MAP0]], #[[$MAP1]], #[[$MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x16_I8, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x16_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    semantics = #iree_gpu.mma_semantics<distributed = false, opaque = false>
 // CHECK:       return %[[MMA]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx90a.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx90a.mlir
@@ -24,13 +24,13 @@ func.func @matmul_lowering_MFMA_f32_16x16x8_bf16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_f32_16x16x8_bf16(
-// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x4x4x16x4x2xbf16>, %[[RHS:.+]]: tensor<?x?x4x2x4x16x4x2xbf16>
-// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x4x4x2x4x16x4xf32>
-// CHECK-SAME: ) -> tensor<?x?x4x4x2x4x16x4xf32>
+// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x8x4x16x4x2xbf16>, %[[RHS:.+]]: tensor<?x?x8x2x4x16x4x2xbf16>
+// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x8x8x2x4x16x4xf32>
+// CHECK-SAME: ) -> tensor<?x?x8x8x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x8_BF16, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x8_BF16, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -57,11 +57,11 @@ func.func @matmul_lowering_MFMA_f64_16x16x4_f64(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_f64_16x16x4_f64(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x2x4x16x2xf64>, %[[RHS:.+]]: tensor<?x?x2x2x4x16x2xf64>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x2x2x2x4x4x16xf64>
-// CHECK-SAME:   ) -> tensor<?x?x2x2x2x2x4x4x16xf64>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x8x4x16x2xf64>, %[[RHS:.+]]: tensor<?x?x8x4x16x2xf64>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x8x8x4x4x16xf64>
+// CHECK-SAME:   ) -> tensor<?x?x8x8x4x4x16xf64>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F64_16x16x4_F64, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F64_16x16x4_F64, intrinsics_m = 8, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx942.mlir
@@ -92,14 +92,14 @@ func.func @set_encoding_LHS_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]] padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 16]
-// CHECK-SAME:      : tensor<?x?xf32> -> tensor<?x?x128x16xf32>
+// CHECK-SAME:      inner_tiles = [256, 16]
+// CHECK-SAME:      : tensor<?x?xf32> -> tensor<?x?x256x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      : tensor<?x?x128x16xf32> into tensor<?x?x2x4x16x4x4xf32>
+// CHECK-SAME:      : tensor<?x?x256x16xf32> into tensor<?x?x16x16x4x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x?x2x4x16x4x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<?x?x2x4x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 3, 6, 4, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x?x16x16x4x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<?x?x16x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 2, 5, 3, 4]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -196,14 +196,14 @@ func.func @set_encoding_ACC_dynamic_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<?x513x
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<?x513xf32> -> tensor<?x5x128x128xf32>
+// CHECK-SAME:      inner_tiles = [256, 256]
+// CHECK-SAME:      : tensor<?x513xf32> -> tensor<?x3x256x256xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      : tensor<?x5x128x128xf32> into tensor<?x5x2x4x4x4x2x4x16xf32>
+// CHECK-SAME:      : tensor<?x3x256x256xf32> into tensor<?x3x16x4x4x8x2x16xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x5x2x4x4x4x2x4x16xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<?x5x2x2x4x4x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<?x3x16x4x4x8x2x16xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<?x3x8x16x2x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 5, 2, 6, 3, 7, 4]
 // CHECK:         return %[[TRANSPOSE]]
 
 // -----
@@ -220,14 +220,14 @@ func.func @set_encoding_ACC_dynamic_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<255x?x
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<255x?xf32> -> tensor<2x?x128x128xf32>
+// CHECK-SAME:      inner_tiles = [256, 256]
+// CHECK-SAME:      : tensor<255x?xf32> -> tensor<1x?x256x256xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      : tensor<2x?x128x128xf32> into tensor<2x?x2x4x4x4x2x4x16xf32>
+// CHECK-SAME:      : tensor<1x?x256x256xf32> into tensor<1x?x16x4x4x8x2x16xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPAND]] : tensor<2x?x2x4x4x4x2x4x16xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<2x?x2x2x4x4x4x16x4xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 6, 3, 7, 4, 8, 5]
+// CHECK-SAME:       ins(%[[EXPAND]] : tensor<1x?x16x4x4x8x2x16xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<1x?x8x16x2x4x16x4xf32>)
+// CHECK-SAME:       permutation = [0, 1, 5, 2, 6, 3, 7, 4]
 // CHECK:         return %[[TRANSPOSE]]
 
 
@@ -243,7 +243,7 @@ func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32(%arg0 : tensor<32x5242
 
 // CHECK-LABEL: func.func @set_encoding_ACC_narrow_M_MFMA_F32_16x16x4_F32
 // CHECK:         %[[PACK:.*]] = linalg.pack
-// CHECK-SAME:      inner_tiles = [32, 512]
+// CHECK-SAME:      inner_tiles = [32, 1024]
 
 // -----
 
@@ -257,7 +257,7 @@ func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32(%arg0 : tensor<524288x
 
 // CHECK-LABEL: func.func @set_encoding_ACC_narrow_N_MFMA_F32_16x16x4_F32
 // CHECK:         %[[PACK:.*]] = linalg.pack
-// CHECK-SAME:      inner_tiles = [512, 32]
+// CHECK-SAME:      inner_tiles = [1024, 32]
 
 // -----
 
@@ -301,16 +301,16 @@ func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32(
 // CHECK-LABEL: func.func @unset_encoding_ACC_dynamic_unroll8x8x4_MFMA_F32_16x16x4_F32
 // CHECK-SAME:       %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[ARG0]] : tensor<?x?x2x2x4x4x4x16x4xf32>)
-// CHECK-SAME:       outs({{.*}} : tensor<?x?x2x4x4x4x2x4x16xf32>)
-// CHECK-SAME:       permutation = [0, 1, 2, 4, 6, 8, 3, 5, 7]
+// CHECK-SAME:       ins(%[[ARG0]] : tensor<?x?x8x16x2x4x16x4xf32>)
+// CHECK-SAME:       outs({{.*}} : tensor<?x?x16x4x4x8x2x16xf32>)
+// CHECK-SAME:       permutation = [0, 1, 3, 5, 7, 2, 4, 6]
 // CHECK:         %[[COLLAPSE:.*]] = tensor.collapse_shape %[[TRANSPOSE]]
-// CHECK-SAME:      : tensor<?x?x2x4x4x4x2x4x16xf32> into tensor<?x?x128x128xf32>
+// CHECK-SAME:      : tensor<?x?x16x4x4x8x2x16xf32> into tensor<?x?x256x256xf32>
 // CHECK:         %[[UNPACK:.*]] = linalg.unpack %[[COLLAPSE]]
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [128, 128]
-// CHECK-SAME:      : tensor<?x?x128x128xf32> -> tensor<?x?xf32>
+// CHECK-SAME:      inner_tiles = [256, 256]
+// CHECK-SAME:      : tensor<?x?x256x256xf32> -> tensor<?x?xf32>
 // CHECK:         return %[[UNPACK]]
 
 // -----
@@ -338,13 +338,13 @@ func.func @matmul_lowering_MFMA_F32_16x16x4_F32(
 // CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-LABEL: func.func @matmul_lowering_MFMA_F32_16x16x4_F32(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x4x4x16x4xf32>, %[[RHS:.+]]: tensor<?x?x2x4x4x16x4xf32>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x2x4x4x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x16x4x16x4xf32>, %[[RHS:.+]]: tensor<?x?x8x2x4x16x4xf32>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x8x16x2x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x8x16x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[$MAP0]], #[[$MAP1]], #[[$MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 16, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -372,13 +372,13 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
 // CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK-LABEL: func.func @batch_matmul_lowering_MFMA_F32_16x16x4_F32(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x2x4x4x16x4xf32>, %[[RHS:.+]]: tensor<?x?x?x2x4x4x16x4xf32>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x16x4x16x4xf32>, %[[RHS:.+]]: tensor<?x?x?x8x2x4x16x4xf32>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x8x16x2x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x8x16x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[$MAP0]], #[[$MAP1]], #[[$MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, intrinsics_m = 16, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -533,13 +533,13 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8(
 // CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-LABEL: func.func @matmul_lowering_MFMA_I32_16x16x32_I8(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x4x4x16x2x8xi8>, %[[RHS:.+]]: tensor<?x?x2x4x4x16x2x8xi8>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x2x4x4x4x16x4xi32>
-// CHECK-SAME:   ) -> tensor<?x?x2x2x4x4x4x16x4xi32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x16x4x16x2x8xi8>, %[[RHS:.+]]: tensor<?x?x8x2x4x16x2x8xi8>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x8x16x2x4x16x4xi32>
+// CHECK-SAME:   ) -> tensor<?x?x8x16x2x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[$MAP0]], #[[$MAP1]], #[[$MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 16, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -597,7 +597,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits
 // CHECK-SAME:    %[[ACC:[a-zA-Z0-9]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 16, intrinsics_n = 2, subgroups_n = 8, operands_interleaving_intrinsics_k = [0, 1]>
 
 // -----
 
@@ -650,7 +650,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_max_load_instruction_bits
 // CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4, intrinsics_k = 4, operands_interleaving_intrinsics_k = [0, 1]>
 
 // -----
 
@@ -703,7 +703,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_simds_per_wgp_1(
 // CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 
 // -----
 
@@ -756,7 +756,7 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_8192(
 // CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 
 // -----
 
@@ -804,11 +804,11 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096(
 }
 
 // CHECK-LABEL: func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_4096
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x2x4x16x2x8xi8>, %[[RHS:.+]]: tensor<?x?x2x2x4x16x2x8xi8>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x2x2x2x4x16x4xi32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x2x4x4x16x2x8xi8>, %[[RHS:.+]]: tensor<?x?x4x2x4x16x2x8xi8>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x2x4x4x2x4x16x4xi32>
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 
 // -----
 
@@ -856,12 +856,12 @@ func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_32768(
 }
 
 // CHECK-LABEL: func.func @matmul_lowering_MFMA_I32_16x16x32_I8_custom_vgpr_space_bits_32768
-// CHECK-SAME:     %[[LHS:.+]]:  tensor<?x?x8x4x16x2x8xi8>
-// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x4x4x4x16x2x8xi8>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x4x8x4x4x16x4xi32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x16x4x16x2x8xi8>
+// CHECK-SAME:     %[[RHS:.+]]: tensor<?x?x8x4x4x16x2x8xi8>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x8x16x4x4x16x4xi32>
 // CHECK:      iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 8, intrinsics_n = 4, subgroups_n = 4, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:     kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x32_I8, intrinsics_m = 16, intrinsics_n = 4, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 
 // -----
 
@@ -892,13 +892,13 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ(
 // CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK-LABEL: func.func @batch_matmul_lowering_MFMA_F32_16x16x32_F8E4M3FNUZ(
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x2x4x4x16x2x8xf8E4M3FNUZ>, %[[RHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x2x4x4x16x2x8xf8E4M3FNUZ>
-// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x16x4x16x2x8xf8E4M3FNUZ>, %[[RHS:[a-zA-Z0-9_]+]]: tensor<?x?x?x8x2x4x16x2x8xf8E4M3FNUZ>
+// CHECK-SAME:     %[[ACC:[a-zA-Z0-9_]+]]: tensor<?x?x?x8x16x2x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x8x16x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[$MAP0]], #[[$MAP1]], #[[$MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_F8E4M3FNUZ, intrinsics_m = 16, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -926,13 +926,13 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16(
 // CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK-LABEL: func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16(
-// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x2x4x4x16x2x4xbf16>, %[[RHS:.+]]: tensor<?x?x?x2x4x4x16x2x4xbf16>
-// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:     %[[LHS:.+]]: tensor<?x?x?x16x4x16x2x4xbf16>, %[[RHS:.+]]: tensor<?x?x?x8x2x4x16x2x4xbf16>
+// CHECK-SAME:     %[[ACC:.+]]: tensor<?x?x?x8x16x2x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x8x16x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
 // CHECK-SAME:    indexing_maps = [#[[$MAP0]], #[[$MAP1]], #[[$MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x16_BF16, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x16_BF16, intrinsics_m = 16, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -960,16 +960,16 @@ func.func @dequantization(
   return %14 : tensor<2x128x64xf32, #encoding>
 }
 
-// CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
-// CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d2, d5, d7)>
+// CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3, d4, d5, d6)>
+// CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
 // CHECK-LABEL: func.func @dequantization
-// CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<2x1x4x2x4x4x16x4xi8>
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<2x1x4x16x4x16x4xi8>
 // CHECK-SAME:     %[[SCALES:[a-zA-Z0-9]+]]: tensor<2x4x4x4xf32>
 // CHECK-SAME:     %[[ZPS:[a-zA-Z0-9]+]]: tensor<2x4x4x4xf32>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x1x4x2x4x4x16x4xf32>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x1x4x16x4x16x4xf32>
 // CHECK:         %[[DEQUANT:.+]] = linalg.generic
 // CHECK-SAME:        indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP1]], #[[$MAP]]]
-// CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+// CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
 // CHECK-SAME:        ins(%[[LHS]], %[[SCALES]], %[[ZPS]]
 // CHECK-SAME:        outs(%[[EMPTY]]
 // CHECK:           arith.extui
@@ -995,16 +995,16 @@ func.func @multi_result_generic(%3: tensor<2x128x64xf32, #encoding>) -> (tensor<
   } -> (tensor<2x128x64xf32, #encoding>, tensor<2x128x64xf16, #encoding>)
   return %15#0, %15#1 : tensor<2x128x64xf32, #encoding>, tensor<2x128x64xf16, #encoding>
 }
-//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3, d4, d5, d6)>
 // CHECK-LABEL: func.func @multi_result_generic(
-// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x2x4x4x16x4xf32>
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x16x4x16x4xf32>
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]]]
-//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
 //  CHECK-SAME:       ins(%[[ARG0]]
 //       CHECK:     arith.addf
 //       CHECK:     arith.truncf
-//       CHECK:     -> (tensor<2x1x4x2x4x4x16x4xf32>, tensor<2x1x4x2x4x4x16x4xf16>)
+//       CHECK:     -> (tensor<2x1x4x16x4x16x4xf32>, tensor<2x1x4x16x4x16x4xf16>)
 
 // -----
 
@@ -1023,15 +1023,15 @@ func.func @interchange_generic(%3: tensor<2x128x64xf32, #encoding>) -> tensor<64
   } -> tensor<64x2x128xf32, #output_encoding>
   return %15 : tensor<64x2x128xf32, #output_encoding>
 }
-//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3, d4, d5, d6)>
 // CHECK-LABEL: func.func @interchange_generic(
-//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x2x4x4x16x4xf32>
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x1x4x16x4x16x4xf32>
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]]]
-//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]
 //  CHECK-SAME:       ins(%[[ARG0]]
 //       CHECK:     arith.addf
-//       CHECK:     -> tensor<2x1x4x2x4x4x16x4xf32>
+//       CHECK:     -> tensor<2x1x4x16x4x16x4xf32>
 // -----
 
 //----------------------------------------------------------------------------//
@@ -1110,17 +1110,17 @@ func.func @set_encoding_rhs_bitcast_f16_to_f32(
   return %0 : tensor<?x?xf32, #encoding_bitcast>
 }
 
-// For f16/f16/f32 matmul RHS, normal tiles would be [128, 32] with expandShape
+// For f16/f16/f32 matmul RHS, normal tiles would be [256, 32] with expandShape
 // splitting 32 into [2, 4, 4]. With f16->f32 bitcast (ratio 16/32 = 1/2):
 // - innerTileSize: 32 * 16/32 = 16
 // - innermost expandShape dim: 4 * 16/32 = 2
-// So expandShape becomes [2, 4, 2] and tiles become [128, 16].
+// So expandShape becomes [8, 2, 2] and tiles become [256, 16].
 // CHECK-LABEL: func.func @set_encoding_rhs_bitcast_f16_to_f32
 // CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK:         %[[PACK:.*]] = linalg.pack %[[ARG0]]
-// CHECK-SAME:      inner_tiles = [128, 16]
+// CHECK-SAME:      inner_tiles = [256, 16]
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      into tensor<?x?x2x4x16x2x4x2xf32>
+// CHECK-SAME:      into tensor<?x?x8x2x16x2x4x2xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:      ins(%[[EXPAND]] : tensor<?x?x2x4x16x2x4x2xf32>)
+// CHECK-SAME:      ins(%[[EXPAND]] : tensor<?x?x8x2x16x2x4x2xf32>)
 // CHECK:         return %[[TRANSPOSE]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx950.mlir
@@ -138,14 +138,14 @@ func.func @matmul_lowering_MFMA_I32_16x16x64_I8(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK:     func.func @matmul_lowering_MFMA_I32_16x16x64_I8(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x2x4x4x16x16xi8>
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x2x4x4x16x16xi8>
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x2x2x4x4x4x16x4xi32>
-// CHECK-SAME:   ) -> tensor<?x?x2x2x4x4x4x16x4xi32>
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x16x4x16x16xi8>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x8x2x4x16x16xi8>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x8x16x2x4x16x4xi32>
+// CHECK-SAME:   ) -> tensor<?x?x8x16x2x4x16x4xi32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x64_I8,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_I32_16x16x64_I8, intrinsics_m = 16, intrinsics_n = 2, subgroups_n = 8, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -177,14 +177,14 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x128_F8E4M3FN(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x4x16x32xf8E4M3FN>
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x4x16x32xf8E4M3FN>
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x2x8x4x16x32xf8E4M3FN>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x4x4x4x16x32xf8E4M3FN>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x8x4x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x2x4x8x4x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x128_F8E4M3FN,  intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x128_F8E4M3FN, intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -212,14 +212,14 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16(
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK:     func.func @batch_matmul_lowering_MFMA_F32_16x16x32_BF16(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x4x16x8xbf16>
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x2x4x4x16x8xbf16>
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x2x2x4x4x4x16x4xf32>
-// CHECK-SAME:   ) -> tensor<?x?x?x2x2x4x4x4x16x4xf32>
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x16x4x16x8xbf16>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x8x2x4x16x8xbf16>
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x8x16x2x4x16x4xf32>
+// CHECK-SAME:   ) -> tensor<?x?x?x8x16x2x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[ARG0]], %[[ARG1]]) outs(%[[ARG2]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_BF16, intrinsics_m = 4, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x32_BF16, intrinsics_m = 16, intrinsics_n = 2, subgroups_n = 8, operands_interleaving_intrinsics_k = [0, 1]>
 // CHECK:       return %[[MMA]]
 
 // -----
@@ -249,14 +249,14 @@ func.func @set_encoding_LHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<255x127x
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
 // CHECK-SAME:      outer_dims_perm = [0, 1, 2]
 // CHECK-SAME:      inner_dims_pos = [0, 1, 2]
-// CHECK-SAME:      inner_tiles = [16, 16, 32]
-// CHECK-SAME:      : tensor<255x127x32xf4E2M1FN> -> tensor<16x8x1x16x16x32xf4E2M1FN>
+// CHECK-SAME:      inner_tiles = [16, 8, 32]
+// CHECK-SAME:      : tensor<255x127x32xf4E2M1FN> -> tensor<16x16x1x16x8x32xf4E2M1FN>
 // CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<16x8x1x16x16x32xf4E2M1FN> into tensor<16x8x1x16x4x4x32xf4E2M1FN>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<16x8x1x4x4x16x32xf4E2M1FN>
+// CHECK-SAME:       : tensor<16x16x1x16x8x32xf4E2M1FN> into tensor<16x16x1x16x2x4x32xf4E2M1FN>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<16x16x1x2x4x16x32xf4E2M1FN>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<16x8x1x16x4x4x32xf4E2M1FN>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<16x8x1x4x4x16x32xf4E2M1FN>)
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<16x16x1x16x2x4x32xf4E2M1FN>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<16x16x1x2x4x16x32xf4E2M1FN>)
 // CHECK-SAME:       permutation = [0, 1, 2, 4, 5, 3, 6]
 // CHECK:         return %[[TRANSPOSE]]
 
@@ -283,14 +283,14 @@ func.func @set_encoding_RHS_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<513x127x
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f4E2M1FN)
 // CHECK-SAME:      outer_dims_perm = [0, 1, 2]
 // CHECK-SAME:      inner_dims_pos = [0, 1, 2]
-// CHECK-SAME:      inner_tiles = [16, 16, 32]
-// CHECK-SAME:      : tensor<513x127x32xf4E2M1FN> -> tensor<33x8x1x16x16x32xf4E2M1FN>
+// CHECK-SAME:      inner_tiles = [16, 8, 32]
+// CHECK-SAME:      : tensor<513x127x32xf4E2M1FN> -> tensor<33x16x1x16x8x32xf4E2M1FN>
 // CHECK:         %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<33x8x1x16x16x32xf4E2M1FN> into tensor<33x8x1x16x4x4x32xf4E2M1FN>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<33x8x1x4x4x16x32xf4E2M1FN>
+// CHECK-SAME:       : tensor<33x16x1x16x8x32xf4E2M1FN> into tensor<33x16x1x16x2x4x32xf4E2M1FN>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<33x16x1x2x4x16x32xf4E2M1FN>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<33x8x1x16x4x4x32xf4E2M1FN>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<33x8x1x4x4x16x32xf4E2M1FN>)
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<33x16x1x16x2x4x32xf4E2M1FN>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<33x16x1x2x4x16x32xf4E2M1FN>)
 // CHECK-SAME:       permutation = [0, 1, 2, 4, 5, 3, 6]
 // CHECK:         return %[[TRANSPOSE]]
 
@@ -317,14 +317,14 @@ func.func @set_encoding_LHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<2
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [16, 16]
-// CHECK-SAME:      : tensor<255x127xf8E8M0FNU> -> tensor<16x8x16x16xf8E8M0FNU>
+// CHECK-SAME:      inner_tiles = [16, 8]
+// CHECK-SAME:      : tensor<255x127xf8E8M0FNU> -> tensor<16x16x16x8xf8E8M0FNU>
 // CHECK:         %[[EXPANDED:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<16x8x16x16xf8E8M0FNU> into tensor<16x8x16x4x4xf8E8M0FNU>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<16x8x4x16x4xf8E8M0FNU>
+// CHECK-SAME:       : tensor<16x16x16x8xf8E8M0FNU> into tensor<16x16x16x2x4xf8E8M0FNU>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<16x16x4x16x2xf8E8M0FNU>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<16x8x16x4x4xf8E8M0FNU>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<16x8x4x16x4xf8E8M0FNU>)
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<16x16x16x2x4xf8E8M0FNU>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<16x16x4x16x2xf8E8M0FNU>)
 // CHECK-SAME:       permutation = [0, 1, 4, 2, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
@@ -351,14 +351,14 @@ func.func @set_encoding_RHS_SCALES_scaled_matmul_f4_f4_f8_f8_f32(%arg0: tensor<5
 // CHECK:         %[[PACK:.*]] = linalg.pack %{{.+}} padding_value(%{{.+}} : f8E8M0FNU)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
 // CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [16, 16]
-// CHECK-SAME:      : tensor<513x127xf8E8M0FNU> -> tensor<33x8x16x16xf8E8M0FNU>
+// CHECK-SAME:      inner_tiles = [16, 8]
+// CHECK-SAME:      : tensor<513x127xf8E8M0FNU> -> tensor<33x16x16x8xf8E8M0FNU>
 // CHECK:         %[[EXPANDED:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:       : tensor<33x8x16x16xf8E8M0FNU> into tensor<33x8x16x4x4xf8E8M0FNU>
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<33x8x4x16x4xf8E8M0FNU>
+// CHECK-SAME:       : tensor<33x16x16x8xf8E8M0FNU> into tensor<33x16x16x2x4xf8E8M0FNU>
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<33x16x4x16x2xf8E8M0FNU>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<33x8x16x4x4xf8E8M0FNU>)
-// CHECK-SAME:       outs(%[[EMPTY]] : tensor<33x8x4x16x4xf8E8M0FNU>)
+// CHECK-SAME:       ins(%[[EXPANDED]] : tensor<33x16x16x2x4xf8E8M0FNU>)
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<33x16x4x16x2xf8E8M0FNU>)
 // CHECK-SAME:       permutation = [0, 1, 4, 2, 3]
 // CHECK:         return %[[TRANSPOSE]]
 
@@ -440,15 +440,15 @@ func.func @scaled_matmul_lowering_large_f4_f4_f8_f8_f32(
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 // CHECK:     func.func @scaled_matmul_lowering_large_f4_f4_f8_f8_f32(
-// CHECK-SAME:  %[[LHS:.+]]: tensor<16x8x1x2x2x4x4x16x32xf4E2M1FN>, %[[RHS:.+]]: tensor<32x8x1x2x2x4x4x16x32xf4E2M1FN>
-// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<16x8x2x2x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<32x8x2x2x4x16x4xf8E8M0FNU>
-// CHECK-SAME:  %[[RESULT:.+]]: tensor<16x32x2x2x2x2x4x16x4xf32>
+// CHECK-SAME:  %[[LHS:.+]]: tensor<16x16x1x2x2x2x4x16x32xf4E2M1FN>, %[[RHS:.+]]: tensor<32x16x1x4x2x4x16x32xf4E2M1FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<16x16x2x4x16x2x2xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<32x16x4x4x16x2xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<16x32x2x4x2x4x16x4xf32>
 // CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
 // CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
 // CHECK-SAME:    outs(%[[RESULT]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 4, operands_interleaving_intrinsics_k = [2, 3]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 2, subgroups_m = 2, subgroups_n = 4, intrinsics_k = 2, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>
 
 
 // -----
@@ -495,15 +495,15 @@ func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32(
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 // CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32(
-// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x4x4x4x16x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x2x4x4x16x32xf4E2M1FN>
-// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x2x4x16x4xf8E8M0FNU>
-// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x4x4x2x4x16x4xf32>
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x2x8x2x4x16x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x4x4x2x4x16x32xf4E2M1FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x2x4x16x8x2xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x4x4x16x4x2xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x2x4x8x4x4x16x4xf32>
 // CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
 // CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
 // CHECK-SAME:    outs(%[[RESULT]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 4, intrinsics_n = 2, subgroups_n = 4, intrinsics_k = 4, operands_interleaving_intrinsics_k = [2, 3]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 8, subgroups_m = 2, intrinsics_n = 4, subgroups_n = 4, intrinsics_k = 2, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>
 
 // -----
 
@@ -549,15 +549,15 @@ func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 // CHECK:     func.func @scaled_matmul_lowering_f8_f8_f8_f8_f32(
-// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x2x2x4x4x16x32xf8E4M3FN>, %[[RHS:.+]]: tensor<?x?x1x2x2x4x4x16x32xf8E4M3FN>
-// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x2x2x4x16x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x2x2x4x16x4xf8E8M0FNU>
-// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x2x2x2x2x4x16x4xf32>
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x8x2x4x16x32xf8E4M3FN>, %[[RHS:.+]]: tensor<?x?x1x8x2x2x4x16x32xf8E4M3FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x4x16x8x2xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x8x4x16x2x2xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x8x8x2x4x16x4xf32>
 // CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
 // CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
 // CHECK-SAME:    outs(%[[RESULT]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 4, operands_interleaving_intrinsics_k = [2, 3]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_16x16x128_B32, lhs_elem_type = f8E4M3FN, rhs_elem_type = f8E4M3FN, acc_elem_type = f32, intrinsics_m = 8, intrinsics_n = 2, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>
 
 // -----
 
@@ -622,15 +622,15 @@ func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
 // CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
 // CHECK:     func.func @scaled_matmul_lowering_f4_f4_f8_f8_f32_MFMA_SCALE_F32_32x32x64_B32(
-// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x2x2x4x2x32x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x2x2x4x2x32x32xf4E2M1FN>
-// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x2x2x2x32x4xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x2x2x2x32x4xf8E8M0FNU>
-// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x2x2x2x2x4x2x32x4xf32>
+// CHECK-SAME:  %[[LHS:.+]]: tensor<?x?x1x8x2x2x32x32xf4E2M1FN>, %[[RHS:.+]]: tensor<?x?x1x8x2x2x32x32xf4E2M1FN>
+// CHECK-SAME:  %[[LHS_SCALES:.+]]: tensor<?x?x2x32x8x2xf8E8M0FNU>, %[[RHS_SCALES:.+]]: tensor<?x?x8x2x32x2xf8E8M0FNU>
+// CHECK-SAME:  %[[RESULT:.+]]: tensor<?x?x8x8x4x2x32x4xf32>
 // CHECK:       %[[SCALED_MATMUL:.+]] = iree_codegen.inner_tiled
 // CHECK-SAME:    ins(%[[LHS]], %[[RHS]], %[[LHS_SCALES]], %[[RHS_SCALES]])
 // CHECK-SAME:    outs(%[[RESULT]])
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]],
 // CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, intrinsics_k = 4, operands_interleaving_intrinsics_k = [2, 3]>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_scaled_mma_layout<intrinsic = MFMA_SCALE_F32_32x32x64_B32, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN, acc_elem_type = f32, intrinsics_m = 8, subgroups_n = 8, intrinsics_k = 2, operands_interleaving_intrinsics_m = [2], operands_interleaving_intrinsics_n = [3], operands_interleaving_intrinsics_k = [2, 3]>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -112,8 +112,7 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
     // will take care of moving small chunks at a time into a shared memory
     // operand that will be created together with the ukernel op.
     SmallVector<int64_t> promotionList = {0, 1};
-    bool isScaled = isa<DataTiledScaledMMAAttr>(dataTiledMmaAttr);
-    if (isScaled) {
+    if (isa<DataTiledScaledMMAAttr>(dataTiledMmaAttr)) {
       promotionList.append({2, 3});
     }
     GPU::appendPromotedOperandsList(context, attrs, promotionList);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -111,15 +111,20 @@ LogicalResult setDataTiledMmaInnerTiledLoweringConfig(
     // large to fit in shared memory, so they just want global memory and they
     // will take care of moving small chunks at a time into a shared memory
     // operand that will be created together with the ukernel op.
-    GPU::appendPromotedOperandsList(context, attrs, {0, 1});
+    SmallVector<int64_t> promotionList = {0, 1};
+    bool isScaled = isa<DataTiledScaledMMAAttr>(dataTiledMmaAttr);
+    if (isScaled) {
+      promotionList.append({2, 3});
+    }
+    GPU::appendPromotedOperandsList(context, attrs, promotionList);
   }
   DictionaryAttr configDict = b.getDictionaryAttr(attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
-  // By default, don't add any special padding or prefetching, since the
-  // data-tiled layout is already what we want.
+  // By default, don't add any special padding since the data-tiled layout is
+  // already what we want. Default to 2 prefetch stages when not specified.
   SmallVector<NamedAttribute, 1> pipelineAttrs;
-  int64_t prefetchStages = prefetchNumStages.value_or(0);
+  int64_t prefetchStages = prefetchNumStages.value_or(2);
   auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
       context, /*prefetchNumStages=*/prefetchStages,
       /*no_reduce_shared_memory_bank_conflicts=*/true,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -173,7 +173,6 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
     }
     SmallVector<VectorType> vectorTypes;
     intrinsicScaledMma.getDistributedTileTypes(vectorTypes);
-
     // For scaled_matmul, the size of the LHS scales and RHS scales are added
     // to the total LHS and RHS sizes, because we use these sizes to select the
     // unrolling factors for M, N, and K, which affect both the input and the
@@ -193,7 +192,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   }
 
   //
-  // Step 1b: Select the K unrolling factor and upper bounds on M/N.
+  // Step 2: Select the K unrolling factor and upper bounds on M/N.
   //
   // The intrinsicsK factor serves to allow loads from the A and B matrices to
   // use the target ISA's vector loads. For instance, if the ISA has 128-bit
@@ -243,7 +242,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   }
 
   //
-  // Step 2: Joint search over (wavesPerSimd, sm, sn, im, in).
+  // Step 3: Joint search over (wavesPerSimd, sm, sn, im, in).
   //
   // The outermost loop iterates occupancy levels (wavesPerSimd). For each,
   // we derive the per-wave VGPR budget and search over subgroup counts (sm, sn)
@@ -272,8 +271,8 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   for (int64_t wps = 1; wps <= maxWavesPerSimd; ++wps) {
     // Empirically, for 1 wave per simd, using all available VGPRs for tile
     // data leads to register spilling, so we impose a safety margin by
-    // dividing available VGPRs by 2 even for 1 wave per simd.
-    int64_t perWaveVgpr = vgprSpaceBits / 2;
+    // dividing available VGPRs by at least 2 even for 1 wave per simd.
+    int64_t perWaveVgpr = vgprSpaceBits / std::max(2LL, wps);
     int64_t maxSubgroups = simdsPerWgp * wps;
     for (int64_t sm = 1; sm <= maxSubgroups; sm <<= 1) {
       for (int64_t sn = 1; sn <= maxSubgroups / sm; sn <<= 1) {
@@ -311,6 +310,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
       }
     }
   }
+
   // We currently never generate subgroupsK != 1, as subgroupsK requires
   // specific partial-accumulator-reduction in the kernel, currently only done
   // in some microkernels that would provide their own DataTiledMMAAttr.

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -252,11 +252,11 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   //   - Per-wave VGPR: im*iK*L + in*iK*R + im*in*A <= vgprSpaceBits/wps
   //   - Total tile limits: sm*im <= maxTotalUnrollM, sn*in <= maxTotalUnrollN
   //   - Workgroup utilization: sm*im*sn*in <= maxTotalUnrollMN
-  //   - LDS: sm*im*iK*L + sn*in*iK*R <= maxLDSBits
+  //   - Shared memory: sm*im*iK*L + sn*in*iK*R <= maxSharedMemoryBits
   //
   int64_t vgprSpaceBits = *wgp.getVgprSpaceBits();
   int64_t simdsPerWgp = *wgp.getSimdsPerWgp();
-  int64_t maxLDSBits = wgp.getMaxWorkgroupMemoryBytes() * 8;
+  int64_t maxSharedMemoryBits = wgp.getMaxWorkgroupMemoryBytes() * 8;
   int64_t maxWavesPerSimd = 2;
   int64_t subgroupsM = 1;
   int64_t subgroupsN = 1;
@@ -286,11 +286,13 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
           int64_t maxInVgpr =
               (perWaveVgpr - im * intrinsicsK * intrinsicSizeBitsLHS) /
               (intrinsicsK * intrinsicSizeBitsRHS + im * intrinsicSizeBitsACC);
-          int64_t maxInLDS =
-              (maxLDSBits - sm * im * intrinsicsK * intrinsicSizeBitsLHS) /
+          int64_t maxInSharedMemory =
+              (maxSharedMemoryBits -
+               sm * im * intrinsicsK * intrinsicSizeBitsLHS) /
               (sn * intrinsicsK * intrinsicSizeBitsRHS);
           int64_t maxInBudget = maxTotalUnrollMN / (sm * im * sn);
-          int64_t in = std::min({maxInVgpr, maxIn, maxInBudget, maxInLDS});
+          int64_t in =
+              std::min({maxInVgpr, maxIn, maxInBudget, maxInSharedMemory});
           if (in <= 0) {
             continue;
           }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -41,6 +41,7 @@
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/Support/DebugLog.h"
+#include "llvm/Support/MathExtras.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/TensorEncoding.h"
@@ -172,6 +173,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
     }
     SmallVector<VectorType> vectorTypes;
     intrinsicScaledMma.getDistributedTileTypes(vectorTypes);
+
     // For scaled_matmul, the size of the LHS scales and RHS scales are added
     // to the total LHS and RHS sizes, because we use these sizes to select the
     // unrolling factors for M, N, and K, which affect both the input and the
@@ -191,8 +193,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   }
 
   //
-  // Step 2: Select the total unrolling factors along the M, N, and K
-  // dimensions.
+  // Step 1b: Select the K unrolling factor and upper bounds on M/N.
   //
   // The intrinsicsK factor serves to allow loads from the A and B matrices to
   // use the target ISA's vector loads. For instance, if the ISA has 128-bit
@@ -202,49 +203,17 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   int intrinsicsK =
       std::max(1, *wgp.getMaxLoadInstructionBits() / intrinsicLoadBits);
 
-  // For scaled intrinsics, there is another reason to unroll K. Scales are held
-  // in a vector of multiple scales, but only a single scale is used for each
-  // instruction. We want to be able to load a contiguous vector of scales into
-  // registers, and use the same vector for consecutive instructions. Choose the
-  // LCM of the scales vector size unrolling factor, and the load bitwidth
-  // unrolling factor, so both are satisfied.
-  // * Note that typically, the load bitwidth unrolling factor will be 1, so the
-  // total K unrolling factor will just be the scales vector size.
+  // For scaled matmuls, operands are loaded in 128-bit blocks but scales are
+  // distributed one byte-sized scale per thread across a subgroup. We unroll K
+  // by a factor of 2 (the minimum that keeps contiguous scale loads when
+  // combined with M/N interleaving) rather than using the load-width formula.
   if (auto scaledMmaAttr = dyn_cast<ScaledMMAAttr>(intrinsicAttr)) {
-    intrinsicsK = std::lcm(intrinsicsK, scaledMmaAttr.getScalesVectorSize());
+    intrinsicsK = 2;
   }
 
-  // The total amount of unrolling along the M and N dimensions is normally
-  // limited only by the number of available registers, since larger M and N
-  // yields higher arithmetic intensity. Here, we do not yet distinguish between
-  // plain unrolling (more instructions on each thread) and
-  // unrolling-to-subgroups (more threads), since expanding to more subgroups
-  // correspondingly divides the available register space between this many
-  // subgroups, making it cancel out of the equation here.
-  //
-  // We need to find the optimal pair (totalUnrollM, totalUnrollN) by
-  // enumerating feasible (tm, tn) candidates. For each candidate, the
-  // following two constraints are enforced:
-  // 1. The A, B and C tiles must fit in VGPR space.
-  //     A-tile + B-tile + C-tile <= wgp.getVgprSpaceBits()
-  // 2. The A, B tiles must fit in shared memory.
-  //     A-tile + B-tile <= wgp.getMaxWorkgroupMemoryBytes() * 8
-  // A-tile: tm * intrinsicsK * intrinsicSizeBitsLHS
-  // B-tile: tn * intrinsicsK * intrinsicSizeBitsRHS
-  // C-tile: tm * tn * intrinsicSizeBitsACC
-  //
-  // The optimization goal is to maximize arithmetic intensity (tm * tn) / (tm +
-  // tn).
-  //
-  // We also self-impose the constraint that tm and tn are powers of 2 to
-  // avoid prematurely entering excessing fine-tuning of unrolling factors.
-  int64_t totalUnrollM = 1;
-  int64_t totalUnrollN = 1;
-  auto computeArithmeticIntensity = [&](int64_t tm, int64_t tn) -> double {
+  auto computeArithmeticIntensity = [](int64_t tm, int64_t tn) -> double {
     return double(tm * tn) / double(tm + tn);
   };
-  double bestArithmeticIntensity =
-      computeArithmeticIntensity(totalUnrollM, totalUnrollN);
   // Upper bounds of tm and tn are decided by the matrix and intrinsic sizes.
   int64_t maxTotalUnrollM = INT64_MAX;
   int64_t maxTotalUnrollN = INT64_MAX;
@@ -272,75 +241,76 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
                            numWGPs * intrinsicMSize * intrinsicNSize);
     }
   }
-  // Iterate over possible tm.
-  for (int64_t tm = 1; tm <= maxTotalUnrollM; tm <<= 1) {
-    // Compute the maximum feasible tn for this tm.
-    int64_t maxFeasibleTnVgpr =
-        (*wgp.getVgprSpaceBits() - tm * intrinsicsK * intrinsicSizeBitsLHS) /
-        (intrinsicsK * intrinsicSizeBitsRHS + tm * intrinsicSizeBitsACC);
-    int64_t maxFeasibleTnSharedMem = (wgp.getMaxWorkgroupMemoryBytes() * 8 -
-                                      tm * intrinsicsK * intrinsicSizeBitsLHS) /
-                                     (intrinsicsK * intrinsicSizeBitsRHS);
-    int64_t tn = std::min(maxFeasibleTnVgpr, maxFeasibleTnSharedMem);
-    // Clamp tn to maxTotalUnrollN.
-    tn = std::min(tn, maxTotalUnrollN);
-    // Clamp tn to maxTotalUnrollMN / tm.
-    tn = std::min(tn, maxTotalUnrollMN / tm);
-    // No feasible tn for this tm. Stop the enumeration.
-    if (tn <= 0) {
-      break;
-    }
-    // Round tn down to nearest power of two.
-    tn = 1 << (int64_t)std::floor(std::log2(tn));
-    // Maximize arithmetic intensity (tm * tn) / (tm + tn).
-    double currentArithmeticIntensity = computeArithmeticIntensity(tm, tn);
-    if (currentArithmeticIntensity > bestArithmeticIntensity) {
-      totalUnrollM = tm;
-      totalUnrollN = tn;
-      bestArithmeticIntensity = currentArithmeticIntensity;
-    }
-  }
 
   //
-  // Step 3: Split `totalUnrollM` and `totalUnrollN` into plain unrolling (more
-  // instructions on each thread) and unrolling-to-subgroups (more threads).
+  // Step 2: Joint search over (wavesPerSimd, sm, sn, im, in).
   //
-  // Unrolling-to-subgroups doesn't change the overall tile
-  // size, as it increases the number of subgroups but correspondingly decreases
-  // the number of registers available to each subgroups. In other words, the
-  // overall tile size determined above only needed to be concerned with the
-  // overall number of registers, not with how they are split between subgroups.
+  // The outermost loop iterates occupancy levels (wavesPerSimd). For each,
+  // we derive the per-wave VGPR budget and search over subgroup counts (sm, sn)
+  // and per-wave tiles (im, in). We prefer values for sm, sn, im, in that
+  // maximize the arithmetic intensity of the matmul breaking ties by favouring
+  // more waves. Constraints:
+  //   - Per-wave VGPR: im*iK*L + in*iK*R + im*in*A <= vgprSpaceBits/wps
+  //   - Total tile limits: sm*im <= maxTotalUnrollM, sn*in <= maxTotalUnrollN
+  //   - Workgroup utilization: sm*im*sn*in <= maxTotalUnrollMN
+  //   - LDS: sm*im*iK*L + sn*in*iK*R <= maxLDSBits
   //
-  // The goal is still to maximize arithmetic intensity, but now we need to
-  // optimize `intrinsicsM(N)` instead of `totalUnrollM(N)`.
+  int64_t vgprSpaceBits = *wgp.getVgprSpaceBits();
+  int64_t simdsPerWgp = *wgp.getSimdsPerWgp();
+  int64_t maxLDSBits = wgp.getMaxWorkgroupMemoryBytes() * 8;
+  int64_t maxWavesPerSimd = 2;
   int64_t subgroupsM = 1;
   int64_t subgroupsN = 1;
   int64_t intrinsicsM = 1;
   int64_t intrinsicsN = 1;
-  bestArithmeticIntensity =
-      computeArithmeticIntensity(intrinsicsM, intrinsicsN);
-  int64_t simdsPerWgp = *wgp.getSimdsPerWgp();
-  // Enumerate possible unrolling-to-subgroups on M dimension.
-  for (int64_t sm = 1; sm <= std::min(simdsPerWgp, totalUnrollM); sm <<= 1) {
-    // Calculate the unrolling-to-subgroups on N dimension, given the current
-    // sm.
-    int64_t sn = std::min(simdsPerWgp / sm, totalUnrollN);
-    // Round sn down to nearest power of two.
-    sn = 1 << (int64_t)std::floor(std::log2(sn));
-    // Calculate the plain (intrinsic) unrolling factors on M and N dimensions.
-    int64_t im = totalUnrollM / sm;
-    int64_t in = totalUnrollN / sn;
-    // Maximize arithmetic intensity (im * in) / (im + in).
-    double currentArithmeticIntensity = computeArithmeticIntensity(im, in);
-    if (currentArithmeticIntensity > bestArithmeticIntensity) {
-      subgroupsM = sm;
-      subgroupsN = sn;
-      intrinsicsM = im;
-      intrinsicsN = in;
-      bestArithmeticIntensity = currentArithmeticIntensity;
+  double bestScore = 0;
+  int64_t bestWaves = 0;
+
+  // TODO: For the same arithmetic intensity, distributing more intrinsics or
+  // subgroups along M vs N yields different performance despite the metric
+  // being symmetric. Investigate why, likely related to memory access patterns.
+  for (int64_t wps = 1; wps <= maxWavesPerSimd; ++wps) {
+    // Empirically, for 1 wave per simd, using all available VGPRs for tile
+    // data leads to register spilling, so we impose a safety margin by
+    // dividing available VGPRs by 2 even for 1 wave per simd.
+    int64_t perWaveVgpr = vgprSpaceBits / 2;
+    int64_t maxSubgroups = simdsPerWgp * wps;
+    for (int64_t sm = 1; sm <= maxSubgroups; sm <<= 1) {
+      for (int64_t sn = 1; sn <= maxSubgroups / sm; sn <<= 1) {
+        int64_t numWaves = sm * sn;
+        int64_t maxIm = maxTotalUnrollM / sm;
+        int64_t maxIn = maxTotalUnrollN / sn;
+        for (int64_t im = 1; im <= maxIm; im <<= 1) {
+          if (im * intrinsicsK * intrinsicSizeBitsLHS > perWaveVgpr) {
+            break;
+          }
+          int64_t maxInVgpr =
+              (perWaveVgpr - im * intrinsicsK * intrinsicSizeBitsLHS) /
+              (intrinsicsK * intrinsicSizeBitsRHS + im * intrinsicSizeBitsACC);
+          int64_t maxInLDS =
+              (maxLDSBits - sm * im * intrinsicsK * intrinsicSizeBitsLHS) /
+              (sn * intrinsicsK * intrinsicSizeBitsRHS);
+          int64_t maxInBudget = maxTotalUnrollMN / (sm * im * sn);
+          int64_t in = std::min({maxInVgpr, maxIn, maxInBudget, maxInLDS});
+          if (in <= 0) {
+            continue;
+          }
+          in = 1LL << llvm::Log2_64(in);
+          double score = computeArithmeticIntensity(sm * im, sn * in);
+          bool accepted =
+              score > bestScore || (score == bestScore && numWaves > bestWaves);
+          if (accepted) {
+            subgroupsM = sm;
+            subgroupsN = sn;
+            intrinsicsM = im;
+            intrinsicsN = in;
+            bestScore = score;
+            bestWaves = numWaves;
+          }
+        }
+      }
     }
   }
-
   // We currently never generate subgroupsK != 1, as subgroupsK requires
   // specific partial-accumulator-reduction in the kernel, currently only done
   // in some microkernels that would provide their own DataTiledMMAAttr.
@@ -360,10 +330,12 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
         /*operands_interleaving_intrinsics_n=*/{},
         /*operands_interleaving_intrinsics_k=*/mmaInterleaveK);
   }
-  // For scaled matmuls, interleaving happens because we want to load all
-  // the unrolled scales with each vector load, so we need to interleave at
-  // the very last dimension for the scales. For the LHS/RHS, we load in blocks,
-  // so we don't need to interleave.
+  // For scaled matmuls, we rely on M/N interleaving to achieve contiguous
+  // loads of scales.
+  auto scaledMmaInterleaveM =
+      DenseI64ArrayAttr::get(ctx, {kScaledMMAOperandLhsScale});
+  auto scaledMmaInterleaveN =
+      DenseI64ArrayAttr::get(ctx, {kScaledMMAOperandRhsScale});
   auto scaledMmaInterleaveK = DenseI64ArrayAttr::get(
       ctx, {kScaledMMAOperandLhsScale, kScaledMMAOperandRhsScale});
   auto intrinsicScaledMma = cast<ScaledMMAAttr>(intrinsicAttr);
@@ -372,8 +344,8 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
       intrinsicScaledMma.getLhsElemType(), intrinsicScaledMma.getRhsElemType(),
       intrinsicScaledMma.getAccElemType(), intrinsicsM, subgroupsM, intrinsicsN,
       subgroupsN, intrinsicsK, subgroupsK,
-      /*operands_interleaving_intrinsics_m=*/{},
-      /*operands_interleaving_intrinsics_n=*/{},
+      /*operands_interleaving_intrinsics_m=*/scaledMmaInterleaveM,
+      /*operands_interleaving_intrinsics_n=*/scaledMmaInterleaveN,
       /*operands_interleaving_intrinsics_k=*/scaledMmaInterleaveK,
       /*unswizzled_operands=*/{});
 }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -272,7 +272,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
     // Empirically, for 1 wave per simd, using all available VGPRs for tile
     // data leads to register spilling, so we impose a safety margin by
     // dividing available VGPRs by at least 2 even for 1 wave per simd.
-    int64_t perWaveVgpr = vgprSpaceBits / std::max(2LL, wps);
+    int64_t perWaveVgpr = vgprSpaceBits / std::max(int64_t(2), wps);
     int64_t maxSubgroups = simdsPerWgp * wps;
     for (int64_t sm = 1; sm <= maxSubgroups; sm <<= 1) {
       for (int64_t sn = 1; sn <= maxSubgroups / sm; sn <<= 1) {
@@ -296,7 +296,7 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
           if (in <= 0) {
             continue;
           }
-          in = 1LL << llvm::Log2_64(in);
+          in = int64_t(1) << llvm::Log2_64(in);
           double score = computeArithmeticIntensity(sm * im, sn * in);
           bool accepted =
               score > bestScore || (score == bestScore && numWaves > bestWaves);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -205,46 +205,21 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   // For scaled intrinsics, there is another reason to unroll K. Scales are held
   // in a vector of multiple scales, but only a single scale is used for each
   // instruction. We want to be able to load a contiguous vector of scales into
-  // registers, and use the same vector for consecutive instructions. Choose the
-  // LCM of the scales vector size unrolling factor, and the load bitwidth
-  // unrolling factor, so both are satisfied.
-  // * Note that typically, the load bitwidth unrolling factor will be 1, so the
-  // total K unrolling factor will just be the scales vector size.
+  // registers, and use the same vector for consecutive instructions.
+  // One way to do this is to choose the LCM of the scales vector size
+  // unrolling factor, and the load bitwidth unrolling factor, so both are
+  // satisfied. However, this leads to a larger than necessary K unrolling
+  // factor. Instead we interleave the M and N dimensions into the scale
+  // operands to achieve the same contiguous loads without sacrificing
+  // arithmetic intensity.
+  int64_t maxWavesPerSimd = 2;
   if (auto scaledMmaAttr = dyn_cast<ScaledMMAAttr>(intrinsicAttr)) {
-    intrinsicsK = std::lcm(intrinsicsK, scaledMmaAttr.getScalesVectorSize());
+    intrinsicsK = 2;
   }
 
-  // The total amount of unrolling along the M and N dimensions is normally
-  // limited only by the number of available registers, since larger M and N
-  // yields higher arithmetic intensity. Here, we do not yet distinguish between
-  // plain unrolling (more instructions on each thread) and
-  // unrolling-to-subgroups (more threads), since expanding to more subgroups
-  // correspondingly divides the available register space between this many
-  // subgroups, making it cancel out of the equation here.
-  //
-  // We need to find the optimal pair (totalUnrollM, totalUnrollN) by
-  // enumerating feasible (tm, tn) candidates. For each candidate, the
-  // following two constraints are enforced:
-  // 1. The A, B and C tiles must fit in VGPR space.
-  //     A-tile + B-tile + C-tile <= wgp.getVgprSpaceBits()
-  // 2. The A, B tiles must fit in shared memory.
-  //     A-tile + B-tile <= wgp.getMaxWorkgroupMemoryBytes() * 8
-  // A-tile: tm * intrinsicsK * intrinsicSizeBitsLHS
-  // B-tile: tn * intrinsicsK * intrinsicSizeBitsRHS
-  // C-tile: tm * tn * intrinsicSizeBitsACC
-  //
-  // The optimization goal is to maximize arithmetic intensity (tm * tn) / (tm +
-  // tn).
-  //
-  // We also self-impose the constraint that tm and tn are powers of 2 to
-  // avoid prematurely entering excessing fine-tuning of unrolling factors.
-  int64_t totalUnrollM = 1;
-  int64_t totalUnrollN = 1;
   auto computeArithmeticIntensity = [&](int64_t tm, int64_t tn) -> double {
     return double(tm * tn) / double(tm + tn);
   };
-  double bestArithmeticIntensity =
-      computeArithmeticIntensity(totalUnrollM, totalUnrollN);
   // Upper bounds of tm and tn are decided by the matrix and intrinsic sizes.
   int64_t maxTotalUnrollM = INT64_MAX;
   int64_t maxTotalUnrollN = INT64_MAX;
@@ -272,75 +247,74 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
                            numWGPs * intrinsicMSize * intrinsicNSize);
     }
   }
-  // Iterate over possible tm.
-  for (int64_t tm = 1; tm <= maxTotalUnrollM; tm <<= 1) {
-    // Compute the maximum feasible tn for this tm.
-    int64_t maxFeasibleTnVgpr =
-        (*wgp.getVgprSpaceBits() - tm * intrinsicsK * intrinsicSizeBitsLHS) /
-        (intrinsicsK * intrinsicSizeBitsRHS + tm * intrinsicSizeBitsACC);
-    int64_t maxFeasibleTnSharedMem = (wgp.getMaxWorkgroupMemoryBytes() * 8 -
-                                      tm * intrinsicsK * intrinsicSizeBitsLHS) /
-                                     (intrinsicsK * intrinsicSizeBitsRHS);
-    int64_t tn = std::min(maxFeasibleTnVgpr, maxFeasibleTnSharedMem);
-    // Clamp tn to maxTotalUnrollN.
-    tn = std::min(tn, maxTotalUnrollN);
-    // Clamp tn to maxTotalUnrollMN / tm.
-    tn = std::min(tn, maxTotalUnrollMN / tm);
-    // No feasible tn for this tm. Stop the enumeration.
-    if (tn <= 0) {
-      break;
-    }
-    // Round tn down to nearest power of two.
-    tn = 1 << (int64_t)std::floor(std::log2(tn));
-    // Maximize arithmetic intensity (tm * tn) / (tm + tn).
-    double currentArithmeticIntensity = computeArithmeticIntensity(tm, tn);
-    if (currentArithmeticIntensity > bestArithmeticIntensity) {
-      totalUnrollM = tm;
-      totalUnrollN = tn;
-      bestArithmeticIntensity = currentArithmeticIntensity;
-    }
-  }
-
   //
-  // Step 3: Split `totalUnrollM` and `totalUnrollN` into plain unrolling (more
-  // instructions on each thread) and unrolling-to-subgroups (more threads).
+  // Step 2: Joint search over (sm, sn, im, in).
   //
-  // Unrolling-to-subgroups doesn't change the overall tile
-  // size, as it increases the number of subgroups but correspondingly decreases
-  // the number of registers available to each subgroups. In other words, the
-  // overall tile size determined above only needed to be concerned with the
-  // overall number of registers, not with how they are split between subgroups.
+  // Step 2: Joint search over (wavesPerSimd, sm, sn, im, in).
   //
-  // The goal is still to maximize arithmetic intensity, but now we need to
-  // optimize `intrinsicsM(N)` instead of `totalUnrollM(N)`.
+  // The outermost loop iterates occupancy levels (wavesPerSimd). For each,
+  // we derive the per-wave VGPR budget and search over subgroup counts (sm, sn)
+  // and per-wave tiles (im, in). Constraints:
+  //   - Per-wave VGPR: im*iK*L + in*iK*R + im*in*A <= vgprSpaceBits/wps
+  //   - Total tile limits: sm*im <= maxTotalUnrollM, sn*in <= maxTotalUnrollN
+  //   - Workgroup utilization: sm*im*sn*in <= maxTotalUnrollMN
+  //   - LDS: sm*im*iK*L + sn*in*iK*R <= maxLDSBits
+  //
+  int64_t vgprSpaceBits = *wgp.getVgprSpaceBits();
+  int64_t simdsPerWgp = *wgp.getSimdsPerWgp();
+  int64_t maxLDSBits = wgp.getMaxWorkgroupMemoryBytes() * 8;
   int64_t subgroupsM = 1;
   int64_t subgroupsN = 1;
   int64_t intrinsicsM = 1;
   int64_t intrinsicsN = 1;
-  bestArithmeticIntensity =
-      computeArithmeticIntensity(intrinsicsM, intrinsicsN);
-  int64_t simdsPerWgp = *wgp.getSimdsPerWgp();
-  // Enumerate possible unrolling-to-subgroups on M dimension.
-  for (int64_t sm = 1; sm <= std::min(simdsPerWgp, totalUnrollM); sm <<= 1) {
-    // Calculate the unrolling-to-subgroups on N dimension, given the current
-    // sm.
-    int64_t sn = std::min(simdsPerWgp / sm, totalUnrollN);
-    // Round sn down to nearest power of two.
-    sn = 1 << (int64_t)std::floor(std::log2(sn));
-    // Calculate the plain (intrinsic) unrolling factors on M and N dimensions.
-    int64_t im = totalUnrollM / sm;
-    int64_t in = totalUnrollN / sn;
-    // Maximize arithmetic intensity (im * in) / (im + in).
-    double currentArithmeticIntensity = computeArithmeticIntensity(im, in);
-    if (currentArithmeticIntensity > bestArithmeticIntensity) {
-      subgroupsM = sm;
-      subgroupsN = sn;
-      intrinsicsM = im;
-      intrinsicsN = in;
-      bestArithmeticIntensity = currentArithmeticIntensity;
+  double bestScore = 0;
+  int64_t bestWaves = 0;
+  // TODO: For the same arithmetic intensity, distributing more intrinsics or
+  // subgroups along M vs N yields different performance despite the metric being
+  // symmetric. The root cause is unclear, likely related to memory access
+  // patterns, LDS layout, or how M/N interleaving interacts with coalescing.
+  for (int64_t wps = 1; wps <= maxWavesPerSimd; ++wps) {
+    int64_t perWaveVgpr = vgprSpaceBits / wps;
+    int64_t maxSubgroups = simdsPerWgp * wps;
+    for (int64_t sm = 1; sm <= maxSubgroups; sm <<= 1) {
+      for (int64_t sn = 1; sn <= maxSubgroups / sm; sn <<= 1) {
+        int64_t numWaves = sm * sn;
+        int64_t maxIm = maxTotalUnrollM / sm;
+        int64_t maxIn = maxTotalUnrollN / sn;
+        for (int64_t im = 1; im <= maxIm; im <<= 1) {
+          if (im * intrinsicsK * intrinsicSizeBitsLHS > perWaveVgpr) {
+            break;
+          }
+          int64_t maxInVgpr =
+              (perWaveVgpr - im * intrinsicsK * intrinsicSizeBitsLHS) /
+              (intrinsicsK * intrinsicSizeBitsRHS + im * intrinsicSizeBitsACC);
+          int64_t maxInLDS =
+              (maxLDSBits - sm * im * intrinsicsK * intrinsicSizeBitsLHS) /
+              (sn * intrinsicsK * intrinsicSizeBitsRHS);
+          int64_t maxInBudget = maxTotalUnrollMN / (sm * im * sn);
+          int64_t in = std::min({maxInVgpr, maxIn, maxInBudget, maxInLDS});
+          if (in <= 0) {
+            continue;
+          }
+          in = 1 << (int64_t)std::floor(std::log2(in));
+          if (in <= 0) {
+            continue;
+          }
+          double score = computeArithmeticIntensity(sm * im, sn * in);
+          bool accepted = score > bestScore ||
+              (score == bestScore && numWaves > bestWaves);
+          if (accepted) {
+            subgroupsM = sm;
+            subgroupsN = sn;
+            intrinsicsM = im;
+            intrinsicsN = in;
+            bestScore = score;
+            bestWaves = numWaves;
+          }
+        }
+      }
     }
   }
-
   // We currently never generate subgroupsK != 1, as subgroupsK requires
   // specific partial-accumulator-reduction in the kernel, currently only done
   // in some microkernels that would provide their own DataTiledMMAAttr.
@@ -364,6 +338,8 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
   // the unrolled scales with each vector load, so we need to interleave at
   // the very last dimension for the scales. For the LHS/RHS, we load in blocks,
   // so we don't need to interleave.
+  auto scaledMmaInterleaveM = DenseI64ArrayAttr::get(ctx, {kScaledMMAOperandLhsScale});
+  auto scaledMmaInterleaveN = DenseI64ArrayAttr::get(ctx, {kScaledMMAOperandRhsScale});
   auto scaledMmaInterleaveK = DenseI64ArrayAttr::get(
       ctx, {kScaledMMAOperandLhsScale, kScaledMMAOperandRhsScale});
   auto intrinsicScaledMma = cast<ScaledMMAAttr>(intrinsicAttr);
@@ -372,8 +348,8 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
       intrinsicScaledMma.getLhsElemType(), intrinsicScaledMma.getRhsElemType(),
       intrinsicScaledMma.getAccElemType(), intrinsicsM, subgroupsM, intrinsicsN,
       subgroupsN, intrinsicsK, subgroupsK,
-      /*operands_interleaving_intrinsics_m=*/{},
-      /*operands_interleaving_intrinsics_n=*/{},
+      /*operands_interleaving_intrinsics_m=*/scaledMmaInterleaveM,
+      /*operands_interleaving_intrinsics_n=*/scaledMmaInterleaveN,
       /*operands_interleaving_intrinsics_k=*/scaledMmaInterleaveK,
       /*unswizzled_operands=*/{});
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -305,7 +305,7 @@ func.func @multi_mma_data_tiled_unrolled_MFMA_F32_16x16x4_F32(
 
 // CHECK-LABEL: func.func @multi_mma_data_tiled_unrolled_MFMA_F32_16x16x4_F32(
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
+//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
 //       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     reduction = [0, 0, 1]
 //  CHECK-SAME:     workgroup = [1, 1, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -276,9 +276,9 @@ module {
 
 // CHECK-LABEL: func.func @data_tiled_scaled_mma_inner_tiled
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [256, 1, 1] subgroup_size = 64
-//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
+//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2, no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}
 //       CHECK:   iree_codegen.inner_tiled {{.*}}lowering_config = #iree_gpu.lowering_config
-//  CHECK-SAME:     promote_operands = [0, 1]
+//  CHECK-SAME:     promote_operands = [0, 1, 2, 3]
 //  CHECK-SAME:     reduction = [0, 0, 1, 1]
 //  CHECK-SAME:     workgroup = [1, 1, 0, 0]
 


### PR DESCRIPTION
This change addresses two gaps in our DT tiling heuristic:
1) The way that we select the number of subgroups and intrinsics to unroll to is overly conservative. We should check if a single wave's worth of work fits in VGPR's not if the entire workgroup tile fits in the VGPRs for a simd.  
2) We should allow for more waves than subgroups so we can have better latency hiding (multiple waves per simd).
