### PR TITLE
[Compiler] Use Repeated<T> for repeated value ranges. NFC.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
@@ -24,6 +24,7 @@
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "llvm/ADT/Repeated.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -683,7 +684,7 @@ struct TopkOpConversion final : OpConversionPattern<chlo::TopKOp> {
         /*output_values=*/negInfTensor, /*output_indices=*/posInfTensor, kDim);
 
     // Define the region of TopK with a GT comparison
-    SmallVector<Type> types(2, valueElementType);
+    llvm::Repeated<Type> types(2, valueElementType);
     SmallVector<Location> locations(2, loc);
     Block *block =
         rewriter.createBlock(&topkOp.getRegion(), {}, types, locations);

--- a/compiler/plugins/input/TOSA/InputConversion/BUILD.bazel
+++ b/compiler/plugins/input/TOSA/InputConversion/BUILD.bazel
@@ -64,6 +64,7 @@ iree_compiler_cc_library(
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/InputConversion/Common",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FunctionInterfaces",

--- a/compiler/plugins/input/TOSA/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/TOSA/InputConversion/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_cc_library(
   DEPS
     ::PassHeaders
     ::PassesIncGen
+    LLVMSupport
     MLIRArithDialect
     MLIRFuncDialect
     MLIRFunctionInterfaces

--- a/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/TosaToLinalgExt.cpp
@@ -7,6 +7,7 @@
 #include "compiler/plugins/input/TOSA/InputConversion/Passes.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "llvm/ADT/Repeated.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -141,7 +142,7 @@ public:
         /*original=*/values, builder.getDenseI64ArrayAttr({0, 1}),
         builder.getBoolAttr(true));
 
-    llvm::SmallVector<Type> args(2, valuesTy.getElementType());
+    llvm::Repeated<Type> args(2, valuesTy.getElementType());
     Block *scatterBody =
         builder.createBlock(&scatter.getRegion(), {}, args,
                             llvm::SmallVector<Location>(2, op.getLoc()));

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "mlir/Dialect/Affine/Utils.h"
@@ -475,8 +476,8 @@ private:
     // async behavior or cancellation.
     auto entryFuncType = entryFuncOp.getFunctionType();
     auto bufferType = moduleBuilder.getType<IREE::HAL::BufferType>();
-    SmallVector<Type> inputTypes(entryFuncType.getNumInputs(), bufferType);
-    SmallVector<Type> outputTypes(entryFuncType.getNumResults(), bufferType);
+    llvm::Repeated<Type> inputTypes(entryFuncType.getNumInputs(), bufferType);
+    llvm::Repeated<Type> outputTypes(entryFuncType.getNumResults(), bufferType);
     auto wrapperFuncType =
         moduleBuilder.getFunctionType(inputTypes, outputTypes);
 

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
+#include "llvm/ADT/Repeated.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
@@ -573,7 +574,8 @@ matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op,
     return rewriter.notifyMatchFailure(op, "no encoding attribute");
   }
 
-  SmallVector<Type> resultTypes(tensorType.getRank(), rewriter.getIndexType());
+  llvm::Repeated<Type> resultTypes(tensorType.getRank(),
+                                   rewriter.getIndexType());
   SmallVector<Value> inputValues;
   Location loc = op.getLoc();
   for (int64_t i : tensorType.getShape()) {

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -264,7 +265,7 @@ static void buildNestedDistributionLoops(
         SmallVector<Value> nestedUbVals =
             getValueOrCreateConstantIndexOp(b, nestedLoc, nestedUbs);
         Value one = arith::ConstantIndexOp::create(rewriter, nestedLoc, 1);
-        SmallVector<Value> unitSteps(nestedLbs.size(), one);
+        llvm::Repeated<Value> unitSteps(nestedLbs.size(), one);
         scf::buildLoopNest(rewriter, nestedLoc, nestedLbVals, nestedUbVals,
                            unitSteps, innerLoopBuilder);
         scf::InParallelOp::create(b, nestedLoc);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
@@ -279,7 +280,7 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
     // Build zero thread indices for dest (uniform across subgroup).
     Location loc = op.getLoc();
     Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
-    SmallVector<Value> zeroThreadIndices(destRank, c0);
+    llvm::Repeated<Value> zeroThreadIndices(destRank, c0);
 
     // Emit gather_to_lds for each batch/outer tile offset.
     for (SmallVector<int64_t> offsets :

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -16,6 +16,7 @@
 #include "iree/compiler/Utils/Indexing.h"
 #include "iree/compiler/Utils/Permutation.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -712,7 +713,7 @@ struct DistributeMapStore final
       // offsets.
       AffineMap permutationMap =
           rewriter.getMultiDimIdentityMap(input.getType().getRank());
-      SmallVector<Value> indices(input.getType().getRank(), zero);
+      llvm::Repeated<Value> indices(input.getType().getRank(), zero);
       SmallVector<Value> distributedOffsets =
           getTransferIndicesFromNestedLayout(rewriter, indices, offsets,
                                              vectorLayout, permutationMap,
@@ -1374,7 +1375,7 @@ struct DistributeMultiReduction final
                                   ArrayRef<int64_t> reductionDims) const {
     Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
     VectorType unDistributedType = valueToWrite.getType();
-    SmallVector<Value> indices(unDistributedType.getRank(), c0);
+    llvm::Repeated<Value> indices(unDistributedType.getRank(), c0);
     SmallVector<bool> inBounds(unDistributedType.getRank(), true);
     auto write = vector::TransferWriteOp::create(rewriter, loc, valueToWrite,
                                                  buffer, indices, inBounds);
@@ -1405,7 +1406,7 @@ struct DistributeMultiReduction final
         rewriter, loc,
         /*vectorType=*/readTy,
         /*source=*/buffer,
-        /*indices=*/SmallVector<Value>(readLayout.getRank(), zero),
+        /*indices=*/llvm::Repeated<Value>(readLayout.getRank(), zero),
         /*permMap=*/rewriter.getMultiDimIdentityMap(readLayout.getRank()),
         /*padding=*/padValue,
         /*mask=*/mask,
@@ -2037,7 +2038,7 @@ private:
       NestedLayoutAttr srcLayout, int64_t reductionDim) const {
     Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
     VectorType valueType = valueToWrite.getType();
-    SmallVector<Value> indices(valueType.getRank(), c0);
+    llvm::Repeated<Value> indices(valueType.getRank(), c0);
     SmallVector<bool> inBounds(valueType.getRank(), true);
 
     auto valueWrite = vector::TransferWriteOp::create(
@@ -2092,13 +2093,13 @@ private:
 
     auto valueRead = vector::TransferReadOp::create(
         rewriter, loc, valueReadTy, valueBuffer,
-        SmallVector<Value>(readLayout.getRank(), zero),
+        llvm::Repeated<Value>(readLayout.getRank(), zero),
         rewriter.getMultiDimIdentityMap(readLayout.getRank()), valuePad,
         /*mask=*/Value(), inBounds);
 
     auto indexRead = vector::TransferReadOp::create(
         rewriter, loc, indexReadTy, indexBuffer,
-        SmallVector<Value>(readLayout.getRank(), zero),
+        llvm::Repeated<Value>(readLayout.getRank(), zero),
         rewriter.getMultiDimIdentityMap(readLayout.getRank()), indexPad,
         /*mask=*/Value(), inBounds);
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.cpp
@@ -23,7 +23,7 @@ static bool isBroadcast(AffineExpr expr) {
 SmallVector<Value> getTransferIndicesFromNestedLayout(
     OpBuilder &b, ValueRange indices, ArrayRef<int64_t> offsets,
     NestedLayoutAttr vectorLayout, AffineMap permutationMap,
-    ArrayRef<Value> warpIndices, ArrayRef<Value> threadIndices) {
+    ValueRange warpIndices, ValueRange threadIndices) {
 
   int64_t rank = vectorLayout.getRank();
   // Permute the batch and outer vector offsets to match the order of

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h
@@ -20,7 +20,7 @@ namespace mlir::iree_compiler {
 SmallVector<Value> getTransferIndicesFromNestedLayout(
     OpBuilder &b, ValueRange indices, ArrayRef<int64_t> offsets,
     IREE::VectorExt::NestedLayoutAttr vectorLayout, AffineMap permutationMap,
-    ArrayRef<Value> warpIndices, ArrayRef<Value> threadIndices);
+    ValueRange warpIndices, ValueRange threadIndices);
 
 /// Computes the warp and thread indices for the given vector layout from a
 /// single linearized thread ID.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -53,7 +54,7 @@ static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
   allocTensorOp.setMemorySpaceAttr(sharedMemoryAddrSpace);
 
   Value c0 = arith::ConstantIndexOp::create(b, loc, 0);
-  SmallVector<Value> indices(vectorType.getRank(), c0);
+  llvm::Repeated<Value> indices(vectorType.getRank(), c0);
   SmallVector<bool> inBounds(vectorType.getRank(), true);
   Value copied = vector::TransferWriteOp::create(b, loc, vector, allocTensorOp,
                                                  indices, inBounds)
@@ -64,7 +65,7 @@ static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
 static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
                                   Value tensor) {
   Value c0 = arith::ConstantIndexOp::create(b, tensor.getLoc(), 0);
-  SmallVector<Value> indices(vectorType.getRank(), c0);
+  llvm::Repeated<Value> indices(vectorType.getRank(), c0);
   SmallVector<bool> inBounds(vectorType.getRank(), true);
   return vector::TransferReadOp::create(b, tensor.getLoc(), vectorType, tensor,
                                         indices, /*padding=*/std::nullopt,

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -23,6 +23,7 @@
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/Support/Casting.h"
 #include "mlir/Analysis/CallGraph.h"
 #include "mlir/Dialect/Affine/Utils.h"
@@ -874,7 +875,7 @@ void ReconcileTranslationInfoPass::runOnOperation() {
       configOp = IREE::Codegen::DispatchConfigOp::create(
           rewriter, loc, FlatSymbolRefAttr::get(rootFuncOp.getNameAttr()));
       IndexType indexType = rewriter.getIndexType();
-      SmallVector<Type> argTypes(numWorkloads, indexType);
+      llvm::Repeated<Type> argTypes(numWorkloads, indexType);
       SmallVector<Location> argLocs(numWorkloads, loc);
       Block *block = rewriter.createBlock(&configOp.getBody(), /*insertPt=*/{},
                                           argTypes, argLocs);

--- a/compiler/src/iree/compiler/Codegen/Common/SMTConstraintUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SMTConstraintUtils.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/SMTConstraintUtils.h"
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -87,7 +88,7 @@ createConstraintsOpShell(OpBuilder &builder, Operation *rootOp,
 
   // Create the constraints op.
   smt::IntType smtIntTy = smt::IntType::get(ctx);
-  SmallVector<Type> blockArgTypes(numLoops, smtIntTy);
+  llvm::Repeated<Type> blockArgTypes(numLoops, smtIntTy);
 
   auto constraintsOp = IREE::Codegen::ConstraintsOp::create(
       builder, loc, rootOpAttr, pipelineAttr, knobs, dimValues);

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/Twine.h"
@@ -472,7 +473,7 @@ ParseResult WorkgroupCountHintOp::parse(OpAsmParser &parser,
   // correctly when used as a custom directive so manually infer it from the
   // number of parsed sizes.
   IndexType indexType = parser.getBuilder().getIndexType();
-  SmallVector<Type> dynamicSizeTypes(dynamicSizes.size(), indexType);
+  llvm::Repeated<Type> dynamicSizeTypes(dynamicSizes.size(), indexType);
 
   if (parser.resolveOperands(dynamicSizes, dynamicSizeTypes,
                              parser.getCurrentLocation(), result.operands)) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseProducers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/PCF/Transforms/FuseProducers.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Dialect/PCF/IR/PCFOps.h"
 #include "iree/compiler/Codegen/Dialect/PCF/Transforms/Passes.h"
 #include "iree/compiler/Codegen/Dialect/PCF/Transforms/Transforms.h"
+#include "llvm/ADT/Repeated.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -192,7 +193,7 @@ static void fuseTilableProducerImpl(RewriterBase &rewriter, OpTy scopedOp,
     if (auto vectorType = dyn_cast<VectorType>(readSlice.getType())) {
       auto tensorType = cast<RankedTensorType>(replacement.getType());
       Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-      SmallVector<Value> indices(tensorType.getRank(), zero);
+      llvm::Repeated<Value> indices(tensorType.getRank(), zero);
       SmallVector<bool> inBounds(tensorType.getRank(), true);
       replacement = vector::TransferReadOp::create(
           rewriter, loc, vectorType, replacement, indices,

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -240,6 +240,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Utils",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:Analysis",

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -172,6 +172,7 @@ iree_cc_library(
     "VectorizableOpInterface.cpp"
   DEPS
     ::VectorizableOpInterfaceGen
+    LLVMSupport
     MLIRAffineDialect
     MLIRAffineUtils
     MLIRAnalysis

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -16,6 +16,7 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/Utils/Indexing.h"
+#include "llvm/ADT/Repeated.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
@@ -167,7 +168,7 @@ struct GatherOpVectorizationModel
         ArrayRef(gatherDims).take_front(gatherOp.getBatchRank()));
     auto indicesVecRead = vector::TransferReadOp::create(
         rewriter, loc, indicesVecTy.clone(indicesTy.getElementType()),
-        gatherOp.getIndices(), SmallVector<Value>(indicesTy.getRank(), zero),
+        gatherOp.getIndices(), llvm::Repeated<Value>(indicesTy.getRank(), zero),
         std::nullopt);
     rewriter.modifyOpInPlace(indicesVecRead, [&] {
       indicesVecRead.getMaskMutable().assign(indicesMask);
@@ -176,7 +177,7 @@ struct GatherOpVectorizationModel
     indicesVec =
         arith::IndexCastOp::create(rewriter, loc, indicesVecTy, indicesVec);
 
-    SmallVector<Value> baseOffsets(sourceTy.getRank(), zero);
+    llvm::Repeated<Value> baseOffsets(sourceTy.getRank(), zero);
     Value padding =
         ub::PoisonOp::create(rewriter, loc, gatherTy.getElementType());
 
@@ -225,7 +226,7 @@ struct GatherOpVectorizationModel
         rewriter, loc, gatherVectorTy, gatherOp.getSource(), baseOffsets,
         ValueRange{indicesVec}, rewriter.getAffineMapArrayAttr(indexingMaps),
         padding, /*mask=*/gatherMask);
-    SmallVector<Value> writeIndices(gatherTy.getRank(), zero);
+    llvm::Repeated<Value> writeIndices(gatherTy.getRank(), zero);
     auto writeOp = vector::TransferWriteOp::create(
         rewriter, loc, transferGatherOp.getResult(), gatherOp.getOutput(),
         writeIndices);
@@ -281,7 +282,7 @@ struct ArgCompareOpVectorizationModel
     SmallVector<Value> inputVecs;
     auto vectorizeInput = [&](Value input) {
       auto inputTy = cast<ShapedType>(input.getType());
-      SmallVector<Value> readIndices(inputTy.getRank(), zero);
+      llvm::Repeated<Value> readIndices(inputTy.getRank(), zero);
       auto inputVecTy =
           VectorType::get(inputTy.getShape(), inputTy.getElementType());
       // TODO(Bangtian): Add masking/padding support for partial tiles.
@@ -301,7 +302,7 @@ struct ArgCompareOpVectorizationModel
     SmallVector<Value> initVecs;
     for (Value init : argCompareOp.getDpsInits()) {
       auto initTy = cast<ShapedType>(init.getType());
-      SmallVector<Value> readIndices(initShape.size(), zero);
+      llvm::Repeated<Value> readIndices(initShape.size(), zero);
       auto initVecTy = VectorType::get(initShape, initTy.getElementType());
       auto readOp = vector::TransferReadOp::create(
           rewriter, loc, initVecTy, init, readIndices, std::nullopt);
@@ -365,7 +366,7 @@ struct ArgCompareOpVectorizationModel
     SmallVector<Value> results;
     for (auto [result, output] : llvm::zip_equal(
              vectorArgCompareOp.getResults(), argCompareOp.getDpsInits())) {
-      SmallVector<Value> writeIndices(initShape.size(), zero);
+      llvm::Repeated<Value> writeIndices(initShape.size(), zero);
       auto writeOp = vector::TransferWriteOp::create(rewriter, loc, result,
                                                      output, writeIndices);
       results.push_back(writeOp.getResult());
@@ -419,7 +420,7 @@ struct ToLayoutOpVectorizationModel
         rewriter, loc,
         /*type=*/vectorType,
         /*source=*/toLayoutOp.getInput(),
-        /*indices=*/ValueRange{SmallVector<Value>(readShape.size(), zero)},
+        /*indices=*/llvm::Repeated<Value>(readShape.size(), zero),
         /*permutation_map=*/identityMap,
         /*padding=*/padValue,
         /*mask=*/mask,
@@ -441,7 +442,7 @@ struct ToLayoutOpVectorizationModel
         /*result=*/resType,
         /*vector=*/newLayoutOp,
         /*source=*/toLayoutOp.getInput(),
-        /*indices=*/ValueRange{SmallVector<Value>(rank, zero)},
+        /*indices=*/llvm::Repeated<Value>(rank, zero),
         /*permutation_map=*/writeIdentityMap,
         /*mask=*/mask,
         /*inBounds=*/writeInBounds);
@@ -502,7 +503,7 @@ struct MapStoreOpVectorizationModel
     rewriter.setInsertionPoint(mapStoreOp);
     ShapedType inputType = mapStoreOp.getInputType();
     Value zero = arith::ConstantIndexOp::create(rewriter, loc, 0);
-    SmallVector<Value> zeros(inputType.getRank(), zero);
+    llvm::Repeated<Value> zeros(inputType.getRank(), zero);
     auto inputVectorType =
         VectorType::get(inputType.getShape(), inputType.getElementType());
     Value inputVector = vector::TransferReadOp::create(
@@ -784,7 +785,7 @@ static FailureOr<SmallVector<Value>> vectorizeGatherLikeGenericToTransferGather(
       Type elemType = getElementTypeOrSelf(index);
       AffineMap readMap = inverseAndBroadcastProjectedPermutation(map);
       VectorType readType = VectorType::get(canonicalVectorSizes, elemType);
-      SmallVector<Value> operandIndices(map.getNumResults(), zero);
+      llvm::Repeated<Value> operandIndices(map.getNumResults(), zero);
       auto read = vector::TransferReadOp::create(
           rewriter, loc, readType, tensor, operandIndices,
           /*padding=*/std::nullopt, readMap);
@@ -831,7 +832,7 @@ static FailureOr<SmallVector<Value>> vectorizeGatherLikeGenericToTransferGather(
   // Create a empty tensor to write to.
   auto emptyOp = tensor::EmptyOp::create(rewriter, loc, canonicalVectorSizes,
                                          gatherTy.getElementType());
-  SmallVector<Value> writeIndices(canonicalVectorSizes.size(), zero);
+  llvm::Repeated<Value> writeIndices(canonicalVectorSizes.size(), zero);
 
   auto writeOp = vector::TransferWriteOp::create(
       rewriter, loc, transferGatherOp.getResult(), emptyOp, writeIndices);
@@ -1036,13 +1037,13 @@ vectorizeImplicitGatherToTransferGather(RewriterBase &rewriter,
   Value f0 =
       arith::ConstantOp::create(rewriter, loc, rewriter.getZeroAttr(elemType));
 
-  SmallVector<Value> baseOffsets(inRank, c0);
+  llvm::Repeated<Value> baseOffsets(inRank, c0);
   auto transferGatherOp = IREE::VectorExt::TransferGatherOp::create(
       rewriter, loc, vectorType, inOperand->get(), baseOffsets,
       ValueRange{indices},
       rewriter.getAffineMapArrayAttr({sourceMap, indexMap}), f0, Value());
 
-  SmallVector<Value> writeOffsets(outRank, c0);
+  llvm::Repeated<Value> writeOffsets(outRank, c0);
   auto transferWriteOp = vector::TransferWriteOp::create(
       rewriter, loc, transferGatherOp.getResult(), outOperand->get(),
       writeOffsets);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -28,6 +28,7 @@
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "iree/compiler/Transforms/Passes.h"
 #include "iree/compiler/Utils/PassUtils.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
@@ -737,7 +738,7 @@ static LogicalResult gpuVectorCopyFn(OpBuilder &builder, Location loc,
   VectorType vectorType =
       VectorType::get(fromType.getShape(), fromType.getElementType());
   Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
-  SmallVector<Value> indices(vectorType.getRank(), c0);
+  llvm::Repeated<Value> indices(vectorType.getRank(), c0);
   SmallVector<bool> inBounds(vectorType.getRank(), true);
   Value read =
       vector::TransferReadOp::create(builder, loc, vectorType, from, indices,

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
+#include "llvm/ADT/Repeated.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -85,7 +86,8 @@ FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
   if (!vmvxLayoutAttr || !hasUkernel(vmvxLayoutAttr.getConfiguration())) {
     return failure();
   }
-  SmallVector<Type> resultTypes(tensorType.getRank(), rewriter.getIndexType());
+  llvm::Repeated<Type> resultTypes(tensorType.getRank(),
+                                   rewriter.getIndexType());
   auto op = IREE::Codegen::QueryTileSizesOp::create(rewriter, loc, resultTypes,
                                                     TypeAttr::get(tensorType));
   SmallVector<Value> innerTileSizeValues = op.getResults();

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/BUILD.bazel
@@ -63,6 +63,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:BytecodeOpInterface",

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     ::FlowExtensionsOpGen
     IREEDialectsTransforms
     IREELinalgTransformDialect
+    LLVMSupport
     MLIRAnalysis
     MLIRArithDialect
     MLIRBytecodeOpInterface

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "llvm/ADT/Repeated.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -395,9 +396,9 @@ rewriteForeachThreadToFlowDispatchWorkgroups(scf::ForallOp forallOp,
     IREE::Flow::ReturnOp::create(rewriter, loc);
   }
   // Add trailing index bbArgs and perform a basic sanity check.
-  block->addArguments(
-      SmallVector<Type>(allTensorDynamicDims.size(), rewriter.getIndexType()),
-      SmallVector<Location>(allTensorDynamicDims.size(), loc));
+  block->addArguments(llvm::Repeated<Type>(allTensorDynamicDims.size(),
+                                           rewriter.getIndexType()),
+                      SmallVector<Location>(allTensorDynamicDims.size(), loc));
   SmallVector<Value> allOperands = nonDimOperands;
   llvm::append_range(allOperands, allTensorDynamicDims);
   assert(block->getNumArguments() == allOperands.size() &&

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -703,7 +704,7 @@ void MapLoadOp::insertTransformationAtStart(
     int64_t numOutputIndices) {
   Block &transformBody = getTransformationRegion().front();
   SmallVector<BlockArgument> oldOutputIndices(transformBody.getArguments());
-  SmallVector<Type> indexTypes(numOutputIndices, builder.getIndexType());
+  llvm::Repeated<Type> indexTypes(numOutputIndices, builder.getIndexType());
   SmallVector<Location> locs(numOutputIndices, getLoc());
 
   // Create the new block arguments for the new output indices, and transform
@@ -812,7 +813,7 @@ MapLoadOp MapLoadOp::createIdentityMapLoad(OpBuilder &builder, Location loc,
   Region &region = mapLoadOp.getTransformationRegion();
   auto outputType = cast<ShapedType>(output.getType());
   SmallVector<Location> blockArgLocs(outputType.getRank(), loc);
-  SmallVector<Type> indexTypes(outputType.getRank(), builder.getIndexType());
+  llvm::Repeated<Type> indexTypes(outputType.getRank(), builder.getIndexType());
   OpBuilder::InsertionGuard guard(builder);
   Block *block =
       builder.createBlock(&region, region.end(), indexTypes, blockArgLocs);
@@ -847,7 +848,7 @@ MapStoreOp MapStoreOp::createIdentityMapStore(OpBuilder &builder, Location loc,
   Region &region = mapStoreOp.getTransformationRegion();
   auto inputType = cast<ShapedType>(input.getType());
   SmallVector<Location> blockArgLocs(inputType.getRank(), loc);
-  SmallVector<Type> indexTypes(inputType.getRank(), builder.getIndexType());
+  llvm::Repeated<Type> indexTypes(inputType.getRank(), builder.getIndexType());
   OpBuilder::InsertionGuard guard(builder);
   Block *block =
       builder.createBlock(&region, region.end(), indexTypes, blockArgLocs);
@@ -928,7 +929,7 @@ void MapStoreOp::insertTransformationAtStart(
     int64_t numSourceIndices) {
   Block &transformBody = getTransformationRegion().front();
   SmallVector<BlockArgument> oldSourceIndices(transformBody.getArguments());
-  SmallVector<Type> indexTypes(numSourceIndices, builder.getIndexType());
+  llvm::Repeated<Type> indexTypes(numSourceIndices, builder.getIndexType());
   SmallVector<Location> locs(numSourceIndices, getLoc());
 
   // Create the new block arguments for the new source indices, and transform

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/BUILD.bazel
@@ -25,6 +25,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Stream/Conversion",
         "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FunctionInterfaces",

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
   SRCS
     "Patterns.cpp"
   DEPS
+    LLVMSupport
     MLIRArithDialect
     MLIRFuncDialect
     MLIRFunctionInterfaces

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/Stream/IR/StreamDialect.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+#include "llvm/ADT/Repeated.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinDialect.h"
@@ -476,7 +477,7 @@ struct ConvertTensorStoreOp
     IndexSet indexSet(op.getLoc(), rewriter);
     SmallVector<Value> convertedIndices = flattenValues(adaptor.getIndices());
     indexSet.populate(convertedIndices);
-    SmallVector<Value> lengths(convertedIndices.size(), indexSet.get(1));
+    llvm::Repeated<Value> lengths(convertedIndices.size(), indexSet.get(1));
     auto targetEncoding = op.getTarget().getType();
     auto fillOp = IREE::Stream::TensorFillOp::create(
         rewriter, op.getLoc(), target.resource, targetEncoding,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "iree/compiler/Dialect/Util/IR/ClosureOpUtils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -964,7 +965,8 @@ struct CanonicalizeResourcePackIntervals : OpRewritePattern<ResourcePackOp> {
       lifetimeIntervals[2 * i + 1] = slice.lifetimeEnd;
       dynamicSliceSizes[i] = slice.dynamicSize;
     }
-    SmallVector<Type> packedOffsetTypes(slices.size(), rewriter.getIndexType());
+    llvm::Repeated<Type> packedOffsetTypes(slices.size(),
+                                           rewriter.getIndexType());
     auto newOp = ResourcePackOp::create(
         rewriter, op.getLoc(), op.getTotalLength().getType(), packedOffsetTypes,
         op.getOffset(), rewriter.getIndexArrayAttr(lifetimeIntervals),

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CommandLine.h"
@@ -1843,7 +1844,7 @@ ResourceAllocaOp::createSuballocations(Type timepointType, Type resourceType,
   // Compute total size and the offsets of all suballocated resources via the
   // pack op.
   auto indexType = builder.getIndexType();
-  SmallVector<Type> packedOffsetTypes(sliceCount, indexType);
+  llvm::Repeated<Type> packedOffsetTypes(sliceCount, indexType);
   auto packOp = IREE::Stream::ResourcePackOp::create(
       builder, fusedLoc, indexType, packedOffsetTypes, /*offset=*/nullptr,
       builder.getIndexArrayAttr(lifetimeIntervals), storageSizes, affinityAttr);
@@ -1949,7 +1950,7 @@ void ResourcePackOp::build(OpBuilder &builder, OperationState &state,
   size_t sliceCount = valueSizes.size();
   SmallVector<int64_t> lifetimeIntervals(sliceCount * 2, 0);
   auto indexType = builder.getIndexType();
-  SmallVector<Type> indexTypes(sliceCount, indexType);
+  llvm::Repeated<Type> indexTypes(sliceCount, indexType);
   build(builder, state, indexType, indexTypes, offset,
         builder.getIndexArrayAttr(lifetimeIntervals), valueSizes, affinity);
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceTransients.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceTransients.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
 #include "iree/compiler/Utils/RegionOpUtils.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
@@ -964,7 +965,7 @@ createPackedAllocation(OpBuilder &builder, Location loc,
   }
 
   // Create the pack operation with affinity from the transients op.
-  SmallVector<Type> packedOffsetTypes(sliceSizes.size(), indexType);
+  llvm::Repeated<Type> packedOffsetTypes(sliceSizes.size(), indexType);
   auto packOp = IREE::Stream::ResourcePackOp::create(
       builder, loc, indexType, packedOffsetTypes,
       /*offset=*/nullptr, builder.getIndexArrayAttr(lifetimeIntervals),

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeTransientSizeQueries.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeTransientSizeQueries.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/SetVector.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
@@ -79,7 +80,8 @@ generateSizeQueryFunction(FunctionOpInterface funcOp, StringRef sizeQueryName,
   // - For each pack, we'll return its total size.
   // - For simplicity, we return one index per pack (the total size).
   SmallVector<Type> inputTypes(funcOp.getArgumentTypes());
-  SmallVector<Type> resultTypes(packOps.size(), moduleBuilder.getIndexType());
+  llvm::Repeated<Type> resultTypes(packOps.size(),
+                                   moduleBuilder.getIndexType());
   auto sizeQueryFuncType =
       FunctionType::get(funcOp.getContext(), inputTypes, resultTypes);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/EquivalenceClasses.h"
+#include "llvm/ADT/Repeated.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Debug.h"
@@ -1105,7 +1106,7 @@ allocateLocalTransients(IREE::Stream::AsyncExecuteOp executeOp,
   // the transient allocation required.
   auto fusedLoc = externalBuilder.getFusedLoc(locs);
   auto indexType = externalBuilder.getIndexType();
-  SmallVector<Type> packedOffsetTypes(dynamicSliceSizes.size(), indexType);
+  llvm::Repeated<Type> packedOffsetTypes(dynamicSliceSizes.size(), indexType);
   auto packOp = IREE::Stream::ResourcePackOp::create(
       externalBuilder, fusedLoc, indexType, packedOffsetTypes,
       /*offset=*/nullptr, externalBuilder.getIndexArrayAttr(lifetimeIntervals),


### PR DESCRIPTION
Replace repeated `SmallVector<Value/Type>(n, x)` temporaries with `llvm::Repeated<Value/Type>` where the result is only consumed as a `ValueRange` or `TypeRange`. This avoids needless memory allocations.

This mirrors the MLIR-side refactoring in llvm/llvm-project#188846.

Assisted-by: codex