### PR TITLE
[Codegen][CPU] Replace transposed_intrinsic with explicit pre-transposed enums.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
@@ -320,6 +320,34 @@ func.func @matmul_i4_i32_avx2_generic(
 
 // -----
 
+// Narrow-N: with `iteration_sizes = [_, 8, _]` the cost model picks the
+// M↔N-swapped orientation MMA_X86_AVX512_16x1x1_F32_F32 (rather than the
+// natural 1x16x1) — the static N=8 caps natural usefulOps to 8, while the
+// transposed orientation fully uses 16 lanes on the M side. Unrolling lands
+// on intrinsics_m=2, intrinsics_n=8 (M_inner=32, N_inner=8). Each operand's
+// pack inherits the intrinsic's natural (outer, inner) ordering — for the
+// 16x1x1 intrinsic, the LHS inner is (M=16, K=1), the RHS inner is (N=1, K=1),
+// and the ACC inner is (M=16, N=1). After cross-intrinsic unrolling, the ACC
+// is stored in physical (M=32, N=8) order, the way row-major matmul tiles are.
+
+#map_t = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map_t1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map_t2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding_t_res = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map_t, #map_t1, #map_t2], iteration_sizes = [127, 8, ?]>
+func.func @unset_encoding_RESULT_inner_tiled_avx512_narrow_n(%arg0: tensor<127x255xf32, #encoding_t_res>, %k: index) -> tensor<127x255xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%k} : tensor<127x255xf32, #encoding_t_res> -> tensor<127x255xf32>
+  return %0 : tensor<127x255xf32>
+}
+// CHECK-LABEL: func @unset_encoding_RESULT_inner_tiled_avx512_narrow_n(
+//  CHECK-SAME:   %[[PACKED_T:[a-zA-Z0-9]+]]: tensor<4x32x32x8xf32>
+//       CHECK:   %[[UNPACK_T:.+]] = linalg.unpack %[[PACKED_T]]
+//  CHECK-SAME:     outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 8]
+//       CHECK:   return %[[UNPACK_T]]
+
+// -----
+
 // It tests with bindings and checks that the reshape ops are folded into bindings.
 
 #executable_target_xyz = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -338,19 +338,34 @@ getRowMajorTilesMNKShape(MMAIntrinsic intrinsic) {
     return Tuple{0, 0, 0};
   case MMAIntrinsic::MMA_X86_AVX2_FMA_1x8x1_F32_F32:
     return Tuple{1, 8, 1};
+  case MMAIntrinsic::MMA_X86_AVX2_FMA_8x1x1_F32_F32:
+    return Tuple{8, 1, 1};
   case MMAIntrinsic::MMA_X86_AVX512_1x8x1_F64_F64:
     return Tuple{1, 8, 1};
+  case MMAIntrinsic::MMA_X86_AVX512_8x1x1_F64_F64:
+    return Tuple{8, 1, 1};
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F32:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
     return Tuple{1, 16, 1};
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
+    return Tuple{16, 1, 1};
   case MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16:
     return Tuple{1, 32, 1};
+  case MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16:
+    return Tuple{32, 1, 1};
   case MMAIntrinsic::MMA_X86_AVX512BF16_1x16x2_F32_BF16:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
     return Tuple{1, 16, 2};
+  case MMAIntrinsic::MMA_X86_AVX512BF16_16x1x2_F32_BF16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
+    return Tuple{16, 1, 2};
   default:
     if (isGenericScalar(intrinsic)) {
       return Tuple{1, 1, 1};
@@ -424,15 +439,22 @@ static Codegen::TileSwizzle fixupSwizzle(Codegen::TileSwizzle swizzle) {
 }
 
 Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
-                                         bool transposed, int operandIdx) {
+                                         int operandIdx) {
   using TileSwizzle = Codegen::TileSwizzle;
   using Dim = TileSwizzle::Dim;
 
-  // Just one scalable intrinsic for now, to allow writing some tests.
-  if (mma == MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32) {
+  // SVE has scalable dims that the row-major path below can't express, so we
+  // hand-roll the swizzle. The natural orientation is 1×4VL×1: 4VL lives on
+  // RHS dim 0 (N) and ACC dim 0 (the convention is `(N, M)` here). The
+  // transposed orientation 4VL×1×1 mirrors that: 4VL on LHS dim 0 (M) and
+  // ACC dim 0 (now `(M, N)`).
+  if (mma == MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32 ||
+      mma == MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32) {
+    bool transposed = (mma == MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32);
     TileSwizzle swizzle;
     swizzle.expandShape().resize(2);
-    if (operandIdx != 0) {
+    int operandWith4VL = transposed ? 0 : 1;
+    if (operandIdx == operandWith4VL || operandIdx == 2) {
       Codegen::expand(
           swizzle, /*srcDim=*/0,
           Dim::internal(4, Dim::SymbolicMultiplier::ArmSveVLIn128bitUnits));
@@ -448,13 +470,6 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
     return TileSwizzle();
   }
   auto [mSize, nSize, kSize] = *maybeMnkTuple;
-  // In the transposed orientation, the intrinsic's hardware (M, N) roles are
-  // logically swapped: what the matmul code sees as M is driven by the
-  // intrinsic's N-dim, and vice versa. Swap the sizes up front so that the
-  // per-operand expansion code below can stay oblivious to orientation.
-  if (transposed) {
-    std::swap(mSize, nSize);
-  }
   TileSwizzle swizzle;
   swizzle.expandShape().resize(2);
   auto expandIfNonUnit = [](TileSwizzle &swizzle, int dim, int size) {
@@ -463,13 +478,9 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
     }
   };
 
-  // For every operand, expandShape[0] is the outer physical dim and
-  // expandShape[1] is the inner physical dim, with identity permutation. For
-  // the ACC in particular, `transposed_intrinsic` flips the logical (M, N) to
-  // physical (N, M), which we encode by swapping which logical dim fills each
-  // expandShape group rather than by a non-identity permutation. That way all
-  // three operand swizzles can be read on equal footing, just like LHS (M, K)
-  // and RHS (N, K).
+  // expandShape[0] is the outer physical dim and expandShape[1] is the inner
+  // physical dim, with identity permutation. LHS is (M, K), RHS is (N, K),
+  // ACC is (M, N).
   if (operandIdx == 0) {
     constexpr int M = 0, K = 1;
     expandIfNonUnit(swizzle, K, kSize);
@@ -479,10 +490,9 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
     expandIfNonUnit(swizzle, K, kSize);
     expandIfNonUnit(swizzle, N, nSize);
   } else {
-    int64_t accOuter = transposed ? nSize : mSize;
-    int64_t accInner = transposed ? mSize : nSize;
-    expandIfNonUnit(swizzle, 1, accInner);
-    expandIfNonUnit(swizzle, 0, accOuter);
+    constexpr int M = 0, N = 1;
+    expandIfNonUnit(swizzle, N, nSize);
+    expandIfNonUnit(swizzle, M, mSize);
   }
   return fixupSwizzle(std::move(swizzle));
 }
@@ -490,8 +500,7 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
 Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
                                 int operandIdx) {
   using TileSwizzle = Codegen::TileSwizzle;
-  TileSwizzle swizzle = getIntrinsicSwizzle(
-      mma.getIntrinsic(), mma.getTransposedIntrinsic(), operandIdx);
+  TileSwizzle swizzle = getIntrinsicSwizzle(mma.getIntrinsic(), operandIdx);
   TileSwizzle::Dim intrinsicsM =
       TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsM());
   TileSwizzle::Dim intrinsicsN =
@@ -500,9 +509,8 @@ Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
       TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsK());
   // Each swizzle is built as (outer physical dim, inner physical dim) in
   // expandShape[0], expandShape[1]. LHS is (M, K), RHS is (N, K), ACC is
-  // (M, N) normally and (N, M) when `transposed_intrinsic` is set. The
-  // expansion below injects the intrinsics_* cross-intrinsic factors into
-  // whichever group represents each logical dim.
+  // (M, N). The expansion below injects the intrinsics_* cross-intrinsic
+  // factors into whichever group represents each logical dim.
   if (operandIdx == 0) {
     constexpr int M = 0, K = 1;
     if (intrinsicsK.size() > 1) {
@@ -520,65 +528,75 @@ Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
       Codegen::expand(swizzle, N, intrinsicsN);
     }
   } else {
-    bool transposed = mma.getTransposedIntrinsic();
-    TileSwizzle::Dim accOuterIntr = transposed ? intrinsicsN : intrinsicsM;
-    TileSwizzle::Dim accInnerIntr = transposed ? intrinsicsM : intrinsicsN;
-    if (accInnerIntr.size() > 1) {
-      Codegen::expand(swizzle, /*srcIdx=*/1, accInnerIntr);
+    constexpr int M = 0, N = 1;
+    if (intrinsicsN.size() > 1) {
+      Codegen::expand(swizzle, N, intrinsicsN);
     }
-    if (accOuterIntr.size() > 1) {
-      Codegen::expand(swizzle, /*srcIdx=*/0, accOuterIntr);
+    if (intrinsicsM.size() > 1) {
+      Codegen::expand(swizzle, M, intrinsicsM);
     }
   }
   return swizzle;
 }
 
-static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *context,
+static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
                                                        MMAIntrinsic intrinsic) {
-  Type f64 = Float64Type::get(context);
-  Type f32 = Float32Type::get(context);
-  Type f16 = Float16Type::get(context);
-  Type bf16 = BFloat16Type::get(context);
-  Type i32 = IntegerType::get(context, 32);
-  Type i16 = IntegerType::get(context, 16);
-  Type i8 = IntegerType::get(context, 8);
+  Type f64 = Float64Type::get(ctx);
+  Type f32 = Float32Type::get(ctx);
+  Type f16 = Float16Type::get(ctx);
+  Type bf16 = BFloat16Type::get(ctx);
+  Type i32 = IntegerType::get(ctx, 32);
+  Type i16 = IntegerType::get(ctx, 16);
+  Type i8 = IntegerType::get(ctx, 8);
   switch (intrinsic) {
   case MMAIntrinsic::None:
     return {Type(), Type(), Type()};
   case MMAIntrinsic::MMA_X86_AVX2_FMA_1x8x1_F32_F32:
+  case MMAIntrinsic::MMA_X86_AVX2_FMA_8x1x1_F32_F32:
     return {f32, f32, f32};
   case MMAIntrinsic::MMA_X86_AVX512_1x8x1_F64_F64:
+  case MMAIntrinsic::MMA_X86_AVX512_8x1x1_F64_F64:
     return {f64, f64, f64};
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F32:
     return {f32, f32, f32};
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
     return {f16, f16, f32};
   case MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16:
+  case MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16:
     return {f16, f16, f16};
   case MMAIntrinsic::MMA_X86_AVX512BF16_1x16x2_F32_BF16:
+  case MMAIntrinsic::MMA_X86_AVX512BF16_16x1x2_F32_BF16:
     return {bf16, bf16, f32};
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16:
     return {i16, i16, i32};
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return {i8, i8, i32};
   case MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32:
+  case MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32:
     return {f32, f32, f32};
   default:
     return {Type(), Type(), Type()};
   }
 }
 
-/// Returns the (LHS, RHS, ACC) *storage* element types for `attr` — what
-/// `getDistributedTileTypes` should plumb into vector types and what the
-/// inner_tiled op's operand types must agree with. For most `MMAIntrinsic`
-/// values these are baked into the enum and the `MMAIntrinsic`-only
-/// overload above suffices. The `MMA_GENERIC_SCALAR_1x1x1_REG*` family is
-/// type-polymorphic — its element types live on the attr's `lhs_type` /
-/// `rhs_type` / `acc_type` parameters. We strip integer signedness here:
-/// storage is always signless, the attr keeps the `siN` / `uiN` annotation
-/// for the lowering to pick `arith.extsi` vs `arith.extui`.
+/// Returns the (LHS, RHS, ACC) element types for `attr`, possibly carrying
+/// signedness annotations. For most `MMAIntrinsic` values these are baked
+/// into the enum and the `MMAIntrinsic`-only overload above suffices. The
+/// `MMA_GENERIC_SCALAR_1x1x1_REG*` family is type-polymorphic — its
+/// element types live on the attr's `lhs_type` / `rhs_type` / `acc_type`
+/// parameters and are returned as-is so the lowering can read the
+/// signedness to pick `arith.extsi` vs `arith.extui`.
+/// Vector tile types in IR (via `getUndistributedTileTypes`) are signless;
+/// the signedness here is for matching against the encoding's
+/// `element_types` and for routing in the lowering.
 static std::tuple<Type, Type, Type>
 getABCElementTypes(MLIRContext *context, IREE::CPU::DataTiledMMAAttr attr) {
   MMAIntrinsic intrinsic = attr.getIntrinsic();
@@ -637,10 +655,7 @@ void DataTiledMMAAttr::getUndistributedTileTypes(
   // inner physical dim) in expandShape[0], expandShape[1]. This mirrors GPU's
   // DataTiledMMA, where the tile types encode the layout directly and no
   // separate `permutations` attribute is needed on `inner_tiled`. LHS is
-  // (M, K), RHS is (N, K), and ACC is (M, N) for non-transposed intrinsics
-  // and (N, M) for transposed ones; that transposition is baked into the ACC
-  // swizzle itself (see getIntrinsicSwizzle), so we can query all three
-  // operands uniformly here.
+  // (M, K), RHS is (N, K), ACC is (M, N).
   auto tileType = [&](Codegen::TileSwizzle swizzle, Type elemType) {
     auto [outer, outerScalable] =
         getVectorAxisSizeAndScalability(swizzle.expandShape()[0]);
@@ -687,19 +702,18 @@ DataTiledMMAAttr::getDistributionWorkerCount(OpBuilder &builder, Location loc,
 // Lowers a MMAIntrinsic to a llvm.call_intrinsic op, plus any necessary
 // additional ops (potentially broadcasting or widening LHS/RHS or creating an
 // add op if the intrinsic isn't already adding the accumulator).
-//
-// Currently assumes that if one of LHS or RHS needs to be broadcasted, then it
-// musst be LHS. This corresponds to the fact that transposed intrinsics are not
-// currently handled by the caller, which is just a temporary limitation.
 static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
                                        MMAIntrinsic intrinsic, Value lhs,
                                        Value rhs, Value acc) {
-  // Replicate LHS (M=1, K elements) across RHS's N lanes so both have the
-  // intrinsic's flat lane width. Going through a (N, K) 2-D form keeps the
-  // K-pair contiguous; a final shape_cast collapses to the flat 1-D vector
-  // the LLVM intrinsic expects. All x86 LLVM intrinsics we target here
-  // (AVX-512 FMA, VNNI vpdpwssd, BF16 dpbf16ps, integer pmaddwd) take same-
-  // width vector operands — there is no narrow-input variant. The ISA-level
+  // Replicate whichever of LHS/RHS has fewer lanes up to the other's lane
+  // count, so both reach the intrinsic's flat lane width. In the natural
+  // 1×N×K orientation that's the LHS (M=1) broadcast across the N lanes of
+  // the RHS; in the M↔N-swapped N×1×K orientation it's the RHS (N=1) that
+  // gets broadcast. Going through a (lanes, K) 2-D form keeps the K-pair
+  // contiguous; a final shape_cast collapses to the flat 1-D vector the
+  // LLVM intrinsic expects. All x86 LLVM intrinsics we target here (AVX-512
+  // FMA, VNNI vpdpwssd, BF16 dpbf16ps, integer pmaddwd) take same-width
+  // vector operands — there is no single-lane-input variant. The ISA-level
   // `{1toN}` broadcast-from-memory form is recovered later by the x86
   // backend's instruction selector pattern-matching this `vector.broadcast`-
   // of-load into the EVEX broadcast operand, so the explicit broadcast here
@@ -711,11 +725,25 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   auto lhsType = cast<VectorType>(lhs.getType());
   auto rhsType = cast<VectorType>(rhs.getType());
   if (lhsType.getNumElements() != rhsType.getNumElements()) {
-    int64_t replicate = rhsType.getNumElements() / lhsType.getNumElements();
-    auto bcastType = VectorType::get({replicate, lhsType.getNumElements()},
-                                     lhsType.getElementType());
-    Value bcast = vector::BroadcastOp::create(builder, loc, bcastType, lhs);
-    lhs = vector::ShapeCastOp::create(builder, loc, rhsType, bcast);
+    // `bcastSrc` is the operand fed into `vector.broadcast`; `bcastDst` is
+    // the operand whose lane count we match. They alias the underlying
+    // lhs/rhs through pointers so the broadcast result flows back into the
+    // variable used by the switch below.
+    Value *bcastSrc = &lhs;
+    Value *bcastDst = &rhs;
+    VectorType bcastSrcType = lhsType;
+    VectorType bcastDstType = rhsType;
+    if (bcastSrcType.getNumElements() > bcastDstType.getNumElements()) {
+      std::swap(bcastSrc, bcastDst);
+      std::swap(bcastSrcType, bcastDstType);
+    }
+    int64_t replicate =
+        bcastDstType.getNumElements() / bcastSrcType.getNumElements();
+    auto bcastType = VectorType::get({replicate, bcastSrcType.getNumElements()},
+                                     bcastSrcType.getElementType());
+    Value bcast =
+        vector::BroadcastOp::create(builder, loc, bcastType, *bcastSrc);
+    *bcastSrc = vector::ShapeCastOp::create(builder, loc, bcastDstType, bcast);
   }
 
   // Sign-/float-extend a vector to a wider element type. Used by the
@@ -741,33 +769,48 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   Type f32 = builder.getF32Type();
   Type i16 = builder.getI16Type();
   Type accType = acc.getType();
+  // The x86 MMAs supported here are LHS/RHS-symmetric (FMA, dpbf16ps,
+  // vpdpwssd, pmaddw), so natural and swapped orientations share the same
+  // LLVM intrinsic and arg order — after the broadcast above both operands
+  // have the same lane count. Asymmetric intrinsics (e.g. vpdpbusd) would
+  // need per-orientation arg-routing and aren't supported.
   switch (intrinsic) {
   case MMAIntrinsic::MMA_X86_AVX2_FMA_1x8x1_F32_F32:
+  case MMAIntrinsic::MMA_X86_AVX2_FMA_8x1x1_F32_F32:
     return call("llvm.fma.v8f32", accType, ValueRange{lhs, rhs, acc});
   case MMAIntrinsic::MMA_X86_AVX512_1x8x1_F64_F64:
+  case MMAIntrinsic::MMA_X86_AVX512_8x1x1_F64_F64:
     return call("llvm.fma.v8f64", accType, ValueRange{lhs, rhs, acc});
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F32:
     return call("llvm.fma.v16f32", accType, ValueRange{lhs, rhs, acc});
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
     return call("llvm.fma.v16f32", accType,
                 ValueRange{widen(lhs, f32), widen(rhs, f32), acc});
   case MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16:
+  case MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16:
     return call("llvm.fma.v32f16", accType, ValueRange{lhs, rhs, acc});
   case MMAIntrinsic::MMA_X86_AVX512BF16_1x16x2_F32_BF16:
+  case MMAIntrinsic::MMA_X86_AVX512BF16_16x1x2_F32_BF16:
     return call("llvm.x86.avx512bf16.dpbf16ps.512", accType,
                 ValueRange{acc, lhs, rhs});
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16:
     return call("llvm.x86.avx512.vpdpwssd.512", accType,
                 ValueRange{acc, lhs, rhs});
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return call("llvm.x86.avx512.vpdpwssd.512", accType,
                 ValueRange{acc, widen(lhs, i16), widen(rhs, i16)});
-  case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16: {
+  case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16: {
     return arith::AddIOp::create(
         builder, loc, acc,
         call("llvm.x86.avx512.pmaddw.d.512", accType, ValueRange{lhs, rhs}));
   }
-  case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16: {
+  case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16: {
     return arith::AddIOp::create(
         builder, loc, acc,
         call("llvm.x86.avx512.pmaddw.d.512", accType,
@@ -835,14 +878,6 @@ static LogicalResult lowerGenericScalarToVectorContract(
 LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
     OpBuilder &builder, Location loc, ValueRange inputs, ValueRange outputs,
     SmallVectorImpl<Value> &results) const {
-  // TODO: handle `transposed_intrinsic`. When set, LHS and RHS swap roles
-  // (narrow-N case), and the broadcast in `createCpuMmaIntrinsicCall` would
-  // need to broadcast whichever operand is narrower rather than always LHS.
-  // Bail for now so we don't silently produce wrong code.
-  if (getTransposedIntrinsic()) {
-    return failure();
-  }
-
   SmallVector<VectorType> regTypes;
   getDistributedTileTypes(regTypes);
   if (inputs.size() != 2 || outputs.size() != 1 ||

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -83,11 +83,11 @@ def IREECPU_DataTiledMMAAttr
     thread-distribution, no concept of subgroups and no interleaving of
     intrinsics' layout.
 
-    The `transposed_intrinsic` boolean toggles between the intrinsic's natural
-    orientation and an M↔N-swapped orientation (same hardware instruction with
-    LHS/RHS roles exchanged, accumulator laid out column-major). Orthogonal to
-    the intrinsic itself: any intrinsic may be used transposed, including
-    square ones where the effect is only the accumulator layout change.
+    Each non-square hardware MMA appears as two `MMAIntrinsic` enum values —
+    one per orientation (e.g. `MMA_X86_AVX512_1x16x1_F32_F32` and its
+    M↔N-swapped sibling `MMA_X86_AVX512_16x1x1_F32_F32`). The cost model
+    treats them as distinct candidates and picks whichever fits the matmul
+    shape better.
 
     For most `intrinsic` values the (LHS, RHS, ACC) element types are baked
     into the enum and `lhs_type` / `rhs_type` / `acc_type` are unused. The
@@ -116,11 +116,6 @@ def IREECPU_DataTiledMMAAttr
           DefaultValuedParameter<
               "int64_t", "1",
               "Intrinsic count along the K dimension.">:$intrinsics_k,
-          DefaultValuedParameter<
-              "bool", "false",
-              "If true, the intrinsic is used in an M↔N-swapped orientation "
-              "(LHS/RHS roles exchanged, accumulator "
-              "column-major).">:$transposed_intrinsic,
           DefaultValuedParameter<
               "::mlir::Type", "::mlir::Type()",
               "LHS element type, used only by type-polymorphic intrinsics "

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -46,13 +46,11 @@ class IREECPU_I32EnumAttr<string name, string summary,
 //       with different tile sizes.
 //
 // Note that even a scalar multiply-accumulate is technically a matmul
-// with MxNxK shape 1x1x1. Vector element-wise multiply-accumulate with vector
-// size N is seen here as a matrix multiply-accumulate with MxNxK shape 1xNx1.
-// It could be equivalently seen as shape Nx1x1, so we have to pick a convention
-// here, breaking the M-N symmetry: we choose to spread the vector dimension
-// along the N matrix dimension. The MMA attribute types that wrap this enum
-// shall combine it with a boolean "transpose" parameter flipping that, which
-// will typically be used for narrow matmuls with a small N-dimension size.
+// with MxNxK shape 1x1x1. A vector multiply-accumulate of N lanes can be
+// spread along either M (Nx1x1) or N (1xNx1); both orientations are
+// useful (different ACC layouts and broadcast directions). We enumerate
+// each orientation as its own `MMAIntrinsic` value — see the bit-0
+// convention on D below.
 //
 // Symbolic names are of the form
 //
@@ -93,7 +91,11 @@ class IREECPU_I32EnumAttr<string name, string summary,
 //   * 4 = 8-bit float (incl. f8E5M2, f8E4M3FN, etc).
 //   * A = 16-bit integer (any signedness).
 //   * C = 8-bit integer (any signedness).
-// * D enumerates intrinsics that share the same 0xABC* bits.
+// * D enumerates intrinsics sharing the same 0xABC* bits. Bit 0 of D
+//   (mask 0x1) marks the M↔N-swapped orientation: each natural/swapped
+//   pair occupies two consecutive values, and the swapped sibling of `X`
+//   is `X ^ 1`. Neither orientation is fundamental — the cost model picks
+//   whichever fits the matmul shape best.
 //
 def IREECPU_MMA_None : I32EnumAttrCase<"None", 0>;
 
@@ -103,34 +105,54 @@ def IREECPU_MMA_None : I32EnumAttrCase<"None", 0>;
 // `+fma`.
 def MMA_X86_AVX2_FMA_1x8x1_F32_F32
     : I32EnumAttrCase<"MMA_X86_AVX2_FMA_1x8x1_F32_F32", 0x1210>;
+def MMA_X86_AVX2_FMA_8x1x1_F32_F32
+    : I32EnumAttrCase<"MMA_X86_AVX2_FMA_8x1x1_F32_F32", 0x1211>;
 
-// X86 AVX-512 (ZMM registers). Only the "natural" (canonical M<=N) orientation
-// of each intrinsic is listed here; the M/N-swapped ("transposed") variant is
-// expressed by the `transposed_intrinsic` boolean on DataTiledMMAAttr rather
-// than as a separate enum value.
+// X86 AVX-512 (ZMM registers). Each intrinsic is listed in both its natural
+// and M↔N-swapped orientations; the swapped variant has bit 0 of D set.
 def MMA_X86_AVX512_1x8x1_F64_F64
     : I32EnumAttrCase<"MMA_X86_AVX512_1x8x1_F64_F64", 0x1300>;
+def MMA_X86_AVX512_8x1x1_F64_F64
+    : I32EnumAttrCase<"MMA_X86_AVX512_8x1x1_F64_F64", 0x1301>;
 def MMA_X86_AVX512_1x16x1_F32_F32
     : I32EnumAttrCase<"MMA_X86_AVX512_1x16x1_F32_F32", 0x1310>;
+def MMA_X86_AVX512_16x1x1_F32_F32
+    : I32EnumAttrCase<"MMA_X86_AVX512_16x1x1_F32_F32", 0x1311>;
 def MMA_X86_AVX512_1x16x1_F32_F16_CASTF32
     : I32EnumAttrCase<"MMA_X86_AVX512_1x16x1_F32_F16_CASTF32", 0x1320>;
+def MMA_X86_AVX512_16x1x1_F32_F16_CASTF32
+    : I32EnumAttrCase<"MMA_X86_AVX512_16x1x1_F32_F16_CASTF32", 0x1321>;
 def MMA_X86_AVX512FP16_1x32x1_F16_F16
-    : I32EnumAttrCase<"MMA_X86_AVX512FP16_1x32x1_F16_F16", 0x1321>;
+    : I32EnumAttrCase<"MMA_X86_AVX512FP16_1x32x1_F16_F16", 0x1322>;
+def MMA_X86_AVX512FP16_32x1x1_F16_F16
+    : I32EnumAttrCase<"MMA_X86_AVX512FP16_32x1x1_F16_F16", 0x1323>;
 def MMA_X86_AVX512BF16_1x16x2_F32_BF16
     : I32EnumAttrCase<"MMA_X86_AVX512BF16_1x16x2_F32_BF16", 0x1330>;
+def MMA_X86_AVX512BF16_16x1x2_F32_BF16
+    : I32EnumAttrCase<"MMA_X86_AVX512BF16_16x1x2_F32_BF16", 0x1331>;
 def MMA_X86_AVX512_1x16x2_I32_I16
     : I32EnumAttrCase<"MMA_X86_AVX512_1x16x2_I32_I16", 0x13A0>;
+def MMA_X86_AVX512_16x1x2_I32_I16
+    : I32EnumAttrCase<"MMA_X86_AVX512_16x1x2_I32_I16", 0x13A1>;
 def MMA_X86_AVX512VNNI_1x16x2_I32_I16
-    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I16", 0x13A1>;
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I16", 0x13A2>;
+def MMA_X86_AVX512VNNI_16x1x2_I32_I16
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_16x1x2_I32_I16", 0x13A3>;
 def MMA_X86_AVX512_1x16x2_I32_I8_CASTI16
     : I32EnumAttrCase<"MMA_X86_AVX512_1x16x2_I32_I8_CASTI16", 0x13C0>;
+def MMA_X86_AVX512_16x1x2_I32_I8_CASTI16
+    : I32EnumAttrCase<"MMA_X86_AVX512_16x1x2_I32_I8_CASTI16", 0x13C1>;
 def MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16
-    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16", 0x13C1>;
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16", 0x13C2>;
+def MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16", 0x13C3>;
 
-// AArch64 SVE `fmla` (f32, f32): 1×N×1 matmul tile; N is a scalable vector of
-// 4 f32 lanes per 128-bit chunk (see `ArmSveVLIn128bitUnits`).
+// AArch64 SVE `fmla` (f32, f32): N×1×1 or 1×N×1 matmul tile; N is a scalable
+// vector of 4 f32 lanes per 128-bit chunk (see `ArmSveVLIn128bitUnits`).
 def MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32
     : I32EnumAttrCase<"MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32", 0x2210>;
+def MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32
+    : I32EnumAttrCase<"MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32", 0x2211>;
 
 // Architecture-agnostic, type-polymorphic generic-scalar fallback. Tile
 // shape is 1×1×1, lowering is a single `vector.contract` over the
@@ -157,19 +179,25 @@ def IREECPU_MMAIntrinsic
           [IREECPU_MMA_None,
 
            // X86 AVX/AVX2 + FMA
-           MMA_X86_AVX2_FMA_1x8x1_F32_F32,
+           MMA_X86_AVX2_FMA_1x8x1_F32_F32, MMA_X86_AVX2_FMA_8x1x1_F32_F32,
 
            // X86 AVX-512
-           MMA_X86_AVX512_1x8x1_F64_F64, MMA_X86_AVX512_1x16x1_F32_F32,
+           MMA_X86_AVX512_1x8x1_F64_F64, MMA_X86_AVX512_8x1x1_F64_F64,
+           MMA_X86_AVX512_1x16x1_F32_F32, MMA_X86_AVX512_16x1x1_F32_F32,
            MMA_X86_AVX512_1x16x1_F32_F16_CASTF32,
-           MMA_X86_AVX512FP16_1x32x1_F16_F16,
-           MMA_X86_AVX512BF16_1x16x2_F32_BF16, MMA_X86_AVX512_1x16x2_I32_I16,
-           MMA_X86_AVX512VNNI_1x16x2_I32_I16,
+           MMA_X86_AVX512_16x1x1_F32_F16_CASTF32,
+           MMA_X86_AVX512FP16_1x32x1_F16_F16, MMA_X86_AVX512FP16_32x1x1_F16_F16,
+           MMA_X86_AVX512BF16_1x16x2_F32_BF16,
+           MMA_X86_AVX512BF16_16x1x2_F32_BF16, MMA_X86_AVX512_1x16x2_I32_I16,
+           MMA_X86_AVX512_16x1x2_I32_I16, MMA_X86_AVX512VNNI_1x16x2_I32_I16,
+           MMA_X86_AVX512VNNI_16x1x2_I32_I16,
            MMA_X86_AVX512_1x16x2_I32_I8_CASTI16,
+           MMA_X86_AVX512_16x1x2_I32_I8_CASTI16,
            MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16,
+           MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16,
 
            // Arm SVE
-           MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32,
+           MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32, MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32,
 
            // Architecture-agnostic generic-scalar fallback (type-polymorphic).
            MMA_GENERIC_SCALAR_1x1x1_REG8, MMA_GENERIC_SCALAR_1x1x1_REG16]>;

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
@@ -64,11 +64,7 @@ SmallVector<int> getTilingLevelsAsInts();
 StringRef getTilingLevelName(TilingLevel level);
 
 // Returns the TileSwizzle for the given intrinsic and operand index.
-// If `transposed` is true, the intrinsic is used in an M↔N-swapped
-// orientation: the physical tile layouts reflect LHS/RHS roles being
-// exchanged, and the accumulator is laid out column-major.
-Codegen::TileSwizzle getIntrinsicSwizzle(MMAIntrinsic mma, bool transposed,
-                                         int operandIdx);
+Codegen::TileSwizzle getIntrinsicSwizzle(MMAIntrinsic mma, int operandIdx);
 
 // Returns the TileSwizzle for the given MMA attr and operand index.
 Codegen::TileSwizzle getSwizzle(DataTiledMMAAttr mma, int operandIdx);

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -211,3 +211,53 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   %[[RHS_UI32:.+]] = arith.extui %{{.+}} : vector<4x1xi8> to vector<4x1xi32>
 //       CHECK:   vector.contract
 //  CHECK-SAME:     %[[LHS_UI32]], %[[RHS_UI32]], %{{.+}} : vector<4x1xi32>, vector<4x1xi32> into vector<4x4xi32>
+
+// -----
+
+// AVX-512 16×1×1 f32 (M↔N-swapped orientation of 1×16×1) with intrinsics_m=2,
+// intrinsics_n=4. The narrow side is RHS, so broadcast widens RHS 1→16; FMA
+// is LHS/RHS-symmetric so the call args don't swap.
+//
+// First test in this dialect to exercise a non-identity ACC swizzle
+// permutation, so it pins the input-side `shape_cast` + `transpose` pair
+// and the matching inverse pair in the reassemble body. Without those, a
+// plain `shape_cast` between distributed (N-major) and logical (M-major)
+// storage scrambles (m, n) coordinates.
+
+#contraction_accesses_t = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_avx512_16x1x1_f32(
+    %lhs: vector<32x1xf32>, %rhs: vector<4x1xf32>, %acc: vector<32x4xf32>)
+    -> vector<32x4xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_t,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_16x1x1_F32_F32, intrinsics_m = 2, intrinsics_n = 4>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<32x1xf32>, vector<4x1xf32> into vector<32x4xf32>
+  return %0 : vector<32x4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_avx512_16x1x1_f32
+//       CHECK:   util.hoistable_conversion "data_tiled_acc_distribute"
+//       CHECK:     vector.shape_cast {{.*}} : vector<32x4xf32> to vector<2x16x4x1xf32>
+//       CHECK:     vector.transpose {{.*}}, [0, 2, 1, 3] : vector<2x16x4x1xf32> to vector<2x4x16x1xf32>
+//       CHECK:   vector.broadcast {{.*}} : vector<1xf32> to vector<16x1xf32>
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"
+//       CHECK:   util.hoistable_conversion "data_tiled_acc_reassemble"
+//       CHECK:     vector.transpose {{.*}}, [0, 2, 1, 3] : vector<2x4x16x1xf32> to vector<2x16x4x1xf32>
+//       CHECK:     vector.shape_cast {{.*}} : vector<2x16x4x1xf32> to vector<32x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel
@@ -48,6 +48,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:VectorDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/MMAUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 
@@ -72,23 +73,29 @@ static SmallVector<int64_t> fullDistributedShape(const TileSwizzle &swizzle) {
   });
 }
 
-// Reshapes `value` to the swizzle's distributed N-D vector type if it is not
-// already in that form. "Distributed" here means every dim of the swizzle's
-// expand groups, with CrossThread dim sizes collapsed to 1 (those factors live
-// in the lane id, not the per-lane vector). CPU `getDistributedTileTypes`
-// produces a 2-D (outer × inner) collapsed form while GPU produces the
-// distributed N-D form; this reshape lets the shared lowering body operate
-// uniformly.
+// Reshapes `value` from operand-natural (M, K)/(N, K)/(M, N) row-major to
+// the swizzle's distributed N-D form (with the swizzle's permutation applied).
 static Value reshapeToSwizzleDistributed(OpBuilder &builder, Location loc,
                                          Value value,
                                          const TileSwizzle &swizzle) {
   auto vecType = cast<VectorType>(value.getType());
-  SmallVector<int64_t> fullShape = fullDistributedShape(swizzle);
-  if (vecType.getShape() == ArrayRef<int64_t>(fullShape)) {
-    return value;
+  ArrayRef<int64_t> perm = swizzle.permutation();
+  // Pre-transpose shape: distributed shape with the inverse permutation
+  // already applied, so that the subsequent transpose by `perm` lands in
+  // the distributed shape. For identity `perm` it's just the distributed
+  // shape and the transpose is a no-op.
+  SmallVector<int64_t> preTransposeShape = applyPermutation(
+      fullDistributedShape(swizzle), invertPermutationVector(perm));
+  Value reshaped = value;
+  if (vecType.getShape() != ArrayRef<int64_t>(preTransposeShape)) {
+    auto reshapedType =
+        VectorType::get(preTransposeShape, vecType.getElementType());
+    reshaped = vector::ShapeCastOp::create(builder, loc, reshapedType, value);
   }
-  auto fullType = VectorType::get(fullShape, vecType.getElementType());
-  return vector::ShapeCastOp::create(builder, loc, fullType, value);
+  if (isIdentityPermutation(perm)) {
+    return reshaped;
+  }
+  return vector::TransposeOp::create(builder, loc, reshaped, perm);
 }
 
 LogicalResult buildDataTiledMMAUnderlyingOperations(
@@ -173,6 +180,13 @@ LogicalResult buildDataTiledMMAUnderlyingOperations(
           acc = vector::InsertStridedSliceOp::create(b, loc, expandedAcc, acc,
                                                      indices, strides);
           incrementIndices(indices, accCrossIntrinsicShape);
+        }
+        // Inverse of the input-side reshape: undo the swizzle's permutation,
+        // then shape_cast back to the original (M, N) tile type.
+        ArrayRef<int64_t> perm = accSwizzle.permutation();
+        if (!isIdentityPermutation(perm)) {
+          acc = vector::TransposeOp::create(b, loc, acc,
+                                            invertPermutationVector(perm));
         }
         if (acc.getType() != origAccType) {
           acc = vector::ShapeCastOp::create(b, loc, origAccType, acc);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -303,10 +303,8 @@ static bool getEnableInnerTiledFromConfig(DictionaryAttr config) {
 }
 
 /// Returns the matmul {M, N, K} tile shape covered by a CPU DataTiledMMAAttr.
-/// Derived directly from `getUndistributedTileTypes`: LHS is M×K (always) and
-/// RHS is N×K (always), regardless of the `transposed_intrinsic` flag. The
-/// ACC layout varies (M×N row-major vs. N×M column-major for transposed
-/// intrinsics), so we derive M and N from the LHS and RHS tiles instead.
+/// Derived directly from `getUndistributedTileTypes`: LHS is M×K and RHS is
+/// N×K, so M comes from LHS dim 0 and N from RHS dim 0.
 static IREE::Codegen::TileMxNxK getTileMxNxK(IREE::CPU::DataTiledMMAAttr mma) {
   SmallVector<VectorType> tiles;
   mma.getUndistributedTileTypes(tiles);
@@ -326,19 +324,29 @@ getMmaIntrinsicRequiredFeatures(IREE::CPU::MMAIntrinsic intr) {
   using IREE::CPU::MMAIntrinsic;
   switch (intr) {
   case MMAIntrinsic::MMA_X86_AVX2_FMA_1x8x1_F32_F32:
+  case MMAIntrinsic::MMA_X86_AVX2_FMA_8x1x1_F32_F32:
     return {"+avx2", "+fma"};
   case MMAIntrinsic::MMA_X86_AVX512_1x8x1_F64_F64:
+  case MMAIntrinsic::MMA_X86_AVX512_8x1x1_F64_F64:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F32:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
     return {"+avx512f"};
   case MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16:
+  case MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16:
     return {"+avx512fp16"};
   case MMAIntrinsic::MMA_X86_AVX512BF16_1x16x2_F32_BF16:
+  case MMAIntrinsic::MMA_X86_AVX512BF16_16x1x2_F32_BF16:
     return {"+avx512bf16"};
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return {"+avx512vnni"};
   default:
     return {};
@@ -361,39 +369,145 @@ pickGenericScalarMMAForTarget(DictionaryAttr config) {
                  : MMAIntrinsic::MMA_GENERIC_SCALAR_1x1x1_REG8;
 }
 
+/// Validates `arr` per the conventions in IREECPUEnums.td. Used inside an
+/// `assert()` at the end of `getMmaIntrinsicsForTargetConfig` so it only
+/// runs in debug builds — it constructs `DataTiledMMAAttr` instances to
+/// inspect tile shapes/types, which would be too expensive to do
+/// unconditionally on every cost-model query.
+///
+/// Conditions:
+///   1. Strictly increasing in enum value (subsumes "no duplicates" and
+///      rules out misordered pairs).
+///   2. By the bit-0 convention from IREECPUEnums.td, every M↔N-swapped
+///      entry (bit 0 set) is immediately preceded by its natural sibling
+///      (`prev == v ^ 1`).
+///   3. For each (natural, swapped) sibling pair, the swapped entry's
+///      tile type has M↔N exchanged and LHS↔RHS element types exchanged
+///      vs the natural's; K and ACC element type are unchanged.
+///   4. A natural entry without a swapped sibling (singleton) must be
+///      self-symmetric: square shape AND identical LHS/RHS element types
+///      — otherwise the swapped orientation would be a distinct operation
+///      and the array would be incomplete.
+///
+/// The type-polymorphic generic-scalar 1×1×1 family is square and
+/// type-polymorphic, so it satisfies (4) vacuously. We skip the
+/// `DataTiledMMAAttr`-based extraction for it (passing null element types
+/// to the attr would invalidate the resulting vector types).
+static bool isMmaIntrinsicArrayValid(MLIRContext *ctx,
+                                     ArrayRef<IREE::CPU::MMAIntrinsic> arr) {
+  using IREE::CPU::DataTiledMMAAttr;
+  using IREE::CPU::MMAIntrinsic;
+
+  // Conventions (1) and (2): order, strict increase, swap-pair structure.
+  if (!arr.empty() && (static_cast<uint32_t>(arr[0]) & 1) != 0) {
+    return false;
+  }
+  for (size_t i = 1; i < arr.size(); ++i) {
+    uint32_t v = static_cast<uint32_t>(arr[i]);
+    uint32_t prev = static_cast<uint32_t>(arr[i - 1]);
+    if (prev >= v) {
+      return false;
+    }
+    if ((v & 1) != 0 && prev != (v ^ 1)) {
+      return false;
+    }
+  }
+
+  // For (3) and (4) we need shape + element types from `DataTiledMMAAttr`.
+  auto getShapeAndTypes = [&](MMAIntrinsic intr) {
+    auto attr = DataTiledMMAAttr::get(ctx, intr, /*intrinsics_m=*/1,
+                                      /*intrinsics_n=*/1, /*intrinsics_k=*/1,
+                                      /*lhs_type=*/Type(),
+                                      /*rhs_type=*/Type(),
+                                      /*acc_type=*/Type());
+    SmallVector<VectorType> tiles;
+    attr.getUndistributedTileTypes(tiles);
+    assert(tiles.size() == 3);
+    return std::make_tuple(tiles[0].getShape()[0],     // M (LHS dim 0)
+                           tiles[1].getShape()[0],     // N (RHS dim 0)
+                           tiles[0].getShape()[1],     // K (LHS dim 1)
+                           tiles[0].getElementType(),  // LHS elem
+                           tiles[1].getElementType(),  // RHS elem
+                           tiles[2].getElementType()); // ACC elem
+  };
+
+  for (size_t i = 0; i < arr.size(); ++i) {
+    if ((static_cast<uint32_t>(arr[i]) & 1) != 0) {
+      continue; // swapped entry — checked when we hit its natural sibling.
+    }
+    if (IREE::CPU::isGenericScalar(arr[i])) {
+      continue; // type-polymorphic 1×1×1: vacuously valid.
+    }
+    auto [mn, nn, kn, lhsn, rhsn, accn] = getShapeAndTypes(arr[i]);
+    bool hasSibling =
+        (i + 1 < arr.size()) && (static_cast<uint32_t>(arr[i + 1]) ==
+                                 (static_cast<uint32_t>(arr[i]) | 1));
+    if (hasSibling) {
+      auto [ms, ns, ks, lhss, rhss, accs] = getShapeAndTypes(arr[i + 1]);
+      // Condition (3): siblings have M↔N and LHS↔RHS exchanged; K and ACC
+      // element type are unchanged.
+      if (ms != nn || ns != mn || ks != kn) {
+        return false;
+      }
+      if (lhss != rhsn || rhss != lhsn || accs != accn) {
+        return false;
+      }
+    } else {
+      // Condition (4): singleton — must be self-symmetric.
+      if (mn != nn || lhsn != rhsn) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 /// Returns the `MMAIntrinsic` cases potentially usable for `config`: the x86
 /// architecture-specific intrinsics whose required ISA extensions are all
-/// present, plus one of the architecture-agnostic type-polymorphic
+/// present (both natural and M↔N-swapped orientations enumerated as separate
+/// values), followed by one of the architecture-agnostic type-polymorphic
 /// `MMA_GENERIC_SCALAR_1x1x1_REG*` fallback variants (the one whose register
-/// budget matches `config`'s target). Only the "natural" (M<=N) orientation
-/// is listed; the M↔N-swapped orientation is expressed by the
-/// `transposed_intrinsic` flag on DataTiledMMAAttr and is enumerated
-/// separately by the cost model. The 1×1×1 generic intrinsic naturally
+/// budget matches `config`'s target). The 1×1×1 generic intrinsic naturally
 /// loses to any real intrinsic that fits, so it only wins as a fallback
 /// when no real MMA covers the requested element types.
+///
+/// There must be no early-return path that omits the trailing
+/// generic-scalar push — `out` is asserted to be non-empty / well-formed at
+/// the bottom and downstream callers rely on always seeing at least the
+/// generic fallback. Place the generic at the end (rather than the front)
+/// because: (a) its enum value sits above the architecture-specific ones,
+/// so trailing it keeps `out` strictly increasing, which the validator
+/// expects, and (b) trailing it lets the cost-model's tie-break (first
+/// wins on equal score) prefer real intrinsics over the generic fallback.
 static SmallVector<IREE::CPU::MMAIntrinsic>
 getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
   using IREE::CPU::MMAIntrinsic;
   if (!config) {
     return {};
   }
-  // Always include the generic-scalar fallback first — it's the only
-  // intrinsic guaranteed to apply on any target, so anchoring the list
-  // with it means an early-return below can never accidentally produce
-  // an empty result for an otherwise-valid target.
-  SmallVector<MMAIntrinsic> out{pickGenericScalarMMAForTarget(config)};
+  SmallVector<MMAIntrinsic> out;
   if (isX86(config)) {
     static const MMAIntrinsic kAllX86[] = {
         MMAIntrinsic::MMA_X86_AVX2_FMA_1x8x1_F32_F32,
+        MMAIntrinsic::MMA_X86_AVX2_FMA_8x1x1_F32_F32,
         MMAIntrinsic::MMA_X86_AVX512_1x8x1_F64_F64,
+        MMAIntrinsic::MMA_X86_AVX512_8x1x1_F64_F64,
         MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F32,
+        MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F32,
         MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32,
+        MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32,
         MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16,
+        MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16,
         MMAIntrinsic::MMA_X86_AVX512BF16_1x16x2_F32_BF16,
+        MMAIntrinsic::MMA_X86_AVX512BF16_16x1x2_F32_BF16,
         MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16,
+        MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16,
         MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I16,
+        MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16,
         MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16,
+        MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16,
         MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16,
+        MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16,
     };
     for (MMAIntrinsic intr : kAllX86) {
       SmallVector<StringRef> required = getMmaIntrinsicRequiredFeatures(intr);
@@ -406,29 +520,32 @@ getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
       }
     }
   }
+  out.push_back(pickGenericScalarMMAForTarget(config));
+  assert(isMmaIntrinsicArrayValid(config.getContext(), out) &&
+         "getMmaIntrinsicsForTargetConfig must return a list satisfying the "
+         "conventions in IREECPUEnums.td (strictly increasing, paired "
+         "natural/swapped entries, etc.)");
   return out;
 }
 
 /// Shape and element-bit-width summary of one intrinsic, with unroll factors
-/// all 1, in a specific orientation. The LHS is (M, K), the RHS is (N, K) —
-/// the `transposed` flag has already swapped M↔N inside the base attr.
-/// Scalable dims (e.g. SVE) are treated as their 128-bit-minimum static
-/// shape here; `getRegisterSpaceBytes` applies the matching simplification
-/// on the capacity side.
+/// all 1. The LHS is (M, K), the RHS is (N, K). Scalable dims (e.g. SVE) are
+/// treated as their 128-bit-minimum static shape here; `getRegisterSpaceBytes`
+/// applies the matching simplification on the capacity side.
 struct IntrinsicInfo {
   int64_t intrinsicM = 0, intrinsicN = 0, intrinsicK = 0;
   int64_t lhsBits = 0, rhsBits = 0, accBits = 0;
 };
 
-/// Returns the IntrinsicInfo for `intr` in the given orientation, if its ABC
-/// element types match `elementTypes`. Returns nullopt otherwise. The
+/// Returns the IntrinsicInfo for `intr` if its ABC element types match
+/// `elementTypes`. Returns nullopt otherwise. The
 /// `MMA_GENERIC_SCALAR_1x1x1_REG*` family is type-polymorphic — those
 /// values match any element-type triple by construction; their `lhsBits` /
 /// `rhsBits` / `accBits` stay at the struct's default 0 since the
 /// generic-scalar branch of `chooseUnrolling` doesn't read them.
 static std::optional<IntrinsicInfo>
 getIntrinsicInfo(MLIRContext *ctx, ArrayRef<Type> elementTypes,
-                 IREE::CPU::MMAIntrinsic intr, bool transposed) {
+                 IREE::CPU::MMAIntrinsic intr) {
   if (IREE::CPU::isGenericScalar(intr)) {
     if (elementTypes.size() != 3 || !elementTypes[0] || !elementTypes[1] ||
         !elementTypes[2]) {
@@ -440,7 +557,7 @@ getIntrinsicInfo(MLIRContext *ctx, ArrayRef<Type> elementTypes,
   }
   auto base = IREE::CPU::DataTiledMMAAttr::get(
       ctx, intr, /*intrinsics_m=*/1, /*intrinsics_n=*/1,
-      /*intrinsics_k=*/1, transposed, /*lhs_type=*/Type(),
+      /*intrinsics_k=*/1, /*lhs_type=*/Type(),
       /*rhs_type=*/Type(), /*acc_type=*/Type());
   SmallVector<VectorType> baseTiles;
   base.getUndistributedTileTypes(baseTiles);
@@ -462,9 +579,8 @@ getIntrinsicInfo(MLIRContext *ctx, ArrayRef<Type> elementTypes,
   return info;
 }
 
-/// Phase 1 of `chooseCpuInnerTiledMmaForEncoding`: jointly pick the
-/// intrinsic and its orientation (`transposed_intrinsic`). We maximize
-/// `usefulOps` per invocation,
+/// Phase 1 of `chooseCpuInnerTiledMmaForEncoding`: pick the intrinsic. We
+/// maximize `usefulOps` per invocation,
 ///   usefulOps = min(intrinsicM, M) * min(intrinsicN, N) * intrinsicK
 /// where the `min` clamps an intrinsicM/intrinsicN that exceeds a narrow
 /// static matmul dim — i.e. it charges the intrinsic for the padding it
@@ -472,11 +588,14 @@ getIntrinsicInfo(MLIRContext *ctx, ArrayRef<Type> elementTypes,
 /// intrinsic size counts toward usefulOps). Ties are broken by the raw
 /// intrinsic size `intrinsicM*intrinsicN*intrinsicK` (prefer the bigger
 /// intrinsic: it gives the Phase-2 register budget more tiles to play with)
-/// and, finally, by iteration order (non-transposed first). `K` is never
-/// narrow for optimization purposes, so it never enters the `min`.
+/// and, finally, by iteration order. The natural and M↔N-swapped
+/// orientations of each hardware MMA appear as distinct enum values in the
+/// candidate list, so the choice between them falls out of this same
+/// scoring loop. `K` is never narrow for optimization purposes, so it never
+/// enters the `min`.
 ///
 /// Returns nullopt if no compatible intrinsic exists.
-static std::optional<std::pair<IREE::CPU::MMAIntrinsic, bool>>
+static IREE::CPU::MMAIntrinsic
 chooseIntrinsic(MLIRContext *ctx, ArrayRef<Type> elementTypes,
                 DictionaryAttr config,
                 const IREE::Encoding::BxMxNxKxKb &matmulSizes) {
@@ -485,24 +604,22 @@ chooseIntrinsic(MLIRContext *ctx, ArrayRef<Type> elementTypes,
                ? intrinsicSize
                : std::min(intrinsicSize, matmulSize);
   };
-  std::optional<std::pair<IREE::CPU::MMAIntrinsic, bool>> best;
+  IREE::CPU::MMAIntrinsic best = IREE::CPU::MMAIntrinsic::None;
   std::pair<int64_t, int64_t> bestScore = {-1, -1};
   for (IREE::CPU::MMAIntrinsic intr : getMmaIntrinsicsForTargetConfig(config)) {
-    for (bool transposed : {false, true}) {
-      std::optional<IntrinsicInfo> info =
-          getIntrinsicInfo(ctx, elementTypes, intr, transposed);
-      if (!info) {
-        continue;
-      }
-      int64_t usefulOps = usefulSize(matmulSizes.M, info->intrinsicM) *
-                          usefulSize(matmulSizes.N, info->intrinsicN) *
-                          info->intrinsicK;
-      int64_t rawOps = info->intrinsicM * info->intrinsicN * info->intrinsicK;
-      std::pair<int64_t, int64_t> score = {usefulOps, rawOps};
-      if (score > bestScore) {
-        bestScore = score;
-        best = {intr, transposed};
-      }
+    std::optional<IntrinsicInfo> info =
+        getIntrinsicInfo(ctx, elementTypes, intr);
+    if (!info) {
+      continue;
+    }
+    int64_t usefulOps = usefulSize(matmulSizes.M, info->intrinsicM) *
+                        usefulSize(matmulSizes.N, info->intrinsicN) *
+                        info->intrinsicK;
+    int64_t rawOps = info->intrinsicM * info->intrinsicN * info->intrinsicK;
+    std::pair<int64_t, int64_t> score = {usefulOps, rawOps};
+    if (score > bestScore) {
+      bestScore = score;
+      best = intr;
     }
   }
   return best;
@@ -525,11 +642,10 @@ static int64_t po2UnrollCap(int64_t matmulSize, int64_t intrinsicSize,
 }
 
 // Phase 2 of `chooseCpuInnerTiledMmaForEncoding`: for an already-chosen
-// (intrinsic, transposed) pair, pick the largest power-of-two unroll
-// factors (intrinsicsM, intrinsicsN) such that the three tiles
-// (ACC + LHS + RHS) still fit in the target's register budget,
-// breaking ties with arithmetic intensity (effM*effN)/(effM+effN) so
-// approximately-square tiles win.
+// intrinsic, pick the largest power-of-two unroll factors (intrinsicsM,
+// intrinsicsN) such that the three tiles (ACC + LHS + RHS) still fit in
+// the target's register budget, breaking ties with arithmetic intensity
+// (effM*effN)/(effM+effN) so approximately-square tiles win.
 //
 // "Register budget" depends on what the lowering will use:
 //   * Architecture-specific SIMD intrinsics use the vector register file,
@@ -550,10 +666,9 @@ static int64_t po2UnrollCap(int64_t matmulSize, int64_t intrinsicSize,
 // tiling outright.
 static std::optional<std::tuple<int64_t, int64_t, int64_t>>
 chooseUnrolling(MLIRContext *ctx, ArrayRef<Type> elementTypes,
-                IREE::CPU::MMAIntrinsic intr, bool transposed,
+                IREE::CPU::MMAIntrinsic intr,
                 const IREE::Encoding::BxMxNxKxKb &matmulSizes) {
-  std::optional<IntrinsicInfo> info =
-      getIntrinsicInfo(ctx, elementTypes, intr, transposed);
+  std::optional<IntrinsicInfo> info = getIntrinsicInfo(ctx, elementTypes, intr);
   if (!info) {
     return std::nullopt;
   }
@@ -639,14 +754,13 @@ chooseCpuInnerTiledMmaForEncoding(MLIRContext *ctx,
   if (failed(matmulSizes)) {
     return {};
   }
-  std::optional<std::pair<IREE::CPU::MMAIntrinsic, bool>> intrChoice =
+  IREE::CPU::MMAIntrinsic intr =
       chooseIntrinsic(ctx, elementTypes, config, *matmulSizes);
-  if (!intrChoice) {
+  if (intr == IREE::CPU::MMAIntrinsic::None) {
     return {};
   }
-  auto [intr, transposed] = *intrChoice;
   std::optional<std::tuple<int64_t, int64_t, int64_t>> unroll =
-      chooseUnrolling(ctx, elementTypes, intr, transposed, *matmulSizes);
+      chooseUnrolling(ctx, elementTypes, intr, *matmulSizes);
   if (!unroll) {
     return {};
   }
@@ -661,8 +775,8 @@ chooseCpuInnerTiledMmaForEncoding(MLIRContext *ctx,
     accType = elementTypes[2];
   }
   return IREE::CPU::DataTiledMMAAttr::get(ctx, intr, intrinsicsM, intrinsicsN,
-                                          intrinsicsK, transposed, lhsType,
-                                          rhsType, accType);
+                                          intrinsicsK, lhsType, rhsType,
+                                          accType);
 }
 
 /// Lowers a contraction under a `CPUEncodingResolverAttr` with


### PR DESCRIPTION
Each non-square hardware MMA now appears as two `MMAIntrinsic` enum values — one per orientation — named after their actual MxNxK shape (e.g. `MMA_X86_AVX512_1x16x1_F32_F32` and its M↔N-swapped sibling `MMA_X86_AVX512_16x1x1_F32_F32`). The swapped sibling of `X` is `X ^ 1` (bit 0 of D in the enum's encoding), so consecutive enum values form natural/swapped pairs. The `transposed_intrinsic` boolean on `DataTiledMMAAttr` is removed; both orientations show up as distinct candidates in `getMmaIntrinsicsForTargetConfig` and the existing `chooseIntrinsic` scoring picks between them.

A new `assert(isMmaIntrinsicArrayValid(...))` at the bottom of `getMmaIntrinsicsForTargetConfig` enforces the convention: strictly increasing, every swapped entry preceded by its natural sibling, and square/type-symmetric singletons allowed (covers the generic-scalar 1×1×1 family).

Motivation: the boolean was originally there to avoid 2× enum growth, but it leaked orientation-handling into every layer that touched MMA layouts — swizzles, ACC encoding-info, the cross-intrinsic ACC index, broadcast direction. It was also poised to get worse: asymmetric LLVM intrinsics (vpdpbusd) and non-x86 targets (no broadcast) would each need bespoke handling under the boolean. With separate enum values, each orientation lowers independently.

MMAUtils permutation fix:

  `buildDataTiledMMAUnderlyingOperations` previously moved between the
  caller's logical (M, N)-ordered tile type and the swizzle's
  distributed N-D form via a linear-preserving `vector.shape_cast` —
  sound only for identity permutations. Pre-existing intrinsics all
  happened to be identity, so the bug was dormant. Every swapped enum
  added here produces a non-identity permutation (cross-intrinsic-N
  injected before cross-intrinsic-M, putting N first in storage), and
  the shape_cast scrambles (m, n) coordinates so result values land in
  the wrong cells.

  Fix: split the reshape into a logical-shape `shape_cast` plus a
  `vector.transpose` by the swizzle's permutation (input side) / its
  inverse (output side). Folds to a no-op for identity permutations,
  so existing natural-orientation intrinsics produce the same IR as
  before. Verified by extending the existing `lower_avx512_16x1x1_f32`
  test in `lower_inner_tiled.mlir` (the first to exercise a
  non-identity permutation) with `CHECK` lines pinning the
  shape_cast/transpose pairs around the FMA call.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Progress towards #24323