### PR TITLE
[Codegen] Preemptively duplicate operations before tile-size analysis

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
@@ -721,10 +721,10 @@ static void setSplitGroup(Operation *op, int64_t groupId) {
 }
 
 // Duplicate all duplicatable operations. If a duplicatable operation has more
-// than one user, it will be duplicated (via clone) and each user will receiver
+// than one user, it will be duplicated (via clone) and each user will receive
 // their own copy of the duplicatable operation. By attaching a split-group to
-// the clones of the same operation as (discardable) attribute, we can later on
-// deduplicated clones of the same operation that received the same tile size
+// the clones of the same operation as (discardable) attribute, we can later
+// deduplicate clones of the same operation that received the same tile size
 // from the analysis.
 static void splitDuplicatableTensorProducers(FunctionOpInterface funcOp) {
   int64_t nextGroupId = 0;
@@ -773,7 +773,13 @@ static void dedupSplitGroup(ArrayRef<Operation *> group) {
     auto tileSizesAttr = dyn_cast_or_null<DenseI64ArrayAttr>(
         op->getAttr(kVectorTileSizesAttrName));
     if (!tileSizesAttr) {
-      continue;
+      // Deduplicate operations that were not assigned a tile size during
+      // analysis. It is safe to assume a single result with tensor type here,
+      // as all operations that end up here must match
+      // `isDuplicatableTensorProducer` earlier.
+      TensorType resTy = cast<TensorType>(op->getResult(0).getType());
+      SmallVector<int64_t> minusOne(resTy.getRank(), -1);
+      tileSizesAttr = DenseI64ArrayAttr::get(op->getContext(), minusOne);
     }
     auto it = llvm::find_if(representatives, [&](auto &entry) {
       return entry.first == tileSizesAttr;
@@ -822,7 +828,7 @@ public:
     FunctionOpInterface funcOp = getOperation();
 
     // Duplicate all duplicatable operations before running the analysis. This
-    // avoid cross-polluting the result of unrelated operations via CSE'd edges
+    // avoids cross-polluting the result of unrelated operations via CSE'd edges
     // such as linalg.fill used as DPS init. Duplicating preemptively instead of
     // on-demand after the analysis has two advantages: It makes the analysis
     // code simpler, as we don't need special case handling for duplicatable

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeVectorTileSizes.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/Util/Analysis/IntegerDivisibilityAnalysis.h"
 
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/Analysis/DataFlow/Utils.h"
@@ -59,11 +60,11 @@ namespace mlir::iree_compiler {
 //   (backward) based on indexing maps and the mapped state is propagated.
 //
 // Duplicatable operations such as `tensor.empty`, constants, and generator
-// linalg ops (e.g. linalg.fill) are excluded from propagation entirely. CSE
-// connects otherwise unrelated compute ops by deduplicating their DPS init
-// operands to a single tensor.empty (or similar). To avoid cross-polluting the
-// vector tile size of unrelated operations, tile sizes from duplicatable
-// operations are never propagated.
+// linalg ops (e.g. linalg.fill) are split per use before analysis when they
+// feed multiple consumers. After splitting, the dataflow analysis can propagate
+// through them normally without cross-polluting unrelated uses. Equivalent
+// clones are deduplicated again after materialization if they ended up with the
+// same concrete vector tile sizes.
 //
 // For some other operations, no propagation rules are defined on purpose. For
 // example, `extract_slice` and `insert_slice` operations are natural boundaries
@@ -279,33 +280,6 @@ private:
   }
 };
 
-/// Returns true if the operation is trivially duplicatable and should not
-/// propagate tile sizes across independent consumers.
-static bool isDuplicatable(Value val) {
-  Operation *defOp = val.getDefiningOp();
-  if (!defOp) {
-    return false;
-  }
-  if (isa<tensor::EmptyOp>(defOp)) {
-    return true;
-  }
-  if (defOp->hasTrait<OpTrait::ConstantLike>()) {
-    return true;
-  }
-  // A linalg op that doesn't read any tensor data (e.g., linalg.fill or a
-  // fill-like linalg.generic broadcasting a scalar) is a generator and
-  // duplicatable.
-  if (auto linalgOp = dyn_cast<linalg::LinalgOp>(defOp)) {
-    if (llvm::none_of(linalgOp->getOpOperands(), [&](OpOperand &operand) {
-          return isa<ShapedType>(operand.get().getType()) &&
-                 linalgOp.payloadUsesValueFromOperand(&operand);
-        })) {
-      return true;
-    }
-  }
-  return false;
-}
-
 //===----------------------------------------------------------------------===//
 // Lattice and analysis definitions
 //===----------------------------------------------------------------------===//
@@ -316,16 +290,13 @@ public:
 };
 
 /// Read the TileSizes from a lattice, returning empty tile sizes if the lattice
-/// value is from a duplicatable operation.
+/// value is not available.
 static TileSizes getTileSizesFor(Value val, const TileSizeLattice *lattice) {
   if (!lattice) {
     return {};
   }
   const TileSizes &tileSizes = lattice->getValue();
   if (tileSizes.empty()) {
-    return {};
-  }
-  if (isDuplicatable(val)) {
     return {};
   }
   return tileSizes;
@@ -694,88 +665,147 @@ static TileSizes getIm2colTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
   return getTileSizesFor(result, lattice);
 }
 
-static std::optional<TileSizes>
-getUseOperandTileSizes(OpOperand &use, const DataFlowSolver &solver) {
-  Operation *user = use.getOwner();
+//===----------------------------------------------------------------------===//
+// Operand duplication and de-duplication.
+//===----------------------------------------------------------------------===//
 
-  if (auto linalgOp = dyn_cast<linalg::LinalgOp>(user)) {
-    TileSizes iterTileSizes =
-        getLinalgIterationSpaceTileSizes(linalgOp, solver);
-    AffineMap map = linalgOp.getMatchingIndexingMap(&use);
-    TileSizes operandTileSizes = iterTileSizes.mapFromIterationSpace(map);
-    if (!operandTileSizes.isDefined()) {
-      return std::nullopt;
-    }
-    return operandTileSizes;
+static constexpr StringLiteral kSplitGroupAttrName =
+    "__iree_vector_tile_size_split_group__";
+
+/// Returns true if the operation is trivially duplicatable and cheap enough to
+/// split per use before analysis.
+static bool isDuplicatable(Value val) {
+  Operation *defOp = val.getDefiningOp();
+  if (!defOp) {
+    return false;
   }
-
-  if (auto toLayoutOp = dyn_cast<ToLayoutOp>(user)) {
-    Value result = toLayoutOp.getResult();
-    const TileSizeLattice *lattice =
-        solver.lookupState<TileSizeLattice>(result);
-    TileSizes tileSizes = getTileSizesFor(result, lattice);
-    if (!tileSizes.isDefined()) {
-      return std::nullopt;
-    }
-    return tileSizes;
+  if (isa<tensor::EmptyOp>(defOp)) {
+    return true;
   }
-
-  return std::nullopt;
+  if (defOp->hasTrait<OpTrait::ConstantLike>()) {
+    return true;
+  }
+  // A linalg op that doesn't read any tensor data (e.g., linalg.fill or a
+  // fill-like linalg.generic broadcasting a scalar) is a generator and
+  // duplicatable.
+  if (auto linalgOp = dyn_cast<linalg::LinalgOp>(defOp)) {
+    if (llvm::none_of(linalgOp->getOpOperands(), [&](OpOperand &operand) {
+          return isa<ShapedType>(operand.get().getType()) &&
+                 linalgOp.payloadUsesValueFromOperand(&operand);
+        })) {
+      return true;
+    }
+  }
+  return false;
 }
 
-static LogicalResult
-materializeDuplicatableLinalgOp(linalg::LinalgOp linalgOp,
-                                const DataFlowSolver &solver) {
-  if (linalgOp->getNumResults() != 1) {
-    return failure();
+static bool isDuplicatableTensorProducer(Operation *op) {
+  if (!op || op->getNumResults() != 1) {
+    return false;
   }
-  if (linalgOp->hasAttr(kVectorTileSizesAttrName)) {
-    return success();
-  }
-  Value result = linalgOp->getResult(0);
-  if (!isDuplicatable(result)) {
-    return failure();
-  }
+  Value result = op->getResult(0);
+  return isa<TensorType>(result.getType()) && isDuplicatable(result);
+}
 
-  SmallVector<std::pair<TileSizes, SmallVector<OpOperand *>>> useGroups;
-  for (OpOperand &use : result.getUses()) {
-    std::optional<TileSizes> maybeTileSizes =
-        getUseOperandTileSizes(use, solver);
-    if (!maybeTileSizes || !maybeTileSizes->isDefined()) {
+static bool needsSplitting(Operation *op) {
+  if (!op->getBlock() || !isDuplicatableTensorProducer(op)) {
+    return false;
+  }
+  return op->getResult(0).getNumUses() > 1;
+}
+
+static void setSplitGroup(Operation *op, int64_t groupId) {
+  op->setAttr(
+      kSplitGroupAttrName,
+      IntegerAttr::get(IntegerType::get(op->getContext(), 64), groupId));
+}
+
+// Duplicate all duplicatable operations. If a duplicatable operation has more
+// than one user, it will be duplicated (via clone) and each user will receiver
+// their own copy of the duplicatable operation. By attaching a split-group to
+// the clones of the same operation as (discardable) attribute, we can later on
+// deduplicated clones of the same operation that received the same tile size
+// from the analysis.
+static void splitDuplicatableTensorProducers(FunctionOpInterface funcOp) {
+  int64_t nextGroupId = 0;
+  SmallVector<Operation *> worklist;
+
+  funcOp.walk([&](Operation *op) {
+    if (needsSplitting(op)) {
+      worklist.push_back(op);
+    }
+  });
+
+  llvm::SmallPtrSet<Operation *, 16> visited;
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    if (!visited.insert(op).second || !needsSplitting(op)) {
       continue;
     }
-    auto it = llvm::find_if(
-        useGroups, [&](auto &entry) { return entry.first == *maybeTileSizes; });
-    if (it == useGroups.end()) {
-      useGroups.emplace_back(*maybeTileSizes, SmallVector<OpOperand *>{&use});
-    } else {
-      it->second.push_back(&use);
+
+    for (OpOperand &operand : op->getOpOperands()) {
+      if (Operation *defOp = operand.get().getDefiningOp()) {
+        worklist.push_back(defOp);
+      }
     }
-  }
 
-  if (useGroups.empty()) {
-    return success();
-  }
+    Value result = op->getResult(0);
+    OpBuilder builder(op);
+    builder.setInsertionPointAfter(op);
+    int64_t groupId = nextGroupId++;
 
-  auto setTileSizeAttr = [](Operation *op, TileSizes tileSizes) {
-    op->setAttr(kVectorTileSizesAttrName,
-                DenseI64ArrayAttr::get(op->getContext(), tileSizes.getDims()));
-  };
-
-  OpBuilder builder(linalgOp);
-  builder.setInsertionPointAfter(linalgOp);
-  for (auto &useGroup : useGroups) {
-    Operation *cloned = builder.clone(*linalgOp.getOperation());
-    setTileSizeAttr(cloned, useGroup.first);
-    Value clonedResult = cloned->getResult(0);
-    for (OpOperand *use : useGroup.second) {
-      use->set(clonedResult);
+    while (!result.use_empty()) {
+      OpOperand &use = *result.use_begin();
+      Operation *clone = builder.clone(*op);
+      setSplitGroup(clone, groupId);
+      use.set(clone->getResult(0));
     }
+    op->erase();
   }
-  if (result.use_empty()) {
-    linalgOp->erase();
+}
+
+static void dedupSplitGroup(ArrayRef<Operation *> group) {
+  SmallVector<std::pair<DenseI64ArrayAttr, Operation *>> representatives;
+  for (Operation *op : group) {
+    if (!op || !op->getBlock()) {
+      continue;
+    }
+    auto tileSizesAttr = dyn_cast_or_null<DenseI64ArrayAttr>(
+        op->getAttr(kVectorTileSizesAttrName));
+    if (!tileSizesAttr) {
+      continue;
+    }
+    auto it = llvm::find_if(representatives, [&](auto &entry) {
+      return entry.first == tileSizesAttr;
+    });
+    if (it == representatives.end()) {
+      representatives.emplace_back(tileSizesAttr, op);
+      continue;
+    }
+    op->getResult(0).replaceAllUsesWith(it->second->getResult(0));
+    op->erase();
   }
-  return success();
+}
+
+// Deduplicate the duplicated operations as much as possible. From the split
+// group attribute attached to the operations, we can identify operations that
+// are clones of the same original operation. Clones of the same operation that
+// have the same tile size after analysis will be merged.
+static void dedupSplitGroups(FunctionOpInterface funcOp) {
+  DenseMap<int64_t, SmallVector<Operation *>> groups;
+  funcOp.walk([&](Operation *op) {
+    auto groupAttr =
+        dyn_cast_if_present<IntegerAttr>(op->getAttr(kSplitGroupAttrName));
+    if (!groupAttr) {
+      return;
+    }
+    groups[groupAttr.getInt()].push_back(op);
+    op->removeAttr(kSplitGroupAttrName);
+  });
+
+  for (auto &[_, group] : groups) {
+    dedupSplitGroup(group);
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -790,6 +820,16 @@ class MaterializeVectorTileSizesPass final
 public:
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
+
+    // Duplicate all duplicatable operations before running the analysis. This
+    // avoid cross-polluting the result of unrelated operations via CSE'd edges
+    // such as linalg.fill used as DPS init. Duplicating preemptively instead of
+    // on-demand after the analysis has two advantages: It makes the analysis
+    // code simpler, as we don't need special case handling for duplicatable
+    // operations. On-demand duplication is also difficult in the presence of
+    // conditional data-flow such as scf.if. After the analysis, we de-duplicate
+    // again based on the analysis result, to reduce IR size.
+    splitDuplicatableTensorProducers(funcOp);
 
     // Stage 1: run baseline analyses and IntegerDivisibilityAnalysis to
     // convergence. We need these results to be stable before the tile size
@@ -812,19 +852,6 @@ public:
             funcOp, llvm::IsaPred<TileSizeForwardAnalysis,
                                   TileSizeBackwardAnalysis>))) {
       return signalPassFailure();
-    }
-
-    SmallVector<linalg::LinalgOp> duplicatableLinalgOps;
-    funcOp.walk([&](linalg::LinalgOp linalgOp) {
-      if (linalgOp->getNumResults() == 1 &&
-          isDuplicatable(linalgOp->getResult(0))) {
-        duplicatableLinalgOps.push_back(linalgOp);
-      }
-    });
-    for (linalg::LinalgOp linalgOp : duplicatableLinalgOps) {
-      if (failed(materializeDuplicatableLinalgOp(linalgOp, solver))) {
-        return signalPassFailure();
-      }
     }
 
     auto materialize = [](Operation *op, TileSizes tileSizes) -> LogicalResult {
@@ -888,8 +915,11 @@ public:
       return WalkResult::advance();
     });
     if (result.wasInterrupted()) {
-      signalPassFailure();
+      return signalPassFailure();
     }
+
+    // Deduplicate based on the analysis result, to reduce IR size again.
+    dedupSplitGroups(funcOp);
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
@@ -129,8 +129,8 @@ func.func @chain_propagation_dynamic(
 // scf.for propagation through iter_args.
 // The to_layout inside the loop should propagate tile sizes to the
 // loop iter_args and through the scf.yield.
-// The fill-like %init generic is duplicatable, so it should NOT receive
-// tile sizes.
+// The fill-like %init generic is duplicatable, but it only has one semantic
+// use after pre-splitting, so it should receive tile sizes.
 
 #layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [8], batch_tile = [1], outer_tile = [1],
@@ -142,7 +142,7 @@ func.func @scf_for_propagation(%arg0: tensor<512xf32>, %lb: index, %ub: index, %
   %empty = tensor.empty() : tensor<512xf32>
   %cst = arith.constant 0.0 : f32
   // CHECK: linalg.generic
-  // CHECK-NOT: iree_codegen.vector_tile_sizes
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 512>
   %init = linalg.generic {
     indexing_maps = [affine_map<(d0) -> ()>, affine_map<(d0) -> (d0)>],
     iterator_types = ["parallel"]
@@ -165,6 +165,28 @@ func.func @scf_for_propagation(%arg0: tensor<512xf32>, %lb: index, %ub: index, %
     scf.yield %updated : tensor<512xf32>
   }
   return %result : tensor<512xf32>
+}
+
+// -----
+
+#layout_loop_init_4 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1, 1, 1], batch_tile = [1, 1, 1, 1], outer_tile = [1, 1, 1, 1],
+  thread_tile = [1, 1, 1, 1], element_tile = [1, 1, 1, 4],
+  subgroup_strides = [0, 0, 0, 0], thread_strides = [0, 0, 0, 0]>
+
+// CHECK-LABEL: @duplicatable_fill_specializes_scf_for_init
+func.func @duplicatable_fill_specializes_scf_for_init(
+    %lb: index, %ub: index, %step: index) -> tensor<1x1x1x1xf32> {
+  %empty = tensor.empty() : tensor<1x1x1x1xf32>
+  %zero = arith.constant 0.0 : f32
+  // CHECK: linalg.fill
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 1, 1, 1, 4>
+  %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%iter = %fill) -> tensor<1x1x1x1xf32> {
+    %laid_out = iree_vector_ext.to_layout %iter to layout(#layout_loop_init_4) : tensor<1x1x1x1xf32>
+    scf.yield %laid_out : tensor<1x1x1x1xf32>
+  }
+  return %loop : tensor<1x1x1x1xf32>
 }
 
 // -----
@@ -224,7 +246,8 @@ func.func @contraction_indexing_maps(
 func.func @scf_if_propagation(%arg0: tensor<512xf32>, %cond: i1) -> tensor<512xf32> {
   %empty = tensor.empty() : tensor<512xf32>
   %cst = arith.constant 0.0 : f32
-  // CHECK-NOT: iree_codegen.vector_tile_sizes
+  // CHECK: linalg.fill
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 512>
   %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<512xf32>) -> tensor<512xf32>
   %if_result = scf.if %cond -> tensor<512xf32> {
     %laid_out = iree_vector_ext.to_layout %arg0 to layout(#layout_if) : tensor<512xf32>
@@ -247,7 +270,7 @@ func.func @scf_if_propagation(%arg0: tensor<512xf32>, %cond: i1) -> tensor<512xf
 
 // -----
 
-// Duplicatable linalg ops are specialized per use at materialization time.
+// Duplicatable linalg ops are split before analysis.
 // One linalg.fill feeding two consumers with different logical vector tile
 // sizes should be duplicated and each clone should keep the tile size of its
 // corresponding use.
@@ -266,14 +289,13 @@ func.func @scf_if_propagation(%arg0: tensor<512xf32>, %cond: i1) -> tensor<512xf
 func.func @result_and_fill_specialization() -> (tensor<16x24xf32>, tensor<16x24xf32>) {
   %empty = tensor.empty() : tensor<16x24xf32>
   %zero = arith.constant 0.0 : f32
-  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<16x24xf32>
   // CHECK: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
   // CHECK-DAG: %[[FILL24:.+]] = linalg.fill
   // CHECK-DAG: iree_codegen.vector_tile_sizes = array<i64: 16, 24>
-  // CHECK-DAG: ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<16x24xf32>) -> tensor<16x24xf32>
+  // CHECK-DAG: ins(%[[ZERO]] : f32) outs(%{{.+}} : tensor<16x24xf32>) -> tensor<16x24xf32>
   // CHECK-DAG: %[[FILL32:.+]] = linalg.fill
   // CHECK-DAG: iree_codegen.vector_tile_sizes = array<i64: 16, 32>
-  // CHECK-DAG: ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<16x24xf32>) -> tensor<16x24xf32>
+  // CHECK-DAG: ins(%[[ZERO]] : f32) outs(%{{.+}} : tensor<16x24xf32>) -> tensor<16x24xf32>
   %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<16x24xf32>) -> tensor<16x24xf32>
   // CHECK-DAG: %[[LAYOUT32:.+]] = iree_vector_ext.to_layout %[[FILL32]] to layout(#{{.+}}) : tensor<16x24xf32>
   // CHECK-DAG: %[[LAYOUT24:.+]] = iree_vector_ext.to_layout %[[FILL24]] to layout(#{{.+}}) : tensor<16x24xf32>
@@ -299,28 +321,76 @@ func.func @result_and_fill_specialization() -> (tensor<16x24xf32>, tensor<16x24x
 func.func @result_and_fill_specialization_with_unclassified_scf_yield_uses(%cond: i1) -> (tensor<16x24xf32>, tensor<16x24xf32>) {
   %empty = tensor.empty() : tensor<16x24xf32>
   %zero = arith.constant 0.0 : f32
-  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<16x24xf32>
   // CHECK: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-  // CHECK: %[[FILL_ORIG:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<16x24xf32>) -> tensor<16x24xf32>
-  // CHECK: %[[FILL32:.+]] = linalg.fill
-  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 16, 32>
-  // CHECK-SAME: ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<16x24xf32>) -> tensor<16x24xf32>
+  // CHECK-DAG: %[[FILL24:.+]] = linalg.fill
+  // CHECK-DAG: iree_codegen.vector_tile_sizes = array<i64: 16, 24>
+  // CHECK-DAG: ins(%[[ZERO]] : f32) outs(%{{.+}} : tensor<16x24xf32>) -> tensor<16x24xf32>
+  // CHECK-DAG: %[[FILL32:.+]] = linalg.fill
+  // CHECK-DAG: iree_codegen.vector_tile_sizes = array<i64: 16, 32>
+  // CHECK-DAG: ins(%[[ZERO]] : f32) outs(%{{.+}} : tensor<16x24xf32>) -> tensor<16x24xf32>
   %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<16x24xf32>) -> tensor<16x24xf32>
   // CHECK: %[[LAYOUT32:.+]] = iree_vector_ext.to_layout %[[FILL32]] to layout(#{{.+}}) : tensor<16x24xf32>
   %laid_out_32 = iree_vector_ext.to_layout %fill to layout(#layout_fill_consumer_32) : tensor<16x24xf32>
   // CHECK: %[[IF:.+]] = scf.if
   %if = scf.if %cond -> tensor<16x24xf32> {
-    // CHECK: scf.yield %[[FILL_ORIG]]
+    // CHECK: scf.yield %[[FILL24]]
     scf.yield %fill : tensor<16x24xf32>
   } else {
-    // CHECK: scf.yield %[[FILL_ORIG]]
+    // CHECK: scf.yield %[[FILL24]]
     scf.yield %fill : tensor<16x24xf32>
   }
-  // CHECK-NOT: iree_codegen.vector_tile_sizes = array<i64: 16, 24>
   // CHECK: %[[LAYOUT24:.+]] = iree_vector_ext.to_layout %[[IF]] to layout(#{{.+}}) : tensor<16x24xf32>
   // CHECK: return %[[LAYOUT32]], %[[LAYOUT24]] : tensor<16x24xf32>, tensor<16x24xf32>
   %laid_out_24 = iree_vector_ext.to_layout %if to layout(#layout_fill_consumer_24) : tensor<16x24xf32>
   return %laid_out_32, %laid_out_24 : tensor<16x24xf32>, tensor<16x24xf32>
+}
+
+// -----
+
+#layout_fill_loop = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1, 1], batch_tile = [1, 1, 1], outer_tile = [1, 1, 1],
+  thread_tile = [1, 1, 1], element_tile = [1, 1, 1],
+  subgroup_strides = [0, 0, 0], thread_strides = [0, 0, 0]>
+
+#layout_reduce_source = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1, 1, 1], batch_tile = [1, 1, 1, 1], outer_tile = [1, 1, 1, 1],
+  thread_tile = [1, 1, 1, 1], element_tile = [1, 1, 1, 4],
+  subgroup_strides = [0, 0, 0, 0], thread_strides = [0, 0, 0, 0]>
+
+#layout_reduce_result = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1, 1], batch_tile = [1, 1, 1], outer_tile = [1, 1, 1],
+  thread_tile = [1, 1, 1], element_tile = [1, 1, 4],
+  subgroup_strides = [0, 0, 0], thread_strides = [0, 0, 0]>
+
+// CHECK-LABEL: @duplicatable_fill_dps_init_does_not_pollute_loop_init
+func.func @duplicatable_fill_dps_init_does_not_pollute_loop_init(
+    %arg0: tensor<1x1x1x1xf32>, %lb: index, %ub: index, %step: index) -> tensor<1x1x1xf32> {
+  %empty = tensor.empty() : tensor<1x1x1xf32>
+  %zero = arith.constant 0.0 : f32
+  // CHECK-DAG: linalg.fill
+  // CHECK-DAG: iree_codegen.vector_tile_sizes = array<i64: 1, 1, 1>
+  // CHECK-DAG: ins(%{{.+}} : f32) outs(%{{.+}} : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
+  // CHECK-DAG: %[[FILL_REDUCE:.+]] = linalg.fill
+  // CHECK-DAG: iree_codegen.vector_tile_sizes = array<i64: 1, 1, 4>
+  // CHECK-DAG: ins(%{{.+}} : f32) outs(%{{.+}} : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
+  %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
+  // CHECK: %[[LOOP:.+]] = scf.for {{.+}} iter_args(%{{.+}} = %{{.+}}) -> (tensor<1x1x1xf32>)
+  %loop = scf.for %iv = %lb to %ub step %step iter_args(%iter = %fill) -> tensor<1x1x1xf32> {
+    %laid_out = iree_vector_ext.to_layout %iter to layout(#layout_fill_loop) : tensor<1x1x1xf32>
+    scf.yield %laid_out : tensor<1x1x1xf32>
+  }
+  %src = iree_vector_ext.to_layout %arg0 to layout(#layout_reduce_source) : tensor<1x1x1x1xf32>
+  // CHECK: linalg.reduce
+  // CHECK-SAME: outs(%{{.+}} : tensor<1x1x1xf32>)
+  // CHECK-SAME: dimensions = [0]
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 1, 1, 1, 4>
+  %reduced = linalg.reduce ins(%src : tensor<1x1x1x1xf32>) outs(%fill : tensor<1x1x1xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %sum = arith.addf %in, %init : f32
+      linalg.yield %sum : f32
+    }
+  %result = iree_vector_ext.to_layout %reduced to layout(#layout_reduce_result) : tensor<1x1x1xf32>
+  return %result : tensor<1x1x1xf32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
@@ -307,6 +307,53 @@ func.func @result_and_fill_specialization() -> (tensor<16x24xf32>, tensor<16x24x
 
 // -----
 
+// Duplicatable linalg ops whose split clones do not get vector tile sizes
+// should still be deduplicated.
+
+// CHECK-LABEL: @dedup_unclassified_fill_clones
+func.func @dedup_unclassified_fill_clones(
+    %arg0: tensor<16x24xf32>, %arg1: tensor<16x24xf32>
+) -> (tensor<16x24xf32>, tensor<16x24xf32>) {
+  %empty = tensor.empty() : tensor<16x24xf32>
+  %zero = arith.constant 0.0 : f32
+  // CHECK: %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[FILL:.+]] = linalg.fill
+  // CHECK-NOT: linalg.fill
+  // CHECK-NOT: iree_codegen.vector_tile_sizes
+  %fill = linalg.fill ins(%zero : f32) outs(%empty : tensor<16x24xf32>) -> tensor<16x24xf32>
+  %empty0 = tensor.empty() : tensor<16x24xf32>
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%[[FILL]], %arg0 : tensor<16x24xf32>, tensor<16x24xf32>)
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%fill, %arg0 : tensor<16x24xf32>, tensor<16x24xf32>)
+    outs(%empty0 : tensor<16x24xf32>) {
+  ^bb0(%in0: f32, %in1: f32, %out: f32):
+    %add = arith.addf %in0, %in1 : f32
+    linalg.yield %add : f32
+  } -> tensor<16x24xf32>
+  %empty1 = tensor.empty() : tensor<16x24xf32>
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%[[FILL]], %arg1 : tensor<16x24xf32>, tensor<16x24xf32>)
+  %1 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%fill, %arg1 : tensor<16x24xf32>, tensor<16x24xf32>)
+    outs(%empty1 : tensor<16x24xf32>) {
+  ^bb0(%in0: f32, %in1: f32, %out: f32):
+    %mul = arith.mulf %in0, %in1 : f32
+    linalg.yield %mul : f32
+  } -> tensor<16x24xf32>
+  return %0, %1 : tensor<16x24xf32>, tensor<16x24xf32>
+}
+
+// -----
+
 #layout_fill_consumer_32 = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1], batch_tile = [1, 2], outer_tile = [1, 1],
   thread_tile = [16, 4], element_tile = [1, 4],


### PR DESCRIPTION
To avoid cross-pollution from easy-to-duplicate operations such as `linalg.fill` in tile size analysis, we treat them as duplicatable. So far, the materialization of the vector tile size analysis duplicated values on demand, based on the analysis result.

This approach has two main downsides: 
- The analysis code needs to account for duplicatable operations with special logic. This logic started to become more complicated when I tried to fix an issue with region control flow locally.
- It can be difficult to trace from the duplicatable operation to the operation that actually uses that value with a specific tile size in the presence of control-flow as pointed out [here](https://github.com/iree-org/iree/pull/24246#discussion_r3187746878). Locally handling `scf.for` introduced even more complexity. 

Therefore, I decided to change the duplication to eager duplication: Before the analysis, every duplicatable operation is duplicated for each of its uses. Analysis can then run without special logic for duplicatable values. Afterwards, operations are deduplicated as much as possible again. Operations that are duplicates of the same original value and have the same tile size will be deduplicated to a single operation. 

This approach avoids both downsides described above. The cost for the increased IR size is completely local to the pass itself. 

This contributes towards https://github.com/iree-org/iree/issues/24221.

Assisted-by: Codex