### PR TITLE
[Codegen] Fix RAW in_bounds false for R&W

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -317,13 +317,8 @@ struct FoldTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     TypedValue<VectorType> wMask = writeOp.getMask();
     TypedValue<VectorType> rMask = readOp.getMask();
 
-    // The fold diverges from the original write+read at positions that are
-    // out-of-bounds: the write does not store there and the read returns
-    // pad, but the fold returns valToStore. This is only a problem when
-    // *both* transfers have OOB dimensions (in_bounds=false). When at
-    // least one side has in_bounds=true, it asserts the position is within
-    // bounds; an actual OOB access is undefined behavior, so the fold
-    // cannot introduce new incorrectness. (Verified with Z3.)
+    // If at least one operation claims that the position is in-bounds
+    // then we can fold.
     //
     // Case 1.1: w_ib = false, r_ib = true, position is actually in_bounds
     // We write val, we read val, we can fold RAW to val.

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -317,13 +317,16 @@ struct FoldTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     TypedValue<VectorType> wMask = writeOp.getMask();
     TypedValue<VectorType> rMask = readOp.getMask();
 
-    // When at least one side has in_bounds=true on every dimension, any
-    // actual OOB access is UB, so the fold cannot introduce new
-    // incorrectness. When *both* have OOB dimensions, we build an
-    // in-bounds mask from the tensor's actual dimensions and select
-    // between valToStore and pad, replicating the read's OOB behavior.
-    // (Correctness verified with Z3, see fold_raw_z3.py.)
-    bool bothOOB = readOp.hasOutOfBoundsDim() && writeOp.hasOutOfBoundsDim();
+    // The fold diverges from the original write+read at positions that are
+    // out-of-bounds: the write does not store there and the read returns
+    // pad, but the fold returns valToStore. This is only a problem when
+    // *both* transfers have OOB dimensions (in_bounds=false). When at
+    // least one side has in_bounds=true, it asserts the position is within
+    // bounds; an actual OOB access is undefined behavior, so the fold
+    // cannot introduce new incorrectness. (Verified with Z3.)
+    if (readOp.hasOutOfBoundsDim() && writeOp.hasOutOfBoundsDim()) {
+      return failure();
+    }
 
     // Build the inner value: select(wMask, valToStore, original).
     // When wMask is absent (unmasked write) or wMask == rMask (original is
@@ -337,50 +340,6 @@ struct FoldTransferRAW : OpRewritePattern<vector::TransferReadOp> {
           /*mask=*/Value(), readOp.getInBoundsAttr());
       inner = arith::SelectOp::create(rewriter, readOp.getLoc(), wMask,
                                       valToStore, originalRead);
-    }
-
-    // When both transfers have OOB dimensions, build
-    //   select(inBoundsMask, inner, broadcast(pad))
-    // to replicate the read's OOB-returns-pad semantics. The in-bounds
-    // mask is derived from the tensor's actual dimensions via
-    // vector.create_mask.
-    if (bothOOB) {
-      Location loc = readOp.getLoc();
-      VectorType vecTy = readOp.getType();
-      Value base = writeOp.getBase();
-      auto shapedTy = cast<ShapedType>(base.getType());
-      unsigned tensorRank = shapedTy.getRank();
-      unsigned vecRank = vecTy.getRank();
-      unsigned leadingRank = tensorRank - vecRank;
-
-      SmallVector<Value> maskDims;
-      for (unsigned i = 0; i < vecRank; ++i) {
-        if (readOp.isDimInBounds(i) && writeOp.isDimInBounds(i)) {
-          // Both in-bounds on this dim: mask extent = vector extent (all true).
-          maskDims.push_back(arith::ConstantIndexOp::create(
-              rewriter, loc, vecTy.getDimSize(i)));
-        } else {
-          // At least one side is OOB on this dim: use the actual tensor dim.
-          unsigned tensorDim = leadingRank + i;
-          if (shapedTy.isDynamicDim(tensorDim)) {
-            maskDims.push_back(
-                tensor::DimOp::create(rewriter, loc, base, tensorDim));
-          } else {
-            maskDims.push_back(arith::ConstantIndexOp::create(
-                rewriter, loc, shapedTy.getDimSize(tensorDim)));
-          }
-        }
-      }
-
-      auto maskTy = VectorType::get(vecTy.getShape(), rewriter.getI1Type());
-      Value inBoundsMask =
-          vector::CreateMaskOp::create(rewriter, loc, maskTy, maskDims);
-
-      Value rPad = readOp.getPadding();
-      Value padVal = vector::BroadcastOp::create(rewriter, rPad.getLoc(),
-                                                 valToStore.getType(), rPad);
-      inner =
-          arith::SelectOp::create(rewriter, loc, inBoundsMask, inner, padVal);
     }
 
     if (!rMask) {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -317,16 +317,13 @@ struct FoldTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     TypedValue<VectorType> wMask = writeOp.getMask();
     TypedValue<VectorType> rMask = readOp.getMask();
 
-    // The fold diverges from the original write+read at positions that are
-    // out-of-bounds: the write does not store there and the read returns
-    // pad, but the fold returns valToStore. This is only a problem when
-    // *both* transfers have OOB dimensions (in_bounds=false). When at
-    // least one side has in_bounds=true, it asserts the position is within
-    // bounds; an actual OOB access is undefined behavior, so the fold
-    // cannot introduce new incorrectness. (Verified with Z3.)
-    if (readOp.hasOutOfBoundsDim() && writeOp.hasOutOfBoundsDim()) {
-      return failure();
-    }
+    // When at least one side has in_bounds=true on every dimension, any
+    // actual OOB access is UB, so the fold cannot introduce new
+    // incorrectness. When *both* have OOB dimensions, we build an
+    // in-bounds mask from the tensor's actual dimensions and select
+    // between valToStore and pad, replicating the read's OOB behavior.
+    // (Correctness verified with Z3, see fold_raw_z3.py.)
+    bool bothOOB = readOp.hasOutOfBoundsDim() && writeOp.hasOutOfBoundsDim();
 
     // Build the inner value: select(wMask, valToStore, original).
     // When wMask is absent (unmasked write) or wMask == rMask (original is
@@ -340,6 +337,50 @@ struct FoldTransferRAW : OpRewritePattern<vector::TransferReadOp> {
           /*mask=*/Value(), readOp.getInBoundsAttr());
       inner = arith::SelectOp::create(rewriter, readOp.getLoc(), wMask,
                                       valToStore, originalRead);
+    }
+
+    // When both transfers have OOB dimensions, build
+    //   select(inBoundsMask, inner, broadcast(pad))
+    // to replicate the read's OOB-returns-pad semantics. The in-bounds
+    // mask is derived from the tensor's actual dimensions via
+    // vector.create_mask.
+    if (bothOOB) {
+      Location loc = readOp.getLoc();
+      VectorType vecTy = readOp.getType();
+      Value base = writeOp.getBase();
+      auto shapedTy = cast<ShapedType>(base.getType());
+      unsigned tensorRank = shapedTy.getRank();
+      unsigned vecRank = vecTy.getRank();
+      unsigned leadingRank = tensorRank - vecRank;
+
+      SmallVector<Value> maskDims;
+      for (unsigned i = 0; i < vecRank; ++i) {
+        if (readOp.isDimInBounds(i) && writeOp.isDimInBounds(i)) {
+          // Both in-bounds on this dim: mask extent = vector extent (all true).
+          maskDims.push_back(arith::ConstantIndexOp::create(
+              rewriter, loc, vecTy.getDimSize(i)));
+        } else {
+          // At least one side is OOB on this dim: use the actual tensor dim.
+          unsigned tensorDim = leadingRank + i;
+          if (shapedTy.isDynamicDim(tensorDim)) {
+            maskDims.push_back(
+                tensor::DimOp::create(rewriter, loc, base, tensorDim));
+          } else {
+            maskDims.push_back(arith::ConstantIndexOp::create(
+                rewriter, loc, shapedTy.getDimSize(tensorDim)));
+          }
+        }
+      }
+
+      auto maskTy = VectorType::get(vecTy.getShape(), rewriter.getI1Type());
+      Value inBoundsMask =
+          vector::CreateMaskOp::create(rewriter, loc, maskTy, maskDims);
+
+      Value rPad = readOp.getPadding();
+      Value padVal = vector::BroadcastOp::create(rewriter, rPad.getLoc(),
+                                                 valToStore.getType(), rPad);
+      inner =
+          arith::SelectOp::create(rewriter, loc, inBoundsMask, inner, padVal);
     }
 
     if (!rMask) {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -317,6 +317,17 @@ struct FoldTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     TypedValue<VectorType> wMask = writeOp.getMask();
     TypedValue<VectorType> rMask = readOp.getMask();
 
+    // The fold diverges from the original write+read at positions that are
+    // out-of-bounds: the write does not store there and the read returns
+    // pad, but the fold returns valToStore. This is only a problem when
+    // *both* transfers have OOB dimensions (in_bounds=false). When at
+    // least one side has in_bounds=true, it asserts the position is within
+    // bounds; an actual OOB access is undefined behavior, so the fold
+    // cannot introduce new incorrectness. (Verified with Z3.)
+    if (readOp.hasOutOfBoundsDim() && writeOp.hasOutOfBoundsDim()) {
+      return failure();
+    }
+
     // Build the inner value: select(wMask, valToStore, original).
     // When wMask is absent (unmasked write) or wMask == rMask (original is
     // never accessed), this simplifies to just valToStore.

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -324,6 +324,16 @@ struct FoldTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     // least one side has in_bounds=true, it asserts the position is within
     // bounds; an actual OOB access is undefined behavior, so the fold
     // cannot introduce new incorrectness. (Verified with Z3.)
+    //
+    // Case 1.1: w_ib = false, r_ib = true, position is actually in_bounds
+    // We write val, we read val, we can fold RAW to val.
+    // Case 1.2: w_ib = false, r_ib = true, position is NOT in_bounds
+    // We skip write, read says it is in_bounds, but that is false, which is UB
+    // therefore we can fold to val.
+    // Case 2.1: w_ib = true, r_ib = false, position is actually in_bounds
+    // We write val, we read val, we can fold RAW to val.
+    // Case 2.2: w_ib = true, r_ib = false, position is NOT in_bounds
+    // UB on the write, therefore we can fold.
     if (readOp.hasOutOfBoundsDim() && writeOp.hasOutOfBoundsDim()) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
@@ -581,16 +581,17 @@ func.func @fold_raw_oob_write_different_masks(%val: vector<1x32x16xf16>, %sz: in
      {in_bounds = [true, true, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
   return %r : vector<1x32x16xf16>
 }
+// The originalRead from tensor.empty is folded to poison by
+// FoldReadFromEmpty, so select(wMask, val, poison) canonicalizes and
+// only the outer rMask select remains.
 // CHECK-LABEL: func.func @fold_raw_oob_write_different_masks
 // CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %{{[a-zA-Z0-9]+}}
-// CHECK-SAME:    %[[WMASK:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %{{[a-zA-Z0-9]+}}
 // CHECK-SAME:    %[[RMASK:[a-zA-Z0-9]+]]
-// CHECK:         %[[ORIG:.*]] = vector.transfer_read
-// CHECK:         %[[INNER:.*]] = arith.select %[[WMASK]], %[[VAL]], %[[ORIG]]
 // CHECK-DAG:     %[[PAD:.*]] = arith.constant dense<0.000000e+00> : vector<1x32x16xf16>
-// CHECK:         %[[OUTER:.*]] = arith.select %[[RMASK]], %[[INNER]], %[[PAD]]
-// CHECK:         return %[[OUTER]]
+// CHECK:         %[[SEL:.*]] = arith.select %[[RMASK]], %[[VAL]], %[[PAD]]
+// CHECK:         return %[[SEL]]
 
 // -----
 
@@ -607,13 +608,14 @@ func.func @fold_raw_oob_write_only_write_masked(%val: vector<1x32x16xf16>, %sz: 
      {in_bounds = [true, true, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
   return %r : vector<1x32x16xf16>
 }
+// The originalRead from tensor.empty is folded to poison by
+// FoldReadFromEmpty, so select(wMask, val, poison) canonicalizes to val.
+// No rMask, so the result is just val.
 // CHECK-LABEL: func.func @fold_raw_oob_write_only_write_masked
 // CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %{{[a-zA-Z0-9]+}}
-// CHECK-SAME:    %[[MASK:[a-zA-Z0-9]+]]
-// CHECK:         %[[ORIG:.*]] = vector.transfer_read
-// CHECK:         %[[SEL:.*]] = arith.select %[[MASK]], %[[VAL]], %[[ORIG]]
-// CHECK:         return %[[SEL]]
+// CHECK-NOT:     vector.transfer_write
+// CHECK-NOT:     vector.transfer_read
+// CHECK:         return %[[VAL]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
@@ -462,6 +462,161 @@ func.func @fold_masked_transfer_raw_unmasked_write_masked_read(%t: tensor<128xf1
 
 // -----
 
+// Test for FoldTransferRAW with OOB.
+// Write has OOB dim, read claims in-bounds, same mask on both: fold is valid.
+func.func @fold_raw_oob_write_same_mask(%val: vector<1x32x16xf16>, %sz: index, %mask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %e = tensor.empty(%sz) : tensor<1x?x16xf16>
+  %w = vector.transfer_write %val, %e[%c0, %c0, %c0], %mask
+     {in_bounds = [true, false, true]} : vector<1x32x16xf16>, tensor<1x?x16xf16>
+  %r = vector.transfer_read %w[%c0, %c0, %c0], %pad, %mask
+     {in_bounds = [true, true, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
+  return %r : vector<1x32x16xf16>
+}
+// CHECK-LABEL: func.func @fold_raw_oob_write_same_mask
+// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %{{[a-zA-Z0-9]+}}
+// CHECK-SAME:    %[[MASK:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[PAD:.*]] = arith.constant dense<0.000000e+00> : vector<1x32x16xf16>
+// CHECK-NOT:     vector.transfer_write
+// CHECK-NOT:     vector.transfer_read
+// CHECK:         %[[SEL:.*]] = arith.select %[[MASK]], %[[VAL]], %[[PAD]]
+// CHECK:         return %[[SEL]]
+
+// -----
+
+// Test for FoldTransferRAW with OOB on both — negative.
+// Both write and read have OOB, no masks: fold must NOT happen.
+func.func @negative_fold_raw_oob_both_no_masks(%val: vector<1x32x16xf16>, %sz: index) -> vector<1x32x16xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %e = tensor.empty(%sz) : tensor<1x?x16xf16>
+  %w = vector.transfer_write %val, %e[%c0, %c0, %c0]
+     {in_bounds = [true, false, true]} : vector<1x32x16xf16>, tensor<1x?x16xf16>
+  %r = vector.transfer_read %w[%c0, %c0, %c0], %pad
+     {in_bounds = [true, false, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
+  return %r : vector<1x32x16xf16>
+}
+// CHECK-LABEL: func.func @negative_fold_raw_oob_both_no_masks
+// CHECK:         vector.transfer_write
+// CHECK:         vector.transfer_read
+
+// -----
+
+// Test for FoldTransferRAW with OOB on both — negative.
+// Both write and read have OOB dim with same mask: fold must NOT happen.
+func.func @negative_fold_raw_oob_both_same_mask(%val: vector<1x32x16xf16>, %sz: index, %mask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %e = tensor.empty(%sz) : tensor<1x?x16xf16>
+  %w = vector.transfer_write %val, %e[%c0, %c0, %c0], %mask
+     {in_bounds = [true, false, true]} : vector<1x32x16xf16>, tensor<1x?x16xf16>
+  %r = vector.transfer_read %w[%c0, %c0, %c0], %pad, %mask
+     {in_bounds = [true, false, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
+  return %r : vector<1x32x16xf16>
+}
+// CHECK-LABEL: func.func @negative_fold_raw_oob_both_same_mask
+// CHECK:         vector.transfer_write
+// CHECK:         vector.transfer_read
+
+// -----
+
+// Test for FoldTransferRAW with OOB.
+// Only read has OOB dim, write claims in-bounds, same mask: fold is valid
+// because the write's in_bounds=true makes OOB positions UB.
+func.func @fold_raw_oob_read_only(%val: vector<1x32x16xf16>, %sz: index, %mask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %e = tensor.empty(%sz) : tensor<1x?x16xf16>
+  %w = vector.transfer_write %val, %e[%c0, %c0, %c0], %mask
+     {in_bounds = [true, true, true]} : vector<1x32x16xf16>, tensor<1x?x16xf16>
+  %r = vector.transfer_read %w[%c0, %c0, %c0], %pad, %mask
+     {in_bounds = [true, false, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
+  return %r : vector<1x32x16xf16>
+}
+// CHECK-LABEL: func.func @fold_raw_oob_read_only
+// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %{{[a-zA-Z0-9]+}}
+// CHECK-SAME:    %[[MASK:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[PAD:.*]] = arith.constant dense<0.000000e+00> : vector<1x32x16xf16>
+// CHECK-NOT:     vector.transfer_write
+// CHECK-NOT:     vector.transfer_read
+// CHECK:         %[[SEL:.*]] = arith.select %[[MASK]], %[[VAL]], %[[PAD]]
+// CHECK:         return %[[SEL]]
+
+// -----
+
+// Test for FoldTransferRAW with OOB.
+// Write has OOB dim, read claims in-bounds, no masks: fold is valid because
+// the read's in_bounds=true makes OOB positions UB.
+func.func @fold_raw_oob_write_no_masks(%val: vector<1x32x16xf16>, %sz: index) -> vector<1x32x16xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %e = tensor.empty(%sz) : tensor<1x?x16xf16>
+  %w = vector.transfer_write %val, %e[%c0, %c0, %c0]
+     {in_bounds = [true, false, true]} : vector<1x32x16xf16>, tensor<1x?x16xf16>
+  %r = vector.transfer_read %w[%c0, %c0, %c0], %pad
+     {in_bounds = [true, true, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
+  return %r : vector<1x32x16xf16>
+}
+// CHECK-LABEL: func.func @fold_raw_oob_write_no_masks
+// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
+// CHECK-NOT:     vector.transfer_write
+// CHECK-NOT:     vector.transfer_read
+// CHECK:         return %[[VAL]]
+
+// -----
+
+// Test for FoldTransferRAW with OOB.
+// Write has OOB dim, read claims in-bounds, different masks: fold is valid.
+// The different masks are handled by the needsOriginal path.
+func.func @fold_raw_oob_write_different_masks(%val: vector<1x32x16xf16>, %sz: index, %wmask: vector<1x32x16xi1>, %rmask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %e = tensor.empty(%sz) : tensor<1x?x16xf16>
+  %w = vector.transfer_write %val, %e[%c0, %c0, %c0], %wmask
+     {in_bounds = [true, false, true]} : vector<1x32x16xf16>, tensor<1x?x16xf16>
+  %r = vector.transfer_read %w[%c0, %c0, %c0], %pad, %rmask
+     {in_bounds = [true, true, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
+  return %r : vector<1x32x16xf16>
+}
+// CHECK-LABEL: func.func @fold_raw_oob_write_different_masks
+// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %{{[a-zA-Z0-9]+}}
+// CHECK-SAME:    %[[WMASK:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[RMASK:[a-zA-Z0-9]+]]
+// CHECK:         %[[ORIG:.*]] = vector.transfer_read
+// CHECK:         %[[INNER:.*]] = arith.select %[[WMASK]], %[[VAL]], %[[ORIG]]
+// CHECK-DAG:     %[[PAD:.*]] = arith.constant dense<0.000000e+00> : vector<1x32x16xf16>
+// CHECK:         %[[OUTER:.*]] = arith.select %[[RMASK]], %[[INNER]], %[[PAD]]
+// CHECK:         return %[[OUTER]]
+
+// -----
+
+// Test for FoldTransferRAW with OOB.
+// Write has OOB dim, only write is masked, read claims in-bounds: fold is
+// valid. The write mask is handled by the needsOriginal path.
+func.func @fold_raw_oob_write_only_write_masked(%val: vector<1x32x16xf16>, %sz: index, %mask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f16
+  %e = tensor.empty(%sz) : tensor<1x?x16xf16>
+  %w = vector.transfer_write %val, %e[%c0, %c0, %c0], %mask
+     {in_bounds = [true, false, true]} : vector<1x32x16xf16>, tensor<1x?x16xf16>
+  %r = vector.transfer_read %w[%c0, %c0, %c0], %pad
+     {in_bounds = [true, true, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
+  return %r : vector<1x32x16xf16>
+}
+// CHECK-LABEL: func.func @fold_raw_oob_write_only_write_masked
+// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %{{[a-zA-Z0-9]+}}
+// CHECK-SAME:    %[[MASK:[a-zA-Z0-9]+]]
+// CHECK:         %[[ORIG:.*]] = vector.transfer_read
+// CHECK:         %[[SEL:.*]] = arith.select %[[MASK]], %[[VAL]], %[[ORIG]]
+// CHECK:         return %[[SEL]]
+
+// -----
+
 // transfer_read from a memref (not tensor semantics): pattern must not fire.
 func.func @negative_read_empty_not_tensor_semantics(%m: memref<128xf16>) -> vector<128xf16> {
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
@@ -486,9 +486,10 @@ func.func @fold_raw_oob_write_same_mask(%val: vector<1x32x16xf16>, %sz: index, %
 
 // -----
 
-// Test for FoldTransferRAW with OOB on both — negative.
-// Both write and read have OOB, no masks: fold must NOT happen.
-func.func @negative_fold_raw_oob_both_no_masks(%val: vector<1x32x16xf16>, %sz: index) -> vector<1x32x16xf16> {
+// Test for FoldTransferRAW with OOB on both.
+// Both write and read have OOB, no masks: fold builds an in-bounds mask
+// from the tensor's actual dimensions and selects between val and pad.
+func.func @fold_raw_oob_both_no_masks(%val: vector<1x32x16xf16>, %sz: index) -> vector<1x32x16xf16> {
   %c0 = arith.constant 0 : index
   %pad = arith.constant 0.0 : f16
   %e = tensor.empty(%sz) : tensor<1x?x16xf16>
@@ -498,15 +499,22 @@ func.func @negative_fold_raw_oob_both_no_masks(%val: vector<1x32x16xf16>, %sz: i
      {in_bounds = [true, false, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
   return %r : vector<1x32x16xf16>
 }
-// CHECK-LABEL: func.func @negative_fold_raw_oob_both_no_masks
-// CHECK:         vector.transfer_write
-// CHECK:         vector.transfer_read
+// CHECK-LABEL: func.func @fold_raw_oob_both_no_masks
+// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[SZ:[a-zA-Z0-9]+]]
+// CHECK-NOT:     vector.transfer_write
+// CHECK-NOT:     vector.transfer_read
+// CHECK-DAG:     %[[PAD:.*]] = arith.constant dense<0.000000e+00> : vector<1x32x16xf16>
+// CHECK:         %[[MASK:.*]] = vector.create_mask {{.*}}, %[[SZ]], {{.*}} : vector<1x32x16xi1>
+// CHECK:         %[[SEL:.*]] = arith.select %[[MASK]], %[[VAL]], %[[PAD]]
+// CHECK:         return %[[SEL]]
 
 // -----
 
-// Test for FoldTransferRAW with OOB on both — negative.
-// Both write and read have OOB dim with same mask: fold must NOT happen.
-func.func @negative_fold_raw_oob_both_same_mask(%val: vector<1x32x16xf16>, %sz: index, %mask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
+// Test for FoldTransferRAW with OOB on both.
+// Both write and read have OOB dim with same mask: fold builds an in-bounds
+// mask and selects. The rMask produces an outer select as well.
+func.func @fold_raw_oob_both_same_mask(%val: vector<1x32x16xf16>, %sz: index, %mask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
   %c0 = arith.constant 0 : index
   %pad = arith.constant 0.0 : f16
   %e = tensor.empty(%sz) : tensor<1x?x16xf16>
@@ -516,9 +524,17 @@ func.func @negative_fold_raw_oob_both_same_mask(%val: vector<1x32x16xf16>, %sz: 
      {in_bounds = [true, false, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
   return %r : vector<1x32x16xf16>
 }
-// CHECK-LABEL: func.func @negative_fold_raw_oob_both_same_mask
-// CHECK:         vector.transfer_write
-// CHECK:         vector.transfer_read
+// CHECK-LABEL: func.func @fold_raw_oob_both_same_mask
+// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[SZ:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[MASK:[a-zA-Z0-9]+]]
+// CHECK-NOT:     vector.transfer_write
+// CHECK-NOT:     vector.transfer_read
+// CHECK-DAG:     %[[PAD:.*]] = arith.constant dense<0.000000e+00> : vector<1x32x16xf16>
+// CHECK:         %[[IB_MASK:.*]] = vector.create_mask {{.*}}, %[[SZ]], {{.*}} : vector<1x32x16xi1>
+// CHECK:         %[[IB_SEL:.*]] = arith.select %[[IB_MASK]], %[[VAL]], %[[PAD]]
+// CHECK:         %[[OUTER:.*]] = arith.select %[[MASK]], %[[IB_SEL]], %[[PAD]]
+// CHECK:         return %[[OUTER]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
@@ -486,10 +486,9 @@ func.func @fold_raw_oob_write_same_mask(%val: vector<1x32x16xf16>, %sz: index, %
 
 // -----
 
-// Test for FoldTransferRAW with OOB on both.
-// Both write and read have OOB, no masks: fold builds an in-bounds mask
-// from the tensor's actual dimensions and selects between val and pad.
-func.func @fold_raw_oob_both_no_masks(%val: vector<1x32x16xf16>, %sz: index) -> vector<1x32x16xf16> {
+// Test for FoldTransferRAW with OOB on both — negative.
+// Both write and read have OOB, no masks: fold must NOT happen.
+func.func @negative_fold_raw_oob_both_no_masks(%val: vector<1x32x16xf16>, %sz: index) -> vector<1x32x16xf16> {
   %c0 = arith.constant 0 : index
   %pad = arith.constant 0.0 : f16
   %e = tensor.empty(%sz) : tensor<1x?x16xf16>
@@ -499,22 +498,15 @@ func.func @fold_raw_oob_both_no_masks(%val: vector<1x32x16xf16>, %sz: index) -> 
      {in_bounds = [true, false, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
   return %r : vector<1x32x16xf16>
 }
-// CHECK-LABEL: func.func @fold_raw_oob_both_no_masks
-// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[SZ:[a-zA-Z0-9]+]]
-// CHECK-NOT:     vector.transfer_write
-// CHECK-NOT:     vector.transfer_read
-// CHECK-DAG:     %[[PAD:.*]] = arith.constant dense<0.000000e+00> : vector<1x32x16xf16>
-// CHECK:         %[[MASK:.*]] = vector.create_mask {{.*}}, %[[SZ]], {{.*}} : vector<1x32x16xi1>
-// CHECK:         %[[SEL:.*]] = arith.select %[[MASK]], %[[VAL]], %[[PAD]]
-// CHECK:         return %[[SEL]]
+// CHECK-LABEL: func.func @negative_fold_raw_oob_both_no_masks
+// CHECK:         vector.transfer_write
+// CHECK:         vector.transfer_read
 
 // -----
 
-// Test for FoldTransferRAW with OOB on both.
-// Both write and read have OOB dim with same mask: fold builds an in-bounds
-// mask and selects. The rMask produces an outer select as well.
-func.func @fold_raw_oob_both_same_mask(%val: vector<1x32x16xf16>, %sz: index, %mask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
+// Test for FoldTransferRAW with OOB on both — negative.
+// Both write and read have OOB dim with same mask: fold must NOT happen.
+func.func @negative_fold_raw_oob_both_same_mask(%val: vector<1x32x16xf16>, %sz: index, %mask: vector<1x32x16xi1>) -> vector<1x32x16xf16> {
   %c0 = arith.constant 0 : index
   %pad = arith.constant 0.0 : f16
   %e = tensor.empty(%sz) : tensor<1x?x16xf16>
@@ -524,17 +516,9 @@ func.func @fold_raw_oob_both_same_mask(%val: vector<1x32x16xf16>, %sz: index, %m
      {in_bounds = [true, false, true]} : tensor<1x?x16xf16>, vector<1x32x16xf16>
   return %r : vector<1x32x16xf16>
 }
-// CHECK-LABEL: func.func @fold_raw_oob_both_same_mask
-// CHECK-SAME:    %[[VAL:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[SZ:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[MASK:[a-zA-Z0-9]+]]
-// CHECK-NOT:     vector.transfer_write
-// CHECK-NOT:     vector.transfer_read
-// CHECK-DAG:     %[[PAD:.*]] = arith.constant dense<0.000000e+00> : vector<1x32x16xf16>
-// CHECK:         %[[IB_MASK:.*]] = vector.create_mask {{.*}}, %[[SZ]], {{.*}} : vector<1x32x16xi1>
-// CHECK:         %[[IB_SEL:.*]] = arith.select %[[IB_MASK]], %[[VAL]], %[[PAD]]
-// CHECK:         %[[OUTER:.*]] = arith.select %[[MASK]], %[[IB_SEL]], %[[PAD]]
-// CHECK:         return %[[OUTER]]
+// CHECK-LABEL: func.func @negative_fold_raw_oob_both_same_mask
+// CHECK:         vector.transfer_write
+// CHECK:         vector.transfer_read
 
 // -----
 

--- a/tests/e2e/regression/dynamic_gather_attention.mlir
+++ b/tests/e2e/regression/dynamic_gather_attention.mlir
@@ -29,6 +29,20 @@ func.func @gather_attention() {
   ^bb0(%arg0: f32):
     iree_linalg_ext.yield %arg0 : f32
   } -> tensor<32x4x2x32xf32>, tensor<32x4x2xf32>, tensor<32x4x2xf32>
-  check.expect_almost_eq_const(%13#0, dense<1.500000e+00> : tensor<32x4x2x32xf32>) : tensor<32x4x2x32xf32>
+  %out_e = tensor.empty() : tensor<32x4x2x32xf32>
+  %cst_one = arith.constant 1.000000e+00 : f32
+  %normalized = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  } ins(%13#0, %13#2 : tensor<32x4x2x32xf32>, tensor<32x4x2xf32>)
+    outs(%out_e : tensor<32x4x2x32xf32>) {
+  ^bb0(%a: f32, %s: f32, %_: f32):
+    %inv = arith.divf %cst_one, %s : f32
+    %v = arith.mulf %a, %inv : f32
+    linalg.yield %v : f32
+  } -> tensor<32x4x2x32xf32>
+  check.expect_almost_eq_const(%normalized, dense<1.500000e+00> : tensor<32x4x2x32xf32>) : tensor<32x4x2x32xf32>
   return
 }

--- a/tests/e2e/regression/dynamic_gather_attention.mlir
+++ b/tests/e2e/regression/dynamic_gather_attention.mlir
@@ -4,6 +4,7 @@
 #map3 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>
 #map4 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d5, d6)>
 #map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+#map6 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2)>
 func.func @gather_attention() {
   %0 = util.unfoldable_constant dense<1.000000e+00> : tensor<32x4x2x32xf16>
   %1 = flow.tensor.dynamic_constant dense<5.000000e-01> : tensor<2x4x16x32xf16> -> tensor<?x4x16x32xf16>
@@ -16,11 +17,18 @@ func.func @gather_attention() {
   %6 = iree_linalg_ext.gather dimension_map = [0] ins(%1, %3 : tensor<?x4x16x32xf16>, tensor<32x?xi64>) outs(%5 : tensor<32x?x4x16x32xf16>) -> tensor<32x?x4x16x32xf16>
   %7 = iree_linalg_ext.gather dimension_map = [0] ins(%2, %3 : tensor<?x4x16x32xf16>, tensor<32x?xi64>) outs(%5 : tensor<32x?x4x16x32xf16>) -> tensor<32x?x4x16x32xf16>
   %cst = arith.constant 1.767580e-01 : f16
-  %8 = tensor.empty() : tensor<32x4x2x32xf16>
-  %9 = iree_linalg_ext.attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5]} ins(%0, %6, %7, %cst, %4 : tensor<32x4x2x32xf16>, tensor<32x?x4x16x32xf16>, tensor<32x?x4x16x32xf16>, f16, tensor<32x4x2x?x16xf16>) outs(%8 : tensor<32x4x2x32xf16>) {
+  %8 = tensor.empty() : tensor<32x4x2x32xf32>
+  %9 = tensor.empty() : tensor<32x4x2xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %10 = linalg.fill ins(%cst_0 : f32) outs(%8 : tensor<32x4x2x32xf32>) -> tensor<32x4x2x32xf32>
+  %11 = linalg.fill ins(%cst_1 : f32) outs(%9 : tensor<32x4x2xf32>) -> tensor<32x4x2xf32>
+  %12 = linalg.fill ins(%cst_2 : f32) outs(%9 : tensor<32x4x2xf32>) -> tensor<32x4x2xf32>
+  %13:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map6, #map6]} ins(%0, %6, %7, %cst, %4 : tensor<32x4x2x32xf16>, tensor<32x?x4x16x32xf16>, tensor<32x?x4x16x32xf16>, f16, tensor<32x4x2x?x16xf16>) outs(%10, %11, %12 : tensor<32x4x2x32xf32>, tensor<32x4x2xf32>, tensor<32x4x2xf32>) {
   ^bb0(%arg0: f32):
     iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<32x4x2x32xf16>
-  check.expect_almost_eq_const(%9, dense<1.500000e+00> : tensor<32x4x2x32xf16>) : tensor<32x4x2x32xf16>
+  } -> tensor<32x4x2x32xf32>, tensor<32x4x2xf32>, tensor<32x4x2xf32>
+  check.expect_almost_eq_const(%13#0, dense<1.500000e+00> : tensor<32x4x2x32xf32>) : tensor<32x4x2x32xf32>
   return
 }


### PR DESCRIPTION
Fix fold for transfer_read(transfer_write(val_to_store)) when in_bounds is not guaranteed.

When transfer_read and transfer_write do not have dimensions being accessed guaranteed to be in_bounds, it is not safe to fold transfer_read(transfer_write(val_to_store)) -> val_to_store. However, when transfer_read XOR transfer_write have in_bounds, we take advantage of undefined behaviour to fold them to val_to_store.

Case 1.1: w_ib = false, r_ib = true, position is actually in_bounds
We write val, we read val, we can fold RAW to val.
Case 1.2: w_ib = false, r_ib = true, position is NOT in_bounds
We skip write, read says it is in_bounds, but that is false, which is UB
therefore we can fold to val.
Case 2.1: w_ib = true, r_ib = false, position is actually in_bounds
We write val, we read val, we can fold RAW to val.
Case 2.2: w_ib = true, r_ib = false, position is NOT in_bounds
UB on the write, therefore we can fold.