### PR TITLE
[LLVMGPU] Avoid degenerate SIMT matmul unit tiles

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1463,6 +1463,7 @@ setVectorDistributionConfig(IREE::GPU::TargetAttr target,
 // Contraction Pipeline Configuration
 //====---------------------------------------------------------------------===//
 
+// Selects an LLVMGPU lowering configuration for matmul-like contractions.
 static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
                                        mlir::FunctionOpInterface entryPoint,
                                        linalg::LinalgOp op) {
@@ -1660,9 +1661,19 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
 
     // SIMT matmul case. Query the best configuration.
     SmallVector<TileWorkgroupSizePair> tileSizeConfig = getMatmulConfig(target);
+    // Treat unit tiles on non-skinny dimensions as degenerate exact matches.
+    auto isDegenerateUnitTile = [&](const TileWorkgroupSizePair &config) {
+      return (config.tileSize[0] == 1 && sizeM > kVerySkinnyDimThreshold) ||
+             (config.tileSize[1] == 1 && sizeN > kVerySkinnyDimThreshold);
+    };
     // Pick the best configuration where the original shape is aligned on the
     // tile size.
     for (TileWorkgroupSizePair &config : tileSizeConfig) {
+      // Skip degenerate matches so later configs can use both parallel
+      // dimensions.
+      if (isDegenerateUnitTile(config)) {
+        continue;
+      }
       if (sizeN % config.tileSize[1] == 0 && sizeM % config.tileSize[0] == 0 &&
           sizeK % config.tileSize[2] == 0) {
         return setMatmulConfig(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/config_tile_and_fuse_sm80.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/config_tile_and_fuse_sm80.mlir
@@ -91,3 +91,37 @@ func.func @matmul_accumulate_256x256x256_f16_f32() {
 //       CHECK:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     convert_acc_gemm
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<NV_MMA_SYNC_F32_16x8x16_F16>
+
+// -----
+
+// Mixed precision f32xbf16xf32 matmuls cannot use NVIDIA MMA intrinsics, but
+// should still avoid degenerate SIMT tiling that only computes one M element
+// per workgroup when M has enough work to tile.
+func.func @mixed_precision_matmul_36x151936x896_f32xbf16xf32(
+    %lhs: tensor<36x896xf32>,
+    %rhs: tensor<151936x896xbf16>) -> tensor<36x151936xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<36x151936xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<36x151936xf32>) -> tensor<36x151936xf32>
+  %result = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d0, d2)>,
+      affine_map<(d0, d1, d2) -> (d1, d2)>,
+      affine_map<(d0, d1, d2) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%lhs, %rhs : tensor<36x896xf32>, tensor<151936x896xbf16>)
+    outs(%fill : tensor<36x151936xf32>) {
+  ^bb0(%in: f32, %in_0: bf16, %out: f32):
+    %0 = arith.extf %in_0 : bf16 to f32
+    %1 = arith.mulf %in, %0 : f32
+    %2 = arith.addf %out, %1 : f32
+    linalg.yield %2 : f32
+  } -> tensor<36x151936xf32>
+  return %result : tensor<36x151936xf32>
+}
+
+// CHECK-LABEL: func.func @mixed_precision_matmul_36x151936x896_f32xbf16xf32(
+//  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 8, 1] subgroup_size = 32
+//       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config<{{[{]}}reduction = [0, 0, 32]
+//  CHECK-SAME:     thread = [1, 16, 0]
+//  CHECK-SAME:     workgroup = [32, 128, 1]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -431,11 +431,12 @@ func.func @not_vmt() {
   return
 }
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [32, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
+// M=5 is just above the very skinny threshold, so avoid a unit M tile.
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [64, 16, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<no_reduce_shared_memory_bank_conflicts = true, use_igemm_convolution = false>}>
 //       CHECK: func.func @not_vmt()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 8], thread = [1, 128, 0], workgroup = [1, 128, 1]}>
+//  CHECK-SAME:       lowering_config = #iree_gpu.lowering_config<{reduction = [0, 0, 64], thread = [1, 8, 0], workgroup = [64, 128, 1]}>
 
 // -----
 


### PR DESCRIPTION
The motivation for this PR is to avoid poor SIMT tiling choices for large mixed-precision matmuls that appear in LLM workloads.  We skip exact-match SIMT matmul configs that tile a non-skinny parallel dimension by one element, so large mixed-precision matmuls do not end up with only one useful lane dimension per workgroup. We also add a regression test for the 36x151936x896 f32xbf16xf32 matmul shape that previously selected a [1, 128, 8] workgroup tile.