### PR TITLE
Reland "[Codegen] Enable DMA by default for F16/BF16 GEMM on gfx950" 3rd attempt 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -173,21 +173,6 @@ static bool sourceIsFromFatRawBuffer(Value source) {
   return hasAMDGPUFatRawBufferAddressSpace(memrefType);
 }
 
-/// Check if the target architecture supports global load DMA.
-/// Returns true only for CDNA4+ (gfx950+) architectures.
-static bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target) {
-  if (!target) {
-    return false;
-  }
-  FailureOr<amdgpu::Chipset> chipset = amdgpu::Chipset::parse(target.getArch());
-  if (failed(chipset)) {
-    return false;
-  }
-  // CDNA4 is gfx950+ (major=9, minor>=5). Other major versions (RDNA, etc.)
-  // do not support global load DMA.
-  return chipset->majorVersion == 9 && chipset->minorVersion >= 5;
-}
-
 /// Returns the subgroup size if the available elements are aligned to DMA
 /// transfer sizes, std::nullopt otherwise.
 static std::optional<int64_t>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -116,6 +116,32 @@ calculateResultSharedMemoryUsedInBytes(const GPUMMASchedule &schedule,
   return (numRes * tileM * tileN * resultBitwidth) / 8;
 }
 
+int64_t calculateTotalSharedMemoryUsedInBytes(const GPUMMASchedule &schedule,
+                                              const GPUMatmulShapeType &problem,
+                                              bool useDirectLoad,
+                                              int64_t prefetchNumStages,
+                                              bool doCPromotion) {
+  int64_t lhsBitwidth = problem.aType.getIntOrFloatBitWidth();
+  int64_t rhsBitwidth = problem.bType.getIntOrFloatBitWidth();
+  int64_t lhsScaleBitwidth =
+      problem.aScaleType ? problem.aScaleType.getIntOrFloatBitWidth() : 0;
+  int64_t rhsScaleBitwidth =
+      problem.bScaleType ? problem.bScaleType.getIntOrFloatBitWidth() : 0;
+
+  int64_t sharedMemoryUsed = calculateOperandsSharedMemoryUsedInBytes(
+      schedule, lhsBitwidth, rhsBitwidth, lhsScaleBitwidth, rhsScaleBitwidth,
+      problem.numHorizontallyFusedOps, useDirectLoad, prefetchNumStages);
+
+  if (doCPromotion) {
+    int64_t resultBitwidth = problem.cType.getIntOrFloatBitWidth();
+    sharedMemoryUsed += calculateResultSharedMemoryUsedInBytes(
+        schedule, resultBitwidth, problem.numHorizontallyFusedOps);
+  }
+
+  sharedMemoryUsed *= schedule.getTotalWorkgroupBatchSize();
+  return sharedMemoryUsed;
+}
+
 /// Check that a GPUMMASchedule fits alignment restrictions. To be aligned,
 /// the problem must be evenly divisible by the number of elements in the
 /// schedule for each dimension. If `mustBeAligned` is false, then the problem
@@ -995,33 +1021,11 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     LDBG() << "Chosen MMA schedule:\n" << schedule;
 
     auto isValidSchedule = [&](const GPUMMASchedule &schedule) -> bool {
-      int64_t lhsBitwidth = problem.aType.getIntOrFloatBitWidth();
-      int64_t rhsBitwidth = problem.bType.getIntOrFloatBitWidth();
-      int64_t resultBitwidth = problem.cType.getIntOrFloatBitWidth();
-      int64_t lhsScaleBitwidth =
-          problem.aScaleType ? problem.aScaleType.getIntOrFloatBitWidth() : 0;
-      int64_t rhsScaleBitwidth =
-          problem.bScaleType ? problem.bScaleType.getIntOrFloatBitWidth() : 0;
       bool isAligned =
           isValidMMASchedule(problem, schedule, mustBeAligned, subgroupSize,
                              transposedLhs, transposedRhs);
-      int64_t sharedMemoryUsed = calculateOperandsSharedMemoryUsedInBytes(
-          schedule, lhsBitwidth, rhsBitwidth, lhsScaleBitwidth,
-          rhsScaleBitwidth, problem.numHorizontallyFusedOps, useDirectLoad,
-          prefetchNumStages);
-      // Add accumulator/result memory when it uses shared memory (LDS):
-      // - Result needs padding in shared memory, OR
-      // - matmul_accumulate loads accumulator from global memory via shared mem
-      // For zero-initialized GEMMs without C promotion, the accumulator stays
-      // in registers and doesn't need shared memory.
-      if (doCPromotion) {
-        sharedMemoryUsed += calculateResultSharedMemoryUsedInBytes(
-            schedule, resultBitwidth, problem.numHorizontallyFusedOps);
-      }
-
-      // Batch tiling multiplies the promoted operand sizes: each batch slice
-      // uses separate shared memory, so total usage scales linearly.
-      sharedMemoryUsed *= totalBatchTile;
+      int64_t sharedMemoryUsed = calculateTotalSharedMemoryUsedInBytes(
+          schedule, problem, useDirectLoad, prefetchNumStages, doCPromotion);
 
       LDBG() << "Available Shared Memory: " << sharedMemLimitInBytes << " bytes"
              << "Predicted Shared Memory Used by Schedule: " << sharedMemoryUsed

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -223,6 +223,15 @@ FailureOr<std::pair<GPUMMASchedule, GPUMMASchedule>> deduceAttentionSchedule(
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const GPUMMASchedule &schedule);
 
+/// Calculate total shared memory used by a schedule in bytes, combining
+/// operand LDS (with optional DMA multi-buffering), result/accumulator LDS
+/// (when C promotion is needed), and batch tiling.
+int64_t calculateTotalSharedMemoryUsedInBytes(const GPUMMASchedule &schedule,
+                                              const GPUMatmulShapeType &problem,
+                                              bool useDirectLoad,
+                                              int64_t prefetchNumStages,
+                                              bool doCPromotion);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_GPU_GPUHEURISTICS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -585,6 +585,52 @@ getSplitReductionTripCount(mlir::FunctionOpInterface entryPoint) {
   return splitReductionTripCnt;
 }
 
+constexpr int64_t kMinWorkgroupsPerCU = 2;
+
+/// Rejects DMA when its extra LDS usage would drop occupancy (WGs/CU) below
+/// `kMinWorkgroupsPerCU` while non-DMA would still meet it. When chip info
+/// is available, the LDS-limited occupancy is capped by actual work
+/// (totalWorkgroups / numCUs) so that under-subscribed shapes are not
+/// penalized.
+static bool shouldRejectDMAForOccupancy(
+    const GPUMMASchedule &schedule, const GPUMatmulShapeType &problem,
+    IREE::GPU::TargetAttr target, int64_t prefetchNumStages, bool doCPromotion,
+    ArrayRef<int64_t> bounds, ArrayRef<int64_t> workgroupTileSizes) {
+  int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
+
+  int64_t dmaLdsBytes = calculateTotalSharedMemoryUsedInBytes(
+      schedule, problem, /*useDirectLoad=*/true, prefetchNumStages,
+      doCPromotion);
+  int64_t nonDmaLdsBytes = calculateTotalSharedMemoryUsedInBytes(
+      schedule, problem, /*useDirectLoad=*/false, /*prefetchNumStages=*/0,
+      doCPromotion);
+
+  assert(dmaLdsBytes > 0 && nonDmaLdsBytes > 0 && "LDS usage must be positive");
+
+  int64_t dmaMaxWgsPerCU = maxSharedMemoryBytes / dmaLdsBytes;
+  int64_t nonDmaMaxWgsPerCU = maxSharedMemoryBytes / nonDmaLdsBytes;
+
+  // When chip info is available, cap effective WGs/CU by how many workgroups
+  // actually exist per CU. This avoids over-rejecting DMA for small shapes
+  // where the GPU is under-subscribed.
+  IREE::GPU::TargetChipAttr chip = target.getChip();
+  if (chip) {
+    int64_t numCUs = chip.getWgpCount();
+    int64_t totalWorkgroups = 1;
+    for (auto [dim, tileSize] : llvm::zip_equal(bounds, workgroupTileSizes)) {
+      if (tileSize > 0) {
+        totalWorkgroups *= llvm::divideCeil(dim, tileSize);
+      }
+    }
+    int64_t maxWgsPerCU = llvm::divideCeil(totalWorkgroups, numCUs);
+    dmaMaxWgsPerCU = std::min(maxWgsPerCU, dmaMaxWgsPerCU);
+    nonDmaMaxWgsPerCU = std::min(maxWgsPerCU, nonDmaMaxWgsPerCU);
+  }
+
+  return dmaMaxWgsPerCU < kMinWorkgroupsPerCU &&
+         nonDmaMaxWgsPerCU >= kMinWorkgroupsPerCU;
+}
+
 /// Returns true if direct load DMA should be rejected, and fall back to stream
 /// copies.
 ///
@@ -945,6 +991,16 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     if (GPU::isNvMmaSync(mmaAttr.getIntrinsic())) {
       GPU::appendConvertAccGemm(context, attrs);
     }
+  }
+
+  // After computing workgroup tile sizes, check whether DMA would cause an
+  // unacceptable occupancy drop.
+  if (useDirectLoad &&
+      shouldRejectDMAForOccupancy(*schedule, problem, target, prefetchNumStages,
+                                  hasExistingAccumulator, bounds,
+                                  workgroupTileSizes)) {
+    LDBG() << "rejecting direct load DMA: LDS limits occupancy (WGs/CU)";
+    useDirectLoad = false;
   }
 
   // Use global load DMA attribute (subgroup sizes will be derived from

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -585,6 +585,42 @@ getSplitReductionTripCount(mlir::FunctionOpInterface entryPoint) {
   return splitReductionTripCnt;
 }
 
+/// Returns true if direct load DMA should be rejected, and fall back to stream
+/// copies.
+///
+/// Rejection cases:
+///   1. Target does not support DMA (requires gfx950+ / CDNA4+).
+///   2. Not a GEMM. TODO(#23907): support convolution.
+///   3. Data types are not f16 or bf16. TODO(#22119): support MXFP4.
+///   4. LHS transposed, RHS not transposed shows regressions. TODO (#24117).
+static bool shouldRejectDirectLoadDMA(IREE::GPU::TargetAttr target, bool isGemm,
+                                      Type lhsElemType, Type rhsElemType,
+                                      bool transposedLhs, bool transposedRhs) {
+  auto isF16OrBF16 = [](Type t) { return t.isF16() || t.isBF16(); };
+
+  // Case 1: DMA requires hardware support (gfx950+ / CDNA4+).
+  if (!targetSupportsGlobalLoadDMA(target)) {
+    return true;
+  }
+
+  // Case 2: Only GEMM are supported currently.
+  if (!isGemm) {
+    return true;
+  }
+
+  // Case 3: Only f16/bf16 are supported currently.
+  if (!isF16OrBF16(lhsElemType) || !isF16OrBF16(rhsElemType)) {
+    return true;
+  }
+
+  // Case 4: LHS transposed, RHS not transposed show regressions with DMA.
+  if (transposedLhs && !transposedRhs) {
+    return true;
+  }
+
+  return false;
+}
+
 /// Create a lowering config for matmul or IGEMM convolution based on iteration
 /// bounds and indexing maps for a given target. This function computes
 /// contraction dimensions and deduces an MMA intrinsic schedule to choose tile
@@ -600,7 +636,7 @@ static FailureOr<std::pair<LoweringConfigAttr, int64_t>>
 getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     ArrayRef<int64_t> bounds, ArrayRef<AffineMap> maps,
     ArrayRef<Value> operands, IREE::GPU::TargetAttr target, bool isGemm,
-    bool scaled, bool useDirectLoad, int64_t prefetchNumStages,
+    bool scaled, bool &useDirectLoad, int64_t prefetchNumStages,
     int64_t splitReductionTripCnt, bool hasExistingAccumulator = false,
     std::optional<ConvToIgemmInfo> convToIgemmInfo = std::nullopt) {
   if (target.getWgp().getMma().empty()) {
@@ -778,13 +814,11 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                              lhsScaleType,
                              rhsScaleType};
 
-  // TODO(#22119): We don't use global load DMA for scaled matmuls, because
-  // compilation doesn't support it. Once this is fixed, we should use global
-  // load DMA here when possible.
   Location loc = operands[0].getLoc();
-  if (scaled && useDirectLoad) {
-    mlir::emitWarning(loc) << "direct load (global load DMA) is not yet "
-                              "supported for scaled matmuls, ignoring";
+  if (useDirectLoad &&
+      shouldRejectDirectLoadDMA(target, isGemm, lhsElemType, rhsElemType,
+                                transposedLhs, transposedRhs)) {
+    LDBG() << "overriding direct load DMA, falling back to stream copies";
     useDirectLoad = false;
   }
 
@@ -922,7 +956,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     // Apply XOR swizzle for BF16 DMA operands whose reduction dim is
     // innermost (contiguous reads) to avoid LDS bank conflicts.
     // TODO(#24255): Fix untuned swizzle logic for DMA.
-    if (lhsElemType.isBF16() && !transposedLhs) {
+    if (!transposedLhs) {
       FailureOr<Attribute> lhsSwizzleAttr = getXorShuffleAttr(
           context, lhsAttr, target, kind, schedule->kTileSizes, kMMAOperandLhs,
           /*skipUntunedFallback=*/true);
@@ -930,7 +964,7 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
         lhsAttr = *lhsSwizzleAttr;
       }
     }
-    if (rhsElemType.isBF16() && transposedRhs) {
+    if (transposedRhs) {
       FailureOr<Attribute> rhsSwizzleAttr = getXorShuffleAttr(
           context, rhsAttr, target, kind, schedule->kTileSizes, kMMAOperandRhs,
           /*skipUntunedFallback=*/true);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -592,6 +592,9 @@ constexpr int64_t kMinWorkgroupsPerCU = 2;
 /// is available, the LDS-limited occupancy is capped by actual work
 /// (totalWorkgroups / numCUs) so that under-subscribed shapes are not
 /// penalized.
+/// TODO(#24375): Remove this guard once the tile-size heuristic stops
+/// over-allocating LDS or 1-warp/SIMD codegen can recover the perf without
+/// requiring inter-SIMD latency hiding via WGs/CU >= 2.
 static bool shouldRejectDMAForOccupancy(
     const GPUMMASchedule &schedule, const GPUMatmulShapeType &problem,
     IREE::GPU::TargetAttr target, int64_t prefetchNumStages, bool doCPromotion,
@@ -861,6 +864,9 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
                              rhsScaleType};
 
   Location loc = operands[0].getLoc();
+  // Stage 1 (problem-size + target-arch) DMA rejection. Stage 2 (tile-size)
+  // happens below via shouldRejectDMAForOccupancy after the schedule and
+  // workgroup tiles are computed.
   if (useDirectLoad &&
       shouldRejectDirectLoadDMA(target, isGemm, lhsElemType, rhsElemType,
                                 transposedLhs, transposedRhs)) {
@@ -993,8 +999,9 @@ getMatmulOrIGEMMLoweringConfigAndWorkgroupSize(
     }
   }
 
-  // After computing workgroup tile sizes, check whether DMA would cause an
-  // unacceptable occupancy drop.
+  // Stage 2 (tile-size) DMA rejection: now that workgroup tiles are known,
+  // check whether DMA would cause an unacceptable occupancy drop. Stage 1
+  // (problem-size + target-arch) ran above via shouldRejectDirectLoadDMA.
   if (useDirectLoad &&
       shouldRejectDMAForOccupancy(*schedule, problem, target, prefetchNumStages,
                                   hasExistingAccumulator, bounds,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -115,7 +115,7 @@ static llvm::cl::opt<bool> clGPUPadConvolution(
 static llvm::cl::opt<bool>
     clUseDirectLoad("iree-llvmgpu-use-direct-load",
                     llvm::cl::desc("Use global load DMA for direct load ops."),
-                    llvm::cl::Hidden, llvm::cl::init(false));
+                    llvm::cl::Hidden, llvm::cl::init(true));
 
 static llvm::cl::opt<bool> clDirectConvolution(
     "iree-codegen-llvmgpu-use-direct-convolution",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
-// RUN: --iree-codegen-llvmgpu-use-igemm=false \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=false \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s
 
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
-// RUN: --iree-codegen-llvmgpu-use-igemm=false \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=false \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" \
 // RUN: --remarks-filter=".*" %s 2>&1 | FileCheck %s --check-prefix=CHECK-REMARKS
 
@@ -36,11 +36,6 @@
 // RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=IGEMM
 
-// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
-// RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
-// RUN: --iree-llvmgpu-use-direct-load=true \
-// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s \
-// RUN: | FileCheck %s --check-prefix=IGEMM-DIRECT-LOAD
 
 #lhs_map = affine_map<(M, N, Ko, Kb) -> (M, Ko, Kb)>
 #rhs_map = affine_map<(M, N, Ko, Kb) -> (N, Ko, Kb)>
@@ -598,21 +593,32 @@ func.func @matmul_bf16(
 
 // -----
 
-// BF16 1x1 conv with DMA. The MMA intrinsic (MFMA_F32_32x32x8_BF16) is not in
-// the tuned swizzle table, so no XOR swizzle should be applied -- only plain
-// use_global_load_dma.
-func.func @conv_bf16_no_untuned_swizzle(
+// BF16 1x1 conv (preprocessed to fold unit spatial dims) with DMA. The MMA intrinsic
+// (MFMA_F32_32x32x8_BF16) is not in the tuned swizzle table, so no XOR
+// swizzle should be applied -- only plain use_global_load_dma.
+func.func @conv_1x1_bf16_no_untuned_swizzle(
     %arg0: tensor<16x96x64x40xbf16>,
-    %arg1: tensor<40x1x1x40xbf16>) -> tensor<16x96x64x40xf32> {
+    %arg1: tensor<40x40xbf16>) -> tensor<16x96x64x40xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %empty = tensor.empty() : tensor<16x96x64x40xf32>
   %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<16x96x64x40xf32>) -> tensor<16x96x64x40xf32>
-  %result = linalg.conv_2d_nhwc_fhwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
-    ins(%arg0, %arg1 : tensor<16x96x64x40xbf16>, tensor<40x1x1x40xbf16>)
-    outs(%fill : tensor<16x96x64x40xf32>) -> tensor<16x96x64x40xf32>
+  %result = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+  } ins(%arg0, %arg1 : tensor<16x96x64x40xbf16>, tensor<40x40xbf16>)
+    outs(%fill : tensor<16x96x64x40xf32>) {
+  ^bb0(%in: bf16, %in_1: bf16, %out: f32):
+    %0 = arith.extf %in : bf16 to f32
+    %1 = arith.extf %in_1 : bf16 to f32
+    %2 = arith.mulf %0, %1 : f32
+    %3 = arith.addf %out, %2 : f32
+    linalg.yield %3 : f32
+  } -> tensor<16x96x64x40xf32>
   return %result : tensor<16x96x64x40xf32>
 }
 
-// IGEMM-DIRECT-LOAD-LABEL: func.func @conv_bf16_no_untuned_swizzle
-// IGEMM-DIRECT-LOAD:       linalg.conv_2d_nhwc_fhwc {
-// IGEMM-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.use_global_load_dma, #iree_gpu.use_global_load_dma]
+// CHECK-DIRECT-LOAD-LABEL: func.func @conv_1x1_bf16_no_untuned_swizzle
+// CHECK-DIRECT-LOAD:       linalg.generic
+// CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.use_global_load_dma, #iree_gpu.use_global_load_dma]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse_gfx950.mlir
@@ -29,8 +29,14 @@
 
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=mi355x@hip \
 // RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
-// RUN: --iree-codegen-llvmgpu-use-igemm=false \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=false \
 // RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=MI355X
+
+// RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=mi355x@hip \
+// RUN: --iree-codegen-llvmgpu-use-tile-and-fuse-matmul=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
+// RUN: --iree-codegen-llvmgpu-use-igemm=false --iree-llvmgpu-use-direct-load=true \
+// RUN: --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s \
+// RUN: | FileCheck %s --check-prefix=MI355X-DIRECT-LOAD
 
 // RUN: iree-opt --mlir-print-local-scope --split-input-file --iree-gpu-test-target=gfx950 \
 // RUN: --iree-codegen-llvmgpu-use-igemm=true --iree-codegen-llvmgpu-test-tile-and-fuse-vectorize=true \
@@ -622,3 +628,35 @@ func.func @conv_1x1_bf16_no_untuned_swizzle(
 // CHECK-DIRECT-LOAD-LABEL: func.func @conv_1x1_bf16_no_untuned_swizzle
 // CHECK-DIRECT-LOAD:       linalg.generic
 // CHECK-DIRECT-LOAD-SAME:    promotion_types = [#iree_gpu.use_global_load_dma, #iree_gpu.use_global_load_dma]
+
+// -----
+
+// mi355x + direct load: prod 1x1 conv (n16 c2048 H8 W32 k576) after preprocessing to a
+// batched GEMM-like linalg.generic; occupancy guard rejects DMA (stream copies).
+func.func @conv_1x1_mi355x_dma_rejected_occ(
+    %arg0: tensor<16x8x32x2048xbf16>,
+    %arg1: tensor<576x2048xbf16>) -> tensor<16x8x32x576xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<16x8x32x576xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<16x8x32x576xf32>) -> tensor<16x8x32x576xf32>
+  %result = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+  } ins(%arg0, %arg1 : tensor<16x8x32x2048xbf16>, tensor<576x2048xbf16>)
+    outs(%fill : tensor<16x8x32x576xf32>) {
+  ^bb0(%in: bf16, %in_1: bf16, %out: f32):
+    %0 = arith.extf %in : bf16 to f32
+    %1 = arith.extf %in_1 : bf16 to f32
+    %2 = arith.mulf %0, %1 : f32
+    %3 = arith.addf %out, %2 : f32
+    linalg.yield %3 : f32
+  } -> tensor<16x8x32x576xf32>
+  return %result : tensor<16x8x32x576xf32>
+}
+
+// MI355X-DIRECT-LOAD-LABEL: func.func @conv_1x1_mi355x_dma_rejected_occ
+// MI355X-DIRECT-LOAD:       linalg.generic
+// MI355X-DIRECT-LOAD-SAME:   promote_operands = [0, 1]
+// MI355X-DIRECT-LOAD-NOT:   use_global_load_dma

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -756,7 +756,7 @@ getOperandBitwidth(IREE::Codegen::InnerTileDescAttrInterface intrinsic,
                    int operandIndex) {
   SmallVector<Type> elementTypes;
   intrinsic.getElementTypes(elementTypes);
-  assert(operandIndex > 0 && "operand index must be positive");
+  assert(operandIndex >= 0 && "operand index must be non-negative");
   return elementTypes[operandIndex].getIntOrFloatBitWidth();
 }
 
@@ -819,6 +819,8 @@ static FailureOr<XorShuffleParams> getXorShuffleParamsForGfx950(
   }
   if (auto mma = dyn_cast<IREE::GPU::MMAAttr>(intrinsic)) {
     switch (mma.getIntrinsic()) {
+    case IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x32_F16:
+    case IREE::GPU::MMAIntrinsic::MFMA_F32_32x32x16_F16:
     case IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x32_BF16:
     case IREE::GPU::MMAIntrinsic::MFMA_F32_32x32x16_BF16:
       return XorShuffleParams({/*rowElems=*/64,
@@ -1309,6 +1311,18 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op) {
   return getGPUTargetAttr(op->getContext(),
                           IREE::HAL::ExecutableTargetAttr::lookup(op));
 }
+
+bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target) {
+  if (!target) {
+    return false;
+  }
+  FailureOr<amdgpu::Chipset> chipset = amdgpu::Chipset::parse(target.getArch());
+  if (failed(chipset)) {
+    return false;
+  }
+  return chipset->majorVersion == 9 && chipset->minorVersion >= 5;
+}
+
 void addConfigGPUTarget(MLIRContext *context,
                         IREE::GPU::TargetAttr gpuTargetAttr,
                         SmallVectorImpl<NamedAttribute> &config) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -330,6 +330,10 @@ IREE::GPU::TargetAttr getGPUTargetAttr(MLIRContext *context,
                                        IREE::HAL::ExecutableTargetAttr attr);
 IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 
+/// Check if the target architecture supports global load DMA.
+/// Returns true only for CDNA4+ (gfx950+) architectures.
+bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target);
+
 // Methods to retrieve information association with `configuration` field
 // of `hal.executable.target` attribute used commonly in GPU codegen pipelines.
 std::optional<int64_t> getConfigWavesPerEu(DictionaryAttr targetAttr);


### PR DESCRIPTION
**First attempt**: https://github.com/iree-org/iree/pull/24117 (reverted due to numerical issue)
**Second attempt**: https://github.com/iree-org/iree/pull/24373 (reverted due to 1x1 conv performance regression)
**This PR**:
- Commit 1: undoing the revert from #24395, and re-enable DMA again
- Commit 2: add an occupancy guard in heuristics so the 1×1-conv regressions do not recur

---

### Geomean speedup (positive is good)

| **test set** | `--iree-rocm-target=mi355x` | `--iree-rocm-target=gfx950` |
|-------|----------------------------|-----------------------------|
| **GEMM** | **+3.47%** | **+4.01%** |
| **Prod Conv** | **−0.55%** | **+0.06%** |
| **All Proxy** | **+1.27%** | **+0.81%** |

---

### GEMM

#### `--iree-rocm-target=gfx950`

<details>
<summary><strong>Top 10 improvements (DMA ON vs OFF)</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | aten::mm '[[1285, 2048], [2048, 3840]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[2048, 1], [3840, 1]]' '['"'"''"'"', '"'"''"'"']' | 54.627 | 34.358 | -37.105% |
| 2 | aten::mm '[[1285, 2048], [2048, 2048]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[2048, 1], [2048, 1]]' '['"'"''"'"', '"'"''"'"']' | 43.125 | 27.24 | -36.834% |
| 3 | aten::mm '[[1285, 8192], [8192, 2048]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[8192, 1], [2048, 1]]' '['"'"''"'"', '"'"''"'"']' | 150.672 | 97.436 | -35.333% |
| 4 | aten::mm '[[1285, 3840], [3840, 2048]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[3840, 1], [2048, 1]]' '['"'"''"'"', '"'"''"'"']' | 75.079 | 49.185 | -34.490% |
| 5 | aten::mm '[[1280, 3840], [3840, 3840]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[3840, 1], [3840, 1]]' '['"'"''"'"', '"'"''"'"']' | 84.376 | 55.647 | -34.050% |
| 6 | aten::bmm '[[32, 96, 21], [32, 21, 96]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[2016, 21, 1], [2016, 96, 1]]' '['"'"''"'"', '"'"''"'"']' | 4.331 | 2.888 | -33.322% |
| 7 | aten::mm '[[1285, 2048], [2048, 3840]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[2048, 1], [1, 2048]]' '['"'"''"'"', '"'"''"'"']' | 51.443 | 34.634 | -32.675% |
| 8 | aten::addmm '[[2048], [1285, 2048], [2048, 2048], [], []]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'Scalar'"'"', '"'"'Scalar'"'"']' '[[1], [2048, 1], [1, 2048], [], []]' '['"'"''"'"', '"'"''"'"', '"'"''"'"', '"'"'1'"'"', '"'"'1'"'"']' | 40.062 | 27.443 | -31.499% |
| 9 | aten::mm '[[1280, 7680], [7680, 3840]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[7680, 1], [3840, 1]]' '['"'"''"'"', '"'"''"'"']' | 160.976 | 114.285 | -29.005% |
| 10 | aten::bmm '[[32, 21, 96], [32, 96, 96]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[2016, 96, 1], [9216, 1, 96]]' '['"'"''"'"', '"'"''"'"']' | 4.428 | 3.149 | -28.897% |

</details>

<details>
<summary><strong>Top 10 regressions (DMA ON vs OFF): similar trend #24117</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | aten::addmm '[[576], [24576, 576], [576, 576], [], []]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'Scalar'"'"', '"'"'Scalar'"'"']' '[[1], [576, 1], [1, 576], [], []]' '['"'"''"'"', '"'"''"'"', '"'"''"'"', '"'"'1'"'"', '"'"'1'"'"']' | 36.095 | 52.051 | +44.206% |
| 2 | aten::addmm '[[2268], [150000, 4096], [4096, 2268], [], []]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'Scalar'"'"', '"'"'Scalar'"'"']' '[[1], [4096, 1], [1, 4096], [], []]' '['"'"''"'"', '"'"''"'"', '"'"''"'"', '"'"'1'"'"', '"'"'1'"'"']' | 3923.219 | 5357.374 | +36.556% |
| 3 | aten::addmm '[[4096], [150000, 16384], [16384, 4096], [], []]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'Scalar'"'"', '"'"'Scalar'"'"']' '[[1], [16384, 1], [1, 16384], [], []]' '['"'"''"'"', '"'"''"'"', '"'"''"'"', '"'"'1'"'"', '"'"'1'"'"']' | 25305.703 | 33481.578 | +32.308% |
| 4 | aten::mm '[[7680, 576], [576, 1728]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[576, 1], [1, 576]]' '['"'"''"'"', '"'"''"'"']' | 30.378 | 39.086 | +28.665% |
| 5 | aten::mm '[[1024, 5], [5, 1024]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[1, 1024], [1024, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.744 | 4.801 | +28.247% |
| 6 | aten::mm '[[576, 32], [32, 576]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[1, 576], [576, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.356 | 4.206 | +25.313% |
| 7 | aten::addmm '[[576], [7680, 576], [576, 576], [], []]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'Scalar'"'"', '"'"'Scalar'"'"']' '[[1], [576, 1], [1, 576], [], []]' '['"'"''"'"', '"'"''"'"', '"'"''"'"', '"'"'1'"'"', '"'"'1'"'"']' | 16.72 | 20.905 | +25.029% |
| 8 | aten::mm '[[2304, 32], [32, 576]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[1, 2304], [576, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.666 | 4.522 | +23.363% |
| 9 | aten::mm '[[7680, 576], [576, 576]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[576, 1], [1, 576]]' '['"'"''"'"', '"'"''"'"']' | 15.845 | 18.924 | +19.426% |
| 10 | aten::mm '[[21760, 3840], [3840, 3840]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[3840, 1], [1, 3840]]' '['"'"''"'"', '"'"''"'"']' | 971.128 | 1148.768 | +18.292% |

</details>

#### `--iree-rocm-target=mi355x`

<details>
<summary><strong>Top 10 improvements (DMA ON vs OFF)</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | aten::mm '[[4112, 8192], [8192, 2048]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[8192, 1], [2048, 1]]' '['"'"''"'"', '"'"''"'"']' | 402.798 | 205.162 | -49.066% |
| 2 | aten::addmm '[[1024], [5, 512], [512, 1024], [], []]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'Scalar'"'"', '"'"'Scalar'"'"']' '[[1], [512, 1], [1, 512], [], []]' '['"'"''"'"', '"'"''"'"', '"'"''"'"', '"'"'1'"'"', '"'"'1'"'"']' | 4.982 | 3.318 | -33.402% |
| 3 | aten::mm '[[1280, 7680], [7680, 3840]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[7680, 1], [3840, 1]]' '['"'"''"'"', '"'"''"'"']' | 164.621 | 115.028 | -30.126% |
| 4 | aten::mm '[[528, 1728], [1728, 576]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[1728, 1], [576, 1]]' '['"'"''"'"', '"'"''"'"']' | 10.956 | 7.745 | -29.310% |
| 5 | aten::mm '[[165, 576], [576, 1728]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[576, 1], [1, 576]]' '['"'"''"'"', '"'"''"'"']' | 5.573 | 3.944 | -29.227% |
| 6 | aten::mm '[[528, 2304], [2304, 576]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[2304, 1], [1, 2304]]' '['"'"''"'"', '"'"''"'"']' | 12.767 | 9.167 | -28.195% |
| 7 | aten::mm '[[528, 576], [576, 576]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[576, 1], [1, 576]]' '['"'"''"'"', '"'"''"'"']' | 5.598 | 4.025 | -28.102% |
| 8 | aten::mm '[[4096, 2048], [2048, 2048]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[2048, 1], [2048, 1]]' '['"'"''"'"', '"'"''"'"']' | 55.38 | 39.93 | -27.899% |
| 9 | aten::mm '[[4096, 4096], [4096, 2048]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[4096, 1], [2048, 1]]' '['"'"''"'"', '"'"''"'"']' | 109.583 | 79.901 | -27.087% |
| 10 | aten::mm '[[4096, 6144], [6144, 2048]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[6144, 1], [2048, 1]]' '['"'"''"'"', '"'"''"'"']' | 157.715 | 116.505 | -26.130% |

</details>

<details>
<summary><strong>Top 10 regressions (DMA ON vs OFF): similar trend #24117</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | aten::addmm '[[576], [24576, 576], [576, 576], [], []]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'Scalar'"'"', '"'"'Scalar'"'"']' '[[1], [576, 1], [1, 576], [], []]' '['"'"''"'"', '"'"''"'"', '"'"''"'"', '"'"'1'"'"', '"'"'1'"'"']' | 35.615 | 51.695 | +45.148% |
| 2 | aten::bmm '[[85, 3, 3], [85, 3, 1152]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[9, 3, 1], [3456, 1152, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.207 | 4.647 | +44.921% |
| 3 | aten::bmm '[[32, 21, 96], [32, 96, 96]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[2016, 1, 21], [9216, 96, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.703 | 5.117 | +38.185% |
| 4 | aten::mm '[[32, 576], [576, 2304]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[576, 1], [2304, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.807 | 5.187 | +36.253% |
| 5 | aten::mm '[[576, 32], [32, 576]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[1, 576], [576, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.323 | 4.503 | +35.513% |
| 6 | aten::mm '[[2304, 32], [32, 576]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[1, 2304], [576, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.391 | 4.595 | +35.510% |
| 7 | aten::mm '[[16, 1024], [1024, 512]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[1024, 1], [512, 1]]' '['"'"''"'"', '"'"''"'"']' | 3.742 | 5.063 | +35.298% |
| 8 | aten::mm '[[150000, 16384], [16384, 4096]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[16384, 1], [4096, 1]]' '['"'"''"'"', '"'"''"'"']' | 21687.734 | 27751.392 | +27.959% |
| 9 | aten::mm '[[7680, 576], [576, 1728]]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"']' '[[576, 1], [1, 576]]' '['"'"''"'"', '"'"''"'"']' | 30.586 | 38.743 | +26.670% |
| 10 | aten::addmm '[[576], [7680, 576], [576, 576], [], []]' '['"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'c10::BFloat16'"'"', '"'"'Scalar'"'"', '"'"'Scalar'"'"']' '[[1], [576, 1], [1, 576], [], []]' '['"'"''"'"', '"'"''"'"', '"'"''"'"', '"'"'1'"'"', '"'"'1'"'"']' | 16.514 | 20.883 | +26.461% |

</details>


---

### Prod Conv

#### `--iree-rocm-target=gfx950`

<details>
<summary><strong>Top 10 improvements (DMA ON vs OFF)</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | convbfp16 -n 16 -c 576 -H 1 -W 2 -k 1024 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 5.437 | 3.324 | -38.867% |
| 2 | convbfp16 -n 16 -c 480 -H 48 -W 32 -k 128 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 11.222 | 7.641 | -31.915% |
| 3 | convbfp16 -n 16 -c 1152 -H 1 -W 1 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 6.027 | 4.705 | -21.929% |
| 4 | convbfp16 -n 16 -c 2 -H 24 -W 16 -k 2 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 3.843 | 3.044 | -20.794% |
| 5 | convbfp16 -n 16 -c 576 -H 1 -W 30 -k 3 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 5.113 | 4.091 | -19.991% |
| 6 | convbfp16 -n 16 -c 576 -H 1 -W 1 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 5.009 | 4.021 | -19.739% |
| 7 | convbfp16 -n 16 -c 64 -H 1 -W 32 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 3.812 | 3.066 | -19.570% |
| 8 | convbfp16 -n 16 -c 40 -H 96 -W 64 -k 48 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 6.634 | 5.34 | -19.500% |
| 9 | convbfp16 -n 16 -c 288 -H 24 -W 16 -k 288 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 8.355 | 6.799 | -18.629% |
| 10 | convbfp16 -n 16 -c 576 -H 1 -W 30 -k 1024 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 8.19 | 6.665 | -18.613% |

</details>

<details>
<summary><strong>Top 10 regressions (DMA ON vs OFF): all noise after rerun</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | convbfp16 -n 16 -c 576 -H 48 -W 32 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 34.07 | 46.854 | +37.525% |
| 2 | convbfp16 -n 16 -c 576 -H 48 -W 32 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 36.229 | 49.711 | +37.214% |
| 3 | convbfp16 -n 16 -c 1 -H 1 -W 1 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 2.331 | 3.175 | +36.207% |
| 4 | convbfp16 -n 16 -c 672 -H 48 -W 32 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 41.145 | 53.899 | +30.998% |
| 5 | convbfp16 -n 16 -c 1 -H 1 -W 1 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 2.705 | 3.363 | +24.325% |
| 6 | convbfp16 -n 16 -c 64 -H 38 -W 38 -k 64 -y 3 -x 1 -p 1 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 5.591 | 6.699 | +19.809% |
| 7 | convbfp16 -n 16 -c 192 -H 23 -W 1 -k 192 -y 3 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 6.321 | 7.555 | +19.530% |
| 8 | convfp16 -n 32 -c 512 -H 50 -W 50 -k 1024 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 261.537 | 308.296 | +17.879% |
| 9 | convbfp16 -n 16 -c 192 -H 12 -W 8 -k 192 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 4.317 | 5.016 | +16.207% |
| 10 | convbfp16 -n 16 -c 576 -H 8 -W 32 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -t 1 -b 0 -F 1 | 13.978 | 16.093 | +15.129% |

</details>

#### `--iree-rocm-target=mi355x`

<details>
<summary><strong>Top 10 improvements (DMA ON vs OFF)</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | convbfp16 -n 16 -c 576 -H 1 -W 30 -k 8192 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 44.75 | 30.446 | -31.964% |
| 2 | convbfp16 -n 16 -c 192 -H 1 -W 21 -k 384 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 4.411 | 3.263 | -26.019% |
| 3 | convbfp16 -n 16 -c 576 -H 1 -W 2 -k 192 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 4.565 | 3.565 | -21.897% |
| 4 | convbfp16 -n 16 -c 64 -H 1 -W 32 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 4.105 | 3.243 | -21.017% |
| 5 | convbfp16 -n 16 -c 576 -H 1 -W 2 -k 192 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 4.241 | 3.458 | -18.460% |
| 6 | convbfp16 -n 1 -c 256 -H 24 -W 16 -k 192 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 4.323 | 3.598 | -16.768% |
| 7 | convbfp16 -n 16 -c 2048 -H 8 -W 32 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 23.713 | 20.165 | -14.965% |
| 8 | convbfp16 -n 16 -c 576 -H 1 -W 2 -k 192 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 4.429 | 3.835 | -13.411% |
| 9 | convbfp16 -n 16 -c 576 -H 48 -W 32 -k 512 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 27.746 | 24.429 | -11.956% |
| 10 | convbfp16 -n 16 -c 2048 -H 8 -W 32 -k 288 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 22.214 | 19.581 | -11.852% |

</details>

<details>
<summary><strong>Top 10 regressions (DMA ON vs OFF): all noise after rerun</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | convbfp16 -n 1 -c 35 -H 24 -W 16 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 3.936 | 5.493 | +39.564% |
| 2 | convbfp16 -n 16 -c 128 -H 1 -W 1 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 2.44 | 3.404 | +39.530% |
| 3 | convbfp16 -n 16 -c 576 -H 48 -W 32 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 35.641 | 49.656 | +39.325% |
| 4 | convbfp16 -n 16 -c 576 -H 48 -W 32 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 34.433 | 46.793 | +35.895% |
| 5 | convbfp16 -n 16 -c 96 -H 24 -W 16 -k 96 -y 3 -x 1 -p 4 -q 0 -u 1 -v 1 -l 4 -j 4 -m conv -g 1 -F 1 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 4.548 | 5.94 | +30.597% |
| 6 | convbfp16 -n 16 -c 192 -H 24 -W 16 -k 48 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 3.219 | 4.185 | +29.980% |
| 7 | convbfp16 -n 16 -c 672 -H 48 -W 32 -k 576 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 41.767 | 53.652 | +28.454% |
| 8 | convbfp16 -n 16 -c 192 -H 23 -W 1 -k 192 -y 3 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 5.094 | 6.461 | +26.834% |
| 9 | convbfp16 -n 16 -c 288 -H 24 -W 16 -k 96 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 5.192 | 6.438 | +23.998% |
| 10 | convbfp16 -n 16 -c 192 -H 12 -W 8 -k 192 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --iter 100 | 5.237 | 6.426 | +22.707% |

</details>


---

### All Proxy

#### `--iree-rocm-target=gfx950`

<details>
<summary><strong>Top 10 improvements (DMA ON vs OFF)</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | convbfp16 -n 5 -c 224 -H 1 -W 1 -k 8 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.437 | 2.348 | -31.679% |
| 2 | convbfp16 -n 5 -c 56 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.042 | 2.863 | -29.156% |
| 3 | convbfp16 -n 3 -c 224 -H 1 -W 1 -k 56 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 5.099 | 3.613 | -29.130% |
| 4 | convbfp16 -n 4 -c 56 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 5.098 | 3.655 | -28.311% |
| 5 | convbfp16 -n 5 -c 448 -H 1 -W 1 -k 112 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.241 | 3.064 | -27.748% |
| 6 | convbfp16 -n 3 -c 896 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.105 | 2.967 | -27.719% |
| 7 | convbfp16 -n 2 -c 224 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.402 | 3.324 | -24.497% |
| 8 | convbfp16 -n 3 -c 896 -H 59 -W 91 -k 2016 -y 1 -x 1 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 65.83 | 50.167 | -23.793% |
| 9 | convbfp16 -n 10 -c 112 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.705 | 3.593 | -23.620% |
| 10 | convbfp16 -n 1 -c 2016 -H 30 -W 46 -k 2016 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 33.202 | 25.517 | -23.145% |

</details>

<details>
<summary><strong>Top 10 regressions (DMA ON vs OFF): all noise after rerun</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | convbfp16 -n 1 -c 112 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.112 | 4.66 | +49.728% |
| 2 | convbfp16 -n 2 -c 896 -H 1 -W 1 -k 112 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 2.93 | 4.306 | +46.966% |
| 3 | convbfp16 -n 2 -c 56 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.32 | 4.823 | +45.262% |
| 4 | convbfp16 -n 3 -c 224 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.112 | 4.457 | +43.223% |
| 5 | convbfp16 -n 7 -c 112 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.438 | 4.769 | +38.719% |
| 6 | convbfp16 -n 10 -c 2016 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.572 | 4.945 | +38.431% |
| 7 | convbfp16 -n 4 -c 224 -H 1 -W 1 -k 56 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.354 | 4.617 | +37.648% |
| 8 | convbfp16 -n 12 -c 56 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.206 | 4.319 | +34.695% |
| 9 | convbfp16 -n 6 -c 56 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.71 | 4.957 | +33.629% |
| 10 | convbfp16 -n 5 -c 224 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.387 | 4.509 | +33.097% |

</details>

#### `--iree-rocm-target=mi355x`

<details>
<summary><strong>Top 10 improvements (DMA ON vs OFF)</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | convbfp16 -n 2 -c 448 -H 1 -W 1 -k 112 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.97 | 2.495 | -37.161% |
| 2 | convbfp16 -n 12 -c 224 -H 1 -W 1 -k 8 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.372 | 2.931 | -32.953% |
| 3 | convbfp16 -n 12 -c 8 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.055 | 2.743 | -32.348% |
| 4 | convbfp16 -n 12 -c 8 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 2 -t 1 | 4.57 | 3.101 | -32.142% |
| 5 | convbfp16 -n 10 -c 896 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 5.121 | 3.507 | -31.520% |
| 6 | convbfp16 -n 4 -c 112 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.568 | 3.187 | -30.227% |
| 7 | convbfp16 -n 5 -c 224 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 5.215 | 3.654 | -29.929% |
| 8 | convbfp16 -n 12 -c 896 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 4.681 | 3.308 | -29.329% |
| 9 | convbfp16 -n 1 -c 224 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1 | 3.965 | 2.806 | -29.226% |
| 10 | convbfp16 -n 3 -c 2016 -H 30 -W 46 -k 4096 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 145.134 | 103.609 | -28.612% |

</details>

<details>
<summary><strong>Top 10 regressions (DMA ON vs OFF): all noise after rerun</strong></summary>

| # | BOO arguments | DMA OFF µs | DMA ON µs | Change |
|---|----------------|------------|-----------|--------|
| 1 | convbfp16 -n 2 -c 896 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.089 | 4.781 | +54.796% |
| 2 | convbfp16 -n 5 -c 896 -H 1 -W 1 -k 112 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.106 | 4.737 | +52.508% |
| 3 | convbfp16 -n 7 -c 56 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 2.961 | 4.475 | +51.111% |
| 4 | convbfp16 -n 1 -c 56 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 2.83 | 4.231 | +49.531% |
| 5 | convbfp16 -n 5 -c 56 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.086 | 4.404 | +42.706% |
| 6 | convbfp16 -n 2 -c 56 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.173 | 4.409 | +38.984% |
| 7 | convbfp16 -n 10 -c 112 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.012 | 4.175 | +38.636% |
| 8 | convbfp16 -n 1 -c 224 -H 1 -W 1 -k 8 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1 | 3.462 | 4.799 | +38.610% |
| 9 | convbfp16 -n 7 -c 224 -H 1 -W 1 -k 2016 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 3.335 | 4.597 | +37.826% |
| 10 | convbfp16 -n 10 -c 224 -H 1 -W 1 -k 8 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1 | 2.559 | 3.518 | +37.504% |

</details>

