### PR TITLE
[Codegen] Fix multi-reduction source layout propagation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -252,34 +252,35 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // -----
 
-// The source layout projects to a different layout than the
-// accumulator/result. Fixup should preserve reduction-dim tiling from the
-// source, but use the result layout for non-reduction dims.
-#source_batch_layout = #iree_vector_ext.nested_layout<
+// Reduced form of the masked multi_reduction emitted from online_attention for
+// flex_attention. The source/mask layout projects to the accumulator/result
+// layout after dropping the reduced score dimension.
+#online_attention_source_layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [2, 1, 1, 1],
+  batch_tile = [1, 1, 1, 2],
+  outer_tile = [1, 1, 1, 1],
+  thread_tile = [32, 1, 1, 1],
+  element_tile = [1, 1, 1, 8],
+  subgroup_strides = [1, 0, 0, 0],
+  thread_strides = [1, 0, 0, 0]
+>
+
+#online_attention_result_layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1, 1],
-  batch_tile = [1, 8, 4],
+  batch_tile = [1, 1, 2],
   outer_tile = [1, 1, 1],
   thread_tile = [1, 1, 1],
-  element_tile = [1, 1, 16],
+  element_tile = [1, 1, 8],
   subgroup_strides = [0, 0, 0],
   thread_strides = [0, 0, 0]
 >
 
-#result_outer_layout = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 8],
-  thread_tile = [1, 1],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 0]
->
-
-func.func @multi_reduction_result_layout_differs_from_source_projection_unmasked(%arg0: vector<1x8x64xf32>, %arg1: vector<1x8xf32>) -> vector<1x8xf32> {
-  %arg1l = iree_vector_ext.to_layout %arg1 to layout(#result_outer_layout) : vector<1x8xf32>
-  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#source_batch_layout) : vector<1x8x64xf32>
-  %0 = vector.multi_reduction <add>, %arg0l, %arg1l [2] : vector<1x8x64xf32> to vector<1x8xf32>
-  return %0 : vector<1x8xf32>
+func.func @masked_multi_reduction_keeps_source_layout(%arg0: vector<64x1x1x16xf32>, %arg1: vector<1x1x16xf32>, %mask: vector<64x1x1x16xi1>) -> vector<1x1x16xf32> {
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#online_attention_source_layout) : vector<64x1x1x16xf32>
+  %arg1l = iree_vector_ext.to_layout %arg1 to layout(#online_attention_result_layout) : vector<1x1x16xf32>
+  %maskl = iree_vector_ext.to_layout %mask to layout(#online_attention_source_layout) : vector<64x1x1x16xi1>
+  %0 = vector.mask %maskl { vector.multi_reduction <add>, %arg0l, %arg1l [0] : vector<64x1x1x16xf32> to vector<1x1x16xf32> } : vector<64x1x1x16xi1> -> vector<1x1x16xf32>
+  return %0 : vector<1x1x16xf32>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -290,50 +291,9 @@ builtin.module attributes { transform.with_named_sequence } {
   }
 }
 
-// CHECK-LABEL: func @multi_reduction_result_layout_differs_from_source_projection_unmasked
-// CHECK-NOT: arith.select
-// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [2, 5, 8] : vector<1x1x4x1x8x1x1x1x16xf32> to vector<1x1x1x8x1x1xf32>
-// CHECK: arith.addf %{{.*}}, %{{.*}} : vector<1x1x1x8x1x1xf32>
-
-// -----
-
-#source_batch_layout = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1, 1],
-  batch_tile = [1, 8, 4],
-  outer_tile = [1, 1, 1],
-  thread_tile = [1, 1, 1],
-  element_tile = [1, 1, 16],
-  subgroup_strides = [0, 0, 0],
-  thread_strides = [0, 0, 0]
->
-
-#result_outer_layout = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 8],
-  thread_tile = [1, 1],
-  element_tile = [1, 1],
-  subgroup_strides = [0, 0],
-  thread_strides = [0, 0]
->
-
-func.func @multi_reduction_result_layout_differs_from_source_projection_masked(%arg0: vector<1x8x64xf32>, %arg1: vector<1x8xf32>, %mask: vector<1x8x64xi1>) -> vector<1x8xf32> {
-  %arg1l = iree_vector_ext.to_layout %arg1 to layout(#result_outer_layout) : vector<1x8xf32>
-  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#source_batch_layout) : vector<1x8x64xf32>
-  %maskl = iree_vector_ext.to_layout %mask to layout(#source_batch_layout) : vector<1x8x64xi1>
-  %0 = vector.mask %maskl { vector.multi_reduction <add>, %arg0l, %arg1l [2] : vector<1x8x64xf32> to vector<1x8xf32> } : vector<1x8x64xi1> -> vector<1x8xf32>
-  return %0 : vector<1x8xf32>
-}
-
-builtin.module attributes { transform.with_named_sequence } {
-  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
-    transform.yield
-  }
-}
-
-// CHECK-LABEL: func @multi_reduction_result_layout_differs_from_source_projection_masked
-// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : vector<1x1x4x1x8x1x1x1x16xi1>, vector<1x1x4x1x8x1x1x1x16xf32>
-// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [2, 5, 8] : vector<1x1x4x1x8x1x1x1x16xf32> to vector<1x1x1x8x1x1xf32>
-// CHECK: arith.addf %{{.*}}, %{{.*}} : vector<1x1x1x8x1x1xf32>
+// CHECK-LABEL: func @masked_multi_reduction_keeps_source_layout
+// CHECK: iree_vector_ext.to_simt %{{.*}} : vector<64x1x1x16xf32> -> vector<1x1x1x2x1x1x1x1x1x1x1x8xf32>
+// CHECK: iree_vector_ext.to_simt %{{.*}} : vector<64x1x1x16xi1> -> vector<1x1x1x2x1x1x1x1x1x1x1x8xi1>
+// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : vector<1x1x1x2x1x1x1x1x1x1x1x8xi1>, vector<1x1x1x2x1x1x1x1x1x1x1x8xf32>
+// CHECK: iree_vector_ext.to_simt %{{.*}} : vector<1x1x16xf32> -> vector<1x1x2x1x1x1x1x1x8xf32>
+// CHECK: arith.addf %{{.*}}, %{{.*}} : vector<1x1x2x1x1x1x1x1x8xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -249,3 +249,91 @@ builtin.module attributes { transform.with_named_sequence } {
 // enough threads on the reduction dimension to do a subgroup reduce.
 // CHECK: vector.transfer_read %{{.*}}[%{{.*}}, %[[C0]]]
 // CHECK-NOT: gpu.subgroup_reduce
+
+// -----
+
+// The source layout projects to a different layout than the
+// accumulator/result. Fixup should preserve reduction-dim tiling from the
+// source, but use the result layout for non-reduction dims.
+#source_batch_layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1, 1],
+  batch_tile = [1, 8, 4],
+  outer_tile = [1, 1, 1],
+  thread_tile = [1, 1, 1],
+  element_tile = [1, 1, 16],
+  subgroup_strides = [0, 0, 0],
+  thread_strides = [0, 0, 0]
+>
+
+#result_outer_layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 8],
+  thread_tile = [1, 1],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 0]
+>
+
+func.func @multi_reduction_result_layout_differs_from_source_projection_unmasked(%arg0: vector<1x8x64xf32>, %arg1: vector<1x8xf32>) -> vector<1x8xf32> {
+  %arg1l = iree_vector_ext.to_layout %arg1 to layout(#result_outer_layout) : vector<1x8xf32>
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#source_batch_layout) : vector<1x8x64xf32>
+  %0 = vector.multi_reduction <add>, %arg0l, %arg1l [2] : vector<1x8x64xf32> to vector<1x8xf32>
+  return %0 : vector<1x8xf32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @multi_reduction_result_layout_differs_from_source_projection_unmasked
+// CHECK-NOT: arith.select
+// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [2, 5, 8] : vector<1x1x4x1x8x1x1x1x16xf32> to vector<1x1x1x8x1x1xf32>
+// CHECK: arith.addf %{{.*}}, %{{.*}} : vector<1x1x1x8x1x1xf32>
+
+// -----
+
+#source_batch_layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1, 1],
+  batch_tile = [1, 8, 4],
+  outer_tile = [1, 1, 1],
+  thread_tile = [1, 1, 1],
+  element_tile = [1, 1, 16],
+  subgroup_strides = [0, 0, 0],
+  thread_strides = [0, 0, 0]
+>
+
+#result_outer_layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 8],
+  thread_tile = [1, 1],
+  element_tile = [1, 1],
+  subgroup_strides = [0, 0],
+  thread_strides = [0, 0]
+>
+
+func.func @multi_reduction_result_layout_differs_from_source_projection_masked(%arg0: vector<1x8x64xf32>, %arg1: vector<1x8xf32>, %mask: vector<1x8x64xi1>) -> vector<1x8xf32> {
+  %arg1l = iree_vector_ext.to_layout %arg1 to layout(#result_outer_layout) : vector<1x8xf32>
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#source_batch_layout) : vector<1x8x64xf32>
+  %maskl = iree_vector_ext.to_layout %mask to layout(#source_batch_layout) : vector<1x8x64xi1>
+  %0 = vector.mask %maskl { vector.multi_reduction <add>, %arg0l, %arg1l [2] : vector<1x8x64xf32> to vector<1x8xf32> } : vector<1x8x64xi1> -> vector<1x8xf32>
+  return %0 : vector<1x8xf32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @multi_reduction_result_layout_differs_from_source_projection_masked
+// CHECK: arith.select %{{.*}}, %{{.*}}, %{{.*}} : vector<1x1x4x1x8x1x1x1x16xi1>, vector<1x1x4x1x8x1x1x1x16xf32>
+// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [2, 5, 8] : vector<1x1x4x1x8x1x1x1x16xf32> to vector<1x1x1x8x1x1xf32>
+// CHECK: arith.addf %{{.*}}, %{{.*}} : vector<1x1x1x8x1x1xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -354,6 +354,58 @@ void LayoutAnalysis::fixupRegion(Region &region) {
   }
 }
 
+/// Returns a source layout for a reduction whose projected layout matches the
+/// resolved result layout. The source layout is preserved on reduction
+/// dimensions, while non-reduction dimensions are taken from the result layout.
+static VectorLayoutInterface
+getSourceLayoutForReduction(VectorLayoutInterface sourceLayout,
+                            VectorLayoutInterface resultLayout,
+                            ArrayRef<bool> reductionMask) {
+  auto nestedSource = dyn_cast_if_present<NestedLayoutAttr>(sourceLayout);
+  auto nestedResult = dyn_cast_if_present<NestedLayoutAttr>(resultLayout);
+  if (!nestedSource || !nestedResult) {
+    return {};
+  }
+
+  int64_t sourceRank = nestedSource.getRank();
+  if (static_cast<int64_t>(reductionMask.size()) != sourceRank) {
+    return {};
+  }
+  if (nestedResult.getRank() != llvm::count(reductionMask, false)) {
+    return {};
+  }
+
+  MLIRContext *context = nestedSource.getContext();
+  SmallVector<AffineExpr> reductionExprs;
+  SmallVector<AffineExpr> resultExprs;
+  reductionExprs.reserve(llvm::count(reductionMask, true));
+  resultExprs.reserve(llvm::count(reductionMask, false));
+
+  for (int64_t sourceDim = 0; sourceDim < sourceRank; ++sourceDim) {
+    AffineExpr dim = getAffineDimExpr(sourceDim, context);
+    if (reductionMask[sourceDim]) {
+      reductionExprs.push_back(dim);
+    } else {
+      resultExprs.push_back(dim);
+    }
+  }
+
+  AffineMap reductionMap =
+      AffineMap::get(sourceRank, /*symbolCount=*/0, reductionExprs, context);
+  AffineMap resultMap =
+      AffineMap::get(sourceRank, /*symbolCount=*/0, resultExprs, context);
+  AffineMap sourceIdentityMap =
+      AffineMap::getMultiDimIdentityMap(sourceRank, context);
+
+  VectorLayoutInterface reductionLayout = nestedSource.apply(reductionMap);
+  if (!reductionLayout) {
+    return {};
+  }
+  return nestedSource.getRecombinedLayout({reductionLayout, nestedResult},
+                                          {reductionMap, resultMap},
+                                          sourceIdentityMap);
+}
+
 /// Fix up operand layouts for a single operation. Result layouts are fixed
 /// (from resolve); this determines what operand layouts should be.
 void LayoutAnalysis::fixupOp(Operation *op) {
@@ -404,8 +456,21 @@ void LayoutAnalysis::fixupOp(Operation *op) {
 
   // multi_dim_reduction: result layout -> acc gets same layout.
   if (auto multiReduce = dyn_cast<vector::MultiDimReductionOp>(op)) {
-    VectorLayoutInterface layout = getResolvedLayout(multiReduce.getResult());
-    setLayoutOrClone(&multiReduce.getAccMutable(), layout);
+    VectorLayoutInterface resultLayout =
+        getResolvedLayout(multiReduce.getResult());
+    setLayoutOrClone(&multiReduce.getAccMutable(), resultLayout);
+
+    VectorLayoutInterface sourceLayout =
+        getResolvedLayout(multiReduce.getSource());
+    VectorLayoutInterface compatibleSourceLayout = getSourceLayoutForReduction(
+        sourceLayout, resultLayout, multiReduce.getReductionMask());
+    setLayoutOrClone(&multiReduce.getSourceMutable(), compatibleSourceLayout);
+
+    if (auto maskOp = dyn_cast<vector::MaskOp>(multiReduce->getParentOp())) {
+      // Multi-reduction masks index the source iteration space, so keep the
+      // parent mask in the same source-compatible layout used by the reduction.
+      setLayoutOrClone(&maskOp.getMaskMutable(), compatibleSourceLayout);
+    }
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -354,58 +354,6 @@ void LayoutAnalysis::fixupRegion(Region &region) {
   }
 }
 
-/// Returns a source layout for a reduction whose projected layout matches the
-/// resolved result layout. The source layout is preserved on reduction
-/// dimensions, while non-reduction dimensions are taken from the result layout.
-static VectorLayoutInterface
-getSourceLayoutForReduction(VectorLayoutInterface sourceLayout,
-                            VectorLayoutInterface resultLayout,
-                            ArrayRef<bool> reductionMask) {
-  auto nestedSource = dyn_cast_if_present<NestedLayoutAttr>(sourceLayout);
-  auto nestedResult = dyn_cast_if_present<NestedLayoutAttr>(resultLayout);
-  if (!nestedSource || !nestedResult) {
-    return {};
-  }
-
-  int64_t sourceRank = nestedSource.getRank();
-  if (static_cast<int64_t>(reductionMask.size()) != sourceRank) {
-    return {};
-  }
-  if (nestedResult.getRank() != llvm::count(reductionMask, false)) {
-    return {};
-  }
-
-  MLIRContext *context = nestedSource.getContext();
-  SmallVector<AffineExpr> reductionExprs;
-  SmallVector<AffineExpr> resultExprs;
-  reductionExprs.reserve(llvm::count(reductionMask, true));
-  resultExprs.reserve(llvm::count(reductionMask, false));
-
-  for (int64_t sourceDim = 0; sourceDim < sourceRank; ++sourceDim) {
-    AffineExpr dim = getAffineDimExpr(sourceDim, context);
-    if (reductionMask[sourceDim]) {
-      reductionExprs.push_back(dim);
-    } else {
-      resultExprs.push_back(dim);
-    }
-  }
-
-  AffineMap reductionMap =
-      AffineMap::get(sourceRank, /*symbolCount=*/0, reductionExprs, context);
-  AffineMap resultMap =
-      AffineMap::get(sourceRank, /*symbolCount=*/0, resultExprs, context);
-  AffineMap sourceIdentityMap =
-      AffineMap::getMultiDimIdentityMap(sourceRank, context);
-
-  VectorLayoutInterface reductionLayout = nestedSource.apply(reductionMap);
-  if (!reductionLayout) {
-    return {};
-  }
-  return nestedSource.getRecombinedLayout({reductionLayout, nestedResult},
-                                          {reductionMap, resultMap},
-                                          sourceIdentityMap);
-}
-
 /// Fix up operand layouts for a single operation. Result layouts are fixed
 /// (from resolve); this determines what operand layouts should be.
 void LayoutAnalysis::fixupOp(Operation *op) {
@@ -454,7 +402,9 @@ void LayoutAnalysis::fixupOp(Operation *op) {
     return;
   }
 
-  // multi_dim_reduction: result layout -> acc gets same layout.
+  // multi_dim_reduction: result layout -> acc gets same layout. The source and
+  // mask index the unreduced source iteration space and should keep the source
+  // layout.
   if (auto multiReduce = dyn_cast<vector::MultiDimReductionOp>(op)) {
     VectorLayoutInterface resultLayout =
         getResolvedLayout(multiReduce.getResult());
@@ -462,14 +412,10 @@ void LayoutAnalysis::fixupOp(Operation *op) {
 
     VectorLayoutInterface sourceLayout =
         getResolvedLayout(multiReduce.getSource());
-    VectorLayoutInterface compatibleSourceLayout = getSourceLayoutForReduction(
-        sourceLayout, resultLayout, multiReduce.getReductionMask());
-    setLayoutOrClone(&multiReduce.getSourceMutable(), compatibleSourceLayout);
+    setLayoutOrClone(&multiReduce.getSourceMutable(), sourceLayout);
 
     if (auto maskOp = dyn_cast<vector::MaskOp>(multiReduce->getParentOp())) {
-      // Multi-reduction masks index the source iteration space, so keep the
-      // parent mask in the same source-compatible layout used by the reduction.
-      setLayoutOrClone(&maskOp.getMaskMutable(), compatibleSourceLayout);
+      setLayoutOrClone(&maskOp.getMaskMutable(), sourceLayout);
     }
     return;
   }


### PR DESCRIPTION
Recombine multi-reduction source layouts from the source reduction dimensions and result non-reduction dimensions so distributed local reductions stay compatible with the accumulator/result layout.

Also keep parent vector.mask operands in the same source-compatible layout for masked multi-reductions.

Uncovered this bug when `flex_attention` -> `online_attention` generated a masked reduction over the score/key dimension.