### PR TITLE
[Codegen][CPU] Drop the power-of-two cap on `chooseUnrolling`.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
@@ -609,11 +609,11 @@ func.func @matmul_lowering_i8i4i32_aarch64_i8mm(
 //
 // FP4 register pressure: K=2 is the smallest power-of-two K that makes
 // K*4 a multiple of 8 (for byte-addressable packed groups). Inside the
-// 16-register budget the cost model lands on a square (im=2, in=2, ik=2)
-// tile (2*2 + 2*2 + 2*2 = 12 registers), which wins on arithmetic
-// intensity. Whether the lowering can actually densely pack f4E2M1FN
-// values into bytes today is orthogonal — the framework only insists
-// that the packed K-group be byte-aligned.
+// 16-register budget the cost model lands on (im=2, in=3, ik=2)
+// (2*3 + 2*2 + 3*2 = 16 registers, saturating the budget). Whether the
+// lowering can actually densely pack f4E2M1FN values into bytes today is
+// orthogonal — the framework only insists that the packed K-group be
+// byte-aligned.
 
 #map_g_fp4 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map_g_fp4_1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -634,7 +634,7 @@ func.func @matmul_fp4_f32_aarch64_generic(
 }
 // CHECK-LABEL: func @matmul_fp4_f32_aarch64_generic(
 //       CHECK:   %[[INNER_FP4:.+]] = iree_codegen.inner_tiled
-//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 2, intrinsics_k = 2, lhs_type = f4E2M1FN, rhs_type = f4E2M1FN, acc_type = f32>
+//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 3, intrinsics_k = 2, lhs_type = f4E2M1FN, rhs_type = f4E2M1FN, acc_type = f32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
@@ -175,7 +175,8 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
   %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding_result_it> -> tensor<?x?xf32>{%d0, %d1}
   return %5 : tensor<?x?xf32>
 }
-//   CHECK-DAG: #[[$MAP_INNER:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
+//   CHECK-DAG: #[[$MAP_INNER_M:.+]] = affine_map<()[s0] -> (s0 ceildiv 29)>
+//   CHECK-DAG: #[[$MAP_INNER_N:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
 //   CHECK-DAG: #[[$MAP_LHS:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 //   CHECK-DAG: #[[$MAP_RHS:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 //   CHECK-DAG: #[[$MAP_ACC:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -186,12 +187,12 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
-//   CHECK-DAG:   %[[OUT_D0:.+]] = affine.apply #[[$MAP_INNER]]()[%[[D0]]]
-//   CHECK-DAG:   %[[OUT_D1:.+]] = affine.apply #[[$MAP_INNER]]()[%[[D1]]]
+//   CHECK-DAG:   %[[OUT_D0:.+]] = affine.apply #[[$MAP_INNER_M]]()[%[[D0]]]
+//   CHECK-DAG:   %[[OUT_D1:.+]] = affine.apply #[[$MAP_INNER_N]]()[%[[D1]]]
 //   CHECK-DAG:   %[[PACK_LHS:.+]] = linalg.pack {{.*}}%[[ARG0]]
 //       CHECK:   %[[PACK_RHS:.+]] = linalg.pack
 //  CHECK-SAME:     %[[ARG1]]
-//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[OUT_D0]], %[[OUT_D1]]) : tensor<?x?x16x16xf32>
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[OUT_D0]], %[[OUT_D1]]) : tensor<?x?x29x16xf32>
 //       CHECK:   %[[FILL:.+]] = linalg.fill
 //  CHECK-SAME:       outs(%[[EMPTY]] :
 //       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled ins(%[[PACK_LHS]], %[[PACK_RHS]]) outs(%[[FILL]])
@@ -200,7 +201,7 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
 // must label its RHS operand with the matching `(d1, d2)` map, otherwise the
 // verifier rejects the op with "shape does not match iteration bounds".
 //  CHECK-SAME:       indexing_maps = [#[[$MAP_LHS]], #[[$MAP_RHS]], #[[$MAP_ACC]]]
-//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 16>, semantics = #iree_cpu.mma_semantics<>
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 29>, semantics = #iree_cpu.mma_semantics<>
 //       CHECK:   %[[UNPACK:.+]] = linalg.unpack %[[INNER]]
 //       CHECK:   return %[[UNPACK]]
 
@@ -233,9 +234,9 @@ func.func @unset_encoding_matmul_RESULT_inner_tiled_avx512(%arg0: tensor<127x255
 // CHECK-LABEL: func @set_encoding_matmul_LHS_inner_tiled_avx512(
 //  CHECK-SAME:   %[[INPUT:[a-zA-Z0-9]+]]: tensor<127x255xf32>
 //   CHECK-DAG:   %[[CST:.+]] = arith.constant 0.0
-//       CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<8x255x16x1xf32>
-//       CHECK:   %[[PACK:.+]] = linalg.pack %[[INPUT]] padding_value(%[[CST]] : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %[[EMPTY]] : tensor<127x255xf32> -> tensor<8x255x16x1xf32>
-//       CHECK:   return %[[PACK]] : tensor<8x255x16x1xf32>
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<5x255x29x1xf32>
+//       CHECK:   %[[PACK:.+]] = linalg.pack %[[INPUT]] padding_value(%[[CST]] : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [29, 1] into %[[EMPTY]] : tensor<127x255xf32> -> tensor<5x255x29x1xf32>
+//       CHECK:   return %[[PACK]] : tensor<5x255x29x1xf32>
 // CHECK-LABEL: func @set_encoding_matmul_RHS_inner_tiled_avx512(
 //  CHECK-SAME:   %[[INPUT_R:[a-zA-Z0-9]+]]: tensor<127x255xf32>
 //   CHECK-DAG:   %[[CST_R:.+]] = arith.constant 0.0
@@ -243,9 +244,9 @@ func.func @unset_encoding_matmul_RESULT_inner_tiled_avx512(%arg0: tensor<127x255
 //       CHECK:   %[[PACK_R:.+]] = linalg.pack %[[INPUT_R]] padding_value(%[[CST_R]] : f32) outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [16, 1] into %[[EMPTY_R]] : tensor<127x255xf32> -> tensor<16x127x16x1xf32>
 //       CHECK:   return %[[PACK_R]] : tensor<16x127x16x1xf32>
 // CHECK-LABEL: func @unset_encoding_matmul_RESULT_inner_tiled_avx512(
-//  CHECK-SAME:   %[[PACKED:[a-zA-Z0-9]+]]: tensor<8x16x16x16xf32>
+//  CHECK-SAME:   %[[PACKED:[a-zA-Z0-9]+]]: tensor<5x16x29x16xf32>
 //       CHECK:   %[[EMPTY_U:.+]] = tensor.empty() : tensor<127x255xf32>
-//       CHECK:   %[[UNPACK:.+]] = linalg.unpack %[[PACKED]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 16] into %[[EMPTY_U]] : tensor<8x16x16x16xf32> -> tensor<127x255xf32>
+//       CHECK:   %[[UNPACK:.+]] = linalg.unpack %[[PACKED]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [29, 16] into %[[EMPTY_U]] : tensor<5x16x29x16xf32> -> tensor<127x255xf32>
 //       CHECK:   return %[[UNPACK]]
 
 // -----
@@ -278,13 +279,12 @@ func.func @matmul_bf16_f32_avx2_generic(
 // the chosen `_REG*` enum case (16 here). One element per register, so the
 // register pressure is `intrinsics_m * intrinsics_n` (ACC) +
 // `intrinsics_m` (LHS) + `intrinsics_n` (RHS). Matmul dims are dynamic
-// here, so all three dims are free; arithmetic-intensity tie-breaking
-// favors approximately-square tiles. (im=2, in=4) and (im=4, in=2) tie at
-// intensity 8/6 — the search picks (im=2, in=4) (lower im first), packing
-// 8 + 2 + 4 = 14 registers within 16.
+// here, so all three dims are free; the arithmetic-intensity formula
+// `effM*effN/(effM+effN)` lands on (im=3, in=3): 3*3 + 3 + 3 = 15
+// registers within 16, intensity 9/6 = 1.5.
 // CHECK-LABEL: func @matmul_bf16_f32_avx2_generic(
 //       CHECK:   %[[INNER_G:.+]] = iree_codegen.inner_tiled
-//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 4, lhs_type = bf16, rhs_type = bf16, acc_type = f32>
+//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 3, intrinsics_n = 3, lhs_type = bf16, rhs_type = bf16, acc_type = f32>
 
 // -----
 
@@ -294,8 +294,8 @@ func.func @matmul_bf16_f32_avx2_generic(
 // the packed layout). Smallest power-of-two K with K*4 % 8 == 0 is K = 2.
 // LHS pressure becomes `intrinsics_m * intrinsics_k`, RHS pressure
 // `intrinsics_n * intrinsics_k`, ACC `intrinsics_m * intrinsics_n`. Inside
-// `_REG16`'s budget, (m=2, n=2, k=2) packs 2·2 + 2·2 + 2·2 = 12 registers
-// and wins on arithmetic intensity (4/4 = 1.0).
+// `_REG16`'s budget, (m=2, n=3, k=2) packs 2·3 + 2·2 + 3·2 = 16 registers
+// (saturating the budget), intensity 6/5 = 1.2.
 
 #map_g4 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map_g4_1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -316,7 +316,7 @@ func.func @matmul_i4_i32_avx2_generic(
 }
 // CHECK-LABEL: func @matmul_i4_i32_avx2_generic(
 //       CHECK:   %[[INNER_G4:.+]] = iree_codegen.inner_tiled
-//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 2, intrinsics_k = 2, lhs_type = i4, rhs_type = i4, acc_type = i32>
+//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 3, intrinsics_k = 2, lhs_type = i4, rhs_type = i4, acc_type = i32>
 
 // -----
 
@@ -324,11 +324,11 @@ func.func @matmul_i4_i32_avx2_generic(
 // M↔N-swapped orientation MMA_X86_AVX512_16x1x1_F32_F32 (rather than the
 // natural 1x16x1) — the static N=8 caps natural usefulOps to 8, while the
 // transposed orientation fully uses 16 lanes on the M side. Unrolling lands
-// on intrinsics_m=2, intrinsics_n=8 (M_inner=32, N_inner=8). Each operand's
+// on intrinsics_m=3, intrinsics_n=8 (M_inner=48, N_inner=8). Each operand's
 // pack inherits the intrinsic's natural (outer, inner) ordering — for the
 // 16x1x1 intrinsic, the LHS inner is (M=16, K=1), the RHS inner is (N=1, K=1),
 // and the ACC inner is (M=16, N=1). After cross-intrinsic unrolling, the ACC
-// is stored in physical (M=32, N=8) order, the way row-major matmul tiles are.
+// is stored in physical (M=48, N=8) order, the way row-major matmul tiles are.
 
 #map_t = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map_t1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -341,9 +341,9 @@ func.func @unset_encoding_RESULT_inner_tiled_avx512_narrow_n(%arg0: tensor<127x2
   return %0 : tensor<127x255xf32>
 }
 // CHECK-LABEL: func @unset_encoding_RESULT_inner_tiled_avx512_narrow_n(
-//  CHECK-SAME:   %[[PACKED_T:[a-zA-Z0-9]+]]: tensor<4x32x32x8xf32>
+//  CHECK-SAME:   %[[PACKED_T:[a-zA-Z0-9]+]]: tensor<3x32x48x8xf32>
 //       CHECK:   %[[UNPACK_T:.+]] = linalg.unpack %[[PACKED_T]]
-//  CHECK-SAME:     outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 8]
+//  CHECK-SAME:     outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [48, 8]
 //       CHECK:   return %[[UNPACK_T]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -52,7 +52,6 @@
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/ADT/bit.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/IR/AffineMap.h"
@@ -624,27 +623,23 @@ chooseIntrinsic(MLIRContext *ctx, ArrayRef<Type> elementTypes,
   return best;
 }
 
-/// Power-of-two cap on one unroll dim. For a static matmul extent
-/// `matmulSize` divided by `intrinsicSize`, we floor the cover count to a
-/// power of two. For dynamic dims we fall back to `fallback`, which callers
-/// set to something at least as large as the register budget — that budget
-/// itself terminates the enumeration below, so no tighter static cap is
-/// needed.
-static int64_t po2UnrollCap(int64_t matmulSize, int64_t intrinsicSize,
-                            int64_t fallback) {
+/// Per-dim cap on the unroll factor: how many intrinsic-sized tiles fit in
+/// the matmul dim. For dynamic matmul dims we return `fallback` (the
+/// register budget), which the budget check in the enumeration loop bounds
+/// anyway.
+static int64_t unrollCap(int64_t matmulSize, int64_t intrinsicSize,
+                         int64_t fallback) {
   if (ShapedType::isDynamic(matmulSize)) {
     return fallback;
   }
-  uint64_t cover =
-      std::max<int64_t>(1, llvm::divideCeil(matmulSize, intrinsicSize));
-  return llvm::bit_floor(cover);
+  return std::max<int64_t>(1, llvm::divideCeil(matmulSize, intrinsicSize));
 }
 
 // Phase 2 of `chooseCpuInnerTiledMmaForEncoding`: for an already-chosen
-// intrinsic, pick the largest power-of-two unroll factors (intrinsicsM,
-// intrinsicsN) such that the three tiles (ACC + LHS + RHS) still fit in
-// the target's register budget, breaking ties with arithmetic intensity
-// (effM*effN)/(effM+effN) so approximately-square tiles win.
+// intrinsic, pick unroll factors (intrinsicsM, intrinsicsN) such that the
+// three tiles (ACC + LHS + RHS) still fit in the target's register budget,
+// breaking ties with arithmetic intensity (effM*effN)/(effM+effN) so
+// approximately-square tiles win.
 //
 // "Register budget" depends on what the lowering will use:
 //   * Architecture-specific SIMD intrinsics use the vector register file,
@@ -701,28 +696,26 @@ chooseUnrolling(MLIRContext *ctx, ArrayRef<Type> elementTypes,
     lhsUnit = info->lhsBits;
     rhsUnit = info->rhsBits;
   }
-  int64_t capMPo2 = po2UnrollCap(matmulSizes.M, info->intrinsicM, budget);
-  int64_t capNPo2 = po2UnrollCap(matmulSizes.N, info->intrinsicN, budget);
+  int64_t capM = unrollCap(matmulSizes.M, info->intrinsicM, budget);
+  int64_t capN = unrollCap(matmulSizes.N, info->intrinsicN, budget);
   int64_t accTerm = info->intrinsicM * info->intrinsicN * accUnit;
   int64_t lhsTerm = info->intrinsicM * info->intrinsicK * intrinsicsK * lhsUnit;
   int64_t rhsTerm = info->intrinsicN * info->intrinsicK * intrinsicsK * rhsUnit;
   std::optional<std::pair<int64_t, int64_t>> bestMN;
   double bestIntensity = -1.0;
-  // Enumerate power-of-two intrinsicsM; for each, pick the largest feasible
-  // power-of-two intrinsicsN under the budget and the static N cap. The
-  // budget bounds im on its own (im*lhsTerm alone must be < budget), which
-  // terminates the loop without any numRegs-style cap.
-  for (int64_t im = 1; im <= capMPo2; im *= 2) {
+  // Enumerate intrinsicsM; for each, pick the largest feasible intrinsicsN
+  // under the budget and the static N cap. The budget bounds im on its own
+  // (im*lhsTerm alone must be < budget), which terminates the loop.
+  for (int64_t im = 1; im <= capM; ++im) {
     int64_t remaining = budget - im * lhsTerm;
     if (remaining <= 0) {
       break;
     }
     int64_t inMaxBudget = remaining / (im * accTerm + rhsTerm);
-    uint64_t inCap = std::min<int64_t>(capNPo2, inMaxBudget);
-    if (inCap < 1) {
+    int64_t in = std::min<int64_t>(capN, inMaxBudget);
+    if (in < 1) {
       continue;
     }
-    int64_t in = llvm::bit_floor(inCap);
     double effM = static_cast<double>(im) * info->intrinsicM;
     double effN = static_cast<double>(in) * info->intrinsicN;
     double intensity = effM * effN / (effM + effN);


### PR DESCRIPTION
`chooseUnrolling` previously enumerated `intrinsics_m` / `intrinsics_n` through powers of two only. There's no real reason for that — within the register budget, the cost model can pick any factor.

Looking ahead: some intrinsics may eventually want the unroll factor on a particular dim to be a multiple of some target-specific number (Arm scalar-by-element FMA forms are an example: the scalar is a lane of a vector register, so covering whole registers is more efficient). But even there it's not a strict preference — narrow matmuls (e.g. matrix-vector) would be better off skipping the padding. So a simple per-intrinsic "preferred multiple" doesn't quite capture it; we'll revisit when a concrete need lands.

Lit-test fallout: relaxing pow2 lets the cost model land on better non-pow2 unrolls in some cases the existing tests pin (e.g. `materialize_encoding_x86_64.mlir`'s dynamic-N AVX-512 case now picks `intrinsics_m = 29` instead of 16 — saturating the zmm register file more tightly, at higher arithmetic intensity per the existing scoring formula). CHECK lines updated.

Progress towards #24323
