### PR TITLE
[LinalgExt] Scalarize rank-0 score payloads in online attention

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_configured.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_configured.mlir
@@ -202,3 +202,33 @@ func.func @vectorize_scan_masked_configured(
 // CHECK:         vector.scan <add>, {{.*}} {inclusive = true, reduction_dim = 1 : i64}
 // CHECK:         vector.transfer_write {{.*}} : vector<8x16xf32>, tensor<?x?xf32>
 // CHECK:         vector.transfer_write {{.*}} : vector<8xf32>, tensor<?xf32>
+
+// -----
+
+#flex_score_mod_config = #iree_cpu.lowering_config<vector_common_parallel = [1, 64, 1]>
+#flex_score_mod_map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+func.func @flex_attention_score_mod_post_qk_vectorizes(
+    %score: tensor<1x64x1xf32>,
+    %output: tensor<1x64x1xf32>) -> tensor<1x64x1xf32> {
+  %bias = arith.constant 1.000000e+00 : f32
+  %result = linalg.generic {
+      indexing_maps = [#flex_score_mod_map, #flex_score_mod_map],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      {lowering_config = #flex_score_mod_config}
+      ins(%score : tensor<1x64x1xf32>)
+      outs(%output : tensor<1x64x1xf32>) {
+  ^bb0(%score_element: f32, %out: f32):
+    %biased = arith.addf %score_element, %bias : f32
+    %modified = math.tanh %biased : f32
+    linalg.yield %modified : f32
+  } -> tensor<1x64x1xf32>
+  return %result : tensor<1x64x1xf32>
+}
+
+// CHECK-LABEL: func.func @flex_attention_score_mod_post_qk_vectorizes
+// CHECK-NOT:   linalg.generic
+// CHECK:       arith.addf {{.*}} : vector<1x64x1xf32>
+// CHECK:       math.tanh {{.*}} : vector<1x64x1xf32>
+// CHECK-NOT:   linalg.generic
+// CHECK:       return

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/CommandLine.h"
@@ -23,6 +24,7 @@
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
@@ -224,6 +226,163 @@ static Value computeMatmul(OpBuilder &builder, Location loc, AffineMap lhsMap,
   return genericOp.getResult(0);
 }
 
+static bool isRank0Tensor(Value value) {
+  auto type = dyn_cast<RankedTensorType>(value.getType());
+  return type && type.getRank() == 0;
+}
+
+static FailureOr<Value>
+getOrCreateScalarForRank0Tensor(Value value,
+                                llvm::DenseMap<Value, Value> &scalarValues,
+                                OpBuilder &builder, Location loc) {
+  if (!isRank0Tensor(value)) {
+    return failure();
+  }
+
+  auto it = scalarValues.find(value);
+  if (it != scalarValues.end()) {
+    return it->second;
+  }
+
+  auto fromElementsOp = value.getDefiningOp<tensor::FromElementsOp>();
+  if (fromElementsOp && fromElementsOp.getElements().size() == 1) {
+    Value scalar = fromElementsOp.getElements().front();
+    scalarValues[value] = scalar;
+    return scalar;
+  }
+
+  auto constantOp = value.getDefiningOp<arith::ConstantOp>();
+  if (constantOp) {
+    if (auto elementsAttr =
+            dyn_cast<DenseElementsAttr>(constantOp.getValue())) {
+      if (elementsAttr.getNumElements() == 1) {
+        auto elementType =
+            cast<RankedTensorType>(value.getType()).getElementType();
+        Attribute elementAttr =
+            elementsAttr.isSplat()
+                ? elementsAttr.getSplatValue<Attribute>()
+                : *elementsAttr.getValues<Attribute>().begin();
+        Value scalar = arith::ConstantOp::create(builder, loc, elementType,
+                                                 cast<TypedAttr>(elementAttr))
+                           .getResult();
+        scalarValues[value] = scalar;
+        return scalar;
+      }
+    }
+  }
+
+  return failure();
+}
+
+static LogicalResult
+scalarizeZeroLoopRank0Generic(OpBuilder &builder, linalg::GenericOp genericOp,
+                              llvm::DenseMap<Value, Value> &scalarValues) {
+  if (genericOp.getNumLoops() != 0 ||
+      !llvm::all_of(genericOp->getOperands(), isRank0Tensor)) {
+    return failure();
+  }
+
+  Block &body = genericOp.getRegion().front();
+  auto yieldOp = cast<linalg::YieldOp>(body.getTerminator());
+  for (Operation &op : body.without_terminator()) {
+    if (op.getNumRegions() != 0 || op.getNumSuccessors() != 0) {
+      return failure();
+    }
+  }
+
+  IRMapping mapper;
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPoint(genericOp);
+  for (auto [blockArg, operand] :
+       llvm::zip_equal(body.getArguments(), genericOp->getOperands())) {
+    FailureOr<Value> scalar = getOrCreateScalarForRank0Tensor(
+        operand, scalarValues, builder, genericOp.getLoc());
+    if (succeeded(scalar)) {
+      mapper.map(blockArg, *scalar);
+      continue;
+    }
+    if (!blockArg.use_empty()) {
+      return failure();
+    }
+  }
+
+  SmallVector<Operation *> clonedOps;
+  for (Operation &op : body.without_terminator()) {
+    clonedOps.push_back(builder.clone(op, mapper));
+  }
+
+  for (auto [result, yielded] :
+       llvm::zip_equal(genericOp.getResults(), yieldOp.getOperands())) {
+    Value scalar = mapper.lookupOrDefault(yielded);
+    if (scalar.getParentBlock() == &body) {
+      for (Operation *clonedOp : llvm::reverse(clonedOps)) {
+        clonedOp->erase();
+      }
+      return failure();
+    }
+    scalarValues[result] = scalar;
+  }
+  return success();
+}
+
+static void eraseUnusedRank0TensorPayloadOps(Block &block) {
+  SmallVector<Operation *> ops;
+  for (Operation &op : block.without_terminator()) {
+    ops.push_back(&op);
+  }
+
+  for (Operation *op : llvm::reverse(ops)) {
+    if (!op->use_empty()) {
+      continue;
+    }
+    if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
+      if (genericOp.getNumLoops() == 0 &&
+          llvm::all_of(genericOp->getOperands(), isRank0Tensor)) {
+        op->erase();
+      }
+      continue;
+    }
+    if (op->getNumResults() == 1 && isRank0Tensor(op->getResult(0)) &&
+        isa<arith::ConstantOp, tensor::EmptyOp, tensor::FromElementsOp>(op)) {
+      op->erase();
+    }
+  }
+}
+
+// Flex attention score_mod callbacks are authored as rank-0 Torch tensors.
+// After Torch-to-Linalg conversion, those callbacks can appear here as nested
+// rank-0 tensor.from_elements/linalg.generic/tensor.extract payloads. This is
+// intentionally a structural cleanup, not callback lowering: the generic body
+// is already lowered, and the tensor wrapper is what blocks vectorization.
+static void scalarizeRank0TensorPayloads(Block &block, OpBuilder &builder) {
+  llvm::DenseMap<Value, Value> scalarValues;
+
+  for (Operation &op : llvm::make_early_inc_range(block.without_terminator())) {
+    if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
+      (void)scalarizeZeroLoopRank0Generic(builder, genericOp, scalarValues);
+      continue;
+    }
+
+    auto extractOp = dyn_cast<tensor::ExtractOp>(op);
+    if (!extractOp || !extractOp.getIndices().empty() ||
+        !isRank0Tensor(extractOp.getTensor())) {
+      continue;
+    }
+
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPoint(extractOp);
+    FailureOr<Value> scalar = getOrCreateScalarForRank0Tensor(
+        extractOp.getTensor(), scalarValues, builder, op.getLoc());
+    if (failed(scalar)) {
+      continue;
+    }
+    extractOp.replaceAllUsesWith(*scalar);
+    extractOp.erase();
+  }
+
+  eraseUnusedRank0TensorPayloadOps(block);
+}
+
 static Value applyPostQKMatmulElementwise(OpBuilder &builder, Location loc,
                                           Region &region, Value value) {
   auto rank = cast<RankedTensorType>(value.getType()).getRank();
@@ -250,6 +409,7 @@ static Value applyPostQKMatmulElementwise(OpBuilder &builder, Location loc,
       op.erase();
     }
   }
+  scalarizeRank0TensorPayloads(block, builder);
 
   {
     OpBuilder::InsertionGuard withinRegion(builder);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_aggregated_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_aggregated_ops.mlir
@@ -89,3 +89,62 @@ func.func @online_attention_f8(%query: tensor<192x1024x64xf8E4M3FNUZ>,
 // CHECK:   arith.mulf
 // CHECK:   arith.addf
 // CHECK:   linalg.yield
+
+// -----
+
+#score_payload_mapQ = affine_map<(batch, m, k1, k2, n) -> (batch, m, k1)>
+#score_payload_mapK = affine_map<(batch, m, k1, k2, n) -> (batch, k2, k1)>
+#score_payload_mapV = affine_map<(batch, m, k1, k2, n) -> (batch, k2, n)>
+#score_payload_mapS = affine_map<(batch, m, k1, k2, n) -> ()>
+#score_payload_mapO = affine_map<(batch, m, k1, k2, n) -> (batch, m, n)>
+#score_payload_mapR = affine_map<(batch, m, k1, k2, n) -> (batch, m)>
+
+func.func @online_attention_rank0_score_payload(
+    %query: tensor<2x4x8xf32>,
+    %key: tensor<2x5x8xf32>,
+    %value: tensor<2x5x3xf32>,
+    %output: tensor<2x4x3xf32>,
+    %max: tensor<2x4xf32>,
+    %sum: tensor<2x4xf32>)
+    -> (tensor<2x4x3xf32>, tensor<2x4xf32>) {
+  %scale = arith.constant 1.0 : f32
+
+  %out:3 = iree_linalg_ext.online_attention
+        { indexing_maps = [#score_payload_mapQ, #score_payload_mapK,
+                           #score_payload_mapV, #score_payload_mapS,
+                           #score_payload_mapO, #score_payload_mapR,
+                           #score_payload_mapR] }
+        ins(%query, %key, %value, %scale
+            : tensor<2x4x8xf32>, tensor<2x5x8xf32>, tensor<2x5x3xf32>, f32)
+        outs(%output, %max, %sum
+            : tensor<2x4x3xf32>, tensor<2x4xf32>, tensor<2x4xf32>) {
+      ^bb0(%score: f32):
+        %score_tensor = tensor.from_elements %score : tensor<f32>
+        %one = arith.constant dense<1.000000e+00> : tensor<f32>
+        %empty = tensor.empty() : tensor<f32>
+        %modified = linalg.generic {
+            indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>,
+                             affine_map<() -> ()>],
+            iterator_types = []}
+            ins(%score_tensor, %one : tensor<f32>, tensor<f32>)
+            outs(%empty : tensor<f32>) {
+          ^bb0(%in: f32, %bias: f32, %out: f32):
+            %biased = arith.addf %in, %bias : f32
+            %tanh = math.tanh %biased : f32
+            linalg.yield %tanh : f32
+        } -> tensor<f32>
+        %extracted = tensor.extract %modified[] : tensor<f32>
+        iree_linalg_ext.yield %extracted : f32
+     }
+        -> tensor<2x4x3xf32>, tensor<2x4xf32>, tensor<2x4xf32>
+
+  return %out#0, %out#2 : tensor<2x4x3xf32>, tensor<2x4xf32>
+}
+
+// CHECK-LABEL: @online_attention_rank0_score_payload
+// CHECK-NOT: tensor.from_elements
+// CHECK-NOT: tensor.extract {{.*}}tensor<f32>
+// CHECK: arith.addf
+// CHECK: math.tanh
+// CHECK-NOT: iterator_types = []
+// CHECK: return


### PR DESCRIPTION
Flex attention score_mod lowering can leave rank-0 tensor payloads in the online_attention score region: tensor.from_elements(score), a zero-loop linalg.generic callback body, and tensor.extract. After online_attention decomposition those payloads end up inside the post-QK elementwise generic and can block generic vectorization.

This scalarizes those rank-0 payloads while cloning the score region during online_attention decomposition, so score_mod stays in the online score path without materializing the full QK score tensor.

