### PR TITLE
[Flow][Dispatch Creation] Fix dispatch tied result crash

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1053,9 +1053,7 @@ DispatchWorkgroupsOp::getOperandAccess(unsigned operandIndex) {
 
 IREE::Util::ValueAccess
 DispatchWorkgroupsOp::getResultAccess(unsigned resultIndex) {
-  unsigned startIndex = getWorkgroupBody().getNumArguments() - getNumResults();
-  BlockArgument arg =
-      getWorkgroupBody().front().getArgument(startIndex + resultIndex);
+  BlockArgument arg = getOutputBlockArgument(resultIndex);
   if (auto tensorType =
           dyn_cast<IREE::TensorExt::DispatchTensorType>(arg.getType())) {
     auto tensorAccess = refineTensorAccess(arg, tensorType);

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_folding.mlir
@@ -126,6 +126,28 @@ util.func public @keep_used_read_write_result(%arg0 : tensor<9xi32>, %arg1 : ten
 
 // -----
 
+// CHECK-LABEL: util.func public @multiple_results_tied_to_same_input
+util.func public @multiple_results_tied_to_same_input(%arg0: tensor<4x4xf32>)
+    -> (tensor<4x4xf32>, tensor<4x4xf32>) {
+  %c1 = arith.constant 1 : index
+  // CHECK: flow.dispatch.workgroups[%c1](%arg0) : (tensor<4x4xf32>) -> (%arg0, %arg0) =
+  // CHECK-NEXT: (%{{.+}}: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x4xf32>>)
+  %0:2 = flow.dispatch.workgroups[%c1, %c1, %c1](%arg0) :
+      (tensor<4x4xf32>) -> (%arg0, %arg0) =
+      (%arg0_capture: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x4xf32>>) {
+    %1 = iree_tensor_ext.dispatch.tensor.load %arg0_capture,
+        offsets = [0, 0], sizes = [4, 4], strides = [1, 1]
+        : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x4xf32>> -> tensor<4x4xf32>
+    iree_tensor_ext.dispatch.tensor.store %1, %arg0_capture,
+        offsets = [0, 0], sizes = [4, 4], strides = [1, 1]
+        : tensor<4x4xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4x4xf32>>
+    flow.return
+  }
+  util.return %0#0, %0#1 : tensor<4x4xf32>, tensor<4x4xf32>
+}
+
+// -----
+
 // CHECK-LABEL: util.func public @drop_unused_dispatch_region_result
 util.func public @drop_unused_dispatch_region_result(
     %arg0: tensor<?x?xf32>, %arg1: tensor<5x10xf32>, %arg2: tensor<7x11xf32>)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -927,6 +927,16 @@ hasUnfusableUseInDispatch(Value v, Operation *dispatchOp,
       return true;
     }
 
+    Operation *ownerWorkgroupsOp =
+        user->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>();
+    Operation *ownerRegionOp =
+        user->getParentOfType<IREE::Flow::DispatchRegionOp>();
+    Operation *owner = ownerWorkgroupsOp ? ownerWorkgroupsOp : ownerRegionOp;
+
+    if (owner != dispatchOp) {
+      continue;
+    }
+
     if (auto insertSlice = dyn_cast<tensor::InsertSliceOp>(user);
         insertSlice && use.get() == insertSlice.getDest()) {
       return true;

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -806,6 +806,37 @@ util.func @never_clone_scatter_outs_tensor_constant(
 
 // -----
 
+// A tensor.insert_slice dest use outside of the dispatch should not prevent
+// cloning the producer into the dispatch.
+util.func @clone_with_external_insert_slice_dest_use(%source : tensor<16x16xf32>)
+    -> (tensor<16x16xf32>, tensor<16x16xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<16x16xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<16x16xf32>)
+      -> tensor<16x16xf32>
+  %0 = flow.dispatch.region -> (tensor<16x16xf32>) {
+    %1 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel"]}
+        outs(%fill : tensor<16x16xf32>) {
+    ^bb0(%out: f32):
+      linalg.yield %out : f32
+    } -> tensor<16x16xf32>
+    flow.return %1 : tensor<16x16xf32>
+  }
+  %1 = tensor.insert_slice %source into %fill[0, 0] [16, 16] [1, 1]
+      : tensor<16x16xf32> into tensor<16x16xf32>
+  util.return %0, %1 : tensor<16x16xf32>, tensor<16x16xf32>
+}
+// CHECK-LABEL: @clone_with_external_insert_slice_dest_use
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     linalg.fill
+//       CHECK:     linalg.generic
+//       CHECK:   tensor.insert_slice
+//       CHECK:   util.return %[[DISPATCH]]
+
+// -----
+
 util.func @clone_gather_elementwise(%source : tensor<2x2x2048xi32>,
                                    %indices : tensor<2xi32>) -> tensor<2048xi32> {
   %empty = tensor.empty() : tensor<2048xi32>


### PR DESCRIPTION
Fixes a crash in `DispatchWorkgroupsOp::getResultAccess()` when multiple `flow.dispatch.workgroups` results are tied to the same input operand. Also restores the dispatch ownership check in `hasUnfusableUseInDispatch()` that was dropped in #24214, so `tensor.insert_slice` dest uses outside the dispatch being analyzed do not block producer cloning.

Fixes https://github.com/iree-org/iree/issues/24385