### PR TITLE
[VectorDistribute] Rework LDS operand promotion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 
 namespace mlir::iree_compiler {
 
@@ -95,6 +96,53 @@ SmallVector<int64_t> getElementVectorTileShape(NestedLayoutAttr vectorLayout) {
     tileShape[i] = 1;
   }
   return tileShape;
+}
+
+FailureOr<NestedLayoutAttr>
+getDerivedThreadLayout(MLIRContext *context, ArrayRef<int64_t> workgroupSize,
+                       ArrayRef<int64_t> logicalShape,
+                       ArrayRef<int64_t> elementTile) {
+  int64_t rank = logicalShape.size();
+  if (rank == 0 || elementTile.size() != rank) {
+    return failure();
+  }
+
+  SmallVector<int64_t> opShape(logicalShape);
+  for (auto [size, element] : llvm::zip_equal(opShape, elementTile)) {
+    if (ShapedType::isDynamic(size) || element <= 0 || size % element != 0) {
+      return failure();
+    }
+    size /= element;
+  }
+
+  SmallVector<int64_t> threadTile(rank, 1);
+  SmallVector<int64_t> threadStrides(rank, 0);
+  int64_t residualThreads = ShapedType::getNumElements(workgroupSize);
+  int64_t currStride = 1;
+  for (auto [tile, stride, size] :
+       llvm::reverse(llvm::zip(threadTile, threadStrides, opShape))) {
+    int64_t threadBlock;
+    if (residualThreads % size == 0) {
+      threadBlock = size;
+    } else if (size % residualThreads == 0) {
+      threadBlock = residualThreads;
+    } else {
+      return failure();
+    }
+
+    tile = threadBlock;
+    stride = currStride;
+    size /= threadBlock;
+    currStride *= threadBlock;
+    residualThreads /= threadBlock;
+  }
+
+  SmallVector<int64_t> subgroupTile(rank, 1);
+  SmallVector<int64_t> subgroupStrides(rank, 0);
+  SmallVector<int64_t> outerTile(rank, 1);
+  return NestedLayoutAttr::get(context, subgroupTile, opShape, outerTile,
+                               threadTile, elementTile, subgroupStrides,
+                               threadStrides);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h
@@ -34,6 +34,13 @@ LogicalResult populateWarpAndThreadIndices(
 SmallVector<int64_t>
 getElementVectorTileShape(IREE::VectorExt::NestedLayoutAttr vectorLayout);
 
+/// Builds the nested layout used by derived_thread_config from explicit
+/// element tile sizes.
+FailureOr<IREE::VectorExt::NestedLayoutAttr>
+getDerivedThreadLayout(MLIRContext *context, ArrayRef<int64_t> workgroupSize,
+                       ArrayRef<int64_t> logicalShape,
+                       ArrayRef<int64_t> elementTile);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_GPU_GPUNESTEDLAYOUTUTILS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -139,6 +139,11 @@ void promoteOperand(OpBuilder &builder, Operation *op, unsigned index,
   op->setOperand(index, replacement);
 }
 
+bool isDpsInputOperand(Operation *op, unsigned index) {
+  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
+  return dpsOp && index < dpsOp.getNumDpsInputs();
+}
+
 struct GPUPromoteMatmulOperandsPass final
     : impl::GPUPromoteMatmulOperandsPassBase<GPUPromoteMatmulOperandsPass> {
   using GPUPromoteMatmulOperandsPassBase::GPUPromoteMatmulOperandsPassBase;
@@ -171,6 +176,10 @@ struct GPUPromoteMatmulOperandsPass final
       builder.setInsertionPoint(op);
       for (auto [operand, maybePromotionType] :
            llvm::zip_longest(promotedOperands.value(), promotionTypes)) {
+        unsigned operandIndex = operand.value();
+        if (skipOperandPromotion && isDpsInputOperand(op, operandIndex)) {
+          continue;
+        }
         auto promotionType = dyn_cast<IREE::GPU::PromotionAttr>(
             maybePromotionType.value_or(derived));
         if (!promotionType) {
@@ -178,7 +187,7 @@ struct GPUPromoteMatmulOperandsPass final
               "promotion types does not implement promotion attr interface");
           return WalkResult::interrupt();
         }
-        promoteOperand(builder, op, operand.value(), promotionType);
+        promoteOperand(builder, op, operandIndex, promotionType);
       }
       return WalkResult::advance();
     });

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -142,7 +142,7 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
 }
 
 struct PromotionCandidate {
-  Operation *op;
+  Operation *op = nullptr;
   Value vector;
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -172,7 +172,7 @@ getPromotionCandidate(Operation *op, const PromotionTypeMap &promotionTypes) {
         return shouldPromoteCandidate(gather.getOperation(),
                                       gather.getResult());
       })
-      .Default([](Operation *) { return std::nullopt; });
+      .Default(std::nullopt);
 }
 
 /// Materialize promotion of operands to LDS.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -40,12 +40,12 @@ namespace {
 using LayoutMap =
     llvm::MapVector<Value, IREE::VectorExt::VectorLayoutInterface>;
 
-// Allocates a tensor to copy the vector into a la bufferization.alloc_tensor.
-// This allocation is always static as vectors are currently always static
-// where this is used.
-static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
-                                                Value vector,
-                                                ArrayRef<int64_t> shape) {
+// Allocates a tensor to copy the vector into a la bufferization.alloc_tensor
+// and then writes the vector into the allocated tensor. This allocation is
+// always static as vectors are currently always static where this is used.
+static FailureOr<Value> allocateTensorAndWriteVector(OpBuilder &b, Location loc,
+                                                     Value vector,
+                                                     ArrayRef<int64_t> shape) {
   VectorType vectorType = cast<VectorType>(vector.getType());
   if (vectorType.isScalable()) {
     return failure();
@@ -70,10 +70,10 @@ static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
   return copied;
 }
 
-static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
-                                                Value vector) {
+static FailureOr<Value> allocateTensorAndWriteVector(OpBuilder &b, Location loc,
+                                                     Value vector) {
   VectorType vectorType = cast<VectorType>(vector.getType());
-  return allocateTensorForVector(b, loc, vector, vectorType.getShape());
+  return allocateTensorAndWriteVector(b, loc, vector, vectorType.getShape());
 }
 
 static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
@@ -87,8 +87,8 @@ static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
       .getResult();
 }
 
-/// Materialize shared memory for all to_layout ops marked with
-/// shared_memory_conversion. Clears the attribute after materialization.
+/// Materialize shared memory roundtrip to resolve layout differences. Clears
+/// the shared_memory_conversion attribute after materialization.
 static LogicalResult
 materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
   SmallVector<IREE::VectorExt::ToLayoutOp> opsToPromote;
@@ -121,7 +121,7 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
     // TODO: Since we know the read/write layout for this memory, we can get
     // optimal swizzling here. Figure out how to do that.
     FailureOr<Value> ret =
-        allocateTensorForVector(builder, op->getLoc(), operand.get());
+        allocateTensorAndWriteVector(builder, op->getLoc(), operand.get());
     if (failed(ret)) {
       return failure();
     }
@@ -146,6 +146,8 @@ struct PromotionCandidate {
   Value vector;
 };
 
+/// Find promotion candidates, i.e., operations that load data from memory and
+/// were reached by a promotion type during analysis propagation.
 static std::optional<PromotionCandidate>
 getPromotionCandidate(Operation *op, const PromotionTypeMap &promotionTypes) {
   auto shouldPromoteCandidate =
@@ -155,6 +157,8 @@ getPromotionCandidate(Operation *op, const PromotionTypeMap &promotionTypes) {
       return std::nullopt;
     }
 
+    // TODO: Currently only handles derived_thread_config promotion types,
+    // extend to other promotion types.
     if (!isa<IREE::GPU::DerivedThreadConfigAttr>(promotionType->second)) {
       return std::nullopt;
     }
@@ -171,6 +175,7 @@ getPromotionCandidate(Operation *op, const PromotionTypeMap &promotionTypes) {
       .Default([](Operation *) { return std::nullopt; });
 }
 
+/// Materialize promotion of operands to LDS.
 static LogicalResult
 materializeSharedMemoryPromotions(FunctionOpInterface funcOp,
                                   const PromotionTypeMap &promotionTypes,
@@ -193,6 +198,20 @@ materializeSharedMemoryPromotions(FunctionOpInterface funcOp,
   if (!workgroupSize) {
     return funcOp.emitOpError("unable to query workgroup_size information");
   }
+  // Assume this candidate operation:
+  //
+  // %read = vector.transfer_read %global_memref ...
+  //
+  // This gets promoted by transforming the IR as follows:
+  //
+  // %read = vector.transfer_read %global_memref ...
+  // %global_layout = vector_ext.to_layout %read, #derived_thread_layout
+  // %alloc = bufferization.alloc_tensor <workgroup_memory>
+  // %lds_write = vector.transfer_write %global_layout, %alloc ...
+  // %barrier = iree_gpu.value_barrier %lds_write
+  // %lds_read = transfer_read %barrier
+  //
+  // All uses of %read except %global_layout will be replaced by %lds_read.
   for (PromotionCandidate candidate : readsToPromote) {
     Value vector = candidate.vector;
     IREE::VectorExt::VectorLayoutInterface allocationLayout =
@@ -219,9 +238,9 @@ materializeSharedMemoryPromotions(FunctionOpInterface funcOp,
     auto toLayout = IREE::VectorExt::ToLayoutOp::create(builder, op->getLoc(),
                                                         vector, *readLayout);
 
-    FailureOr<Value> copied =
-        allocateTensorForVector(builder, op->getLoc(), toLayout.getResult(),
-                                allocationLayout.getUndistributedShape());
+    FailureOr<Value> copied = allocateTensorAndWriteVector(
+        builder, op->getLoc(), toLayout.getResult(),
+        allocationLayout.getUndistributedShape());
     if (failed(copied)) {
       return failure();
     }
@@ -276,11 +295,13 @@ struct GPUVectorAllocPass final
       }
     });
 
+    // Materialize operand promotions based on the analysis.
     if (failed(materializeSharedMemoryPromotions(funcOp, promotionTypes,
                                                  layouts))) {
       return signalPassFailure();
     }
 
+    // Materialize LDS roundtrips for layout conflicts.
     if (failed(materializeSharedMemoryConversions(funcOp))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -4,9 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
+#include "iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
@@ -14,6 +17,7 @@
 #include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Repeated.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -33,11 +37,15 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+using LayoutMap =
+    llvm::MapVector<Value, IREE::VectorExt::VectorLayoutInterface>;
+
 // Allocates a tensor to copy the vector into a la bufferization.alloc_tensor.
 // This allocation is always static as vectors are currently always static
 // where this is used.
 static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
-                                                Value vector) {
+                                                Value vector,
+                                                ArrayRef<int64_t> shape) {
   VectorType vectorType = cast<VectorType>(vector.getType());
   if (vectorType.isScalable()) {
     return failure();
@@ -46,9 +54,8 @@ static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
   Attribute sharedMemoryAddrSpace = gpu::AddressSpaceAttr::get(
       b.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
 
-  RankedTensorType tensorType =
-      RankedTensorType::get(vectorType.getShape(), vectorType.getElementType(),
-                            sharedMemoryAddrSpace);
+  RankedTensorType tensorType = RankedTensorType::get(
+      shape, vectorType.getElementType(), sharedMemoryAddrSpace);
   // Vectors are always statically shaped.
   auto allocTensorOp = bufferization::AllocTensorOp::create(
       b, loc, tensorType, ValueRange{}, Value());
@@ -61,6 +68,12 @@ static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
                                                  indices, inBounds)
                      .getResult();
   return copied;
+}
+
+static FailureOr<Value> allocateTensorForVector(OpBuilder &b, Location loc,
+                                                Value vector) {
+  VectorType vectorType = cast<VectorType>(vector.getType());
+  return allocateTensorForVector(b, loc, vector, vectorType.getShape());
 }
 
 static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
@@ -128,6 +141,102 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
   return success();
 }
 
+struct PromotionCandidate {
+  Operation *op;
+  Value vector;
+};
+
+static std::optional<PromotionCandidate>
+getPromotionCandidate(Operation *op, const PromotionTypeMap &promotionTypes) {
+  auto shouldPromoteCandidate =
+      [&](Operation *op, Value vector) -> std::optional<PromotionCandidate> {
+    auto promotionType = promotionTypes.find(vector);
+    if (promotionType == promotionTypes.end()) {
+      return std::nullopt;
+    }
+
+    if (!isa<IREE::GPU::DerivedThreadConfigAttr>(promotionType->second)) {
+      return std::nullopt;
+    }
+    return PromotionCandidate{op, vector};
+  };
+  return TypeSwitch<Operation *, std::optional<PromotionCandidate>>(op)
+      .Case([&](vector::TransferReadOp read) {
+        return shouldPromoteCandidate(read.getOperation(), read.getVector());
+      })
+      .Case([&](vector::GatherOp gather) {
+        return shouldPromoteCandidate(gather.getOperation(),
+                                      gather.getResult());
+      })
+      .Default([](Operation *) { return std::nullopt; });
+}
+
+static LogicalResult
+materializeSharedMemoryPromotions(FunctionOpInterface funcOp,
+                                  const PromotionTypeMap &promotionTypes,
+                                  const LayoutMap &layouts) {
+  SmallVector<PromotionCandidate> readsToPromote;
+  funcOp.walk([&](Operation *op) {
+    std::optional<PromotionCandidate> candidate =
+        getPromotionCandidate(op, promotionTypes);
+    if (candidate) {
+      readsToPromote.push_back(*candidate);
+    }
+  });
+
+  if (readsToPromote.empty()) {
+    return success();
+  }
+
+  OpBuilder builder(funcOp);
+  std::optional<SmallVector<int64_t>> workgroupSize = getWorkgroupSize(funcOp);
+  if (!workgroupSize) {
+    return funcOp.emitOpError("unable to query workgroup_size information");
+  }
+  for (PromotionCandidate candidate : readsToPromote) {
+    Value vector = candidate.vector;
+    IREE::VectorExt::VectorLayoutInterface allocationLayout =
+        layouts.lookup(vector);
+    if (!allocationLayout) {
+      return candidate.op->emitOpError(
+          "missing layout for promoted read-like op");
+    }
+
+    VectorType readType = cast<VectorType>(vector.getType());
+    SmallVector<int64_t> elementTile = IREE::GPU::deriveThreadTileSizes(
+        readType.getShape(), ShapedType::getNumElements(*workgroupSize),
+        readType.getElementTypeBitWidth());
+    FailureOr<IREE::VectorExt::NestedLayoutAttr> readLayout =
+        getDerivedThreadLayout(candidate.op->getContext(), *workgroupSize,
+                               readType.getShape(), elementTile);
+    if (failed(readLayout)) {
+      return candidate.op->emitOpError(
+          "failed to derive layout for promoted read-like op");
+    }
+    Operation *op = candidate.op;
+    builder.setInsertionPointAfter(op);
+
+    auto toLayout = IREE::VectorExt::ToLayoutOp::create(builder, op->getLoc(),
+                                                        vector, *readLayout);
+
+    FailureOr<Value> copied =
+        allocateTensorForVector(builder, op->getLoc(), toLayout.getResult(),
+                                allocationLayout.getUndistributedShape());
+    if (failed(copied)) {
+      return failure();
+    }
+
+    auto synced =
+        IREE::GPU::ValueBarrierOp::create(builder, op->getLoc(), *copied);
+    Value newRead =
+        readVectorFromTensor(builder, readType, synced.getResult(0));
+
+    vector.replaceUsesWithIf(
+        newRead, [&](OpOperand &use) { return use.getOwner() != toLayout; });
+  }
+  return success();
+}
+
 struct GPUVectorAllocPass final
     : impl::GPUVectorAllocPassBase<GPUVectorAllocPass> {
   void runOnOperation() override {
@@ -141,10 +250,18 @@ struct GPUVectorAllocPass final
       walkAndApplyPatterns(funcOp, std::move(patterns));
     }
 
+    // Run the promotion propagation to propagate promotion information from
+    // compute ops up to the ops accessing memory.
+    PromotionTypeMap promotionTypes = analyzePromotionTypes(funcOp);
+
+    // Remove the existing promotion information. All those operations will have
+    // their promotion materialized based on the analysis above.
+    funcOp.walk([](IREE::VectorExt::ToLayoutOp op) {
+      op.removeSharedMemoryConversionAttr();
+    });
+
     // Run layout analysis to find additional conflict points.
-    // The analysis sees the materialized shared memory roundtrips and
-    // only detects genuinely new conflicts.
-    llvm::MapVector<Value, IREE::VectorExt::VectorLayoutInterface> layouts;
+    LayoutMap layouts;
     propagateVectorLayoutInfo(funcOp, layouts);
 
     // Mark newly-inserted to_layout ops where input/output layouts don't
@@ -159,7 +276,11 @@ struct GPUVectorAllocPass final
       }
     });
 
-    // Phase 3: Materialize any newly-found conflicts.
+    if (failed(materializeSharedMemoryPromotions(funcOp, promotionTypes,
+                                                 layouts))) {
+      return signalPassFailure();
+    }
+
     if (failed(materializeSharedMemoryConversions(funcOp))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -87,6 +87,30 @@ static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
       .getResult();
 }
 
+static void insertWorkgroupBarrierAtBlockStart(OpBuilder &builder,
+                                               Operation *op) {
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(op->getBlock());
+  gpu::BarrierOp::create(builder, op->getLoc(), gpu::AddressSpace::Workgroup);
+}
+
+static LogicalResult
+validateSharedMemoryConversionAttrs(FunctionOpInterface funcOp) {
+  WalkResult result = funcOp.walk([&](IREE::VectorExt::ToLayoutOp op) {
+    Attribute attr = op->getAttr("shared_memory_conversion");
+    if (!attr) {
+      return WalkResult::advance();
+    }
+    if (llvm::isa<IREE::GPU::PromotionAttr>(attr)) {
+      return WalkResult::advance();
+    }
+    op.emitOpError("shared_memory_conversion attribute must implement "
+                   "IREE::GPU::PromotionAttr");
+    return WalkResult::interrupt();
+  });
+  return failure(result.wasInterrupted());
+}
+
 /// Materialize shared memory roundtrip to resolve layout differences. Clears
 /// the shared_memory_conversion attribute after materialization.
 static LogicalResult
@@ -113,8 +137,7 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
     // Synchronize before the write to shared memory to avoid stepping over
     // reads in the previous iteration of a loop. We set this barrier
     // at the start of this block.
-    builder.setInsertionPointToStart(op->getBlock());
-    gpu::BarrierOp::create(builder, op->getLoc(), gpu::AddressSpace::Workgroup);
+    insertWorkgroupBarrierAtBlockStart(builder, op);
 
     builder.setInsertionPoint(op);
     OpOperand &operand = op.getInputMutable();
@@ -235,6 +258,11 @@ materializeSharedMemoryPromotions(FunctionOpInterface funcOp,
     Operation *op = candidate.op;
     builder.setInsertionPointAfter(op);
 
+    // Synchronize before the write to shared memory to avoid stepping over
+    // reads in the previous iteration of a loop. We set this barrier at the
+    // start of this block.
+    insertWorkgroupBarrierAtBlockStart(builder, op);
+
     auto toLayout = IREE::VectorExt::ToLayoutOp::create(builder, op->getLoc(),
                                                         vector, *readLayout);
 
@@ -271,10 +299,14 @@ struct GPUVectorAllocPass final
 
     // Run the promotion propagation to propagate promotion information from
     // compute ops up to the ops accessing memory.
+    if (failed(validateSharedMemoryConversionAttrs(funcOp))) {
+      return signalPassFailure();
+    }
     PromotionTypeMap promotionTypes = analyzePromotionTypes(funcOp);
 
-    // Remove the existing promotion information. All those operations will have
-    // their promotion materialized based on the analysis above.
+    // Remove the existing promotion information. The direct operand promotion
+    // path uses the analysis result above; newly detected layout conflicts
+    // below will get fresh markers.
     funcOp.walk([](IREE::VectorExt::ToLayoutOp op) {
       op.removeSharedMemoryConversionAttr();
     });

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -286,6 +286,11 @@ def GPUPromoteMatmulOperandsPass :
     logic for "promoting" an operand is deferred to an attribute interface
     allowing for custom logic.
   }];
+  let options = [
+    Option<"skipOperandPromotion", "skip-operand-promotion", "bool",
+            /*default=*/"false",
+           "Skip promotion of DPS input operands, promoting only results.">,
+  ];
   let dependentDialects = [
     "::mlir::bufferization::BufferizationDialect",
     "::mlir::gpu::GPUDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands),canonicalize)" | FileCheck %s
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands{skip-operand-promotion=true}),canonicalize)" | FileCheck %s --check-prefix=RESULTS-ONLY
 
 #lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1]}>
 
@@ -130,6 +131,15 @@ func.func @promote_result(%a : tensor<?x?xf32>, %b : tensor<?x?xf32>, %mdim : in
 //  CHECK-SAME:       {lowering_config = #iree_gpu.derived_thread_config}
 //  CHECK-SAME:       ins(%[[BARRIER]] : tensor<?x?xf32>)
 //       CHECK:   return %[[COPY2]] : tensor<?x?xf32>
+// RESULTS-ONLY-LABEL: func @promote_result(
+// RESULTS-ONLY:       %[[MATMUL:.+]] = linalg.matmul
+// RESULTS-ONLY:       %[[ALLOC:.+]] = bufferization.alloc_tensor
+// RESULTS-ONLY:       %[[COPY1:.+]] = linalg.copy
+// RESULTS-ONLY-SAME:      ins(%[[MATMUL]] : tensor<?x?xf32>) outs(%[[ALLOC]] : tensor<?x?xf32>)
+// RESULTS-ONLY:       %[[BARRIER:.+]] = iree_codegen.fusion_barrier %[[COPY1]]
+// RESULTS-ONLY:       %[[COPY2:.+]] = linalg.copy
+// RESULTS-ONLY-SAME:      ins(%[[BARRIER]] : tensor<?x?xf32>)
+// RESULTS-ONLY:       return %[[COPY2]] : tensor<?x?xf32>
 
 // -----
 
@@ -159,6 +169,44 @@ func.func @promote_padded_result(%a : tensor<?x?xf32>, %b : tensor<?x?xf32>, %md
 //  CHECK-SAME:       {lowering_config = #iree_gpu.derived_thread_config}
 //  CHECK-SAME:       ins(%[[EXTRACT]] : tensor<?x?xf32>)
 //       CHECK:   return %[[COPY2]] : tensor<?x?xf32>
+// RESULTS-ONLY-LABEL: func @promote_padded_result(
+// RESULTS-ONLY:       %[[MATMUL:.+]] = linalg.matmul
+// RESULTS-ONLY:       %[[ALLOC:.+]] = bufferization.alloc_tensor
+// RESULTS-ONLY:       %[[COPY1:.+]] = linalg.copy
+// RESULTS-ONLY-SAME:      ins(%[[MATMUL]] : tensor<?x?xf32>) outs(%[[ALLOC]] : tensor<?x?xf32>)
+// RESULTS-ONLY:       %[[BARRIER:.+]] = iree_codegen.fusion_barrier %[[COPY1]]
+// RESULTS-ONLY:       %[[EXTRACT:.+]] = tensor.extract_slice %[[BARRIER]]
+// RESULTS-ONLY:       %[[COPY2:.+]] = linalg.copy
+// RESULTS-ONLY-SAME:      ins(%[[EXTRACT]] : tensor<?x?xf32>)
+// RESULTS-ONLY:       return %[[COPY2]] : tensor<?x?xf32>
+
+// -----
+
+#lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1, 2]}>
+
+func.func @promote_results_only(%a: tensor<32x1024xf32>, %b: tensor<1024x128xf32>) -> tensor<32x128xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<32x128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x128xf32>) -> tensor<32x128xf32>
+  %mm = linalg.matmul {lowering_config = #lowering_config}
+    ins(%a, %b : tensor<32x1024xf32>, tensor<1024x128xf32>) outs(%fill : tensor<32x128xf32>) -> tensor<32x128xf32>
+  return %mm : tensor<32x128xf32>
+}
+
+// CHECK-LABEL: func.func @promote_results_only
+//  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<32x1024xf32>
+//  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<1024x128xf32>
+//       CHECK:   %[[PA:.+]] = linalg.copy {{.*}} ins(%[[A]] : tensor<32x1024xf32>)
+//       CHECK:   %[[PB:.+]] = linalg.copy {{.*}} ins(%[[B]] : tensor<1024x128xf32>)
+//       CHECK:   %[[MM:.+]] = linalg.matmul {{.*}} ins(%[[PA]], %[[PB]] : tensor<32x1024xf32>, tensor<1024x128xf32>)
+//       CHECK:   linalg.copy{{.*}}ins(%[[MM]] : tensor<32x128xf32>)
+// RESULTS-ONLY-LABEL: func.func @promote_results_only
+//  RESULTS-ONLY-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<32x1024xf32>
+//  RESULTS-ONLY-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<1024x128xf32>
+//   RESULTS-ONLY-NOT:   linalg.copy {{.*}} ins(%[[A]] : tensor<32x1024xf32>)
+//   RESULTS-ONLY-NOT:   linalg.copy {{.*}} ins(%[[B]] : tensor<1024x128xf32>)
+//       RESULTS-ONLY:   %[[MM:.+]] = linalg.matmul {{.*}} ins(%[[A]], %[[B]] : tensor<32x1024xf32>, tensor<1024x128xf32>)
+//       RESULTS-ONLY:   linalg.copy{{.*}}ins(%[[MM]] : tensor<32x128xf32>)
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands),canonicalize)" | FileCheck %s
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands{skip-operand-promotion=true}),canonicalize)" | FileCheck %s --check-prefix=RESULTS-ONLY
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands),canonicalize)" | FileCheck %s --check-prefixes=CHECK,RESULT
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands{skip-operand-promotion=true}),canonicalize)" | FileCheck %s --check-prefixes=RESULT,SKIP-OPERAND
 
 #lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1]}>
 
@@ -120,26 +120,17 @@ func.func @promote_result(%a : tensor<?x?xf32>, %b : tensor<?x?xf32>, %mdim : in
   return %mm : tensor<?x?xf32>
 }
 
-// CHECK-LABEL: func @promote_result(
-//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
-//       CHECK:   %[[ALLOC:.+]] = bufferization.alloc_tensor
-//       CHECK:   %[[COPY1:.+]] = linalg.copy
-//  CHECK-SAME:       ins(%[[MATMUL]] : tensor<?x?xf32>) outs(%[[ALLOC]] : tensor<?x?xf32>)
-//  CHECK-SAME:       -> tensor<?x?xf32>
-//       CHECK:   %[[BARRIER:.+]] = iree_codegen.fusion_barrier %[[COPY1]]
-//       CHECK:   %[[COPY2:.+]] = linalg.copy
-//  CHECK-SAME:       {lowering_config = #iree_gpu.derived_thread_config}
-//  CHECK-SAME:       ins(%[[BARRIER]] : tensor<?x?xf32>)
-//       CHECK:   return %[[COPY2]] : tensor<?x?xf32>
-// RESULTS-ONLY-LABEL: func @promote_result(
-// RESULTS-ONLY:       %[[MATMUL:.+]] = linalg.matmul
-// RESULTS-ONLY:       %[[ALLOC:.+]] = bufferization.alloc_tensor
-// RESULTS-ONLY:       %[[COPY1:.+]] = linalg.copy
-// RESULTS-ONLY-SAME:      ins(%[[MATMUL]] : tensor<?x?xf32>) outs(%[[ALLOC]] : tensor<?x?xf32>)
-// RESULTS-ONLY:       %[[BARRIER:.+]] = iree_codegen.fusion_barrier %[[COPY1]]
-// RESULTS-ONLY:       %[[COPY2:.+]] = linalg.copy
-// RESULTS-ONLY-SAME:      ins(%[[BARRIER]] : tensor<?x?xf32>)
-// RESULTS-ONLY:       return %[[COPY2]] : tensor<?x?xf32>
+// RESULT-LABEL: func @promote_result(
+// RESULT:       %[[MATMUL:.+]] = linalg.matmul
+// RESULT:       %[[ALLOC:.+]] = bufferization.alloc_tensor
+// RESULT:       %[[COPY1:.+]] = linalg.copy
+// RESULT-SAME:      ins(%[[MATMUL]] : tensor<?x?xf32>) outs(%[[ALLOC]] : tensor<?x?xf32>)
+// RESULT-SAME:      -> tensor<?x?xf32>
+// RESULT:       %[[BARRIER:.+]] = iree_codegen.fusion_barrier %[[COPY1]]
+// RESULT:       %[[COPY2:.+]] = linalg.copy
+// RESULT-SAME:      {lowering_config = #iree_gpu.derived_thread_config}
+// RESULT-SAME:      ins(%[[BARRIER]] : tensor<?x?xf32>)
+// RESULT:       return %[[COPY2]] : tensor<?x?xf32>
 
 // -----
 
@@ -158,27 +149,17 @@ func.func @promote_padded_result(%a : tensor<?x?xf32>, %b : tensor<?x?xf32>, %md
   return %mm_slice : tensor<?x?xf32>
 }
 
-// CHECK-LABEL: func @promote_padded_result(
-//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
-//       CHECK:   %[[ALLOC:.+]] = bufferization.alloc_tensor
-//       CHECK:   %[[COPY1:.+]] = linalg.copy
-//  CHECK-SAME:       ins(%[[MATMUL]] : tensor<?x?xf32>) outs(%[[ALLOC]] : tensor<?x?xf32>)
-//       CHECK:   %[[BARRIER:.+]] = iree_codegen.fusion_barrier %[[COPY1]]
-//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[BARRIER]]
-//       CHECK:   %[[COPY2:.+]] = linalg.copy
-//  CHECK-SAME:       {lowering_config = #iree_gpu.derived_thread_config}
-//  CHECK-SAME:       ins(%[[EXTRACT]] : tensor<?x?xf32>)
-//       CHECK:   return %[[COPY2]] : tensor<?x?xf32>
-// RESULTS-ONLY-LABEL: func @promote_padded_result(
-// RESULTS-ONLY:       %[[MATMUL:.+]] = linalg.matmul
-// RESULTS-ONLY:       %[[ALLOC:.+]] = bufferization.alloc_tensor
-// RESULTS-ONLY:       %[[COPY1:.+]] = linalg.copy
-// RESULTS-ONLY-SAME:      ins(%[[MATMUL]] : tensor<?x?xf32>) outs(%[[ALLOC]] : tensor<?x?xf32>)
-// RESULTS-ONLY:       %[[BARRIER:.+]] = iree_codegen.fusion_barrier %[[COPY1]]
-// RESULTS-ONLY:       %[[EXTRACT:.+]] = tensor.extract_slice %[[BARRIER]]
-// RESULTS-ONLY:       %[[COPY2:.+]] = linalg.copy
-// RESULTS-ONLY-SAME:      ins(%[[EXTRACT]] : tensor<?x?xf32>)
-// RESULTS-ONLY:       return %[[COPY2]] : tensor<?x?xf32>
+// RESULT-LABEL: func @promote_padded_result(
+// RESULT:       %[[MATMUL:.+]] = linalg.matmul
+// RESULT:       %[[ALLOC:.+]] = bufferization.alloc_tensor
+// RESULT:       %[[COPY1:.+]] = linalg.copy
+// RESULT-SAME:      ins(%[[MATMUL]] : tensor<?x?xf32>) outs(%[[ALLOC]] : tensor<?x?xf32>)
+// RESULT:       %[[BARRIER:.+]] = iree_codegen.fusion_barrier %[[COPY1]]
+// RESULT:       %[[EXTRACT:.+]] = tensor.extract_slice %[[BARRIER]]
+// RESULT:       %[[COPY2:.+]] = linalg.copy
+// RESULT-SAME:      {lowering_config = #iree_gpu.derived_thread_config}
+// RESULT-SAME:      ins(%[[EXTRACT]] : tensor<?x?xf32>)
+// RESULT:       return %[[COPY2]] : tensor<?x?xf32>
 
 // -----
 
@@ -200,13 +181,13 @@ func.func @promote_results_only(%a: tensor<32x1024xf32>, %b: tensor<1024x128xf32
 //       CHECK:   %[[PB:.+]] = linalg.copy {{.*}} ins(%[[B]] : tensor<1024x128xf32>)
 //       CHECK:   %[[MM:.+]] = linalg.matmul {{.*}} ins(%[[PA]], %[[PB]] : tensor<32x1024xf32>, tensor<1024x128xf32>)
 //       CHECK:   linalg.copy{{.*}}ins(%[[MM]] : tensor<32x128xf32>)
-// RESULTS-ONLY-LABEL: func.func @promote_results_only
-//  RESULTS-ONLY-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<32x1024xf32>
-//  RESULTS-ONLY-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<1024x128xf32>
-//   RESULTS-ONLY-NOT:   linalg.copy {{.*}} ins(%[[A]] : tensor<32x1024xf32>)
-//   RESULTS-ONLY-NOT:   linalg.copy {{.*}} ins(%[[B]] : tensor<1024x128xf32>)
-//       RESULTS-ONLY:   %[[MM:.+]] = linalg.matmul {{.*}} ins(%[[A]], %[[B]] : tensor<32x1024xf32>, tensor<1024x128xf32>)
-//       RESULTS-ONLY:   linalg.copy{{.*}}ins(%[[MM]] : tensor<32x128xf32>)
+// SKIP-OPERAND-LABEL: func.func @promote_results_only
+//  SKIP-OPERAND-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<32x1024xf32>
+//  SKIP-OPERAND-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<1024x128xf32>
+//   SKIP-OPERAND-NOT:   linalg.copy {{.*}} ins(%[[A]] : tensor<32x1024xf32>)
+//   SKIP-OPERAND-NOT:   linalg.copy {{.*}} ins(%[[B]] : tensor<1024x128xf32>)
+//       SKIP-OPERAND:   %[[MM:.+]] = linalg.matmul {{.*}} ins(%[[A]], %[[B]] : tensor<32x1024xf32>, tensor<1024x128xf32>)
+//       SKIP-OPERAND:   linalg.copy{{.*}}ins(%[[MM]] : tensor<32x128xf32>)
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-vector-alloc))" | FileCheck %s
 
-#translation = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 #consumer_layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
@@ -37,7 +37,7 @@ func.func @promote_global_transfer_read(%src: memref<16x16xf16>) -> vector<16x16
 
 // -----
 
-#translation = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 #consumer_layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
@@ -1,45 +1,118 @@
 // RUN: iree-opt %s --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-vector-alloc))" | FileCheck %s
 
-#layout = #iree_vector_ext.nested_layout<
+#translation = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+#consumer_layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
   batch_tile = [1, 1],
   outer_tile = [1, 1],
   thread_tile = [4, 16],
   element_tile = [4, 1],
-
-  subgroup_strides = [1, 1],
+  subgroup_strides = [0, 0],
   thread_strides   = [0, 0]
 >
 
-func.func @test(%vector: vector<16x16xf16>) -> vector<16x16xf16> {
-  %out = iree_vector_ext.to_layout %vector to layout(#layout) {shared_memory_conversion = #iree_gpu.derived_thread_config} : vector<16x16xf16>
+func.func @promote_global_transfer_read(%src: memref<16x16xf16>) -> vector<16x16xf16>
+    attributes {translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %read to layout(#consumer_layout)
+      {shared_memory_conversion = #iree_gpu.derived_thread_config} : vector<16x16xf16>
   return %out : vector<16x16xf16>
 }
 
-
-//    CHECK-LABEL: func.func @test
-//         CHECK:    gpu.barrier memfence [#gpu.address_space<workgroup>]
-//         CHECK:    %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<16x16xf16, #gpu.address_space<workgroup>>
-//         CHECK:    %[[WRITE:.+]] = vector.transfer_write %{{.*}}, %[[ALLOC]]
-//         CHECK:    %[[BAR:.+]]   = iree_gpu.value_barrier %[[WRITE]]
-//         CHECK:    %[[READ:.+]]  = vector.transfer_read %[[BAR]]
-//         CHECK:    %[[OUT:.+]]   = iree_vector_ext.to_layout %[[READ]]
+// CHECK-DAG: #[[$READ_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [16, 4], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [4, 1]>
+// CHECK-DAG: #[[$CONSUMER_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [4, 16], element_tile = [4, 1], subgroup_strides = [0, 0], thread_strides = [0, 0]>
+// CHECK-LABEL: func.func @promote_global_transfer_read
+// CHECK: %[[GLOBAL:.+]] = vector.transfer_read %{{.*}} : memref<16x16xf16>, vector<16x16xf16>
+// CHECK: %[[READ_LAYOUT_VALUE:.+]] = iree_vector_ext.to_layout %[[GLOBAL]] to layout(#[[$READ_LAYOUT]]) : vector<16x16xf16>
+// CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<16x16xf16, #gpu.address_space<workgroup>>
+// CHECK: %[[WRITE:.+]] = vector.transfer_write %[[READ_LAYOUT_VALUE]], %[[ALLOC]]
+// CHECK: %[[BARRIER:.+]] = iree_gpu.value_barrier %[[WRITE]]
+// CHECK: %[[LDS_READ:.+]] = vector.transfer_read %[[BARRIER]]
+// CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[LDS_READ]] to layout(#[[$CONSUMER_LAYOUT]])
+// CHECK-NOT: shared_memory_conversion
+// CHECK: return %[[OUT]]
 
 // -----
 
-#layout = #iree_vector_ext.nested_layout<
+#translation = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+#consumer_layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
   batch_tile = [1, 1],
   outer_tile = [1, 1],
   thread_tile = [4, 16],
   element_tile = [4, 1],
-
-  subgroup_strides = [1, 1],
+  subgroup_strides = [0, 0],
   thread_strides   = [0, 0]
 >
 
-func.func @invalid_shared_memory_conversion_attr(%vector: vector<16x16xf16>) -> vector<16x16xf16> {
-  // expected-error @+1 {{shared_memory_conversion attribute must implement IREE::GPU::PromotionAttr}}
-  %out = iree_vector_ext.to_layout %vector to layout(#layout) {shared_memory_conversion = "invalid"} : vector<16x16xf16>
+func.func @promote_global_gather(%src: memref<16x16xf16>,
+                                 %indices: vector<16x16xindex>,
+                                 %mask: vector<16x16xi1>,
+                                 %passthru: vector<16x16xf16>) -> vector<16x16xf16>
+    attributes {translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %gather = vector.gather %src[%c0, %c0] [%indices], %mask, %passthru
+      : memref<16x16xf16>, vector<16x16xindex>, vector<16x16xi1>, vector<16x16xf16> into vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %gather to layout(#consumer_layout)
+      {shared_memory_conversion = #iree_gpu.derived_thread_config} : vector<16x16xf16>
   return %out : vector<16x16xf16>
 }
+
+// CHECK-DAG: #[[$GATHER_READ_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [16, 4], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [4, 1]>
+// CHECK-DAG: #[[$GATHER_CONSUMER_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [4, 16], element_tile = [4, 1], subgroup_strides = [0, 0], thread_strides = [0, 0]>
+// CHECK-LABEL: func.func @promote_global_gather
+// CHECK: %[[GLOBAL:.+]] = vector.gather %{{.*}} : memref<16x16xf16>, vector<16x16xindex>, vector<16x16xi1>, vector<16x16xf16> into vector<16x16xf16>
+// CHECK: %[[READ_LAYOUT_VALUE:.+]] = iree_vector_ext.to_layout %[[GLOBAL]] to layout(#[[$GATHER_READ_LAYOUT]]) : vector<16x16xf16>
+// CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<16x16xf16, #gpu.address_space<workgroup>>
+// CHECK: %[[WRITE:.+]] = vector.transfer_write %[[READ_LAYOUT_VALUE]], %[[ALLOC]]
+// CHECK: %[[BARRIER:.+]] = iree_gpu.value_barrier %[[WRITE]]
+// CHECK: %[[LDS_READ:.+]] = vector.transfer_read %[[BARRIER]]
+// CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[LDS_READ]] to layout(#[[$GATHER_CONSUMER_LAYOUT]])
+// CHECK-NOT: shared_memory_conversion
+// CHECK: return %[[OUT]]
+
+// -----
+
+#layout_a = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
+  subgroup_strides = [0, 0],
+  thread_strides   = [4, 1]
+>
+
+#layout_b = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [4, 1],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @materialize_layout_conflict(%vector: vector<16x16xf16>) -> vector<16x16xf16> {
+  %a = iree_vector_ext.to_layout %vector to layout(#layout_a) : vector<16x16xf16>
+  %b = iree_vector_ext.to_layout %a to layout(#layout_b) : vector<16x16xf16>
+  return %b : vector<16x16xf16>
+}
+
+// CHECK-DAG: #[[$CONFLICT_LAYOUT_A:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [16, 4], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [4, 1]>
+// CHECK-DAG: #[[$CONFLICT_LAYOUT_B:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [4, 16], element_tile = [4, 1], subgroup_strides = [0, 0], thread_strides = [0, 0]>
+// CHECK-LABEL: func.func @materialize_layout_conflict
+// CHECK: gpu.barrier memfence [#gpu.address_space<workgroup>]
+// CHECK: %[[A:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$CONFLICT_LAYOUT_A]]) : vector<16x16xf16>
+// CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<16x16xf16, #gpu.address_space<workgroup>>
+// CHECK: %[[WRITE:.+]] = vector.transfer_write %[[A]], %[[ALLOC]]
+// CHECK: %[[BARRIER:.+]] = iree_gpu.value_barrier %[[WRITE]]
+// CHECK: %[[LDS_READ:.+]] = vector.transfer_read %[[BARRIER]]
+// CHECK: %[[B:.+]] = iree_vector_ext.to_layout %[[LDS_READ]] to layout(#[[$CONFLICT_LAYOUT_B]]) : vector<16x16xf16>
+// CHECK-NOT: shared_memory_conversion
+// CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[B]] to layout(#[[$CONFLICT_LAYOUT_B]]) : vector<16x16xf16>
+// CHECK: return %[[OUT]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
@@ -25,6 +25,7 @@ func.func @promote_global_transfer_read(%src: memref<16x16xf16>) -> vector<16x16
 // CHECK-DAG: #[[$READ_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [16, 4], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [4, 1]>
 // CHECK-DAG: #[[$CONSUMER_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [4, 16], element_tile = [4, 1], subgroup_strides = [0, 0], thread_strides = [0, 0]>
 // CHECK-LABEL: func.func @promote_global_transfer_read
+// CHECK: gpu.barrier memfence [#gpu.address_space<workgroup>]
 // CHECK: %[[GLOBAL:.+]] = vector.transfer_read %{{.*}} : memref<16x16xf16>, vector<16x16xf16>
 // CHECK: %[[READ_LAYOUT_VALUE:.+]] = iree_vector_ext.to_layout %[[GLOBAL]] to layout(#[[$READ_LAYOUT]]) : vector<16x16xf16>
 // CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<16x16xf16, #gpu.address_space<workgroup>>
@@ -34,6 +35,37 @@ func.func @promote_global_transfer_read(%src: memref<16x16xf16>) -> vector<16x16
 // CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[LDS_READ]] to layout(#[[$CONSUMER_LAYOUT]])
 // CHECK-NOT: shared_memory_conversion
 // CHECK: return %[[OUT]]
+
+// -----
+
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+#consumer_layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [4, 1],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @promote_global_transfer_read_dma(%src: memref<16x16xf16>) -> vector<16x16xf16>
+    attributes {translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %read to layout(#consumer_layout)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}
+
+// CHECK-DAG: #[[$DMA_CONSUMER_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [4, 16], element_tile = [4, 1], subgroup_strides = [0, 0], thread_strides = [0, 0]>
+// CHECK-LABEL: func.func @promote_global_transfer_read_dma
+// CHECK: %[[DMA_GLOBAL:.+]] = vector.transfer_read %{{.*}} : memref<16x16xf16>, vector<16x16xf16>
+// CHECK-NEXT: %[[DMA_OUT:.+]] = iree_vector_ext.to_layout %[[DMA_GLOBAL]] to layout(#[[$DMA_CONSUMER_LAYOUT]])
+// CHECK-NOT: shared_memory_conversion
+// CHECK: return %[[DMA_OUT]]
 
 // -----
 
@@ -65,6 +97,7 @@ func.func @promote_global_gather(%src: memref<16x16xf16>,
 // CHECK-DAG: #[[$GATHER_READ_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [16, 4], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [4, 1]>
 // CHECK-DAG: #[[$GATHER_CONSUMER_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [4, 16], element_tile = [4, 1], subgroup_strides = [0, 0], thread_strides = [0, 0]>
 // CHECK-LABEL: func.func @promote_global_gather
+// CHECK: gpu.barrier memfence [#gpu.address_space<workgroup>]
 // CHECK: %[[GLOBAL:.+]] = vector.gather %{{.*}} : memref<16x16xf16>, vector<16x16xindex>, vector<16x16xi1>, vector<16x16xf16> into vector<16x16xf16>
 // CHECK: %[[READ_LAYOUT_VALUE:.+]] = iree_vector_ext.to_layout %[[GLOBAL]] to layout(#[[$GATHER_READ_LAYOUT]]) : vector<16x16xf16>
 // CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<16x16xf16, #gpu.address_space<workgroup>>
@@ -74,6 +107,44 @@ func.func @promote_global_gather(%src: memref<16x16xf16>,
 // CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[LDS_READ]] to layout(#[[$GATHER_CONSUMER_LAYOUT]])
 // CHECK-NOT: shared_memory_conversion
 // CHECK: return %[[OUT]]
+
+// -----
+
+#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+#consumer_layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [4, 1],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 0]
+>
+
+func.func @promote_global_transfer_read_in_loop(%src: memref<16x16xf16>,
+                                                %init: vector<16x16xf16>) -> vector<16x16xf16>
+    attributes {translation_info = #translation} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %cst = arith.constant 0.0 : f16
+  %result = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %init) -> (vector<16x16xf16>) {
+    %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
+    %out = iree_vector_ext.to_layout %read to layout(#consumer_layout)
+        {shared_memory_conversion = #iree_gpu.derived_thread_config} : vector<16x16xf16>
+    scf.yield %out : vector<16x16xf16>
+  }
+  return %result : vector<16x16xf16>
+}
+
+// CHECK-LABEL: func.func @promote_global_transfer_read_in_loop
+// CHECK: scf.for
+// CHECK: gpu.barrier memfence [#gpu.address_space<workgroup>]
+// CHECK: vector.transfer_read
+// CHECK: vector.transfer_write
+// CHECK: iree_gpu.value_barrier
+// CHECK: scf.yield
 
 // -----
 
@@ -116,3 +187,21 @@ func.func @materialize_layout_conflict(%vector: vector<16x16xf16>) -> vector<16x
 // CHECK-NOT: shared_memory_conversion
 // CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[B]] to layout(#[[$CONFLICT_LAYOUT_B]]) : vector<16x16xf16>
 // CHECK: return %[[OUT]]
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
+  subgroup_strides = [0, 0],
+  thread_strides   = [4, 1]
+>
+
+func.func @invalid_shared_memory_conversion_attr(%vector: vector<16x16xf16>) -> vector<16x16xf16> {
+  // expected-error @+1 {{shared_memory_conversion attribute must implement IREE::GPU::PromotionAttr}}
+  %out = iree_vector_ext.to_layout %vector to layout(#layout) {shared_memory_conversion = "invalid"} : vector<16x16xf16>
+  return %out : vector<16x16xf16>
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -159,6 +159,13 @@ deriveIm2colOpThreadTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
                                           vectorizableDim);
 }
 
+SmallVector<int64_t> deriveThreadTileSizes(ArrayRef<int64_t> loopRanges,
+                                           int64_t numThreads,
+                                           int64_t elementBitWidth) {
+  int64_t vectorSize = kPreferredCopyNumBits / elementBitWidth;
+  return getVectorTileSizesFromLoopRanges(loopRanges, numThreads, vectorSize);
+}
+
 SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
   std::optional<SmallVector<int64_t>> workgroupSize =
       getWorkgroupSize(op->getParentOfType<FunctionOpInterface>());

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.h
@@ -13,6 +13,9 @@
 namespace mlir::iree_compiler::IREE::GPU {
 
 SmallVector<int64_t> deriveThreadTileSizes(Operation *op);
+SmallVector<int64_t> deriveThreadTileSizes(ArrayRef<int64_t> loopRanges,
+                                           int64_t numThreads,
+                                           int64_t elementBitWidth);
 SmallVector<int64_t> globalLoadDMATileSizes(Operation *op);
 
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
+#include "iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
@@ -372,65 +373,14 @@ static LogicalResult setDerivedThreadConfigLayout(
     ArrayRef<int64_t> workgroupSize, RewriterBase &rewriter) {
 
   SmallVector<int64_t> opShape = getIterationSpaceBounds(candidate);
-  int64_t opRank = opShape.size();
-
   SmallVector<int64_t> elementTile = config.getStaticTilingLevelSizes(
       static_cast<unsigned>(IREE::GPU::TilingLevel::Thread),
       candidate.getOperation());
-
-  for (auto [index, size, element] : llvm::enumerate(opShape, elementTile)) {
-    if (ShapedType::isDynamic(size)) {
-      candidate->emitError() << "opShape could not be inferred";
-      return failure();
-    }
-
-    if (size % element != 0) {
-      candidate->emitError()
-          << "Operation with unsupported number of elements. "
-             "Chosen vector tile sizes for operation are not "
-             "divisible by operation loop ranges at dim: "
-          << index << ", size=" << size << ", vector size = " << element;
-      return failure();
-    }
-
-    size /= element;
+  FailureOr<NestedLayoutAttr> layout = getDerivedThreadLayout(
+      rewriter.getContext(), workgroupSize, opShape, elementTile);
+  if (failed(layout)) {
+    return candidate->emitError("cannot build derived thread layout");
   }
-
-  SmallVector<int64_t> threadTile(opRank, 1);
-  SmallVector<int64_t> threadStrides(opRank, 0);
-
-  int64_t residualThreads = ShapedType::getNumElements(workgroupSize);
-  int64_t currStride = 1;
-
-  for (auto [tile, stride, size] :
-       llvm::reverse(llvm::zip(threadTile, threadStrides, opShape))) {
-    int64_t threadBlock;
-    if (residualThreads % size == 0) {
-      threadBlock = size;
-    } else if (size % residualThreads == 0) {
-      threadBlock = residualThreads;
-    } else {
-      candidate->emitError()
-          << "Operation with unsupported number of elements.";
-      return failure();
-    }
-
-    tile = threadBlock;
-    stride = currStride;
-    size /= threadBlock;
-
-    currStride *= threadBlock;
-    residualThreads /= threadBlock;
-  }
-
-  SmallVector<int64_t> subgroupTile(opRank, 1);
-  SmallVector<int64_t> subgroupStrides(opRank, 0);
-  SmallVector<int64_t> outerTile(opRank, 1);
-
-  MLIRContext *context = rewriter.getContext();
-  auto layout = IREE::VectorExt::NestedLayoutAttr::get(
-      context, subgroupTile, opShape, outerTile, threadTile, elementTile,
-      subgroupStrides, threadStrides);
 
   Location loc = candidate->getLoc();
   auto dpsOp = cast<DestinationStyleOpInterface>(candidate.getOperation());
@@ -440,7 +390,7 @@ static LogicalResult setDerivedThreadConfigLayout(
     AffineMap resultMap = candidate.getMatchingIndexingMap(
         dpsOp.getDpsInitOperand(result.getResultNumber()));
     auto toLayout =
-        ToLayoutOp::create(rewriter, loc, result, layout.apply(resultMap));
+        ToLayoutOp::create(rewriter, loc, result, layout->apply(resultMap));
     rewriter.replaceAllUsesExcept(result, toLayout, toLayout);
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -755,7 +755,11 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
 
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-  funcPassManager.addPass(createGPUPromoteMatmulOperandsPass());
+  {
+    GPUPromoteMatmulOperandsPassOptions options;
+    options.skipOperandPromotion = true;
+    funcPassManager.addPass(createGPUPromoteMatmulOperandsPass(options));
+  }
 
   // Tile to reduction loops.
   {


### PR DESCRIPTION
Rework how promotion of operands to LDS works in the VectorDistribute pipeline. 

So far, `linalg.copy` operations were inserted early in the pipeline. Now, we skip the insertion of `linalg.copy` for operands (we keep the behavior for results). Instead, the analysis from https://github.com/iree-org/iree/pull/24227 propagates the promotion types upwards from the compute operations that actually configure the promotion of operands up to the operations accessing the data in memory (`transfer_read`, `gather`) when we reach `GPUVectorAlloc`. Based on the propagated information, the necessary promotion to LDS can be inserted. 

Layout conflicts are still resolved through an LDS roundtrip at the conflict point.

Assisted-by: Codex