### PR TITLE
[VectorDistribute] Support swizzling in `async_dma` lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
@@ -21,6 +22,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/AffineMap.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-amdgpu-lower-async-dma"
@@ -162,6 +164,17 @@ getGlobalLoadDMALayout(MLIRContext *context, ArrayRef<int64_t> shape,
   return failure();
 }
 
+static std::optional<IREE::Codegen::XORShuffleAttr>
+getDestXorSwizzleAttr(Value dest) {
+  while (auto viewOp = dest.getDefiningOp<ViewLikeOpInterface>()) {
+    dest = viewOp.getViewSource();
+  }
+  if (auto hintOp = dest.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
+    return dyn_cast<IREE::Codegen::XORShuffleAttr>(hintOp.getSwizzle());
+  }
+  return std::nullopt;
+}
+
 struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
   LowerAsyncDMA(MLIRContext *context, Value threadId, int64_t subgroupSize,
                 int64_t numThreads)
@@ -211,6 +224,8 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
       return rewriter.notifyMatchFailure(
           op, "dest does not have workgroup address space");
     }
+    std::optional<IREE::Codegen::XORShuffleAttr> destSwizzle =
+        getDestXorSwizzleAttr(op.getDest());
     // For now, only support contiguous memrefs.
     // TODO(#23782): Relax this constraint.
     if (!destType.areTrailingDimsContiguous(destType.getRank())) {
@@ -240,11 +255,25 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
     SmallVector<int64_t> transferShape(transferVectorType.getShape());
 
     int64_t elementBitWidth = destType.getElementTypeBitWidth();
+    int64_t destRank = destType.getRank();
     MLIRContext *context = op.getContext();
+
+    // When dest has a swizzle_hint, filter DMA sizes to those where
+    // elementsPerDMA fits within one swizzle access block. This ensures
+    // gather_to_lds writes contiguous dest elements that all map to contiguous
+    // source elements under the XOR permutation.
+    SmallVector<int64_t> filteredDmaSizes(dmaSizes);
+    if (destSwizzle) {
+      int64_t accessElems = destSwizzle->getAccessElementCount();
+      llvm::erase_if(filteredDmaSizes, [&](int64_t dmaSize) {
+        int64_t elemsPerDMA = dmaSize / elementBitWidth;
+        return accessElems % elemsPerDMA != 0;
+      });
+    }
 
     FailureOr<NestedLayoutAttr> dmaLayoutOrFailure =
         getGlobalLoadDMALayout(context, transferShape, numThreads, subgroupSize,
-                               elementBitWidth, dmaSizes);
+                               elementBitWidth, filteredDmaSizes);
     if (failed(dmaLayoutOrFailure)) {
       return rewriter.notifyMatchFailure(op, "failed to compute DMA layout");
     }
@@ -268,7 +297,6 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
     SmallVector<int64_t> tileShape = getElementVectorTileShape(dmaLayout);
 
     // Get permutation map (or identity).
-    int64_t destRank = destType.getRank();
     AffineMap permutationMap =
         AffineMap::getMultiDimIdentityMap(destRank, context);
     if (auto mapAttr = op.getPermutationMapAttr()) {
@@ -286,11 +314,37 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
     for (SmallVector<int64_t> offsets :
          StaticTileOffsetRange(distributedShape, tileShape)) {
 
-      // Source indices: divergent (include thread contribution).
-      SmallVector<Value> srcBaseIndices(op.getSourceIndices());
-      SmallVector<Value> srcIndices = getTransferIndicesFromNestedLayout(
-          rewriter, srcBaseIndices, offsets, dmaLayout, permutationMap,
-          warpIndices, threadIndices);
+      SmallVector<Value> srcIndices;
+      if (destSwizzle) {
+        // Swizzled source indices: compute per-lane tile-relative offset,
+        // apply swizzle (self-inverse), delinearize, map to source coords.
+        // Zero base because the swizzle operates on tile-relative positions;
+        // source base indices are added via the permutation map loop below.
+        SmallVector<Value> zeroBase(destRank, c0);
+        SmallVector<Value> multiDimLane = getTransferIndicesFromNestedLayout(
+            rewriter, zeroBase, offsets, dmaLayout, destIdentityMap,
+            warpIndices, threadIndices);
+        Value flatLane = affine::AffineLinearizeIndexOp::create(
+            rewriter, loc, multiDimLane, transferShape, /*disjoint=*/true);
+        Value swizzledFlat = applyInverseXorSwizzleToDMASourceOffset(
+            rewriter, loc, flatLane, *destSwizzle, op.getDest());
+
+        auto coords = affine::AffineDelinearizeIndexOp::create(
+            rewriter, loc, swizzledFlat, transferShape);
+
+        srcIndices = SmallVector<Value>(op.getSourceIndices());
+        for (auto [i, dim] : llvm::enumerate(permutationMap.getResults())) {
+          unsigned pos = cast<AffineDimExpr>(dim).getPosition();
+          srcIndices[pos] = arith::AddIOp::create(
+              rewriter, loc, srcIndices[pos], coords.getResult(i));
+        }
+      } else {
+        // Source indices: divergent (include thread contribution).
+        SmallVector<Value> srcBaseIndices(op.getSourceIndices());
+        srcIndices = getTransferIndicesFromNestedLayout(
+            rewriter, srcBaseIndices, offsets, dmaLayout, permutationMap,
+            warpIndices, threadIndices);
+      }
 
       // Dest indices: uniform (zero thread contribution).
       SmallVector<Value> destBaseIndices(op.getDestIndices());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
@@ -164,18 +164,14 @@ getGlobalLoadDMALayout(MLIRContext *context, ArrayRef<int64_t> shape,
   return failure();
 }
 
-static std::optional<IREE::Codegen::XORShuffleAttr>
-getDestXorSwizzleAttr(Value dest) {
+static IREE::Codegen::XORShuffleAttr getDestXorSwizzleAttr(Value dest) {
   while (auto viewOp = dest.getDefiningOp<ViewLikeOpInterface>()) {
     dest = viewOp.getViewSource();
   }
   if (auto hintOp = dest.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
-    if (auto xorSwizzle =
-            dyn_cast<IREE::Codegen::XORShuffleAttr>(hintOp.getSwizzle())) {
-      return xorSwizzle;
-    }
+    return dyn_cast<IREE::Codegen::XORShuffleAttr>(hintOp.getSwizzle());
   }
-  return std::nullopt;
+  return {};
 }
 
 struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
@@ -227,8 +223,7 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
       return rewriter.notifyMatchFailure(
           op, "dest does not have workgroup address space");
     }
-    std::optional<IREE::Codegen::XORShuffleAttr> destSwizzle =
-        getDestXorSwizzleAttr(op.getDest());
+
     // For now, only support contiguous memrefs.
     // TODO(#23782): Relax this constraint.
     if (!destType.areTrailingDimsContiguous(destType.getRank())) {
@@ -261,15 +256,23 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
     int64_t destRank = destType.getRank();
     MLIRContext *context = op.getContext();
 
+    IREE::Codegen::XORShuffleAttr destSwizzle =
+        getDestXorSwizzleAttr(op.getDest());
     // When dest has a swizzle_hint, filter DMA sizes to those where
     // elementsPerDMA fits within one swizzle access block. This ensures
     // gather_to_lds writes contiguous dest elements that all map to contiguous
     // source elements under the XOR permutation.
     SmallVector<int64_t> filteredDmaSizes(dmaSizes);
     if (destSwizzle) {
-      int64_t accessElems = destSwizzle->getAccessElementCount();
+      int64_t accessElems = destSwizzle.getAccessElementCount();
       llvm::erase_if(filteredDmaSizes, [&](int64_t dmaSize) {
+        if (dmaSize % elementBitWidth != 0) {
+          return true;
+        }
         int64_t elemsPerDMA = dmaSize / elementBitWidth;
+        if (elemsPerDMA == 0) {
+          return true;
+        }
         return accessElems % elemsPerDMA != 0;
       });
     }
@@ -346,7 +349,7 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
       Value flatLane = affine::AffineLinearizeIndexOp::create(
           rewriter, loc, multiDimLane, transferShape, /*disjoint=*/true);
       Value swizzledFlat = applyInverseXorSwizzleToDMASourceOffset(
-          rewriter, loc, flatLane, *destSwizzle, op.getDest());
+          rewriter, loc, flatLane, destSwizzle, op.getDest());
 
       auto coords = affine::AffineDelinearizeIndexOp::create(
           rewriter, loc, swizzledFlat, transferShape);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
@@ -170,7 +170,10 @@ getDestXorSwizzleAttr(Value dest) {
     dest = viewOp.getViewSource();
   }
   if (auto hintOp = dest.getDefiningOp<IREE::Codegen::SwizzleHintOp>()) {
-    return dyn_cast<IREE::Codegen::XORShuffleAttr>(hintOp.getSwizzle());
+    if (auto xorSwizzle =
+            dyn_cast<IREE::Codegen::XORShuffleAttr>(hintOp.getSwizzle())) {
+      return xorSwizzle;
+    }
   }
   return std::nullopt;
 }
@@ -314,44 +317,46 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
     for (SmallVector<int64_t> offsets :
          StaticTileOffsetRange(distributedShape, tileShape)) {
 
-      SmallVector<Value> srcIndices;
-      if (destSwizzle) {
-        // Swizzled source indices: compute per-lane tile-relative offset,
-        // apply swizzle (self-inverse), delinearize, map to source coords.
-        // Zero base because the swizzle operates on tile-relative positions;
-        // source base indices are added via the permutation map loop below.
-        SmallVector<Value> zeroBase(destRank, c0);
-        SmallVector<Value> multiDimLane = getTransferIndicesFromNestedLayout(
-            rewriter, zeroBase, offsets, dmaLayout, destIdentityMap,
-            warpIndices, threadIndices);
-        Value flatLane = affine::AffineLinearizeIndexOp::create(
-            rewriter, loc, multiDimLane, transferShape, /*disjoint=*/true);
-        Value swizzledFlat = applyInverseXorSwizzleToDMASourceOffset(
-            rewriter, loc, flatLane, *destSwizzle, op.getDest());
-
-        auto coords = affine::AffineDelinearizeIndexOp::create(
-            rewriter, loc, swizzledFlat, transferShape);
-
-        srcIndices = SmallVector<Value>(op.getSourceIndices());
-        for (auto [i, dim] : llvm::enumerate(permutationMap.getResults())) {
-          unsigned pos = cast<AffineDimExpr>(dim).getPosition();
-          srcIndices[pos] = arith::AddIOp::create(
-              rewriter, loc, srcIndices[pos], coords.getResult(i));
-        }
-      } else {
-        // Source indices: divergent (include thread contribution).
-        SmallVector<Value> srcBaseIndices(op.getSourceIndices());
-        srcIndices = getTransferIndicesFromNestedLayout(
-            rewriter, srcBaseIndices, offsets, dmaLayout, permutationMap,
-            warpIndices, threadIndices);
-      }
-
       // Dest indices: uniform (zero thread contribution).
       SmallVector<Value> destBaseIndices(op.getDestIndices());
       SmallVector<Value> dstIndices = getTransferIndicesFromNestedLayout(
           rewriter, destBaseIndices, offsets, dmaLayout, destIdentityMap,
           warpIndices, zeroThreadIndices);
 
+      if (!destSwizzle) {
+        // Source indices: divergent (include thread contribution).
+        SmallVector<Value> srcBaseIndices(op.getSourceIndices());
+        SmallVector<Value> srcIndices = getTransferIndicesFromNestedLayout(
+            rewriter, srcBaseIndices, offsets, dmaLayout, permutationMap,
+            warpIndices, threadIndices);
+
+        amdgpu::GatherToLDSOp::create(rewriter, loc, op.getSource(), srcIndices,
+                                      op.getDest(), dstIndices,
+                                      TypeAttr::get(transferType));
+        continue;
+      }
+      // Swizzled source indices: compute per-lane tile-relative offset,
+      // apply swizzle (self-inverse), delinearize, map to source coords.
+      // Zero base because the swizzle operates on tile-relative positions;
+      // source base indices are added via the permutation map loop below.
+      llvm::Repeated<Value> zeroBase(destRank, c0);
+      SmallVector<Value> multiDimLane = getTransferIndicesFromNestedLayout(
+          rewriter, zeroBase, offsets, dmaLayout, destIdentityMap, warpIndices,
+          threadIndices);
+      Value flatLane = affine::AffineLinearizeIndexOp::create(
+          rewriter, loc, multiDimLane, transferShape, /*disjoint=*/true);
+      Value swizzledFlat = applyInverseXorSwizzleToDMASourceOffset(
+          rewriter, loc, flatLane, *destSwizzle, op.getDest());
+
+      auto coords = affine::AffineDelinearizeIndexOp::create(
+          rewriter, loc, swizzledFlat, transferShape);
+
+      SmallVector<Value> srcIndices(op.getSourceIndices());
+      for (auto [i, dim] : llvm::enumerate(permutationMap.getResults())) {
+        unsigned pos = cast<AffineDimExpr>(dim).getPosition();
+        srcIndices[pos] = arith::AddIOp::create(rewriter, loc, srcIndices[pos],
+                                                coords.getResult(i));
+      }
       amdgpu::GatherToLDSOp::create(rewriter, loc, op.getSource(), srcIndices,
                                     op.getDest(), dstIndices,
                                     TypeAttr::get(transferType));

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_async_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_async_dma.mlir
@@ -32,8 +32,8 @@
 // CHECK:         %[[SRC_D1:.+]] = affine.linearize_index [%[[DELIN]]#2, %[[J]]] by (8, 8)
 // CHECK:         amdgpu.gather_to_lds %[[SRC]][%[[SRC_D0_B0]], %[[SRC_D1]]], %[[DST]][%[[I]], %[[J]]] : vector<8xf16>
 //   Batch 1: source dim0 includes batch offset + thread, dest dim0 includes batch offset only.
-// CHECK:         %[[SRC_D0_B1:.+]] = affine.linearize_index [%[[C1]], %[[DELIN]]#1, %[[I]]] by (2, 8, 1)
 // CHECK:         %[[DST_D0_B1:.+]] = affine.linearize_index [%[[C1]], %[[C0]], %[[I]]] by (2, 8, 1)
+// CHECK:         %[[SRC_D0_B1:.+]] = affine.linearize_index [%[[C1]], %[[DELIN]]#1, %[[I]]] by (2, 8, 1)
 // CHECK:         amdgpu.gather_to_lds %[[SRC]][%[[SRC_D0_B1]], %[[SRC_D1]]], %[[DST]][%[[DST_D0_B1]], %[[J]]] : vector<8xf16>
 // CHECK-NOT:     amdgpu.gather_to_lds
 // CHECK-NOT:     iree_gpu.async_dma
@@ -81,15 +81,15 @@ func.func @lower_async_dma_basic(
 // CHECK:         %[[SG_DELIN:.+]]:3 = affine.delinearize_index %[[TID]] into (4, 64)
 //   Thread delinearization: tid -> (_, thread_d0, thread_d1).
 // CHECK:         %[[TH_DELIN:.+]]:3 = affine.delinearize_index %[[TID]] into (8, 8)
+//   Batch 0: dst dim0 = subgroup*batch*thread + i (uniform, no thread offset).
+// CHECK:         %[[DST_D0_B0:.+]] = affine.linearize_index [%[[SG_DELIN]]#1, %[[C0]], %[[C0]], %[[I]]] by (4, 2, 8, 1)
 //   Batch 0: src dim0 = subgroup*batch*thread + thread_d0 + i (divergent).
 // CHECK:         %[[SRC_D0_B0:.+]] = affine.linearize_index [%[[SG_DELIN]]#1, %[[C0]], %[[TH_DELIN]]#1, %[[I]]] by (4, 2, 8, 1)
 // CHECK:         %[[SRC_D1:.+]] = affine.linearize_index [%[[TH_DELIN]]#2, %[[J]]] by (8, 8)
-//   Batch 0: dst dim0 = subgroup*batch*thread + i (uniform, no thread offset).
-// CHECK:         %[[DST_D0_B0:.+]] = affine.linearize_index [%[[SG_DELIN]]#1, %[[C0]], %[[C0]], %[[I]]] by (4, 2, 8, 1)
 // CHECK:         amdgpu.gather_to_lds %[[SRC]][%[[SRC_D0_B0]], %[[SRC_D1]]], %[[DST]][%[[DST_D0_B0]], %[[J]]] : vector<8xf16>
 //   Batch 1: batch index advances by 1 in the batch dimension.
-// CHECK:         %[[SRC_D0_B1:.+]] = affine.linearize_index [%[[SG_DELIN]]#1, %[[C1]], %[[TH_DELIN]]#1, %[[I]]] by (4, 2, 8, 1)
 // CHECK:         %[[DST_D0_B1:.+]] = affine.linearize_index [%[[SG_DELIN]]#1, %[[C1]], %[[C0]], %[[I]]] by (4, 2, 8, 1)
+// CHECK:         %[[SRC_D0_B1:.+]] = affine.linearize_index [%[[SG_DELIN]]#1, %[[C1]], %[[TH_DELIN]]#1, %[[I]]] by (4, 2, 8, 1)
 // CHECK:         amdgpu.gather_to_lds %[[SRC]][%[[SRC_D0_B1]], %[[SRC_D1]]], %[[DST]][%[[DST_D0_B1]], %[[J]]] : vector<8xf16>
 // CHECK-NOT:     amdgpu.gather_to_lds
 // CHECK-NOT:     iree_gpu.async_dma

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_async_dma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/amdgpu_lower_async_dma.mlir
@@ -214,3 +214,70 @@ func.func @lower_async_dma_rejects_noncontiguous_source(
   gpu.barrier {addr_space = #gpu.address_space<workgroup>}
   return
 }
+
+// -----
+
+// Test: Swizzle-aware lowering. Dest traces through expand_shape to a
+// swizzle_hint on a flat LDS memref.
+// DMA layout computation for transferShape=[4,64], 64 threads, f16:
+//   128-bit DMA: elementsPerDMA=8, fails (can't distribute 64 threads over [4,8])
+//   32-bit DMA: elementsPerDMA=2, element=[1,2], thread=[2,32], batch=[2,1]
+// Dest indices use normal uniform path (2D). Source indices include xori from
+// the swizzle (self-inverse XOR applied to flat offset).
+
+#executable_target_swizzle = #hal.executable.target<"rocm",
+  "rocm-hsaco-fb", {iree_codegen.target_info = #iree_gpu.target<
+  arch = "gfx950", features = "", wgp = <
+    compute = fp32, storage = b32, subgroup = none,
+    subgroup_size_choices = [64, 64],
+    max_workgroup_sizes = [1024, 1024, 1024],
+    max_thread_count_per_workgroup = 1024,
+    max_workgroup_memory_bytes = 65536,
+    max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+    dma_sizes = [32, 128]>>}>
+
+#translation_swizzle = #iree_codegen.translation_info<
+  pipeline = #iree_gpu.pipeline<VectorDistribute>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64>
+
+// CHECK-LABEL: func.func @lower_async_dma_swizzled
+// CHECK-SAME:    %[[SRC:.+]]: memref<4x64xf16, #amdgpu.address_space<fat_raw_buffer>>
+// CHECK-SAME:    %[[I:.+]]: index, %[[J:.+]]: index
+// CHECK:         %[[HINT:.+]] = iree_codegen.swizzle_hint %{{.+}}[#iree_codegen.xor_shuffle<64, 8>]
+// CHECK:         %[[EXPANDED:.+]] = memref.expand_shape %[[HINT]]
+//   Batch 0: linearize tile offset -> xori (swizzle) -> delinearize -> add to source base.
+// CHECK:         %[[FLAT0:.+]] = affine.linearize_index disjoint {{.*}} by (4, 64)
+// CHECK:         %[[XORI0:.+]] = arith.xori
+// CHECK:         %[[DELIN0:.+]]:2 = affine.delinearize_index {{.*}} into (4, 64)
+// CHECK:         %[[SRC_D0_B0:.+]] = arith.addi %[[I]], %[[DELIN0]]#0
+// CHECK:         %[[SRC_D1_B0:.+]] = arith.addi %[[J]], %[[DELIN0]]#1
+//   Dest is uniform (no thread contribution, writes to expanded memref).
+// CHECK:         amdgpu.gather_to_lds %[[SRC]][%[[SRC_D0_B0]], %[[SRC_D1_B0]]], %[[EXPANDED]][{{.+}}] : vector<2xf16>
+//   Batch 1: same swizzle pattern, dest includes batch offset.
+// CHECK:         %[[FLAT1:.+]] = affine.linearize_index disjoint {{.*}} by (4, 64)
+// CHECK:         %[[XORI1:.+]] = arith.xori
+// CHECK:         %[[DELIN1:.+]]:2 = affine.delinearize_index {{.*}} into (4, 64)
+// CHECK:         %[[SRC_D0_B1:.+]] = arith.addi %[[I]], %[[DELIN1]]#0
+// CHECK:         %[[SRC_D1_B1:.+]] = arith.addi %[[J]], %[[DELIN1]]#1
+// CHECK:         amdgpu.gather_to_lds %[[SRC]][%[[SRC_D0_B1]], %[[SRC_D1_B1]]], %[[EXPANDED]][{{.+}}] : vector<2xf16>
+// CHECK-NOT:     iree_gpu.async_dma
+func.func @lower_async_dma_swizzled(
+    %source: memref<4x64xf16, #amdgpu.address_space<fat_raw_buffer>>,
+    %i: index, %j: index)
+  attributes {
+    hal.executable.target = #executable_target_swizzle,
+    translation_info = #translation_swizzle} {
+  %alloc = memref.alloc() : memref<256xf16, #gpu.address_space<workgroup>>
+  %hint = iree_codegen.swizzle_hint %alloc[#iree_codegen.xor_shuffle<64, 8>]
+      : memref<256xf16, #gpu.address_space<workgroup>>
+  %expanded = memref.expand_shape %hint [[0, 1]] output_shape [4, 64]
+      : memref<256xf16, #gpu.address_space<workgroup>>
+      into memref<4x64xf16, #gpu.address_space<workgroup>>
+  gpu.barrier {addr_space = #gpu.address_space<workgroup>}
+  iree_gpu.async_dma %source[%i, %j] to %expanded[%i, %j], vector<4x64xf16>
+      : memref<4x64xf16, #amdgpu.address_space<fat_raw_buffer>>,
+        memref<4x64xf16, #gpu.address_space<workgroup>>
+  gpu.barrier {addr_space = #gpu.address_space<workgroup>}
+  return
+}


### PR DESCRIPTION
Extend the pass that lowers and distributes `async_dma` operations to support self-inverse XOR swizzling.

This is part of https://github.com/iree-org/iree/issues/23782.

Assisted-by: Claude Code and Codex