### PR TITLE
[StableHLO] Guard convolution widen operand fusion

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -90,6 +90,9 @@ class TargetConverter:
                 "@llvm-project//mlir:TargetSMTLIB": ["MLIRExportSMTLIB"],
                 "@llvm-project//mlir:VectorOps": ["MLIRVector"],
                 # StableHLO.
+                "@stablehlo//:base": [
+                    "StablehloBase",
+                ],
                 "@stablehlo//:chlo_ops": [
                     "ChloOps",
                 ],

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/BUILD.bazel
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/BUILD.bazel
@@ -94,6 +94,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
+        "@stablehlo//:base",
         "@stablehlo//:chlo_ops",
         "@stablehlo//:stablehlo_ops",
     ],

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/CMakeLists.txt
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/CMakeLists.txt
@@ -78,6 +78,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTransformUtils
     MLIRTransforms
+    StablehloBase
     StablehloOps
   PUBLIC
 )

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -22,6 +22,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/Base.h"
 #include "stablehlo/dialect/ChloOps.h"
 #include "stablehlo/dialect/StablehloOps.h"
 
@@ -1437,6 +1438,25 @@ struct ReorderBroadcastInDimOpAndElementwiseOp final
   }
 };
 
+// Accepts fused widening operands for ops that have no additional type
+// constraints.
+template <typename Op>
+LogicalResult verifyFusedWidenOperands(Op op, ArrayRef<Value> operands) {
+  return success();
+}
+
+// Rejects convolution fusion when the resulting operand types violate
+// StableHLO.
+LogicalResult verifyFusedWidenOperands(mlir::stablehlo::ConvolutionOp op,
+                                       ArrayRef<Value> operands) {
+  Type lhsType = getElementTypeOrSelf(operands[0].getType());
+  Type rhsType = getElementTypeOrSelf(operands[1].getType());
+  if (!mlir::hlo::isCompatibleForHloTypeInference(lhsType, rhsType)) {
+    return failure();
+  }
+  return success();
+}
+
 // Identifies cases where a dense operation has inputs that come from widening
 // operations. For instance, a dot product widening from FP16 to FP32 is better
 // to have the casting operation fused into the dot operation. This decreases
@@ -1445,6 +1465,8 @@ template <class Op>
 struct FuseWidenOperands final : OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
 
+  // Fuses widening converts into dense ops after checking op-specific type
+  // rules.
   LogicalResult matchAndRewrite(Op op,
                                 PatternRewriter &rewriter) const override {
     llvm::SmallVector<Value> operands;
@@ -1474,6 +1496,13 @@ struct FuseWidenOperands final : OpRewritePattern<Op> {
             llvm::zip_equal(operands, op->getOperands()),
             [](auto pair) { return std::get<0>(pair) == std::get<1>(pair); })) {
       return failure();
+    }
+
+    // Recheck type constraints after replacing widened operands with their
+    // inputs.
+    if (failed(verifyFusedWidenOperands(op, operands))) {
+      return rewriter.notifyMatchFailure(
+          op, "fused operands do not satisfy op type constraints");
     }
 
     rewriter.replaceOpWithNewOp<Op>(op, op->getResultTypes(), operands,

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -1460,13 +1460,12 @@ LogicalResult verifyFusedWidenOperands(mlir::stablehlo::ConvolutionOp op,
 // Identifies cases where a dense operation has inputs that come from widening
 // operations. For instance, a dot product widening from FP16 to FP32 is better
 // to have the casting operation fused into the dot operation. This decreases
-// the loading required during a dense computation.
+// the loading required during a dense computation. Fusion is skipped when it
+// would produce invalid operand types.
 template <class Op>
 struct FuseWidenOperands final : OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
 
-  // Fuses widening converts into dense ops after checking op-specific type
-  // rules.
   LogicalResult matchAndRewrite(Op op,
                                 PatternRewriter &rewriter) const override {
     llvm::SmallVector<Value> operands;

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/stablehlo_to_stablehlo.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/stablehlo_to_stablehlo.mlir
@@ -377,9 +377,9 @@ func.func @convolution(%arg0: tensor<16x32x256xbf16>, %arg1: tensor<1x256x256xbf
 // -----
 
 // Checks that mixed bf16/f32 convolutions preserve the required lhs widening convert.
-// CHECK-LABEL: @convolution_mixed_filter
+// CHECK-LABEL: @convolution_mixed_precision
 // CHECK-SAME:     (%[[ARG0:.+]]: tensor<1x6144x13xbf16>, %[[ARG1:.+]]: tensor<6144x1x4xf32>)
-func.func @convolution_mixed_filter(%arg0: tensor<1x6144x13xbf16>, %arg1: tensor<6144x1x4xf32>) -> tensor<1x6144x16xf32> {
+func.func @convolution_mixed_precision(%arg0: tensor<1x6144x13xbf16>, %arg1: tensor<6144x1x4xf32>) -> tensor<1x6144x16xf32> {
   // A convolution requires compatible lhs/rhs element types. If only the lhs
   // has a widening convert, preprocessing must preserve it instead of creating
   // an invalid bf16/f32 convolution.

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/stablehlo_to_stablehlo.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/stablehlo_to_stablehlo.mlir
@@ -376,6 +376,37 @@ func.func @convolution(%arg0: tensor<16x32x256xbf16>, %arg1: tensor<1x256x256xbf
 
 // -----
 
+// Checks that mixed bf16/f32 convolutions preserve the required lhs widening convert.
+// CHECK-LABEL: @convolution_mixed_filter
+// CHECK-SAME:     (%[[ARG0:.+]]: tensor<1x6144x13xbf16>, %[[ARG1:.+]]: tensor<6144x1x4xf32>)
+func.func @convolution_mixed_filter(%arg0: tensor<1x6144x13xbf16>, %arg1: tensor<6144x1x4xf32>) -> tensor<1x6144x16xf32> {
+  // A convolution requires compatible lhs/rhs element types. If only the lhs
+  // has a widening convert, preprocessing must preserve it instead of creating
+  // an invalid bf16/f32 convolution.
+  // CHECK: %[[CAST:.+]] = stablehlo.convert %[[ARG0]]
+  // CHECK-SAME: (tensor<1x6144x13xbf16>) -> tensor<1x6144x13xf32>
+  %cast0 = stablehlo.convert %arg0 : (tensor<1x6144x13xbf16>) -> tensor<1x6144x13xf32>
+  // CHECK: %[[LHS:.+]] = stablehlo.transpose %[[CAST]]
+  // CHECK: %[[RHS:.+]] = stablehlo.transpose %[[ARG1]]
+  // CHECK: %[[CONV:.+]] = stablehlo.convolution(%[[LHS]], %[[RHS]])
+  // CHECK-SAME: : (tensor<1x13x6144xf32>, tensor<4x1x6144xf32>) -> tensor<1x16x6144xf32>
+  %0 = "stablehlo.convolution"(%cast0, %arg1) {
+     batch_group_count = 1 : i64,
+     dimension_numbers = #stablehlo.conv<[b, f, 0]x[o, i, 0]->[b, f, 0]>,
+     feature_group_count = 6144 : i64,
+     lhs_dilation = array<i64: 1>,
+     padding = dense<3> : tensor<1x2xi64>,
+     precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>],
+     rhs_dilation = array<i64: 1>,
+     window_strides = array<i64: 1>
+   } : (tensor<1x6144x13xf32>, tensor<6144x1x4xf32>) -> tensor<1x6144x16xf32>
+  // CHECK: %[[RESULT:.+]] = stablehlo.transpose %[[CONV]]
+  // CHECK: return %[[RESULT]]
+  func.return %0 : tensor<1x6144x16xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @dynamic_dot_general
 // This verifies non-crashing, the lowering to linalg happens elsewhere.
 func.func @dynamic_dot_general(%arg1: tensor<?x1024x16x64xf32>, %arg2: tensor<?x1024x16x64xf32>) -> tensor<?x16x1024x1024xf32> {


### PR DESCRIPTION
The motivation for this PR is to keep StableHLO preprocessing valid for mixed-precision models that contain bf16/f32 convolutions. IREE currently folds widening converts into dense ops to reduce explicit casts, but doing this for stablehlo.convolution can create invalid operand type combinations that StableHLO type inference rejects. This PR avoid folding widening converts into stablehlo.convolution when doing so would make the lhs and rhs element types invalid for StableHLO type inference.