### PR TITLE
[GlobalOptimization] Raise generic-form gathers to iree_linalg_ext.gather

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -16,6 +16,7 @@
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
@@ -128,6 +129,14 @@ void SPIRVTileAndDistributePass::runOnOperation() {
   MLIRContext *context = &getContext();
   mlir::FunctionOpInterface funcOp = getOperation();
   if (!isEntryPoint(funcOp)) {
+    return;
+  }
+
+  // A dispatch whose root compute op (e.g. `iree_linalg_ext.gather`) has
+  // already been canonicalized away by the time invocation-level tiling runs
+  // should be a no-op for this pass. Downstream `memref.copy -> linalg.copy ->
+  // scf` lowering takes care of distribution. Bail gracefully in such cases.
+  if (getComputeOps(funcOp).empty()) {
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -460,3 +460,32 @@ hal.executable @matvec {
 //       CHECK:       linalg.matvec
 //  CHECK-SAME:         ins(%[[INPUT]], %[[B]] : memref<1x1024xf32, strided<[1024, 1], offset: ?>>, memref<1024xf32>
 //  CHECK-SAME:         outs(%[[OUTPUT]] : memref<1xf32, strided<[1], offset: ?>>)
+
+// -----
+
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<BaseDistribute> workgroup_size = [64, 1, 1]>
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @copy_only_dispatch {
+  hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
+    hal.executable.export public @copy_only_dispatch layout(#pipeline_layout) attributes {
+      workgroup_size = [64: index, 1: index, 1: index],
+      translation_info = #translation
+    }
+    builtin.module {
+      func.func @copy_only_dispatch() {
+        %c0 = arith.constant 0 : index
+        %src = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<1x5xi32>
+        %dst = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<1x5xi32>
+        memref.copy %src, %dst : memref<1x5xi32> to memref<1x5xi32>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @copy_only_dispatch()
+//       CHECK:   memref.copy
+//   CHECK-NOT:   gpu.thread_id

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -41,6 +41,209 @@ namespace {
 // Slice Raising
 //===----------------------------------------------------------------------===//
 
+/// Matches a linalg.generic operation that has the structural shape of a
+/// gather (a single tensor.extract whose indices come from one or more
+/// `arith.index_cast` of a block argument fed by a single "indices" input,
+/// with the remaining indices being `linalg.index` ops along passthrough
+/// dimensions) and raises it to `iree_linalg_ext.gather`.
+///
+/// This is the form `torch.aten.index_select` lowers to via torch-mlir, and
+/// without raising it the `iree_linalg_ext.attention` op cannot fuse the
+/// gather into its dispatch (the dispatch creation pass intentionally only
+/// clones the `iree_linalg_ext.gather` form -- see PR #20866 and its
+/// `dont_clone_gather_like` test). Lifting the form here, before dispatch
+/// creation, lets paged-attention models collapse to a single attention
+/// dispatch.
+///
+/// The current implementation handles `index_depth == 1` (a single source
+/// dimension is gathered, which is the only shape `torch.aten.index_select`
+/// produces). All other source dimensions must be passthrough (`linalg.index`)
+/// dimensions in source order matching the trailing output dimensions of the
+/// generic. The output indexing map must be identity.
+static FailureOr<IREE::LinalgExt::GatherOp>
+raiseGenericToGather(linalg::GenericOp linalgOp, RewriterBase &rewriter) {
+  if (!linalgOp.hasPureTensorSemantics()) {
+    return failure();
+  }
+  if (linalgOp.getNumDpsInits() != 1) {
+    return failure();
+  }
+  if (!llvm::all_of(linalgOp.getIteratorTypesArray(),
+                    linalg::isParallelIterator)) {
+    return failure();
+  }
+
+  // The output indexing map must be a rank-preserving identity. The gather op
+  // we produce has an identity output indexing map, so anything else would
+  // require an extra transpose / broadcast we don't want to materialize here.
+  OpOperand *outOperand = linalgOp.getDpsInitOperand(0);
+  AffineMap outMap = linalgOp.getMatchingIndexingMap(outOperand);
+  if (!outMap.isIdentity()) {
+    return failure();
+  }
+
+  // The body must be: zero or more pure ops that compute scalar indices, a
+  // single tensor.extract, and a yield of that extract. We tolerate other
+  // shape/index-arithmetic ops but require exactly one tensor.extract.
+  Block *body = linalgOp.getBody();
+  auto extractOps = body->getOps<tensor::ExtractOp>();
+  if (!llvm::hasSingleElement(extractOps)) {
+    return failure();
+  }
+  tensor::ExtractOp extractOp = *extractOps.begin();
+  auto yieldOp = dyn_cast<linalg::YieldOp>(body->getTerminator());
+  if (!yieldOp || yieldOp.getNumOperands() != 1 ||
+      yieldOp.getOperand(0) != extractOp.getResult()) {
+    return failure();
+  }
+  // The source of the extract must be defined outside the generic, otherwise
+  // it isn't really a gather "source".
+  Value source = extractOp.getTensor();
+  if (auto srcArg = dyn_cast<BlockArgument>(source)) {
+    if (srcArg.getOwner() == body) {
+      return failure();
+    }
+  }
+
+  // Classify each tensor.extract index into one of three buckets:
+  //   * "indexed":     arith.index_cast of a block argument fed by some ins
+  //                    operand of the linalg.generic. This is the index that
+  //                    the gather op reads from its `indices` operand.
+  //   * "passthrough": linalg.index N. This dimension flows directly from a
+  //                    parallel iteration dim into the source. The
+  //                    corresponding source dim becomes a contiguous slice
+  //                    dim of the gather result.
+  //   * everything else (incl. constants other than what we explicitly
+  //     allow) -> bail out.
+  SmallVector<int64_t> indexedSourceDims;
+  // For each indexed source dim, the index of the `ins` operand (and its
+  // corresponding block argument) that feeds the index_cast.
+  SmallVector<unsigned> indexedInsOperandIdxs;
+  // For passthrough source dims, record the loop dim used by linalg.index.
+  SmallVector<std::pair<int64_t, unsigned>> passthroughSourceDimToLoopDim;
+
+  for (auto [srcDim, indexValue] : llvm::enumerate(extractOp.getIndices())) {
+    if (auto idxOp = indexValue.getDefiningOp<linalg::IndexOp>()) {
+      passthroughSourceDimToLoopDim.emplace_back(srcDim, idxOp.getDim());
+      continue;
+    }
+    auto castOp = indexValue.getDefiningOp<arith::IndexCastOp>();
+    if (!castOp) {
+      return failure();
+    }
+    auto blockArg = dyn_cast<BlockArgument>(castOp.getIn());
+    if (!blockArg || blockArg.getOwner() != body) {
+      return failure();
+    }
+    // Block argument index in the body matches the operand index for inputs
+    // (linalg generics put inputs first, then inits).
+    unsigned argNo = blockArg.getArgNumber();
+    if (argNo >= linalgOp.getNumDpsInputs()) {
+      return failure();
+    }
+    indexedSourceDims.push_back(srcDim);
+    indexedInsOperandIdxs.push_back(argNo);
+  }
+
+  // We currently only handle index_depth == 1 (the only form
+  // torch.aten.index_select produces).
+  if (indexedSourceDims.size() != 1) {
+    return failure();
+  }
+  unsigned indicesOperandIdx = indexedInsOperandIdxs.front();
+  OpOperand *indicesOperand =
+      linalgOp.getDpsInputOperand(indicesOperandIdx);
+  Value indicesTensor = indicesOperand->get();
+  auto indicesType = dyn_cast<RankedTensorType>(indicesTensor.getType());
+  auto sourceType = dyn_cast<RankedTensorType>(source.getType());
+  auto outputType =
+      dyn_cast<RankedTensorType>(linalgOp.getResult(0).getType());
+  if (!indicesType || !sourceType || !outputType) {
+    return failure();
+  }
+
+  // Index element type must be an integer (gather op accepts int or index).
+  if (!indicesType.getElementType().isIntOrIndex()) {
+    return failure();
+  }
+
+  // Each passthrough source dim's loop dim must correspond to the trailing
+  // output dims, in source order. Because outMap is identity, loop dim k is
+  // output dim k. Concretely: with `indexDepth == 1`, output rank
+  // == batchRank + sliceRank == batchRank + (sourceRank - 1). The trailing
+  // sliceRank output dims must be the loop dims of the passthrough source
+  // dims, in source order.
+  int64_t sourceRank = sourceType.getRank();
+  int64_t outputRank = outputType.getRank();
+  int64_t sliceRank = sourceRank - /*indexDepth=*/1;
+  if (sliceRank < 0) {
+    return failure();
+  }
+  int64_t batchRank = outputRank - sliceRank;
+  if (batchRank < 1) {
+    return failure();
+  }
+  if (static_cast<int64_t>(passthroughSourceDimToLoopDim.size()) != sliceRank) {
+    return failure();
+  }
+  // Sort passthrough entries by source dim; gather expects source slice dims
+  // in order.
+  llvm::sort(passthroughSourceDimToLoopDim);
+  for (auto [i, entry] : llvm::enumerate(passthroughSourceDimToLoopDim)) {
+    int64_t srcDim = entry.first;
+    unsigned loopDim = entry.second;
+    // Source dim must skip over the indexed dim.
+    int64_t expectedSrcDim = (srcDim < indexedSourceDims[0]) ? i : i + 1;
+    if (srcDim != expectedSrcDim) {
+      return failure();
+    }
+    // The loop dim must be the matching trailing output dim.
+    if (loopDim != static_cast<unsigned>(batchRank + i)) {
+      return failure();
+    }
+  }
+
+  // The indices tensor's indexing map must project the iteration domain onto
+  // the leading batch loop dims in identity order. For index_depth == 1 the
+  // gather op expects `indices.rank == batchRank` with shape exactly the
+  // batch portion of the output.
+  AffineMap indicesMap = linalgOp.getMatchingIndexingMap(indicesOperand);
+  if (indicesMap.getNumResults() != batchRank) {
+    return failure();
+  }
+  for (unsigned d = 0; d < batchRank; ++d) {
+    auto dimExpr = dyn_cast<AffineDimExpr>(indicesMap.getResult(d));
+    if (!dimExpr || dimExpr.getPosition() != d) {
+      return failure();
+    }
+  }
+  // The batch shape of indices must match the batch portion of output.
+  if (indicesType.getShape() != outputType.getShape().take_front(batchRank)) {
+    return failure();
+  }
+
+  // All other ins operands must be unused (we'd otherwise be dropping
+  // computation on the floor).
+  for (OpOperand *insOp : linalgOp.getDpsInputOperands()) {
+    if (insOp->getOperandNumber() == indicesOperandIdx) {
+      continue;
+    }
+    BlockArgument arg = body->getArgument(insOp->getOperandNumber());
+    if (!arg.use_empty()) {
+      return failure();
+    }
+  }
+
+  // All set: emit the gather op replacing the linalg.generic.
+  Value output = outOperand->get();
+  SmallVector<int64_t> dimensionMap = {indexedSourceDims[0]};
+  auto gatherOp = IREE::LinalgExt::GatherOp::create(
+      rewriter, linalgOp.getLoc(), TypeRange{outputType},
+      /*source=*/source, /*indices=*/indicesTensor, /*mask=*/Value{},
+      /*output=*/output, dimensionMap);
+  return gatherOp;
+}
+
 /// Matches a linalg.generic operation reading data from a tensor `source` using
 /// tensor.extract, and raises the `source` tensor to an input of the linalg
 /// operation.
@@ -1023,9 +1226,22 @@ struct RaiseSpecialOpsPass
     funcOp->walk([&](linalg::GenericOp op) { genericOps.push_back(op); });
 
     for (linalg::GenericOp linalgOp : genericOps) {
-      // Try raising to tensor.extract to an input and create an linalg.generic.
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(linalgOp);
+
+      // First, try raising the generic to iree_linalg_ext.gather. This must
+      // run before raiseTensorExtractToInput because the gather form has a
+      // tensor.extract whose indices come from a captured `ins` operand
+      // (via arith.index_cast), which raiseTensorExtractToInput doesn't
+      // recognize and would prevent us from ever lifting this to a gather.
+      FailureOr<IREE::LinalgExt::GatherOp> maybeGather =
+          raiseGenericToGather(linalgOp, rewriter);
+      if (succeeded(maybeGather)) {
+        rewriter.replaceOp(linalgOp, maybeGather->getResult(0));
+        continue;
+      }
+
+      // Try raising to tensor.extract to an input and create an linalg.generic.
       FailureOr<linalg::GenericOp> maybeNewOp =
           raiseTensorExtractToInput(linalgOp, rewriter);
       if (succeeded(maybeNewOp)) {

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -24,6 +24,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -41,51 +42,58 @@ namespace {
 // Slice Raising
 //===----------------------------------------------------------------------===//
 
-/// Matches a linalg.generic operation that has the structural shape of a
-/// gather (a single tensor.extract whose indices come from one or more
-/// `arith.index_cast` of a block argument fed by a single "indices" input,
-/// with the remaining indices being `linalg.index` ops along passthrough
-/// dimensions) and raises it to `iree_linalg_ext.gather`.
-///
-/// This is the form `torch.aten.index_select` lowers to via torch-mlir, and
-/// without raising it the `iree_linalg_ext.attention` op cannot fuse the
-/// gather into its dispatch (the dispatch creation pass intentionally only
-/// clones the `iree_linalg_ext.gather` form -- see PR #20866 and its
-/// `dont_clone_gather_like` test). Lifting the form here, before dispatch
-/// creation, lets paged-attention models collapse to a single attention
-/// dispatch.
-///
-/// The current implementation handles `index_depth == 1` (a single source
-/// dimension is gathered, which is the only shape `torch.aten.index_select`
-/// produces). All other source dimensions must be passthrough (`linalg.index`)
-/// dimensions in source order matching the trailing output dimensions of the
-/// generic. The output indexing map must be identity.
-static FailureOr<IREE::LinalgExt::GatherOp>
-raiseGenericToGather(linalg::GenericOp linalgOp, RewriterBase &rewriter) {
+/// (sourceDim, loopDim) pair for each slice source dim of the gather.
+struct GatherSliceDim {
+  /// Position of this slice dim in the gather's `source` tensor.
+  int64_t sourceDim;
+  /// Loop dim of the `linalg.generic` driving this slice dim (via
+  /// `linalg.index loopDim`).
+  unsigned loopDim;
+};
+
+/// Match record for a `linalg.generic` recognized as an
+/// `iree_linalg_ext.gather`.
+struct GatherMatch {
+  /// Source tensor read by the body's `tensor.extract`.
+  Value source;
+  /// `ins` operand of the `linalg.generic` carrying the gather indices.
+  OpOperand *indicesOperand;
+  /// Source dim that is read via `indices` (becomes `dimension_map[0]`).
+  int64_t indexedDim;
+  /// Source dims read via `linalg.index` (the slice dims).
+  SmallVector<GatherSliceDim> slice;
+};
+
+/// Coarse structural filter:
+///   - Pure tensor semantics, single `outs`, all-parallel iterators.
+///   - Identity output indexing map (matches the gather op's output map).
+static bool isGatherCandidateShape(linalg::GenericOp linalgOp) {
   if (!linalgOp.hasPureTensorSemantics()) {
-    return failure();
+    return false;
   }
   if (linalgOp.getNumDpsInits() != 1) {
-    return failure();
+    return false;
   }
   if (!llvm::all_of(linalgOp.getIteratorTypesArray(),
                     linalg::isParallelIterator)) {
-    return failure();
+    return false;
   }
+  return linalgOp.getMatchingIndexingMap(linalgOp.getDpsInitOperand(0))
+      .isIdentity();
+}
 
-  // The output indexing map must be a rank-preserving identity. The gather op
-  // we produce has an identity output indexing map, so anything else would
-  // require an extra transpose / broadcast we don't want to materialize here.
-  OpOperand *outOperand = linalgOp.getDpsInitOperand(0);
-  AffineMap outMap = linalgOp.getMatchingIndexingMap(outOperand);
-  if (!outMap.isIdentity()) {
-    return failure();
-  }
-
-  // The body must be: zero or more pure ops that compute scalar indices, a
-  // single tensor.extract, and a yield of that extract. We tolerate other
-  // shape/index-arithmetic ops but require exactly one tensor.extract.
+/// Body match for a gather:
+///   - Exactly one `tensor.extract`, yielded directly by `linalg.yield`.
+///   - All body ops are memory-effect-free.
+///   - The extract source is captured from outside the body.
+///   - Each extract index is `linalg.index N` (slice) or
+///     `arith.index_cast %blockArg` of an `ins` block arg (indexed).
+///   - Exactly one indexed dim (`index_depth == 1`).
+///   - Every other `ins` operand has an unused block argument (we'd
+///     otherwise silently drop live computation when dropping the body).
+static FailureOr<GatherMatch> matchGatherBody(linalg::GenericOp linalgOp) {
   Block *body = linalgOp.getBody();
+
   auto extractOps = body->getOps<tensor::ExtractOp>();
   if (!llvm::hasSingleElement(extractOps)) {
     return failure();
@@ -96,35 +104,25 @@ raiseGenericToGather(linalg::GenericOp linalgOp, RewriterBase &rewriter) {
       yieldOp.getOperand(0) != extractOp.getResult()) {
     return failure();
   }
-  // The source of the extract must be defined outside the generic, otherwise
-  // it isn't really a gather "source".
-  Value source = extractOp.getTensor();
-  if (auto srcArg = dyn_cast<BlockArgument>(source)) {
-    if (srcArg.getOwner() == body) {
+
+  for (Operation &op : body->without_terminator()) {
+    if (!isMemoryEffectFree(&op)) {
       return failure();
     }
   }
 
-  // Classify each tensor.extract index into one of three buckets:
-  //   * "indexed":     arith.index_cast of a block argument fed by some ins
-  //                    operand of the linalg.generic. This is the index that
-  //                    the gather op reads from its `indices` operand.
-  //   * "passthrough": linalg.index N. This dimension flows directly from a
-  //                    parallel iteration dim into the source. The
-  //                    corresponding source dim becomes a contiguous slice
-  //                    dim of the gather result.
-  //   * everything else (incl. constants other than what we explicitly
-  //     allow) -> bail out.
-  SmallVector<int64_t> indexedSourceDims;
-  // For each indexed source dim, the index of the `ins` operand (and its
-  // corresponding block argument) that feeds the index_cast.
-  SmallVector<unsigned> indexedInsOperandIdxs;
-  // For passthrough source dims, record the loop dim used by linalg.index.
-  SmallVector<std::pair<int64_t, unsigned>> passthroughSourceDimToLoopDim;
+  Value source = extractOp.getTensor();
+  if (source.getParentBlock() == body) {
+    return failure();
+  }
 
+  std::optional<unsigned> indicesArgNo;
+  std::optional<int64_t> indexedDim;
+  SmallVector<GatherSliceDim> slice;
   for (auto [srcDim, indexValue] : llvm::enumerate(extractOp.getIndices())) {
     if (auto idxOp = indexValue.getDefiningOp<linalg::IndexOp>()) {
-      passthroughSourceDimToLoopDim.emplace_back(srcDim, idxOp.getDim());
+      slice.push_back({static_cast<int64_t>(srcDim),
+                       static_cast<unsigned>(idxOp.getDim())});
       continue;
     }
     auto castOp = indexValue.getDefiningOp<arith::IndexCastOp>();
@@ -135,79 +133,77 @@ raiseGenericToGather(linalg::GenericOp linalgOp, RewriterBase &rewriter) {
     if (!blockArg || blockArg.getOwner() != body) {
       return failure();
     }
-    // Block argument index in the body matches the operand index for inputs
-    // (linalg generics put inputs first, then inits).
     unsigned argNo = blockArg.getArgNumber();
-    if (argNo >= linalgOp.getNumDpsInputs()) {
+    if (argNo >= linalgOp.getNumDpsInputs() || indicesArgNo) {
       return failure();
     }
-    indexedSourceDims.push_back(srcDim);
-    indexedInsOperandIdxs.push_back(argNo);
+    indicesArgNo = argNo;
+    indexedDim = static_cast<int64_t>(srcDim);
   }
-
-  // We currently only handle index_depth == 1 (the only form
-  // torch.aten.index_select produces).
-  if (indexedSourceDims.size() != 1) {
-    return failure();
-  }
-  unsigned indicesOperandIdx = indexedInsOperandIdxs.front();
-  OpOperand *indicesOperand =
-      linalgOp.getDpsInputOperand(indicesOperandIdx);
-  Value indicesTensor = indicesOperand->get();
-  auto indicesType = dyn_cast<RankedTensorType>(indicesTensor.getType());
-  auto sourceType = dyn_cast<RankedTensorType>(source.getType());
-  auto outputType =
-      dyn_cast<RankedTensorType>(linalgOp.getResult(0).getType());
-  if (!indicesType || !sourceType || !outputType) {
+  if (!indicesArgNo) {
     return failure();
   }
 
-  // Index element type must be an integer (gather op accepts int or index).
-  if (!indicesType.getElementType().isIntOrIndex()) {
+  for (OpOperand *insOp : linalgOp.getDpsInputOperands()) {
+    unsigned argNo = insOp->getOperandNumber();
+    if (argNo == *indicesArgNo) {
+      continue;
+    }
+    if (!body->getArgument(argNo).use_empty()) {
+      return failure();
+    }
+  }
+
+  return GatherMatch{source, linalgOp.getDpsInputOperand(*indicesArgNo),
+                     *indexedDim, std::move(slice)};
+}
+
+/// Geometry check:
+///   - Iteration domain partitions cleanly into batch + slice dims.
+///   - Slice source dims align with trailing output dims.
+///   - Indices indexing map is identity-on-batch with shape equal to the
+///     output's batch portion.
+static LogicalResult verifyGatherGeometry(linalg::GenericOp linalgOp,
+                                          GatherMatch &match) {
+  auto sourceType = dyn_cast<RankedTensorType>(match.source.getType());
+  auto outputType = dyn_cast<RankedTensorType>(linalgOp.getResult(0).getType());
+  auto indicesType =
+      dyn_cast<RankedTensorType>(match.indicesOperand->get().getType());
+  if (!sourceType || !outputType || !indicesType ||
+      !indicesType.getElementType().isIntOrIndex()) {
     return failure();
   }
 
-  // Each passthrough source dim's loop dim must correspond to the trailing
-  // output dims, in source order. Because outMap is identity, loop dim k is
-  // output dim k. Concretely: with `indexDepth == 1`, output rank
-  // == batchRank + sliceRank == batchRank + (sourceRank - 1). The trailing
-  // sliceRank output dims must be the loop dims of the passthrough source
-  // dims, in source order.
-  int64_t sourceRank = sourceType.getRank();
-  int64_t outputRank = outputType.getRank();
-  int64_t sliceRank = sourceRank - /*indexDepth=*/1;
+  // The gather op's `dimension_map` is a permutation of [0, index_depth), so
+  // the indexed source dims are always the leading `index_depth` dims of
+  // `source`; the op has no representation for an indexed dim sitting after a
+  // slice dim - that would require an explicit source transpose, which we don't
+  // currently support.
+  if (match.indexedDim != 0) {
+    return failure();
+  }
+
+  // With index_depth == 1: output rank == batch_rank + (source_rank - 1),
+  // and source dims [1, sourceRank) are the slice dims in order.
+  int64_t sliceRank = sourceType.getRank() - /*indexDepth=*/1;
   if (sliceRank < 0) {
     return failure();
   }
-  int64_t batchRank = outputRank - sliceRank;
-  if (batchRank < 1) {
+  int64_t batchRank = outputType.getRank() - sliceRank;
+  if (batchRank < 1 || static_cast<int64_t>(match.slice.size()) != sliceRank) {
     return failure();
   }
-  if (static_cast<int64_t>(passthroughSourceDimToLoopDim.size()) != sliceRank) {
-    return failure();
-  }
-  // Sort passthrough entries by source dim; gather expects source slice dims
-  // in order.
-  llvm::sort(passthroughSourceDimToLoopDim);
-  for (auto [i, entry] : llvm::enumerate(passthroughSourceDimToLoopDim)) {
-    int64_t srcDim = entry.first;
-    unsigned loopDim = entry.second;
-    // Source dim must skip over the indexed dim.
-    int64_t expectedSrcDim = (srcDim < indexedSourceDims[0]) ? i : i + 1;
-    if (srcDim != expectedSrcDim) {
-      return failure();
-    }
-    // The loop dim must be the matching trailing output dim.
-    if (loopDim != static_cast<unsigned>(batchRank + i)) {
+  llvm::sort(match.slice, [](const GatherSliceDim &a, const GatherSliceDim &b) {
+    return a.sourceDim < b.sourceDim;
+  });
+  for (auto [i, p] : llvm::enumerate(match.slice)) {
+    if (p.sourceDim != static_cast<int64_t>(i) + 1 ||
+        p.loopDim != static_cast<unsigned>(batchRank + i)) {
       return failure();
     }
   }
 
-  // The indices tensor's indexing map must project the iteration domain onto
-  // the leading batch loop dims in identity order. For index_depth == 1 the
-  // gather op expects `indices.rank == batchRank` with shape exactly the
-  // batch portion of the output.
-  AffineMap indicesMap = linalgOp.getMatchingIndexingMap(indicesOperand);
+  AffineMap indicesMap = linalgOp.getMatchingIndexingMap(match.indicesOperand);
   if (indicesMap.getNumResults() != batchRank) {
     return failure();
   }
@@ -217,31 +213,41 @@ raiseGenericToGather(linalg::GenericOp linalgOp, RewriterBase &rewriter) {
       return failure();
     }
   }
-  // The batch shape of indices must match the batch portion of output.
   if (indicesType.getShape() != outputType.getShape().take_front(batchRank)) {
     return failure();
   }
+  return success();
+}
 
-  // All other ins operands must be unused (we'd otherwise be dropping
-  // computation on the floor).
-  for (OpOperand *insOp : linalgOp.getDpsInputOperands()) {
-    if (insOp->getOperandNumber() == indicesOperandIdx) {
-      continue;
-    }
-    BlockArgument arg = body->getArgument(insOp->getOperandNumber());
-    if (!arg.use_empty()) {
-      return failure();
-    }
+/// Match a `linalg.generic` that should raise to `iree_linalg_ext.gather`.
+static FailureOr<GatherMatch> matchGatherOp(linalg::GenericOp linalgOp) {
+  if (!isGatherCandidateShape(linalgOp)) {
+    return failure();
   }
+  FailureOr<GatherMatch> match = matchGatherBody(linalgOp);
+  if (failed(match)) {
+    return failure();
+  }
+  if (failed(verifyGatherGeometry(linalgOp, *match))) {
+    return failure();
+  }
+  return match;
+}
 
-  // All set: emit the gather op replacing the linalg.generic.
-  Value output = outOperand->get();
-  SmallVector<int64_t> dimensionMap = {indexedSourceDims[0]};
-  auto gatherOp = IREE::LinalgExt::GatherOp::create(
-      rewriter, linalgOp.getLoc(), TypeRange{outputType},
-      /*source=*/source, /*indices=*/indicesTensor, /*mask=*/Value{},
-      /*output=*/output, dimensionMap);
-  return gatherOp;
+/// Matches a linalg.generic operation that has the structural shape of a
+/// gather and raises it to `iree_linalg_ext.gather`. Match -> build.
+static FailureOr<IREE::LinalgExt::GatherOp>
+raiseGenericToGather(linalg::GenericOp linalgOp, RewriterBase &rewriter) {
+  FailureOr<GatherMatch> match = matchGatherOp(linalgOp);
+  if (failed(match)) {
+    return failure();
+  }
+  Value output = linalgOp.getDpsInitOperand(0)->get();
+  SmallVector<int64_t> dimensionMap = {match->indexedDim};
+  return IREE::LinalgExt::GatherOp::create(
+      rewriter, linalgOp.getLoc(), TypeRange{linalgOp.getResult(0).getType()},
+      /*source=*/match->source, /*indices=*/match->indicesOperand->get(),
+      /*mask=*/Value{}, /*output=*/output, dimensionMap);
 }
 
 /// Matches a linalg.generic operation reading data from a tensor `source` using

--- a/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
@@ -773,3 +773,94 @@ util.func public @constant_pad_f32(%arg0: tensor<?x?xf32>, %x: index, %y: index)
 //       CHECK:   %[[PAD:.+]] = tensor.pad %[[ARG0]] low[1, 2] high[%[[H0]], %[[H1]]]
 //       CHECK:     tensor.yield %[[C1]]
 //       CHECK:   util.return %[[PAD]]
+
+// -----
+
+// Raise the linalg.generic + tensor.extract gather form (what
+// `torch.aten.index_select` lowers to) into `iree_linalg_ext.gather` so it can
+// fuse with a downstream `iree_linalg_ext.attention` (see iree-org/iree#24374).
+util.func public @raise_index_select_gather(%src: tensor<24576x512xf16>,
+                                            %idx: tensor<2048xi64>)
+    -> tensor<2048x512xf16> {
+  %empty = tensor.empty() : tensor<2048x512xf16>
+  %0 = linalg.generic
+      {indexing_maps = [affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]}
+      ins(%idx : tensor<2048xi64>)
+      outs(%empty : tensor<2048x512xf16>) {
+    ^bb0(%in: i64, %out: f16):
+      %ci = arith.index_cast %in : i64 to index
+      %cj = linalg.index 1 : index
+      %e = tensor.extract %src[%ci, %cj] : tensor<24576x512xf16>
+      linalg.yield %e : f16
+    } -> tensor<2048x512xf16>
+  util.return %0 : tensor<2048x512xf16>
+}
+// CHECK-LABEL: util.func public @raise_index_select_gather
+//  CHECK-SAME:     %[[SRC:[A-Za-z0-9]+]]: tensor<24576x512xf16>
+//  CHECK-SAME:     %[[IDX:[A-Za-z0-9]+]]: tensor<2048xi64>
+//   CHECK-NOT:   linalg.generic
+//   CHECK-NOT:   tensor.extract
+//       CHECK:   %[[GATHER:.+]] = iree_linalg_ext.gather dimension_map = [0]
+//  CHECK-SAME:       ins(%[[SRC]], %[[IDX]] : tensor<24576x512xf16>, tensor<2048xi64>)
+//       CHECK:   util.return %[[GATHER]]
+
+// -----
+
+// The same shape that paged-attention models actually produce (gather along
+// dim 0, with multi-dim batch/slice on either side).
+util.func public @raise_index_select_gather_3d(%src: tensor<1024x4x128xf16>,
+                                               %idx: tensor<8x2048xi32>)
+    -> tensor<8x2048x4x128xf16> {
+  %empty = tensor.empty() : tensor<8x2048x4x128xf16>
+  %0 = linalg.generic
+      {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+       iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%idx : tensor<8x2048xi32>)
+      outs(%empty : tensor<8x2048x4x128xf16>) {
+    ^bb0(%in: i32, %out: f16):
+      %ci = arith.index_cast %in : i32 to index
+      %cj = linalg.index 2 : index
+      %ck = linalg.index 3 : index
+      %e = tensor.extract %src[%ci, %cj, %ck] : tensor<1024x4x128xf16>
+      linalg.yield %e : f16
+    } -> tensor<8x2048x4x128xf16>
+  util.return %0 : tensor<8x2048x4x128xf16>
+}
+// CHECK-LABEL: util.func public @raise_index_select_gather_3d
+//  CHECK-SAME:     %[[SRC:[A-Za-z0-9]+]]: tensor<1024x4x128xf16>
+//  CHECK-SAME:     %[[IDX:[A-Za-z0-9]+]]: tensor<8x2048xi32>
+//       CHECK:   %[[GATHER:.+]] = iree_linalg_ext.gather dimension_map = [0]
+//  CHECK-SAME:       ins(%[[SRC]], %[[IDX]] :
+//       CHECK:   util.return %[[GATHER]]
+
+// -----
+
+// Don't raise when an index doesn't come from a recognized source -- e.g.
+// when the gather index is computed by `arith.addi` of a block argument and a
+// runtime offset (not an `iree_linalg_ext.gather` shape).
+util.func public @no_raise_offset_gather(%src: tensor<24576x512xf16>,
+                                         %idx: tensor<2048xi64>,
+                                         %off: i64) -> tensor<2048x512xf16> {
+  %empty = tensor.empty() : tensor<2048x512xf16>
+  %0 = linalg.generic
+      {indexing_maps = [affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]}
+      ins(%idx : tensor<2048xi64>)
+      outs(%empty : tensor<2048x512xf16>) {
+    ^bb0(%in: i64, %out: f16):
+      %sum = arith.addi %in, %off : i64
+      %ci = arith.index_cast %sum : i64 to index
+      %cj = linalg.index 1 : index
+      %e = tensor.extract %src[%ci, %cj] : tensor<24576x512xf16>
+      linalg.yield %e : f16
+    } -> tensor<2048x512xf16>
+  util.return %0 : tensor<2048x512xf16>
+}
+// CHECK-LABEL: util.func public @no_raise_offset_gather
+//   CHECK-NOT:   iree_linalg_ext.gather
+//       CHECK:   linalg.generic
+//       CHECK:   tensor.extract

--- a/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
@@ -776,9 +776,6 @@ util.func public @constant_pad_f32(%arg0: tensor<?x?xf32>, %x: index, %y: index)
 
 // -----
 
-// Raise the linalg.generic + tensor.extract gather form (what
-// `torch.aten.index_select` lowers to) into `iree_linalg_ext.gather` so it can
-// fuse with a downstream `iree_linalg_ext.attention` (see iree-org/iree#24374).
 util.func public @raise_index_select_gather(%src: tensor<24576x512xf16>,
                                             %idx: tensor<2048xi64>)
     -> tensor<2048x512xf16> {
@@ -808,8 +805,6 @@ util.func public @raise_index_select_gather(%src: tensor<24576x512xf16>,
 
 // -----
 
-// The same shape that paged-attention models actually produce (gather along
-// dim 0, with multi-dim batch/slice on either side).
 util.func public @raise_index_select_gather_3d(%src: tensor<1024x4x128xf16>,
                                                %idx: tensor<8x2048xi32>)
     -> tensor<8x2048x4x128xf16> {
@@ -838,9 +833,7 @@ util.func public @raise_index_select_gather_3d(%src: tensor<1024x4x128xf16>,
 
 // -----
 
-// Don't raise when an index doesn't come from a recognized source -- e.g.
-// when the gather index is computed by `arith.addi` of a block argument and a
-// runtime offset (not an `iree_linalg_ext.gather` shape).
+// Don't raise when an index doesn't come from a recognized source.
 util.func public @no_raise_offset_gather(%src: tensor<24576x512xf16>,
                                          %idx: tensor<2048xi64>,
                                          %off: i64) -> tensor<2048x512xf16> {
@@ -864,3 +857,98 @@ util.func public @no_raise_offset_gather(%src: tensor<24576x512xf16>,
 //   CHECK-NOT:   iree_linalg_ext.gather
 //       CHECK:   linalg.generic
 //       CHECK:   tensor.extract
+
+// -----
+
+// Pure indexed case is the smallest possible gather.
+util.func public @raise_index_select_1d(%src: tensor<2048xf16>,
+                                        %idx: tensor<128xi64>)
+    -> tensor<128xf16> {
+  %empty = tensor.empty() : tensor<128xf16>
+  %0 = linalg.generic
+      {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+       iterator_types = ["parallel"]}
+      ins(%idx : tensor<128xi64>)
+      outs(%empty : tensor<128xf16>) {
+    ^bb0(%in: i64, %out: f16):
+      %ci = arith.index_cast %in : i64 to index
+      %e = tensor.extract %src[%ci] : tensor<2048xf16>
+      linalg.yield %e : f16
+    } -> tensor<128xf16>
+  util.return %0 : tensor<128xf16>
+}
+// CHECK-LABEL: util.func public @raise_index_select_1d
+//  CHECK-SAME:     %[[SRC:[A-Za-z0-9]+]]: tensor<2048xf16>
+//  CHECK-SAME:     %[[IDX:[A-Za-z0-9]+]]: tensor<128xi64>
+//       CHECK:   %[[GATHER:.+]] = iree_linalg_ext.gather dimension_map = [0]
+//  CHECK-SAME:       ins(%[[SRC]], %[[IDX]] : tensor<2048xf16>, tensor<128xi64>)
+//       CHECK:   util.return %[[GATHER]]
+
+// -----
+
+util.func public @no_raise_trailing_indexed(%src: tensor<512x24576xf16>,
+                                            %idx: tensor<2048xi64>)
+    -> tensor<2048x512xf16> {
+  %empty = tensor.empty() : tensor<2048x512xf16>
+  %0 = linalg.generic
+      {indexing_maps = [affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]}
+      ins(%idx : tensor<2048xi64>)
+      outs(%empty : tensor<2048x512xf16>) {
+    ^bb0(%in: i64, %out: f16):
+      %ci = arith.index_cast %in : i64 to index
+      %d1 = linalg.index 1 : index
+      %e = tensor.extract %src[%d1, %ci] : tensor<512x24576xf16>
+      linalg.yield %e : f16
+    } -> tensor<2048x512xf16>
+  util.return %0 : tensor<2048x512xf16>
+}
+// CHECK-LABEL: util.func public @no_raise_trailing_indexed
+//   CHECK-NOT:   iree_linalg_ext.gather
+
+// -----
+
+// Pure slice case is basically the generic being a pure broadcast/copy,
+// not a gather.
+util.func public @no_raise_pure_slice(%src: tensor<2048x512xf16>)
+    -> tensor<2048x512xf16> {
+  %empty = tensor.empty() : tensor<2048x512xf16>
+  %0 = linalg.generic
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+       iterator_types = ["parallel", "parallel"]}
+      outs(%empty : tensor<2048x512xf16>) {
+    ^bb0(%out: f16):
+      %d0 = linalg.index 0 : index
+      %d1 = linalg.index 1 : index
+      %e = tensor.extract %src[%d0, %d1] : tensor<2048x512xf16>
+      linalg.yield %e : f16
+    } -> tensor<2048x512xf16>
+  util.return %0 : tensor<2048x512xf16>
+}
+// CHECK-LABEL: util.func public @no_raise_pure_slice
+//   CHECK-NOT:   iree_linalg_ext.gather
+
+// -----
+
+util.func public @no_raise_transposed_slice(%src: tensor<24576x4x128xf16>,
+                                            %idx: tensor<2048xi64>)
+    -> tensor<2048x128x4xf16> {
+  %empty = tensor.empty() : tensor<2048x128x4xf16>
+  %0 = linalg.generic
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d0)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+       iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%idx : tensor<2048xi64>)
+      outs(%empty : tensor<2048x128x4xf16>) {
+    ^bb0(%in: i64, %out: f16):
+      %ci = arith.index_cast %in : i64 to index
+      %a = linalg.index 1 : index
+      %b = linalg.index 2 : index
+      %e = tensor.extract %src[%ci, %b, %a] : tensor<24576x4x128xf16>
+      linalg.yield %e : f16
+    } -> tensor<2048x128x4xf16>
+  util.return %0 : tensor<2048x128x4xf16>
+}
+// CHECK-LABEL: util.func public @no_raise_transposed_slice
+//   CHECK-NOT:   iree_linalg_ext.gather


### PR DESCRIPTION
Raise `linalg.generic + tensor.extract` (the form `torch.aten.index_select` lowers to) to `iree_linalg_ext.gather` in `RaiseSpecialOps`. This lets the existing fusion machinery of `iree_linalg_ext.attention` only consuming
  canonical gather form and not "gather_like" fuse the raised gather into the attention dispatch.

Fixes: https://github.com/iree-org/iree/issues/24374