### PR TITLE
[Codegen][CPU] Add x86 AVX-512 VNNI vpdpbusd MMA intrinsic.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -330,7 +330,7 @@ SmallVector<bool> LoweringConfigAttr::getVectorScalableFlags() const {
 // If you're trying to add support for a new intrinsic that doesn't have a
 // row-major tile layout, don't look at this function, go directly to
 // getIntrinsicSwizzle.
-static std::optional<std::tuple<int64_t, int64_t, int64_t>>
+std::optional<std::tuple<int64_t, int64_t, int64_t>>
 getRowMajorTilesMNKShape(MMAIntrinsic intrinsic) {
   using Tuple = std::tuple<int64_t, int64_t, int64_t>;
   switch (intrinsic) {
@@ -366,6 +366,10 @@ getRowMajorTilesMNKShape(MMAIntrinsic intrinsic) {
   case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return Tuple{16, 1, 2};
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
+    return Tuple{1, 16, 4};
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
+    return Tuple{16, 1, 4};
   default:
     if (isGenericScalar(intrinsic)) {
       return Tuple{1, 1, 1};
@@ -539,8 +543,8 @@ Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
   return swizzle;
 }
 
-static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
-                                                       MMAIntrinsic intrinsic) {
+std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
+                                                MMAIntrinsic intrinsic) {
   Type f64 = Float64Type::get(ctx);
   Type f32 = Float32Type::get(ctx);
   Type f16 = Float16Type::get(ctx);
@@ -579,6 +583,13 @@ static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
   case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return {i8, i8, i32};
+  // vpdpbusd: returned types preserve signedness for the cost model to
+  // match against the encoding's `element_types`; tile types in IR are
+  // signless and get stripped in `getUndistributedTileTypes` below.
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
+    return {IntegerType::get(ctx, 8, IntegerType::Unsigned), i8, i32};
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
+    return {i8, IntegerType::get(ctx, 8, IntegerType::Unsigned), i32};
   case MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32:
   case MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32:
     return {f32, f32, f32};
@@ -601,15 +612,7 @@ static std::tuple<Type, Type, Type>
 getABCElementTypes(MLIRContext *context, IREE::CPU::DataTiledMMAAttr attr) {
   MMAIntrinsic intrinsic = attr.getIntrinsic();
   if (isGenericScalar(intrinsic)) {
-    auto signless = [&](Type t) -> Type {
-      if (auto intTy = dyn_cast_if_present<IntegerType>(t);
-          intTy && !intTy.isSignless()) {
-        return IntegerType::get(context, intTy.getWidth());
-      }
-      return t;
-    };
-    return {signless(attr.getLhsType()), signless(attr.getRhsType()),
-            signless(attr.getAccType())};
+    return {attr.getLhsType(), attr.getRhsType(), attr.getAccType()};
   }
   return getABCElementTypes(context, intrinsic);
 }
@@ -651,6 +654,18 @@ void DataTiledMMAAttr::getUndistributedTileTypes(
     return;
   }
   auto [aType, bType, cType] = getABCElementTypes(ctx, *this);
+  // Tile types in IR are signless (IREE convention); strip the signedness
+  // that `getABCElementTypes` carries for cost-model matching.
+  auto signless = [&](Type t) -> Type {
+    if (auto intTy = dyn_cast_if_present<IntegerType>(t);
+        intTy && !intTy.isSignless()) {
+      return IntegerType::get(ctx, intTy.getWidth());
+    }
+    return t;
+  };
+  aType = signless(aType);
+  bType = signless(bType);
+  cType = signless(cType);
   // Each operand's swizzle encodes its tile shape as (outer physical dim,
   // inner physical dim) in expandShape[0], expandShape[1]. This mirrors GPU's
   // DataTiledMMA, where the tile types encode the layout directly and no
@@ -769,11 +784,12 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   Type f32 = builder.getF32Type();
   Type i16 = builder.getI16Type();
   Type accType = acc.getType();
-  // The x86 MMAs supported here are LHS/RHS-symmetric (FMA, dpbf16ps,
-  // vpdpwssd, pmaddw), so natural and swapped orientations share the same
-  // LLVM intrinsic and arg order — after the broadcast above both operands
-  // have the same lane count. Asymmetric intrinsics (e.g. vpdpbusd) would
-  // need per-orientation arg-routing and aren't supported.
+  // The x86 MMAs supported here are mostly LHS/RHS-symmetric (FMA, dpbf16ps,
+  // vpdpwssd, pmaddw): natural and swapped orientations share the same LLVM
+  // intrinsic and arg order, since after the broadcast above both operands
+  // have the same lane count. The exception is vpdpbusd, which is asymmetric
+  // (first byte source is unsigned, second is signed); for its swapped
+  // sibling we route `rhs` (the unsigned operand) into the first slot.
   switch (intrinsic) {
   case MMAIntrinsic::MMA_X86_AVX2_FMA_1x8x1_F32_F32:
   case MMAIntrinsic::MMA_X86_AVX2_FMA_8x1x1_F32_F32:
@@ -816,6 +832,14 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
         call("llvm.x86.avx512.pmaddw.d.512", accType,
              ValueRange{widen(lhs, i16), widen(rhs, i16)}));
   }
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
+    // LHS unsigned, RHS signed — vpdpbusd takes (acc, unsigned, signed).
+    return call("llvm.x86.avx512.vpdpbusd.512", accType,
+                ValueRange{acc, lhs, rhs});
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
+    // LHS signed, RHS unsigned — swap to put the unsigned operand first.
+    return call("llvm.x86.avx512.vpdpbusd.512", accType,
+                ValueRange{acc, rhs, lhs});
   default:
     return {};
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -146,6 +146,14 @@ def MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16
     : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16", 0x13C2>;
 def MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16
     : I32EnumAttrCase<"MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16", 0x13C3>;
+// vpdpbusd: 4-byte K dot-product, asymmetric (LHS unsigned, RHS signed in
+// the natural orientation; swapped in the sibling, with arg-routing
+// reversed at lowering). IR storage is signless `i8`; the signedness
+// distinction lives on the encoding's `element_types`.
+def MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8", 0x13C4>;
+def MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8", 0x13C5>;
 
 // AArch64 SVE `fmla` (f32, f32): N×1×1 or 1×N×1 matmul tile; N is a scalable
 // vector of 4 f32 lanes per 128-bit chunk (see `ArmSveVLIn128bitUnits`).
@@ -195,6 +203,8 @@ def IREECPU_MMAIntrinsic
            MMA_X86_AVX512_16x1x2_I32_I8_CASTI16,
            MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16,
            MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16,
+           MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8,
+           MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8,
 
            // Arm SVE
            MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32, MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32,

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
@@ -85,6 +85,19 @@ bool isGenericScalar(MMAIntrinsic intr);
 // budget encoded in the enum case (8 or 16). Asserts otherwise.
 int64_t getGenericScalarRegisterBudget(MMAIntrinsic intr);
 
+// Returns the (LHS, RHS, ACC) element types for `intrinsic`, with
+// signedness preserved (e.g. `ui8` for vpdpbusd) — used by the cost model
+// to match against an encoding's `element_types`. Tile types in IR are
+// signless; `DataTiledMMAAttr::getUndistributedTileTypes` strips the
+// signedness annotations.
+std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
+                                                MMAIntrinsic intrinsic);
+
+// Returns the (M, N, K) tile shape for a row-major-tile intrinsic, or
+// nullopt otherwise (e.g. SVE).
+std::optional<std::tuple<int64_t, int64_t, int64_t>>
+getRowMajorTilesMNKShape(MMAIntrinsic intrinsic);
+
 } // namespace mlir::iree_compiler::IREE::CPU
 
 // clang-format on

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -261,3 +261,69 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   util.hoistable_conversion "data_tiled_acc_reassemble"
 //       CHECK:     vector.transpose {{.*}}, [0, 2, 1, 3] : vector<2x4x16x1xf32> to vector<2x16x4x1xf32>
 //       CHECK:     vector.shape_cast {{.*}} : vector<2x16x4x1xf32> to vector<32x4xf32>
+
+// -----
+
+// vpdpbusd is asymmetric (first byte source unsigned, second signed). The
+// natural variant lowers as `(acc, lhs, rhs)`; the swapped variant flips
+// the args at the call so the unsigned operand still lands first.
+
+#contraction_accesses_b = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_avx512vnni_1x16x4_vpdpbusd(
+    %lhs: vector<1x4xi8>, %rhs: vector<16x4xi8>, %acc: vector<1x16xi32>)
+    -> vector<1x16xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_b,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x4xi8>, vector<16x4xi8> into vector<1x16xi32>
+  return %0 : vector<1x16xi32>
+}
+
+func.func @lower_avx512vnni_16x1x4_vpdpbusd(
+    %lhs: vector<16x4xi8>, %rhs: vector<1x4xi8>, %acc: vector<16x1xi32>)
+    -> vector<16x1xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_b,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<16x4xi8>, vector<1x4xi8> into vector<16x1xi32>
+  return %0 : vector<16x1xi32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// Natural: LHS (ui8, narrow) is broadcast and routed into vpdpbusd's
+// first (unsigned) byte-source slot.
+// CHECK-LABEL: func @lower_avx512vnni_1x16x4_vpdpbusd(
+//  CHECK-SAME:   %[[N_LHS:[a-zA-Z0-9]+]]: vector<1x4xi8>
+//  CHECK-SAME:   %[[N_RHS:[a-zA-Z0-9]+]]: vector<16x4xi8>
+//       CHECK:   %[[N_RHS_FLAT:.+]] = vector.shape_cast %[[N_RHS]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   %[[N_BCAST:.+]] = vector.broadcast %[[N_LHS]] : vector<1x4xi8> to vector<16x4xi8>
+//       CHECK:   %[[N_LHS_FLAT:.+]] = vector.shape_cast %[[N_BCAST]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   llvm.call_intrinsic "llvm.x86.avx512.vpdpbusd.512"(%{{.+}}, %[[N_LHS_FLAT]], %[[N_RHS_FLAT]])
+
+// Swapped: RHS (ui8, narrow) is broadcast; the lowering swaps arg order at
+// the call so the broadcast result still lands in vpdpbusd's first slot.
+// CHECK-LABEL: func @lower_avx512vnni_16x1x4_vpdpbusd(
+//  CHECK-SAME:   %[[S_LHS:[a-zA-Z0-9]+]]: vector<16x4xi8>
+//  CHECK-SAME:   %[[S_RHS:[a-zA-Z0-9]+]]: vector<1x4xi8>
+//       CHECK:   %[[S_LHS_FLAT:.+]] = vector.shape_cast %[[S_LHS]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   %[[S_BCAST:.+]] = vector.broadcast %[[S_RHS]] : vector<1x4xi8> to vector<16x4xi8>
+//       CHECK:   %[[S_RHS_FLAT:.+]] = vector.shape_cast %[[S_BCAST]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   llvm.call_intrinsic "llvm.x86.avx512.vpdpbusd.512"(%{{.+}}, %[[S_RHS_FLAT]], %[[S_LHS_FLAT]])

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -347,6 +347,8 @@ getMmaIntrinsicRequiredFeatures(IREE::CPU::MMAIntrinsic intr) {
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
     return {"+avx512vnni"};
   default:
     return {};
@@ -413,22 +415,15 @@ static bool isMmaIntrinsicArrayValid(MLIRContext *ctx,
     }
   }
 
-  // For (3) and (4) we need shape + element types from `DataTiledMMAAttr`.
+  // (3) and (4) need types *with* signedness so e.g. vpdpbusd's natural
+  // `ui8` LHS visibly swaps with its sibling's `ui8` RHS. Read directly
+  // from `getABCElementTypes`; `getUndistributedTileTypes` would strip it.
   auto getShapeAndTypes = [&](MMAIntrinsic intr) {
-    auto attr = DataTiledMMAAttr::get(ctx, intr, /*intrinsics_m=*/1,
-                                      /*intrinsics_n=*/1, /*intrinsics_k=*/1,
-                                      /*lhs_type=*/Type(),
-                                      /*rhs_type=*/Type(),
-                                      /*acc_type=*/Type());
-    SmallVector<VectorType> tiles;
-    attr.getUndistributedTileTypes(tiles);
-    assert(tiles.size() == 3);
-    return std::make_tuple(tiles[0].getShape()[0],     // M (LHS dim 0)
-                           tiles[1].getShape()[0],     // N (RHS dim 0)
-                           tiles[0].getShape()[1],     // K (LHS dim 1)
-                           tiles[0].getElementType(),  // LHS elem
-                           tiles[1].getElementType(),  // RHS elem
-                           tiles[2].getElementType()); // ACC elem
+    auto mnk = IREE::CPU::getRowMajorTilesMNKShape(intr);
+    assert(mnk && "validator only handles row-major-tile intrinsics");
+    auto [m, n, k] = *mnk;
+    auto [lhs, rhs, acc] = IREE::CPU::getABCElementTypes(ctx, intr);
+    return std::make_tuple(m, n, k, lhs, rhs, acc);
   };
 
   for (size_t i = 0; i < arr.size(); ++i) {
@@ -508,6 +503,8 @@ getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
         MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16,
         MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16,
         MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16,
+        MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8,
+        MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8,
     };
     for (MMAIntrinsic intr : kAllX86) {
       SmallVector<StringRef> required = getMmaIntrinsicRequiredFeatures(intr);
@@ -555,27 +552,29 @@ getIntrinsicInfo(MLIRContext *ctx, ArrayRef<Type> elementTypes,
     info.intrinsicM = info.intrinsicN = info.intrinsicK = 1;
     return info;
   }
-  auto base = IREE::CPU::DataTiledMMAAttr::get(
-      ctx, intr, /*intrinsics_m=*/1, /*intrinsics_n=*/1,
-      /*intrinsics_k=*/1, /*lhs_type=*/Type(),
-      /*rhs_type=*/Type(), /*acc_type=*/Type());
-  SmallVector<VectorType> baseTiles;
-  base.getUndistributedTileTypes(baseTiles);
-  if (baseTiles.size() != 3) {
+  // Same as the validator above: match against the encoding's
+  // `element_types` *with* signedness — vpdpbusd's `ui8` is what
+  // distinguishes it from CASTI16 paths.
+  auto [lhsTy, rhsTy, accTy] = IREE::CPU::getABCElementTypes(ctx, intr);
+  if (!lhsTy || !rhsTy || !accTy) {
     return std::nullopt;
   }
-  if (baseTiles[0].getElementType() != elementTypes[0] ||
-      baseTiles[1].getElementType() != elementTypes[1] ||
-      baseTiles[2].getElementType() != elementTypes[2]) {
+  if (lhsTy != elementTypes[0] || rhsTy != elementTypes[1] ||
+      accTy != elementTypes[2]) {
     return std::nullopt;
   }
+  auto mnk = IREE::CPU::getRowMajorTilesMNKShape(intr);
+  if (!mnk) {
+    return std::nullopt;
+  }
+  auto [m, n, k] = *mnk;
   IntrinsicInfo info;
-  info.intrinsicM = baseTiles[0].getShape()[0];
-  info.intrinsicK = baseTiles[0].getShape()[1];
-  info.intrinsicN = baseTiles[1].getShape()[0];
-  info.lhsBits = baseTiles[0].getElementType().getIntOrFloatBitWidth();
-  info.rhsBits = baseTiles[1].getElementType().getIntOrFloatBitWidth();
-  info.accBits = baseTiles[2].getElementType().getIntOrFloatBitWidth();
+  info.intrinsicM = m;
+  info.intrinsicN = n;
+  info.intrinsicK = k;
+  info.lhsBits = lhsTy.getIntOrFloatBitWidth();
+  info.rhsBits = rhsTy.getIntOrFloatBitWidth();
+  info.accBits = accTy.getIntOrFloatBitWidth();
   return info;
 }
 

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -258,11 +258,9 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ("bf16", "f32"),
 ]]
 
-# Mixed unsigned-LHS / signed-RHS i8 matmul. The test framework otherwise
-# only generates symmetric-type matmuls. No matching MMA intrinsic exists
-# yet on any of the `target_cpu_features_variants` here — the test
-# exercises the standard codegen fallback through the data-tiling +
-# inner-tiled pipeline.
+# Mixed unsigned-LHS / signed-RHS i8 matmul: exercises x86 AVX-512 VNNI
+# `vpdpbusd`, our first asymmetric MMA. The `generic` variant exercises
+# the standard codegen fallback (no matching MMA intrinsic).
 iree_generated_e2e_runner_test(
     name = "e2e_matmul_cpu_dt_inner_tiled_ui8_i8_i32",
     compiler_flags = [
@@ -285,6 +283,7 @@ iree_generated_e2e_runner_test(
     ],
     target_cpu_features_variants = [
         "generic",
+        "x86_64:avx512vnni:" + ",".join(X86_64_AVX512_VNNI),
     ],
     test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
     test_type = "matmul",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -735,6 +735,7 @@ iree_generated_e2e_runner_test(
     "--iree-llvmcpu-enable-inner-tiled"
   TARGET_CPU_FEATURES_VARIANTS
     "generic"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
 )
 
 iree_generated_e2e_runner_test(


### PR DESCRIPTION
Adds the AVX-512 VNNI `vpdpbusd` MMA intrinsic — the byte dot-product whose first source is unsigned and second is signed, the first intrinsic to exercise distinct LHS/RHS types end-to-end.

Two new enum values, `MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8` and its M↔N-swapped sibling `MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8`, both lowering to `llvm.x86.avx512.vpdpbusd.512`. The swapped lowering flips its `(lhs, rhs)` call args so the unsigned operand still lands in the first slot.

Per IREE convention, vector tile types in IR are signless; the signed/unsigned distinction lives on the encoding's `element_types`. `getABCElementTypes(intrinsic)` returns `ui8` where applicable (used by the cost model and validator); `getUndistributedTileTypes` strips signedness when constructing tile types. The validator and `getIntrinsicInfo` bypass `getUndistributedTileTypes` and read shape + types straight from the intrinsic via `getRowMajorTilesMNKShape` and `getABCElementTypes`, which become public for that reason.

Progress towards #24323
