### PR TITLE
[VectorExt] Add generic lowering of iree_vector_ext.arg_compare

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -212,9 +212,6 @@ void GenericVectorizationPass::runOnOperation() {
     if (!vectorizeMapStore && isa<IREE::LinalgExt::MapStoreOp>(operation)) {
       return;
     }
-    if (!vectorizeArgCompare && isa<IREE::LinalgExt::ArgCompareOp>(operation)) {
-      return;
-    }
     candidates.push_back(op);
   });
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -647,12 +647,7 @@ def GenericVectorizationPass :
             /*default=*/"2147483647",
            "Max vector size allowed to avoid creating large vectors.">,
     Option<"vectorizeMapStore", "vectorize-map-store", "bool", /*default=*/"false",
-      "Enable vectorization of iree_linalg_ext.map_store operations via VectorizableOpInterface.">,
-    Option<"vectorizeArgCompare", "vectorize-arg-compare", "bool", /*default=*/"true",
-      "Vectorize iree_linalg_ext.arg_compare. Disable for pipelines without a "
-      "lowering for iree_vector_ext.arg_compare. "
-      "TODO(#24365): remove once a generic vector lowering for "
-      "iree_vector_ext.arg_compare exists.">
+      "Enable vectorization of iree_linalg_ext.map_store operations via VectorizableOpInterface.">
   ];
   let dependentDialects = [
     "::mlir::arith::ArithDialect"

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -279,9 +279,6 @@ def IREEVectorExt_YieldOp : IREEVectorExt_PureOp<"yield", [
 // LinalgExt-style ops.
 //===----------------------------------------------------------------------===//
 
-// TODO(#24365): the only lowering for this op today is via the nested-layout
-// distribution patterns owned by the VectorDistribute pipeline. Add a generic
-// lowering (e.g. via vector.* ops) so CPU and other GPU backends can use it.
 def IREEVectorExt_ArgCompareOp : IREEVectorExt_PureOp<"arg_compare", [
   Pure,
   AttrSizedOperandSegments,

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
@@ -58,6 +58,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:BufferizationInterfaces",
         "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
@@ -37,6 +37,7 @@ iree_compiler_cc_library(
     srcs = [
         "BufferizationInterfaces.cpp",
         "DistributionPatterns.cpp",
+        "LowerArgCompareToVector.cpp",
         "LowerTransferGatherScatterOps.cpp",
         "LowerTransferGatherScatterToVector.cpp",
         "Passes.cpp",
@@ -61,6 +62,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_cc_library(
   SRCS
     "BufferizationInterfaces.cpp"
     "DistributionPatterns.cpp"
+    "LowerArgCompareToVector.cpp"
     "LowerTransferGatherScatterOps.cpp"
     "LowerTransferGatherScatterToVector.cpp"
     "Passes.cpp"
@@ -45,6 +46,7 @@ iree_cc_library(
     MLIRFunctionInterfaces
     MLIRIR
     MLIRPass
+    MLIRSCFDialect
     MLIRSupport
     MLIRTensorDialect
     MLIRTransformUtils

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/LowerArgCompareToVector.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/LowerArgCompareToVector.cpp
@@ -1,0 +1,230 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+using namespace mlir::iree_compiler::IREE::VectorExt;
+
+namespace mlir::iree_compiler::IREE::VectorExt {
+
+#define GEN_PASS_DEF_LOWERARGCOMPARETOVECTORPASS
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.h.inc"
+
+namespace {
+
+static Value cloneComparatorRegion(RewriterBase &rewriter, Region &region,
+                                   Value lhs, Value rhs) {
+  Block &block = region.front();
+  IRMapping mapper;
+  mapper.map(block.getArgument(0), lhs);
+  mapper.map(block.getArgument(1), rhs);
+  for (Operation &op : block.without_terminator()) {
+    Operation *clonedOp = rewriter.clone(op, mapper);
+    for (const auto &[origResult, clonedResult] :
+         llvm::zip_equal(op.getResults(), clonedOp->getResults())) {
+      mapper.map(origResult, clonedResult);
+    }
+  }
+  auto yieldOp = cast<YieldOp>(block.getTerminator());
+  return mapper.lookup(yieldOp.getValues()[0]);
+}
+
+static SmallVector<int64_t> delinearizeIndex(int64_t linearIdx,
+                                             ArrayRef<int64_t> shape) {
+  SmallVector<int64_t> indices;
+  for (int64_t i = static_cast<int64_t>(shape.size()) - 1; i >= 0; --i) {
+    indices.push_back(linearIdx % shape[i]);
+    linearIdx /= shape[i];
+  }
+  std::reverse(indices.begin(), indices.end());
+  return indices;
+}
+
+static SmallVector<int64_t> buildMoveToLastPerm(int64_t rank, int64_t dim) {
+  SmallVector<int64_t> perm;
+  for (int64_t i = 0; i < rank; ++i) {
+    if (i != dim) {
+      perm.push_back(i);
+    }
+  }
+  perm.push_back(dim);
+  return perm;
+}
+
+struct LowerArgCompareToVector final : OpRewritePattern<ArgCompareOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(ArgCompareOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    VectorType inputType = op.getInputValueType();
+
+    if (inputType.isScalable()) {
+      return rewriter.notifyMatchFailure(op, "scalable vectors not supported");
+    }
+
+    int64_t rank = inputType.getRank();
+    int64_t reductionDim = op.getDimension();
+    int64_t reductionSize = inputType.getShape()[reductionDim];
+
+    Value inputValue = op.getInputValue();
+    Value inputIndex = op.getInputIndex();
+    Value initValue = op.getInitValue();
+    Value initIndex = op.getInitIndex();
+    Value indexBase = op.getIndexBase();
+    Type indexElemTy = op.getInitIndexElementType();
+
+    bool needsTranspose = (reductionDim != rank - 1) && (rank > 1);
+    if (needsTranspose) {
+      SmallVector<int64_t> perm = buildMoveToLastPerm(rank, reductionDim);
+      inputValue = vector::TransposeOp::create(rewriter, loc, inputValue, perm);
+      if (inputIndex) {
+        inputIndex =
+            vector::TransposeOp::create(rewriter, loc, inputIndex, perm);
+      }
+      reductionDim = rank - 1;
+    }
+
+    VectorType transposedType = cast<VectorType>(inputValue.getType());
+    ArrayRef<int64_t> shape = transposedType.getShape();
+
+    SmallVector<int64_t> parallelShape(shape.begin(), shape.end() - 1);
+    int64_t numParallelElems = ShapedType::getNumElements(parallelShape);
+
+    VectorType resultValueType = op.getInitValueType();
+    VectorType resultIndexType = op.getInitIndexType();
+
+    Value resultValue = initValue;
+    Value resultIndex = initIndex;
+
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value cRedSize =
+        arith::ConstantIndexOp::create(rewriter, loc, reductionSize);
+
+    for (int64_t p = 0; p < numParallelElems; ++p) {
+      SmallVector<int64_t> parallelIndices =
+          delinearizeIndex(p, parallelShape);
+
+      Value accVal, accIdx;
+      if (resultValueType.getRank() == 0) {
+        accVal = vector::ExtractOp::create(rewriter, loc, initValue,
+                                           ArrayRef<int64_t>{});
+        accIdx = vector::ExtractOp::create(rewriter, loc, initIndex,
+                                           ArrayRef<int64_t>{});
+      } else {
+        accVal = vector::ExtractOp::create(rewriter, loc, initValue,
+                                           parallelIndices);
+        accIdx = vector::ExtractOp::create(rewriter, loc, initIndex,
+                                           parallelIndices);
+      }
+
+      Value inputSlice, indexSlice;
+      if (rank == 1) {
+        inputSlice = inputValue;
+        if (inputIndex) {
+          indexSlice = inputIndex;
+        }
+      } else {
+        inputSlice = vector::ExtractOp::create(rewriter, loc, inputValue,
+                                               parallelIndices);
+        if (inputIndex) {
+          indexSlice = vector::ExtractOp::create(rewriter, loc, inputIndex,
+                                                 parallelIndices);
+        }
+      }
+
+      auto forOp = scf::ForOp::create(rewriter, loc, c0, cRedSize, c1,
+                                      ValueRange{accVal, accIdx});
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(forOp.getBody());
+        Value iv = forOp.getInductionVar();
+        Value bestVal = forOp.getRegionIterArg(0);
+        Value bestIdx = forOp.getRegionIterArg(1);
+
+        Value candidate =
+            vector::ExtractOp::create(rewriter, loc, inputSlice, iv);
+
+        Value cmpResult =
+            cloneComparatorRegion(rewriter, op.getRegion(), candidate, bestVal);
+
+        Value newVal = arith::SelectOp::create(rewriter, loc, cmpResult,
+                                               candidate, bestVal);
+
+        Value candidateIdx;
+        if (inputIndex) {
+          candidateIdx =
+              vector::ExtractOp::create(rewriter, loc, indexSlice, iv);
+        } else {
+          candidateIdx = iv;
+          if (indexBase) {
+            candidateIdx =
+                arith::AddIOp::create(rewriter, loc, indexBase, candidateIdx);
+          }
+          if (candidateIdx.getType() != indexElemTy) {
+            candidateIdx = arith::IndexCastOp::create(
+                rewriter, loc, indexElemTy, candidateIdx);
+          }
+        }
+
+        Value newIdx = arith::SelectOp::create(rewriter, loc, cmpResult,
+                                               candidateIdx, bestIdx);
+
+        scf::YieldOp::create(rewriter, loc, ValueRange{newVal, newIdx});
+      }
+
+      Value reducedVal = forOp.getResult(0);
+      Value reducedIdx = forOp.getResult(1);
+
+      if (resultValueType.getRank() == 0) {
+        resultValue = vector::BroadcastOp::create(rewriter, loc,
+                                                  resultValueType, reducedVal);
+        resultIndex = vector::BroadcastOp::create(rewriter, loc,
+                                                  resultIndexType, reducedIdx);
+      } else {
+        resultValue = vector::InsertOp::create(rewriter, loc, reducedVal,
+                                               resultValue, parallelIndices);
+        resultIndex = vector::InsertOp::create(rewriter, loc, reducedIdx,
+                                               resultIndex, parallelIndices);
+      }
+    }
+
+    rewriter.replaceOp(op, ValueRange{resultValue, resultIndex});
+    return success();
+  }
+};
+
+struct LowerArgCompareToVectorPass final
+    : impl::LowerArgCompareToVectorPassBase<LowerArgCompareToVectorPass> {
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.add<LowerArgCompareToVector>(ctx);
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+void populateLowerArgCompareToVectorPatterns(RewritePatternSet &patterns) {
+  patterns.add<LowerArgCompareToVector>(patterns.getContext());
+}
+
+} // namespace mlir::iree_compiler::IREE::VectorExt

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/LowerArgCompareToVector.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/LowerArgCompareToVector.cpp
@@ -10,11 +10,12 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE::VectorExt;
@@ -40,18 +41,7 @@ static Value cloneComparatorRegion(RewriterBase &rewriter, Region &region,
     }
   }
   auto yieldOp = cast<YieldOp>(block.getTerminator());
-  return mapper.lookup(yieldOp.getValues()[0]);
-}
-
-static SmallVector<int64_t> delinearizeIndex(int64_t linearIdx,
-                                             ArrayRef<int64_t> shape) {
-  SmallVector<int64_t> indices;
-  for (int64_t i = static_cast<int64_t>(shape.size()) - 1; i >= 0; --i) {
-    indices.push_back(linearIdx % shape[i]);
-    linearIdx /= shape[i];
-  }
-  std::reverse(indices.begin(), indices.end());
-  return indices;
+  return mapper.lookupOrDefault(yieldOp.getValues()[0]);
 }
 
 static SmallVector<int64_t> buildMoveToLastPerm(int64_t rank, int64_t dim) {
@@ -102,7 +92,15 @@ struct LowerArgCompareToVector final : OpRewritePattern<ArgCompareOp> {
     VectorType transposedType = cast<VectorType>(inputValue.getType());
     ArrayRef<int64_t> shape = transposedType.getShape();
 
-    SmallVector<int64_t> parallelShape(shape.begin(), shape.end() - 1);
+    // Fully unroll the parallel dimensions at compile time. Safe today
+    // because setArgCompareConfig gives every parallel loop a thread tile of
+    // 1, so `numParallelElems` is 1; static extract/insert positions also
+    // satisfy LLVMGPULegalizeNDVectors on rank > 1 vectors.
+    // TODO(Bangtian): if a config produces non-unit parallel dims, replace
+    // with an scf.for over a vector.shape_cast'd flat leading dim (a dynamic
+    // loop index can't be used directly — LLVMGPULegalizeNDVectors rejects
+    // dynamic positions on rank > 1 vectors).
+    ArrayRef<int64_t> parallelShape = shape.drop_back();
     int64_t numParallelElems = ShapedType::getNumElements(parallelShape);
 
     VectorType resultValueType = op.getInitValueType();
@@ -118,20 +116,12 @@ struct LowerArgCompareToVector final : OpRewritePattern<ArgCompareOp> {
 
     for (int64_t p = 0; p < numParallelElems; ++p) {
       SmallVector<int64_t> parallelIndices =
-          delinearizeIndex(p, parallelShape);
+          delinearize(p, computeStrides(parallelShape));
 
-      Value accVal, accIdx;
-      if (resultValueType.getRank() == 0) {
-        accVal = vector::ExtractOp::create(rewriter, loc, initValue,
-                                           ArrayRef<int64_t>{});
-        accIdx = vector::ExtractOp::create(rewriter, loc, initIndex,
-                                           ArrayRef<int64_t>{});
-      } else {
-        accVal = vector::ExtractOp::create(rewriter, loc, initValue,
-                                           parallelIndices);
-        accIdx = vector::ExtractOp::create(rewriter, loc, initIndex,
-                                           parallelIndices);
-      }
+      Value accVal =
+          vector::ExtractOp::create(rewriter, loc, initValue, parallelIndices);
+      Value accIdx =
+          vector::ExtractOp::create(rewriter, loc, initIndex, parallelIndices);
 
       Value inputSlice, indexSlice;
       if (rank == 1) {
@@ -215,9 +205,7 @@ struct LowerArgCompareToVectorPass final
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<LowerArgCompareToVector>(ctx);
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-      return signalPassFailure();
-    }
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.td
@@ -28,6 +28,8 @@ def LowerTransferGatherScatterToVectorPass :
   ];
 }
 
+// TODO(Bangtian): Consolidate per-op lowering passes into a single generic
+// pass once we have more such lowerings.
 def LowerArgCompareToVectorPass :
     Pass<"iree-vector-ext-lower-arg-compare-to-vector", "func::FuncOp"> {
   let summary = "Lower iree_vector_ext.arg_compare to vector/SCF ops";

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.td
@@ -28,4 +28,15 @@ def LowerTransferGatherScatterToVectorPass :
   ];
 }
 
+def LowerArgCompareToVectorPass :
+    Pass<"iree-vector-ext-lower-arg-compare-to-vector", "func::FuncOp"> {
+  let summary = "Lower iree_vector_ext.arg_compare to vector/SCF ops";
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::scf::SCFDialect",
+    "::mlir::vector::VectorDialect",
+    "::mlir::iree_compiler::IREE::VectorExt::IREEVectorExtDialect"
+  ];
+}
+
 #endif // IREE_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_PASSES

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h
@@ -17,6 +17,8 @@ void populateVectorTransferGatherScatterLoweringPatterns(
 void populateLowerTransferGatherScatterToVectorPatterns(
     RewritePatternSet &patterns);
 
+void populateLowerArgCompareToVectorPatterns(RewritePatternSet &patterns);
+
 }; // namespace mlir::iree_compiler::IREE::VectorExt
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_TRANSFORMS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
+            "lower_arg_compare.mlir",
             "lower_transfer_gather_scatter_to_vector.mlir",
             "vector_ext_fold_unit_extent_dims.mlir",
             "vectorize_vector_ext_ops.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "lower_arg_compare.mlir"
     "lower_transfer_gather_scatter_to_vector.mlir"
     "vector_ext_fold_unit_extent_dims.mlir"
     "vectorize_vector_ext_ops.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/lower_arg_compare.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/lower_arg_compare.mlir
@@ -1,0 +1,261 @@
+// RUN: iree-opt %s -pass-pipeline='builtin.module(func.func(iree-vector-ext-lower-arg-compare-to-vector))' --split-input-file --mlir-print-local-scope | FileCheck %s
+
+func.func @argmax_1d_i32(%input: vector<128xf32>,
+                         %init_val: vector<f32>,
+                         %init_idx: vector<i32>)
+    -> (vector<f32>, vector<i32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<128xf32>)
+    inits(%init_val, %init_idx : vector<f32>, vector<i32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<f32>, vector<i32>
+  return %result#0, %result#1 : vector<f32>, vector<i32>
+}
+// CHECK-LABEL: func.func @argmax_1d_i32
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C128:.*]] = arith.constant 128 : index
+// CHECK:         %[[INIT_VAL:.*]] = vector.extract %{{.*}}[] : f32 from vector<f32>
+// CHECK:         %[[INIT_IDX:.*]] = vector.extract %{{.*}}[] : i32 from vector<i32>
+// CHECK:         %[[FOR:.*]]:2 = scf.for %[[IV:.*]] = %[[C0]] to %[[C128]] step %[[C1]]
+// CHECK-SAME:        iter_args(%[[BV:.*]] = %[[INIT_VAL]], %[[BI:.*]] = %[[INIT_IDX]])
+// CHECK:           %[[CAND:.*]] = vector.extract %{{.*}}[%[[IV]]] : f32 from vector<128xf32>
+// CHECK:           %[[CMP:.*]] = arith.cmpf ogt, %[[CAND]], %[[BV]] : f32
+// CHECK:           %[[SEL_VAL:.*]] = arith.select %[[CMP]], %[[CAND]], %[[BV]] : f32
+// CHECK:           %[[IDX:.*]] = arith.index_cast %[[IV]] : index to i32
+// CHECK:           %[[SEL_IDX:.*]] = arith.select %[[CMP]], %[[IDX]], %[[BI]] : i32
+// CHECK:           scf.yield %[[SEL_VAL]], %[[SEL_IDX]]
+// CHECK:         vector.broadcast %[[FOR]]#0 : f32 to vector<f32>
+// CHECK:         vector.broadcast %[[FOR]]#1 : i32 to vector<i32>
+
+// -----
+
+func.func @argmax_1d_i64(%input: vector<128xf32>,
+                         %init_val: vector<f32>,
+                         %init_idx: vector<i64>)
+    -> (vector<f32>, vector<i64>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<128xf32>)
+    inits(%init_val, %init_idx : vector<f32>, vector<i64>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<f32>, vector<i64>
+  return %result#0, %result#1 : vector<f32>, vector<i64>
+}
+// CHECK-LABEL: func.func @argmax_1d_i64
+// CHECK:         arith.index_cast %{{.*}} : index to i64
+
+// -----
+
+func.func @argmax_2d_reduce_last_dim(%input: vector<4x128xf32>,
+                                     %init_val: vector<4xf32>,
+                                     %init_idx: vector<4xi32>)
+    -> (vector<4xf32>, vector<4xi32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(1)
+    ins(%input : vector<4x128xf32>)
+    inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
+}
+// CHECK-LABEL: func.func @argmax_2d_reduce_last_dim
+// CHECK-NOT:     vector.transpose
+// CHECK:         arith.constant 128 : index
+// CHECK-COUNT-4: scf.for {{.*}} to %{{.*}} step
+// CHECK:         return %{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi32>
+
+// -----
+
+func.func @argmax_2d_reduce_first_dim(%input: vector<2x4xf32>,
+                                      %init_val: vector<4xf32>,
+                                      %init_idx: vector<4xi64>)
+    -> (vector<4xf32>, vector<4xi64>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<2x4xf32>)
+    inits(%init_val, %init_idx : vector<4xf32>, vector<4xi64>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi64>
+  return %result#0, %result#1 : vector<4xf32>, vector<4xi64>
+}
+// CHECK-LABEL: func.func @argmax_2d_reduce_first_dim
+// CHECK:         arith.constant 2 : index
+// CHECK:         vector.transpose %{{.*}}, [1, 0] : vector<2x4xf32> to vector<4x2xf32>
+// CHECK-COUNT-4: scf.for {{.*}} to %{{.*}} step
+// CHECK:         arith.index_cast %{{.*}} : index to i64
+// CHECK:         return %{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi64>
+
+// -----
+
+func.func @argmax_3d_reduce_first_dim(%input: vector<2x3x4xf32>,
+                                      %init_val: vector<3x4xf32>,
+                                      %init_idx: vector<3x4xi64>)
+    -> (vector<3x4xf32>, vector<3x4xi64>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<2x3x4xf32>)
+    inits(%init_val, %init_idx : vector<3x4xf32>, vector<3x4xi64>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<3x4xf32>, vector<3x4xi64>
+  return %result#0, %result#1 : vector<3x4xf32>, vector<3x4xi64>
+}
+// CHECK-LABEL: func.func @argmax_3d_reduce_first_dim
+// CHECK:         arith.constant 2 : index
+// CHECK:         vector.transpose %{{.*}}, [1, 2, 0] : vector<2x3x4xf32> to vector<3x4x2xf32>
+// CHECK-COUNT-12: scf.for {{.*}} to %{{.*}} step
+// CHECK:         return %{{.*}}, %{{.*}} : vector<3x4xf32>, vector<3x4xi64>
+
+// -----
+
+func.func @argmax_3d_reduce_middle_dim(%input: vector<3x4x5xf32>,
+                                       %init_val: vector<3x5xf32>,
+                                       %init_idx: vector<3x5xi32>)
+    -> (vector<3x5xf32>, vector<3x5xi32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(1)
+    ins(%input : vector<3x4x5xf32>)
+    inits(%init_val, %init_idx : vector<3x5xf32>, vector<3x5xi32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<3x5xf32>, vector<3x5xi32>
+  return %result#0, %result#1 : vector<3x5xf32>, vector<3x5xi32>
+}
+// CHECK-LABEL: func.func @argmax_3d_reduce_middle_dim
+// CHECK:         arith.constant 4 : index
+// CHECK:         vector.transpose %{{.*}}, [0, 2, 1] : vector<3x4x5xf32> to vector<3x5x4xf32>
+// CHECK-COUNT-15: scf.for {{.*}} to %{{.*}} step
+// CHECK:         return %{{.*}}, %{{.*}} : vector<3x5xf32>, vector<3x5xi32>
+
+// -----
+
+func.func @argmax_explicit_index_last_dim(%input_val: vector<4x32xf32>,
+                                          %input_idx: vector<4x32xi32>,
+                                          %init_val: vector<4xf32>,
+                                          %init_idx: vector<4xi32>)
+    -> (vector<4xf32>, vector<4xi32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(1)
+    ins(%input_val, %input_idx : vector<4x32xf32>, vector<4x32xi32>)
+    inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
+}
+// CHECK-LABEL: func.func @argmax_explicit_index_last_dim
+// CHECK-NOT:     vector.transpose
+// CHECK-NOT:     arith.index_cast
+// CHECK-COUNT-4: scf.for
+// CHECK-NOT:     scf.for
+// CHECK:         vector.extract %{{.*}}[%{{.*}}] : i32 from vector<32xi32>
+// CHECK:         return %{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi32>
+
+// -----
+
+func.func @argmax_explicit_index_first_dim(%input_val: vector<2x4xf32>,
+                                           %input_idx: vector<2x4xi32>,
+                                           %init_val: vector<4xf32>,
+                                           %init_idx: vector<4xi32>)
+    -> (vector<4xf32>, vector<4xi32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input_val, %input_idx : vector<2x4xf32>, vector<2x4xi32>)
+    inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
+}
+// CHECK-LABEL: func.func @argmax_explicit_index_first_dim
+// CHECK-DAG:     vector.transpose %{{.*}}, [1, 0] : vector<2x4xf32> to vector<4x2xf32>
+// CHECK-DAG:     vector.transpose %{{.*}}, [1, 0] : vector<2x4xi32> to vector<4x2xi32>
+// CHECK-NOT:     arith.index_cast
+// CHECK-COUNT-4: scf.for
+// CHECK-NOT:     scf.for
+// CHECK:         return %{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi32>
+
+// -----
+
+func.func @argmax_index_base(%input: vector<128xf32>,
+                             %init_val: vector<f32>,
+                             %init_idx: vector<i32>,
+                             %base: index)
+    -> (vector<f32>, vector<i32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<128xf32>)
+    inits(%init_val, %init_idx : vector<f32>, vector<i32>)
+    index_base(%base : index) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<f32>, vector<i32>
+  return %result#0, %result#1 : vector<f32>, vector<i32>
+}
+// CHECK-LABEL: func.func @argmax_index_base
+// CHECK-SAME:    %[[BASE:[a-zA-Z0-9]+]]: index
+// CHECK:         scf.for %[[IV:[a-zA-Z0-9]+]] =
+// CHECK:           arith.addi %[[BASE]], %[[IV]] : index
+// CHECK:           arith.index_cast %{{.*}} : index to i32
+// CHECK:         vector.broadcast %{{.*}} : f32 to vector<f32>
+// CHECK:         vector.broadcast %{{.*}} : i32 to vector<i32>
+
+// -----
+
+func.func @argmin_1d(%input: vector<128xf32>,
+                     %init_val: vector<f32>,
+                     %init_idx: vector<i32>)
+    -> (vector<f32>, vector<i32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<128xf32>)
+    inits(%init_val, %init_idx : vector<f32>, vector<i32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf olt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<f32>, vector<i32>
+  return %result#0, %result#1 : vector<f32>, vector<i32>
+}
+// CHECK-LABEL: func.func @argmin_1d
+// CHECK:         scf.for
+// CHECK:           arith.cmpf olt, %{{.*}}, %{{.*}} : f32
+// CHECK:           arith.select
+// CHECK:           arith.select
+// CHECK:           scf.yield
+// CHECK:         vector.broadcast %{{.*}} : f32 to vector<f32>
+// CHECK:         vector.broadcast %{{.*}} : i32 to vector<i32>
+
+// -----
+
+func.func @argmax_scalable_rejection(%input: vector<[128]xf32>,
+                                     %init_val: vector<f32>,
+                                     %init_idx: vector<i32>)
+    -> (vector<f32>, vector<i32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<[128]xf32>)
+    inits(%init_val, %init_idx : vector<f32>, vector<i32>) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<f32>, vector<i32>
+  return %result#0, %result#1 : vector<f32>, vector<i32>
+}
+// CHECK-LABEL: func.func @argmax_scalable_rejection
+// CHECK:         iree_vector_ext.arg_compare
+// CHECK-NOT:     scf.for

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/lower_arg_compare.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/lower_arg_compare.mlir
@@ -70,6 +70,7 @@ func.func @argmax_2d_reduce_last_dim(%input: vector<4x128xf32>,
 // CHECK-NOT:     vector.transpose
 // CHECK:         arith.constant 128 : index
 // CHECK-COUNT-4: scf.for {{.*}} to %{{.*}} step
+// CHECK-NOT:     scf.for
 // CHECK:         return %{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi32>
 
 // -----
@@ -89,9 +90,10 @@ func.func @argmax_2d_reduce_first_dim(%input: vector<2x4xf32>,
   return %result#0, %result#1 : vector<4xf32>, vector<4xi64>
 }
 // CHECK-LABEL: func.func @argmax_2d_reduce_first_dim
-// CHECK:         arith.constant 2 : index
-// CHECK:         vector.transpose %{{.*}}, [1, 0] : vector<2x4xf32> to vector<4x2xf32>
+// CHECK-DAG:     arith.constant 2 : index
+// CHECK-DAG:     vector.transpose %{{.*}}, [1, 0] : vector<2x4xf32> to vector<4x2xf32>
 // CHECK-COUNT-4: scf.for {{.*}} to %{{.*}} step
+// CHECK-NOT:     scf.for
 // CHECK:         arith.index_cast %{{.*}} : index to i64
 // CHECK:         return %{{.*}}, %{{.*}} : vector<4xf32>, vector<4xi64>
 
@@ -112,9 +114,10 @@ func.func @argmax_3d_reduce_first_dim(%input: vector<2x3x4xf32>,
   return %result#0, %result#1 : vector<3x4xf32>, vector<3x4xi64>
 }
 // CHECK-LABEL: func.func @argmax_3d_reduce_first_dim
-// CHECK:         arith.constant 2 : index
-// CHECK:         vector.transpose %{{.*}}, [1, 2, 0] : vector<2x3x4xf32> to vector<3x4x2xf32>
+// CHECK-DAG:     arith.constant 2 : index
+// CHECK-DAG:     vector.transpose %{{.*}}, [1, 2, 0] : vector<2x3x4xf32> to vector<3x4x2xf32>
 // CHECK-COUNT-12: scf.for {{.*}} to %{{.*}} step
+// CHECK-NOT:     scf.for
 // CHECK:         return %{{.*}}, %{{.*}} : vector<3x4xf32>, vector<3x4xi64>
 
 // -----
@@ -134,9 +137,10 @@ func.func @argmax_3d_reduce_middle_dim(%input: vector<3x4x5xf32>,
   return %result#0, %result#1 : vector<3x5xf32>, vector<3x5xi32>
 }
 // CHECK-LABEL: func.func @argmax_3d_reduce_middle_dim
-// CHECK:         arith.constant 4 : index
-// CHECK:         vector.transpose %{{.*}}, [0, 2, 1] : vector<3x4x5xf32> to vector<3x5x4xf32>
+// CHECK-DAG:     arith.constant 4 : index
+// CHECK-DAG:     vector.transpose %{{.*}}, [0, 2, 1] : vector<3x4x5xf32> to vector<3x5x4xf32>
 // CHECK-COUNT-15: scf.for {{.*}} to %{{.*}} step
+// CHECK-NOT:     scf.for
 // CHECK:         return %{{.*}}, %{{.*}} : vector<3x5xf32>, vector<3x5xi32>
 
 // -----
@@ -239,6 +243,78 @@ func.func @argmin_1d(%input: vector<128xf32>,
 // CHECK:           scf.yield
 // CHECK:         vector.broadcast %{{.*}} : f32 to vector<f32>
 // CHECK:         vector.broadcast %{{.*}} : i32 to vector<i32>
+
+// -----
+
+func.func @argmax_captured_predicate(%input: vector<128xf32>,
+                                     %init_val: vector<f32>,
+                                     %init_idx: vector<i32>,
+                                     %external_cmp: i1)
+    -> (vector<f32>, vector<i32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<128xf32>)
+    inits(%init_val, %init_idx : vector<f32>, vector<i32>) {
+  ^bb0(%a: f32, %b: f32):
+    iree_vector_ext.yield %external_cmp : i1
+  } -> vector<f32>, vector<i32>
+  return %result#0, %result#1 : vector<f32>, vector<i32>
+}
+// CHECK-LABEL: func.func @argmax_captured_predicate
+// CHECK-SAME:    %[[EXT_CMP:[a-zA-Z0-9]+]]: i1
+// CHECK:         scf.for
+// CHECK:           arith.select %[[EXT_CMP]]
+// CHECK:           arith.select %[[EXT_CMP]]
+// CHECK:           scf.yield
+
+// -----
+
+func.func @argmax_multi_op_comparator(%input: vector<128xf32>,
+                                      %init_val: vector<f32>,
+                                      %init_idx: vector<i32>)
+    -> (vector<f32>, vector<i32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(0)
+    ins(%input : vector<128xf32>)
+    inits(%init_val, %init_idx : vector<f32>, vector<i32>) {
+  ^bb0(%a: f32, %b: f32):
+    %diff = arith.subf %a, %b : f32
+    %zero = arith.constant 0.0 : f32
+    %cmp = arith.cmpf ogt, %diff, %zero : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<f32>, vector<i32>
+  return %result#0, %result#1 : vector<f32>, vector<i32>
+}
+// CHECK-LABEL: func.func @argmax_multi_op_comparator
+// CHECK:         scf.for
+// CHECK:           arith.subf
+// CHECK:           arith.cmpf ogt
+// CHECK:           arith.select
+// CHECK:           arith.select
+// CHECK:           scf.yield
+
+// -----
+
+func.func @argmax_index_base_2d(%input: vector<4x128xf32>,
+                                 %init_val: vector<4xf32>,
+                                 %init_idx: vector<4xi32>,
+                                 %base: index)
+    -> (vector<4xf32>, vector<4xi32>) {
+  %result:2 = iree_vector_ext.arg_compare
+    dimension(1)
+    ins(%input : vector<4x128xf32>)
+    inits(%init_val, %init_idx : vector<4xf32>, vector<4xi32>)
+    index_base(%base : index) {
+  ^bb0(%a: f32, %b: f32):
+    %cmp = arith.cmpf ogt, %a, %b : f32
+    iree_vector_ext.yield %cmp : i1
+  } -> vector<4xf32>, vector<4xi32>
+  return %result#0, %result#1 : vector<4xf32>, vector<4xi32>
+}
+// CHECK-LABEL: func.func @argmax_index_base_2d
+// CHECK-COUNT-4: arith.addi
+// CHECK-NOT:     arith.addi
+// CHECK-NOT:     iree_vector_ext.arg_compare
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -576,6 +576,10 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
                             /*enableMasking=*/true,
                             /*foldIdentitySlices=*/true,
                             /*decomposeMasks=*/false);
+  // Lower vectorized arg_compare to scf.for + vector ops before bufferization.
+  // Only needed for the TileAndFuse pipeline; the VectorDistribute pipeline
+  // handles arg_compare later via DistributeArgCompare in
+  // LLVMGPUVectorDistributePass, so this pass is not part of that pipeline.
   funcPassManager.addPass(IREE::VectorExt::createLowerArgCompareToVectorPass());
   funcPassManager.addPass(createCleanupBufferAllocViewPass());
   funcPassManager.addPass(createGPUCombineValueSemanticBarriersPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -16,6 +16,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
@@ -272,8 +273,7 @@ static void tileAndBufferize(OpPassManager &funcPassManager) {
 static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
                                       bool vectorizeCopies, bool enableMasking,
                                       bool foldIdentitySlices,
-                                      bool decomposeMasks,
-                                      bool vectorizeArgCompare) {
+                                      bool decomposeMasks) {
   funcPassManager.addPass(createDecomposeConvolutionToLowerDimOpsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -287,7 +287,6 @@ static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
   options.foldCastIntoContract = true;
   options.enableVectorMasking = enableMasking;
   options.vectorizeMapStore = true;
-  options.vectorizeArgCompare = vectorizeArgCompare;
   funcPassManager.addPass(createGenericVectorizationPass(options));
   // Im2col decomposition runs after vectorization so that im2col ops get
   // direct vectorization via VectorizableOpInterface when possible. Any
@@ -328,8 +327,7 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager) {
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/true,
                             /*enableMasking=*/false,
                             /*foldIdentitySlices=*/false,
-                            /*decomposeMasks=*/false,
-                            /*vectorizeArgCompare=*/true);
+                            /*decomposeMasks=*/false);
 
   // tensor to memref
   addBufferizePasses(funcPassManager);
@@ -574,18 +572,11 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createGPUCombineValueSemanticBarriersPass());
 
   // Step 6. Vectorize.
-  // Skip vectorization of `iree_linalg_ext.arg_compare` here: the resulting
-  // `iree_vector_ext.arg_compare` only has a lowering through the nested-layout
-  // distribution patterns owned by the VectorDistribute pipeline. Ops routed
-  // to TileAndFuse (small reductions, f64) need the scalar-loop lowering from
-  // `LinalgExtToLoops` instead. This gate is intentionally narrow.
-  // TODO(#24365): Remove this option once a generic vector lowering for
-  // `iree_vector_ext.arg_compare` exists.
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false,
                             /*enableMasking=*/true,
                             /*foldIdentitySlices=*/true,
-                            /*decomposeMasks=*/false,
-                            /*vectorizeArgCompare=*/false);
+                            /*decomposeMasks=*/false);
+  funcPassManager.addPass(IREE::VectorExt::createLowerArgCompareToVectorPass());
   funcPassManager.addPass(createCleanupBufferAllocViewPass());
   funcPassManager.addPass(createGPUCombineValueSemanticBarriersPass());
 
@@ -670,8 +661,7 @@ void addGPUWinogradVectorizePassPipeline(OpPassManager &funcPassManager) {
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/true,
                             /*enableMasking=*/false,
                             /*foldIdentitySlices=*/false,
-                            /*decomposeMasks=*/false,
-                            /*vectorizeArgCompare=*/true);
+                            /*decomposeMasks=*/false);
 
   // tensor to memref
   addBufferizePasses(funcPassManager);
@@ -834,8 +824,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/true,
                             /*enableMasking=*/true,
                             /*foldIdentitySlices=*/false,
-                            /*decomposeMasks=*/true,
-                            /*vectorizeArgCompare=*/true);
+                            /*decomposeMasks=*/true);
 
   // Allocate tensors for copies to shared memory.
   funcPassManager.addPass(createGPUVectorAllocPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "config_vector_distribute_reduction_gfx942.mlir",
             "config_vector_distribute_reduction_gfx950.mlir",
             "configure_buffer_instructions.mlir",
+            "pipeline_argcompare_tile_and_fuse.mlir",
             "pipeline_argcompare_vector_distribute.mlir",
             "pipeline_direct_conv_tile_and_fuse.mlir",
             "pipeline_elementwise_f8fnuz.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_lit_test_suite(
     "config_vector_distribute_reduction_gfx942.mlir"
     "config_vector_distribute_reduction_gfx950.mlir"
     "configure_buffer_instructions.mlir"
+    "pipeline_argcompare_tile_and_fuse.mlir"
     "pipeline_argcompare_vector_distribute.mlir"
     "pipeline_direct_conv_tile_and_fuse.mlir"
     "pipeline_elementwise_f8fnuz.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_argcompare_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_argcompare_tile_and_fuse.mlir
@@ -1,0 +1,177 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN:   --iree-codegen-llvmgpu-rocdl-lowering-pipeline='include-llvm-lowering=false' %s | FileCheck %s
+
+// Small 3-D reduction over dim 0 (non-last-dim). Reduction size 2 is smaller
+// than subgroup size, so setReductionConfig rejects and falls through to
+// setArgCompareConfig (TileAndFuse).
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#config = #iree_gpu.lowering_config<{thread = [0, 1, 1], workgroup = [0, 1, 4]}>
+#translation = #iree_codegen.translation_info<
+  pipeline = #iree_gpu.pipeline<TileAndFuse>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64>
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_small_3d_dim0()
+  attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x3x4xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xi64>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 3, 4], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2x3x4xf32>> -> tensor<2x3x4xf32>
+  %4 = tensor.empty() : tensor<3x4xf32>
+  %5 = tensor.empty() : tensor<3x4xi64>
+  %6:2 = iree_linalg_ext.arg_compare {lowering_config = #config} dimension(0) ins(%3 : tensor<2x3x4xf32>) outs(%4, %5 : tensor<3x4xf32>, tensor<3x4xi64>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<3x4xf32>, tensor<3x4xi64>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0, 0], sizes = [3, 4], strides = [1, 1] : tensor<3x4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xf32>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0, 0], sizes = [3, 4], strides = [1, 1] : tensor<3x4xi64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<3x4xi64>>
+  return
+}
+
+// Non-last-dim reduction over dim 0: the 3-D input is read as vector<2x1x1xf32>
+// and shape_cast to vector<2xf32> before the scf.for reduction loop.
+// CHECK-LABEL: func.func @argcompare_small_3d_dim0
+//     CHECK:     vector.shape_cast %{{.*}} : vector<2x1x1xf32> to vector<2xf32>
+//     CHECK:     scf.for
+//     CHECK:       arith.cmpf ogt
+//     CHECK:       arith.select
+//     CHECK:     vector.transfer_write
+// CHECK-NOT:     iree_vector_ext.arg_compare
+// CHECK-NOT:     iree_linalg_ext.arg_compare
+
+// -----
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#config = #iree_gpu.lowering_config<{thread = [1, 0], workgroup = [4, 0]}>
+#translation = #iree_codegen.translation_info<
+  pipeline = #iree_gpu.pipeline<TileAndFuse>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64>
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_last_dim_reduction()
+  attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x128xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xi32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [4, 128], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x128xf32>> -> tensor<4x128xf32>
+  %4 = tensor.empty() : tensor<4xf32>
+  %5 = tensor.empty() : tensor<4xi32>
+  %6:2 = iree_linalg_ext.arg_compare {lowering_config = #config} dimension(1) ins(%3 : tensor<4x128xf32>) outs(%4, %5 : tensor<4xf32>, tensor<4xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<4xf32>, tensor<4xi32>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0], sizes = [4], strides = [1] : tensor<4xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xf32>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0], sizes = [4], strides = [1] : tensor<4xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<4xi32>>
+  return
+}
+
+// Last-dim reduction: no transpose/shape_cast needed; input read directly as
+// vector<128xf32> and reduced via scf.for.
+// CHECK-LABEL: func.func @argcompare_last_dim_reduction
+// CHECK-NOT:     vector.transpose
+//     CHECK:     vector.transfer_read {{.*}} vector<128xf32>
+//     CHECK:     scf.for
+//     CHECK:       arith.cmpf ogt
+//     CHECK:       arith.select
+//     CHECK:     vector.transfer_write
+// CHECK-NOT:     iree_vector_ext.arg_compare
+// CHECK-NOT:     iree_linalg_ext.arg_compare
+
+// -----
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#config = #iree_gpu.lowering_config<{thread = [1, 0], workgroup = [8, 0]}>
+#translation = #iree_codegen.translation_info<
+  pipeline = #iree_gpu.pipeline<TileAndFuse>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64>
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_unaligned_reduction()
+  attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x100xf32>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf32>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 100], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x100xf32>> -> tensor<8x100xf32>
+  %4 = tensor.empty() : tensor<8xf32>
+  %5 = tensor.empty() : tensor<8xi32>
+  %6:2 = iree_linalg_ext.arg_compare {lowering_config = #config} dimension(1) ins(%3 : tensor<8x100xf32>) outs(%4, %5 : tensor<8xf32>, tensor<8xi32>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<8xf32>, tensor<8xi32>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf32>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0], sizes = [8], strides = [1] : tensor<8xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
+  return
+}
+
+// Unaligned reduction: input read as vector<100xf32>, reduced via scf.for.
+// CHECK-LABEL: func.func @argcompare_unaligned_reduction
+//     CHECK:     vector.transfer_read {{.*}} vector<100xf32>
+//     CHECK:     scf.for
+//     CHECK:       arith.cmpf ogt
+//     CHECK:       arith.select
+// CHECK-NOT:     iree_vector_ext.arg_compare
+// CHECK-NOT:     iree_linalg_ext.arg_compare
+
+// -----
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#config = #iree_gpu.lowering_config<{thread = [1, 0], workgroup = [8, 0]}>
+#translation = #iree_codegen.translation_info<
+  pipeline = #iree_gpu.pipeline<TileAndFuse>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64>
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_f64_fallback()
+  attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x256xf64>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf64>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x256xf64>> -> tensor<8x256xf64>
+  %4 = tensor.empty() : tensor<8xf64>
+  %5 = tensor.empty() : tensor<8xi32>
+  %6:2 = iree_linalg_ext.arg_compare {lowering_config = #config} dimension(1) ins(%3 : tensor<8x256xf64>) outs(%4, %5 : tensor<8xf64>, tensor<8xi32>) {
+    ^bb0(%a: f64, %b: f64):
+      %cmp = arith.cmpf ogt, %a, %b : f64
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<8xf64>, tensor<8xi32>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf64>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0], sizes = [8], strides = [1] : tensor<8xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi32>>
+  return
+}
+
+// f64 fallback: input read as vector<256xf64>, reduced via scf.for with f64 compare.
+// CHECK-LABEL: func.func @argcompare_f64_fallback
+//     CHECK:     vector.transfer_read {{.*}} vector<256xf64>
+//     CHECK:     scf.for
+//     CHECK:       arith.cmpf ogt, %{{.*}}, %{{.*}} : f64
+//     CHECK:       arith.select
+// CHECK-NOT:     iree_vector_ext.arg_compare
+// CHECK-NOT:     iree_linalg_ext.arg_compare


### PR DESCRIPTION
This PR adds `LowerArgCompareToVectorPass`, which lowers iree_vector_ext.arg_compare to scf.for loops with scalar `vector.extract/vector.insert` and cloned comparator regions. This provides a generic lowering path for backends that don't use the AMDGPU-specific ballot/DPP/shuffle lowering in the VectorDistribute pipeline.  

The pass is integrated into the TileAndFuse GPU pipeline after vectorization, replacing the previous workaround that skipped arg_compare vectorization entirely (`vectorizeArgCompare=false`). The redundant `vectorizeArgCompare`option (always true now) is removed. 

Closes #24365         
Assisted-by:  [Claude Code](https://claude.ai/code)                                                                                                                                                                                                                                                                                                                                                                                             