### PR TITLE
[LLVMGPU] Enable NVIDIA BF16 mma.sync lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -135,6 +135,8 @@ int64_t getIntrinsicSubgroupSize(MMAIntrinsic intrinsic) {
   return is_AMD_MFMA(intrinsic) ? 64 : 32;
 }
 
+// Returns the operand and accumulator element types required by each MMA
+// intrinsic.
 static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *context,
                                                        MMAIntrinsic intrinsic) {
   Type f8E4M3FNUZ = Float8E4M3FNUZType::get(context);
@@ -187,6 +189,8 @@ static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *context,
   case MMAIntrinsic::MFMA_F32_32x32x16_BF16:
   case MMAIntrinsic::WMMAR3_F32_16x16x16_BF16:
   case MMAIntrinsic::WMMAR4_F32_16x16x16_BF16:
+  // NVIDIA BF16 mma.sync multiplies bf16 fragments and accumulates into f32.
+  case MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_BF16:
   case MMAIntrinsic::WMMA_F32_16x16x32_BF16:
     return {bf16, bf16, f32};
   case MMAIntrinsic::WMMAR3_BF16_16x16x16_BF16:
@@ -282,6 +286,7 @@ getUnsupportedMNKShape(MMAIntrinsic intrinsic) {
   return {};
 }
 
+// Returns the per-lane register layout used to map each MMA operand.
 MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
                                                 int operandIndex) {
   auto mfmaLhs16xK = [](int64_t k) -> MMASingleSubgroupLayout {
@@ -705,6 +710,8 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
     }
   case MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16:
   case MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16:
+  // BF16 mma.sync uses the same 16x8x16 register layout as the f16 variants.
+  case MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_BF16:
     switch (operandIndex) {
     case kMMAOperandLhs:
       return {/*outer=*/{2, 2}, /*thread=*/{8, 4}, /*strides=*/{4, 1},
@@ -980,6 +987,7 @@ SmallVector<VirtualMMAIntrinsic> MMAAttr::getVirtualIntrinsics() const {
   }
 }
 
+// Creates the target-specific MMA operation for the selected intrinsic layout.
 static Value createMmaOp(OpBuilder &builder, Location loc,
                          MMAIntrinsic intrinsic, Type resultType, Value lhs,
                          Value rhs, Value acc, bool colMajor = false) {
@@ -1080,7 +1088,10 @@ static Value createMmaOp(OpBuilder &builder, Location loc,
     // ordering expected by mma.sync. The input shape differs between pipelines:
     // VectorDistribute produces 2x2x1x2, TileAndFuse produces 2x1x2x2.
     // Remove the unit dimension to simplify the transpose.
-    auto nonUnitVecType = VectorType::get({2, 2, 2}, builder.getF16Type());
+    // Preserve the operand element type so BF16 fragments are not reshaped as
+    // f16.
+    Type elementType = cast<VectorType>(lhs.getType()).getElementType();
+    auto nonUnitVecType = VectorType::get({2, 2, 2}, elementType);
     auto reshaped =
         vector::ShapeCastOp::create(builder, loc, nonUnitVecType, lhs);
     auto permAttr = builder.getDenseI64ArrayAttr({1, 0, 2});

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -272,6 +272,7 @@ def WMMA_F16_16x16x128_F8E4M3FN_F8E5M2 : I32EnumAttrCase<"WMMA_F16_16x16x128_F8E
 // NV intrinsics with explicit layout (mma.sync)
 def NV_MMA_SYNC_F32_16x8x16_F16 : I32EnumAttrCase<"NV_MMA_SYNC_F32_16x8x16_F16", 0x2020>;
 def NV_MMA_SYNC_F16_16x8x16_F16 : I32EnumAttrCase<"NV_MMA_SYNC_F16_16x8x16_F16", 0x2021>;
+def NV_MMA_SYNC_F32_16x8x16_BF16 : I32EnumAttrCase<"NV_MMA_SYNC_F32_16x8x16_BF16", 0x2022>;
 
 // opaque NV intrinsics
 def NV_WMMA_F32_16x16x16_F16 : I32EnumAttrCase<"NV_WMMA_F32_16x16x16_F16", 0x2120>;
@@ -392,6 +393,7 @@ def IREEGPU_MMAIntrinsic : IREEGPU_I32EnumAttr<"MMAIntrinsic",
       // NV intrinsics with layout
       NV_MMA_SYNC_F32_16x8x16_F16,
       NV_MMA_SYNC_F16_16x8x16_F16,
+      NV_MMA_SYNC_F32_16x8x16_BF16,
       // opaque NV intrinsics.
       NV_WMMA_F32_16x16x16_F16,
       NV_WMMA_F16_16x16x16_F16,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -913,10 +913,14 @@ StringRef normalizeARMGPUTarget(StringRef target) {
 // cooperative matrix layouts are opaque. We need to create NVIDIA specific WMMA
 // intrinsics if we need to have explicit layout analysis and register mapping.
 
+// Reports Ampere-class NVIDIA tensor core capabilities for GPU target
+// selection.
 const WgpDetails *getAmpereWgpDetails() {
+  // Expose BF16 mma.sync where Ampere-class hardware supports the instruction.
   static const MMAIntrinsic mmaOps[] = {
       MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_F16,
       MMAIntrinsic::NV_MMA_SYNC_F16_16x8x16_F16,
+      MMAIntrinsic::NV_MMA_SYNC_F32_16x8x16_BF16,
       MMAIntrinsic::NV_WMMA_F32_16x16x16_F16,
       MMAIntrinsic::NV_WMMA_F16_16x16x16_F16,
   };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "bf16_mma_sm80.mlir",
             "config_tile_and_fuse_sm80.mlir",
             "config_vector_distribute_sm80.mlir",
             "pipeline_full_smoketests.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "bf16_mma_sm80.mlir"
     "config_tile_and_fuse_sm80.mlir"
     "config_vector_distribute_sm80.mlir"
     "pipeline_full_smoketests.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/bf16_mma_sm80.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/bf16_mma_sm80.mlir
@@ -1,0 +1,39 @@
+// RUN: iree-opt --mlir-print-local-scope --iree-gpu-test-target=sm_80 \
+// RUN:   --pass-pipeline="builtin.module(iree-llvmgpu-select-lowering-strategy)" %s | FileCheck %s --check-prefix=CONFIG
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=sm_80 \
+// RUN:   --iree-codegen-llvmgpu-configuration-pipeline --iree-codegen-llvmgpu-nvvm-lowering-pipeline %s | FileCheck %s --check-prefix=NVVM
+
+// Test that Ampere selects and lowers BF16 matmuls through NVIDIA mma.sync.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+// Drives BF16xbf16xf32 matmul selection through the NVIDIA mma.sync path.
+func.func @matmul_256x256x256_bf16_f32() {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xbf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xbf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xbf16>> -> tensor<256x256xbf16>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<256x256xbf16>> -> tensor<256x256xbf16>
+  %5 = tensor.empty() : tensor<256x256xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<256x256xf32>) -> tensor<256x256xf32>
+  %7 = linalg.matmul ins(%3, %4 : tensor<256x256xbf16>, tensor<256x256xbf16>) outs(%6 : tensor<256x256xf32>) -> tensor<256x256xf32>
+  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : tensor<256x256xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<256x256xf32>>
+  return
+}
+
+// CONFIG-LABEL: func.func @matmul_256x256x256_bf16_f32(
+//       CONFIG:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CONFIG-SAME:     mma_kind = #iree_gpu.mma_layout<NV_MMA_SYNC_F32_16x8x16_BF16>
+//  CONFIG-SAME:     promote_operands = [0, 1]
+
+// NVVM-LABEL: llvm.func @matmul_256x256x256_bf16_f32(
+//       NVVM:   nvvm.mma.sync
+//  NVVM-SAME:     multiplicandAPtxType = #nvvm.mma_type<bf16>
+//  NVVM-SAME:     multiplicandBPtxType = #nvvm.mma_type<bf16>
+//  NVVM-SAME:     shape = #nvvm.shape<m = 16, n = 8, k = 16>
+//  NVVM-SAME:     : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>


### PR DESCRIPTION
Enable NVIDIA BF16 mma.sync lowering for Ampere-class targets to upports BF16 tensor core instructions.
