### PR TITLE
[Codegen][GPU] Relax 32-bit reduction/arg_compare ceiling for VectorDistribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -929,16 +929,17 @@ static VectorValue reshapeFlatToTarget(RewriterBase &rewriter, Location loc,
 }
 
 static LogicalResult checkBitwidthForShuffle(Operation *op, Type type,
-                                             int64_t maxBitsPerShuffle,
                                              StringRef typeName,
                                              PatternRewriter &rewriter) {
   unsigned bitwidth = type.getIntOrFloatBitWidth();
-  if (bitwidth > maxBitsPerShuffle) {
-    return rewriter.notifyMatchFailure(
-        op, llvm::formatv("{0} bitwidth {1} greater than maxBitsPerShuffle {2}",
-                          typeName, bitwidth, maxBitsPerShuffle));
+  if (targetSupportsShuffleBitwidth(getGPUTargetAttr(op), bitwidth)) {
+    return success();
   }
-  return success();
+  return rewriter.notifyMatchFailure(
+      op, llvm::formatv("{0} bitwidth {1} exceeds native shuffle width {2}; "
+                        "wider widths require a target with a decomposing "
+                        "gpu.shuffle lowering",
+                        typeName, bitwidth, kShuffleNativeBits));
 }
 
 /// Creates an equality comparison operation for the given values.
@@ -1194,9 +1195,9 @@ struct DistributeMultiReduction final
   using MaskedOpDistributionPattern::MaskedOpDistributionPattern;
 
   DistributeMultiReduction(MLIRContext *context, int64_t subgroupSize,
-                           int64_t maxBitsPerShuffle, int64_t benefit = 1)
+                           int64_t benefit = 1)
       : MaskedOpDistributionPattern(context, benefit),
-        subgroupSize(subgroupSize), maxBitsPerShuffle(maxBitsPerShuffle) {}
+        subgroupSize(subgroupSize) {}
 
   LogicalResult
   matchAndRewrite(vector::MultiDimReductionOp multiReduceOp,
@@ -1218,8 +1219,8 @@ struct DistributeMultiReduction final
     }
 
     Type elemTy = srcVector.getType().getElementType();
-    if (failed(checkBitwidthForShuffle(multiReduceOp, elemTy, maxBitsPerShuffle,
-                                       "element", rewriter))) {
+    if (failed(checkBitwidthForShuffle(multiReduceOp, elemTy, "element",
+                                       rewriter))) {
       return failure();
     }
 
@@ -1517,7 +1518,6 @@ struct DistributeMultiReduction final
   }
 
   int64_t subgroupSize;
-  int64_t maxBitsPerShuffle;
 };
 
 /// Distributes `iree_vector_ext.arg_compare` ops with nested layouts.
@@ -1527,9 +1527,9 @@ struct DistributeArgCompare final
     : MaskedOpDistributionPattern<IREE::VectorExt::ArgCompareOp> {
 
   DistributeArgCompare(MLIRContext *context, int64_t subgroupSize,
-                       int64_t maxBitsPerShuffle, int64_t benefit = 1)
+                       int64_t benefit = 1)
       : MaskedOpDistributionPattern(context, benefit),
-        subgroupSize(subgroupSize), maxBitsPerShuffle(maxBitsPerShuffle) {}
+        subgroupSize(subgroupSize) {}
 
   LogicalResult
   matchAndRewrite(IREE::VectorExt::ArgCompareOp argCompareOp,
@@ -1571,15 +1571,14 @@ struct DistributeArgCompare final
     }
 
     Type elemTy = inputValue.getType().getElementType();
-    if (failed(checkBitwidthForShuffle(argCompareOp, elemTy, maxBitsPerShuffle,
-                                       "element", rewriter))) {
+    if (failed(checkBitwidthForShuffle(argCompareOp, elemTy, "element",
+                                       rewriter))) {
       return failure();
     }
 
-    // No bitwidth check on the index type: the index is only forwarded from
-    // the winning lane via `gpu.shuffle idx`, which handles wider types (i64).
-    // TODO(Bangtian): On AMD, ROCDL decomposes 64-bit shuffles into 32-bit
-    // pairs. Consider dropping the value bitwidth check above too.
+    // No bitwidth check on the index type: `gpu.shuffle idx` forwards the
+    // winning lane's index and handles wider types (i64). The value-side
+    // check above already honors the AMDGPU shuffle whitelist.
 
     // Only explicit index mode; iota indices are materialized earlier.
     if (!inputIndex) {
@@ -2176,7 +2175,6 @@ private:
   }
 
   int64_t subgroupSize;
-  int64_t maxBitsPerShuffle;
 };
 
 /// Broadcast every element of |source| from the last lane in a scan cluster
@@ -2377,10 +2375,15 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
     bool needsCrossThread = srcLayout.getThreadTile()[scanDim] > 1;
     bool needsCrossSubgroup = srcLayout.getSubgroupTile()[scanDim] > 1;
     Type elemTy = source.getType().getElementType();
-    if ((needsCrossThread || needsCrossSubgroup) &&
-        failed(checkBitwidthForShuffle(scanOp, elemTy, maxBitsPerShuffle,
-                                       "element", rewriter))) {
-      return failure();
+    if (needsCrossThread || needsCrossSubgroup) {
+      unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
+      if (bitwidth > maxBitsPerShuffle) {
+        return rewriter.notifyMatchFailure(
+            scanOp,
+            llvm::formatv("element bitwidth {0} greater than maxBitsPerShuffle "
+                          "{1}",
+                          bitwidth, maxBitsPerShuffle));
+      }
     }
 
     // Reject multi-subgroup for now.
@@ -3426,10 +3429,8 @@ void IREE::VectorExt::populateNestedLayoutDistributionPatterns(
                                         subgroupSize, workgroupSize);
   patterns.add<DistributeBroadcast, DistributeTranspose, DistributeShapeCast>(
       patterns.getContext());
-  patterns.add<DistributeMultiReduction>(patterns.getContext(), subgroupSize,
-                                         maxBitsPerShuffle);
-  patterns.add<DistributeArgCompare>(patterns.getContext(), subgroupSize,
-                                     maxBitsPerShuffle);
+  patterns.add<DistributeMultiReduction>(patterns.getContext(), subgroupSize);
+  patterns.add<DistributeArgCompare>(patterns.getContext(), subgroupSize);
   patterns.add<DistributeScan>(patterns.getContext(), subgroupSize,
                                maxBitsPerShuffle);
   patterns.add<DistributeContract>(patterns.getContext());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -1576,9 +1576,10 @@ struct DistributeArgCompare final
       return failure();
     }
 
-    // No bitwidth check on the index type: `gpu.shuffle idx` forwards the
-    // winning lane's index and handles wider types (i64). The value-side
-    // check above already honors the AMDGPU shuffle whitelist.
+    // No bitwidth check on the index payload: it is broadcast from the
+    // winning lane via `gpu.shuffle idx`, and the AMDGPU lowering decomposes
+    // wide values (e.g. i64) into i32 chunks. The value-side check above
+    // already gates element types.
 
     // Only explicit index mode; iota indices are materialized earlier.
     if (!inputIndex) {
@@ -2375,6 +2376,11 @@ struct DistributeScan final : OpDistributionPattern<vector::ScanOp> {
     bool needsCrossThread = srcLayout.getThreadTile()[scanDim] > 1;
     bool needsCrossSubgroup = srcLayout.getSubgroupTile()[scanDim] > 1;
     Type elemTy = source.getType().getElementType();
+    // Intentional carve-out: unlike DistributeMultiReduction and
+    // DistributeArgCompare (which use targetSupportsShuffleBitwidth and accept
+    // wider widths on AMDGPU via a decomposing gpu.shuffle lowering), scan is
+    // kept on the 32-bit ceiling until the wider-width scan path has been
+    // separately validated.
     if (needsCrossThread || needsCrossSubgroup) {
       unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
       if (bitwidth > maxBitsPerShuffle) {
@@ -3429,8 +3435,8 @@ void IREE::VectorExt::populateNestedLayoutDistributionPatterns(
                                         subgroupSize, workgroupSize);
   patterns.add<DistributeBroadcast, DistributeTranspose, DistributeShapeCast>(
       patterns.getContext());
-  patterns.add<DistributeMultiReduction>(patterns.getContext(), subgroupSize);
-  patterns.add<DistributeArgCompare>(patterns.getContext(), subgroupSize);
+  patterns.add<DistributeMultiReduction, DistributeArgCompare>(
+      patterns.getContext(), subgroupSize);
   patterns.add<DistributeScan>(patterns.getContext(), subgroupSize,
                                maxBitsPerShuffle);
   patterns.add<DistributeContract>(patterns.getContext());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_argcompare.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_argcompare.mlir
@@ -1,6 +1,9 @@
-// RUN: iree-opt --iree-transform-dialect-interpreter --split-input-file --canonicalize --cse %s | FileCheck %s
+// RUN: iree-opt --iree-transform-dialect-interpreter --iree-gpu-test-target=gfx942 --split-input-file --canonicalize --cse %s | FileCheck %s
 
-// Tests for DistributeArgCompare pattern with explicit index mode.
+// Tests for DistributeArgCompare pattern with explicit index mode. Runs
+// under `--iree-gpu-test-target=gfx942` so 64-bit-element cases (which
+// rely on AMDGPU's decomposing `gpu.shuffle` lowering) reach the pattern.
+// All other test cases here use <=32-bit elements and are target-agnostic.
 
 #layout_2d_element_only = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
@@ -555,6 +558,121 @@ func.func @argmax_full_reduce_with_subgroup(
   %result_idx_layout = iree_vector_ext.to_layout %result#1 to layout(#layout_0d_subgroup) : vector<i32>
 
   func.return %result_val_layout, %result_idx_layout : vector<f16>, vector<i32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// i64 arg_compare on AMDGPU: passes the bitwidth gate. The commutative
+// comparator selects the ballot path: subgroup_reduce on i64 + a single
+// i32 shuffle for the winning lane index.
+
+#layout_1d_thread_only = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile = [1],
+  outer_tile = [1],
+  thread_tile = [64],
+  element_tile = [1],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+#layout_0d_thread_only = #iree_vector_ext.nested_layout<
+  subgroup_tile = [],
+  batch_tile = [],
+  outer_tile = [],
+  thread_tile = [],
+  element_tile = [],
+
+  subgroup_strides = [],
+  thread_strides   = []
+>
+
+// CHECK-LABEL: func @argcompare_i64
+// CHECK-NOT: iree_vector_ext.arg_compare
+// CHECK: gpu.subgroup_reduce maxsi {{.*}} : (i64) -> i64
+// CHECK: gpu.shuffle idx {{.*}} : i32
+func.func @argcompare_i64(
+    %input: vector<64xi64>,
+    %input_idx: vector<64xi32>,
+    %init_val: vector<i64>,
+    %init_idx: vector<i32>) -> (vector<i64>, vector<i32>) {
+  %v = iree_vector_ext.to_layout %input to layout(#layout_1d_thread_only) : vector<64xi64>
+  %i = iree_vector_ext.to_layout %input_idx to layout(#layout_1d_thread_only) : vector<64xi32>
+  %iv = iree_vector_ext.to_layout %init_val to layout(#layout_0d_thread_only) : vector<i64>
+  %ii = iree_vector_ext.to_layout %init_idx to layout(#layout_0d_thread_only) : vector<i32>
+  %res:2 = iree_vector_ext.arg_compare dimension(0)
+      ins(%v, %i : vector<64xi64>, vector<64xi32>)
+      inits(%iv, %ii : vector<i64>, vector<i32>) {
+    ^bb0(%a: i64, %b: i64):
+      %cmp = arith.cmpi sgt, %a, %b : i64
+      iree_vector_ext.yield %cmp : i1
+  } -> vector<i64>, vector<i32>
+  return %res#0, %res#1 : vector<i64>, vector<i32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// i64 *index* path: exempt from the bitwidth check (`gpu.shuffle idx`
+// handles wider types). Pins that behavior under the new plumbing.
+
+#layout_1d_thread_only = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile = [1],
+  outer_tile = [1],
+  thread_tile = [64],
+  element_tile = [1],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+#layout_0d_thread_only = #iree_vector_ext.nested_layout<
+  subgroup_tile = [],
+  batch_tile = [],
+  outer_tile = [],
+  thread_tile = [],
+  element_tile = [],
+
+  subgroup_strides = [],
+  thread_strides   = []
+>
+
+// CHECK-LABEL: func @argcompare_index_i64
+// CHECK: gpu.shuffle idx {{.*}} : i64
+func.func @argcompare_index_i64(
+    %input: vector<64xf32>,
+    %input_idx: vector<64xi64>,
+    %init_val: vector<f32>,
+    %init_idx: vector<i64>) -> (vector<f32>, vector<i64>) {
+  %v = iree_vector_ext.to_layout %input to layout(#layout_1d_thread_only) : vector<64xf32>
+  %i = iree_vector_ext.to_layout %input_idx to layout(#layout_1d_thread_only) : vector<64xi64>
+  %iv = iree_vector_ext.to_layout %init_val to layout(#layout_0d_thread_only) : vector<f32>
+  %ii = iree_vector_ext.to_layout %init_idx to layout(#layout_0d_thread_only) : vector<i64>
+  %res:2 = iree_vector_ext.arg_compare dimension(0)
+      ins(%v, %i : vector<64xf32>, vector<64xi64>)
+      inits(%iv, %ii : vector<f32>, vector<i64>) {
+    ^bb0(%a: f32, %b: f32):
+      %cmp = arith.cmpf ogt, %a, %b : f32
+      iree_vector_ext.yield %cmp : i1
+  } -> vector<f32>, vector<i64>
+  return %res#0, %res#1 : vector<f32>, vector<i64>
 }
 
 builtin.module attributes { transform.with_named_sequence } {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_argcompare.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_argcompare.mlir
@@ -1,9 +1,6 @@
-// RUN: iree-opt --iree-transform-dialect-interpreter --iree-gpu-test-target=gfx942 --split-input-file --canonicalize --cse %s | FileCheck %s
+// RUN: iree-opt --iree-transform-dialect-interpreter --split-input-file --canonicalize --cse %s | FileCheck %s
 
-// Tests for DistributeArgCompare pattern with explicit index mode. Runs
-// under `--iree-gpu-test-target=gfx942` so 64-bit-element cases (which
-// rely on AMDGPU's decomposing `gpu.shuffle` lowering) reach the pattern.
-// All other test cases here use <=32-bit elements and are target-agnostic.
+// Tests for DistributeArgCompare pattern with explicit index mode.
 
 #layout_2d_element_only = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
@@ -570,67 +567,9 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // -----
 
-// i64 arg_compare on AMDGPU: passes the bitwidth gate. The commutative
-// comparator selects the ballot path: subgroup_reduce on i64 + a single
-// i32 shuffle for the winning lane index.
-
-#layout_1d_thread_only = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1],
-  batch_tile = [1],
-  outer_tile = [1],
-  thread_tile = [64],
-  element_tile = [1],
-
-  subgroup_strides = [1],
-  thread_strides   = [1]
->
-
-#layout_0d_thread_only = #iree_vector_ext.nested_layout<
-  subgroup_tile = [],
-  batch_tile = [],
-  outer_tile = [],
-  thread_tile = [],
-  element_tile = [],
-
-  subgroup_strides = [],
-  thread_strides   = []
->
-
-// CHECK-LABEL: func @argcompare_i64
-// CHECK-NOT: iree_vector_ext.arg_compare
-// CHECK: gpu.subgroup_reduce maxsi {{.*}} : (i64) -> i64
-// CHECK: gpu.shuffle idx {{.*}} : i32
-func.func @argcompare_i64(
-    %input: vector<64xi64>,
-    %input_idx: vector<64xi32>,
-    %init_val: vector<i64>,
-    %init_idx: vector<i32>) -> (vector<i64>, vector<i32>) {
-  %v = iree_vector_ext.to_layout %input to layout(#layout_1d_thread_only) : vector<64xi64>
-  %i = iree_vector_ext.to_layout %input_idx to layout(#layout_1d_thread_only) : vector<64xi32>
-  %iv = iree_vector_ext.to_layout %init_val to layout(#layout_0d_thread_only) : vector<i64>
-  %ii = iree_vector_ext.to_layout %init_idx to layout(#layout_0d_thread_only) : vector<i32>
-  %res:2 = iree_vector_ext.arg_compare dimension(0)
-      ins(%v, %i : vector<64xi64>, vector<64xi32>)
-      inits(%iv, %ii : vector<i64>, vector<i32>) {
-    ^bb0(%a: i64, %b: i64):
-      %cmp = arith.cmpi sgt, %a, %b : i64
-      iree_vector_ext.yield %cmp : i1
-  } -> vector<i64>, vector<i32>
-  return %res#0, %res#1 : vector<i64>, vector<i32>
-}
-
-builtin.module attributes { transform.with_named_sequence } {
-  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
-    transform.yield
-  }
-}
-
-// -----
-
-// i64 *index* path: exempt from the bitwidth check (`gpu.shuffle idx`
-// handles wider types). Pins that behavior under the new plumbing.
+// i64 *index* path: the index payload is broadcast via `gpu.shuffle idx`,
+// whose AMDGPU lowering decomposes wide values into i32 chunks, so no
+// bitwidth check applies on the index side.
 
 #layout_1d_thread_only = #iree_vector_ext.nested_layout<
   subgroup_tile = [1],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -1,4 +1,8 @@
-// RUN: iree-opt --iree-transform-dialect-interpreter --split-input-file --canonicalize -mlir-print-local-scope --cse %s | FileCheck %s
+// RUN: iree-opt --iree-transform-dialect-interpreter --iree-gpu-test-target=gfx942 --split-input-file --canonicalize -mlir-print-local-scope --cse %s | FileCheck %s
+
+// Runs under `--iree-gpu-test-target=gfx942` so 64-bit-element cases (which
+// rely on AMDGPU's decomposing `gpu.shuffle` lowering) reach the pattern.
+// All other test cases here use <=32-bit elements and are target-agnostic.
 
 #nested = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
@@ -249,3 +253,75 @@ builtin.module attributes { transform.with_named_sequence } {
 // enough threads on the reduction dimension to do a subgroup reduce.
 // CHECK: vector.transfer_read %{{.*}}[%{{.*}}, %[[C0]]]
 // CHECK-NOT: gpu.subgroup_reduce
+
+// -----
+
+// f64 vector.multi_reduction on AMDGPU: passes the bitwidth gate, so the
+// pattern fires and emits `gpu.subgroup_reduce ... : (f64) -> f64`.
+
+#nested_f64 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 2],
+  outer_tile = [1, 1],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
+
+  subgroup_strides = [1, 1],
+  thread_strides = [1, 16]
+>
+
+func.func @reduce_f64_dim1(%arg0: vector<32x32xf64>, %arg1: vector<32xf64>) -> vector<32xf64> {
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested_f64) : vector<32x32xf64>
+  %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<32x32xf64> to vector<32xf64>
+  return %0 : vector<32xf64>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduce_f64_dim1
+// Local reduction on the distributed batch shape.
+// CHECK: vector.multi_reduction <maximumf>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<2x2x1x1x1x4xf64> to vector<2x1x1xf64>
+// Global reduction across threads on the 64-bit element type.
+// CHECK: gpu.subgroup_reduce maximumf %{{.*}} cluster(size = 4, stride = 16) : (f64) -> f64
+
+// -----
+
+// i64 vector.multi_reduction on AMDGPU: parallel to @reduce_f64_dim1,
+// exercises the same 64-bit shuffle gate for an integer reduction kind.
+
+#nested_i64 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 2],
+  outer_tile = [1, 1],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
+
+  subgroup_strides = [1, 1],
+  thread_strides = [1, 16]
+>
+
+func.func @reduce_i64_dim1(%arg0: vector<32x32xi64>, %arg1: vector<32xi64>) -> vector<32xi64> {
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested_i64) : vector<32x32xi64>
+  %0 = vector.multi_reduction <add>, %arg0l, %arg1 [1] : vector<32x32xi64> to vector<32xi64>
+  return %0 : vector<32xi64>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduce_i64_dim1
+// Local reduction on the distributed batch shape.
+// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<2x2x1x1x1x4xi64> to vector<2x1x1xi64>
+// Global reduction across threads on the 64-bit element type.
+// CHECK: gpu.subgroup_reduce add %{{.*}} cluster(size = 4, stride = 16) : (i64) -> i64

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -1,8 +1,4 @@
-// RUN: iree-opt --iree-transform-dialect-interpreter --iree-gpu-test-target=gfx942 --split-input-file --canonicalize -mlir-print-local-scope --cse %s | FileCheck %s
-
-// Runs under `--iree-gpu-test-target=gfx942` so 64-bit-element cases (which
-// rely on AMDGPU's decomposing `gpu.shuffle` lowering) reach the pattern.
-// All other test cases here use <=32-bit elements and are target-agnostic.
+// RUN: iree-opt --iree-transform-dialect-interpreter --split-input-file --canonicalize -mlir-print-local-scope --cse %s | FileCheck %s
 
 #nested = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
@@ -253,75 +249,3 @@ builtin.module attributes { transform.with_named_sequence } {
 // enough threads on the reduction dimension to do a subgroup reduce.
 // CHECK: vector.transfer_read %{{.*}}[%{{.*}}, %[[C0]]]
 // CHECK-NOT: gpu.subgroup_reduce
-
-// -----
-
-// f64 vector.multi_reduction on AMDGPU: passes the bitwidth gate, so the
-// pattern fires and emits `gpu.subgroup_reduce ... : (f64) -> f64`.
-
-#nested_f64 = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [2, 2],
-  outer_tile = [1, 1],
-  thread_tile = [16, 4],
-  element_tile = [1, 4],
-
-  subgroup_strides = [1, 1],
-  thread_strides = [1, 16]
->
-
-func.func @reduce_f64_dim1(%arg0: vector<32x32xf64>, %arg1: vector<32xf64>) -> vector<32xf64> {
-  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested_f64) : vector<32x32xf64>
-  %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<32x32xf64> to vector<32xf64>
-  return %0 : vector<32xf64>
-}
-
-builtin.module attributes { transform.with_named_sequence } {
-  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
-    transform.yield
-  }
-}
-
-// CHECK-LABEL: func @reduce_f64_dim1
-// Local reduction on the distributed batch shape.
-// CHECK: vector.multi_reduction <maximumf>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<2x2x1x1x1x4xf64> to vector<2x1x1xf64>
-// Global reduction across threads on the 64-bit element type.
-// CHECK: gpu.subgroup_reduce maximumf %{{.*}} cluster(size = 4, stride = 16) : (f64) -> f64
-
-// -----
-
-// i64 vector.multi_reduction on AMDGPU: parallel to @reduce_f64_dim1,
-// exercises the same 64-bit shuffle gate for an integer reduction kind.
-
-#nested_i64 = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [2, 2],
-  outer_tile = [1, 1],
-  thread_tile = [16, 4],
-  element_tile = [1, 4],
-
-  subgroup_strides = [1, 1],
-  thread_strides = [1, 16]
->
-
-func.func @reduce_i64_dim1(%arg0: vector<32x32xi64>, %arg1: vector<32xi64>) -> vector<32xi64> {
-  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested_i64) : vector<32x32xi64>
-  %0 = vector.multi_reduction <add>, %arg0l, %arg1 [1] : vector<32x32xi64> to vector<32xi64>
-  return %0 : vector<32xi64>
-}
-
-builtin.module attributes { transform.with_named_sequence } {
-  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
-    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
-    transform.yield
-  }
-}
-
-// CHECK-LABEL: func @reduce_i64_dim1
-// Local reduction on the distributed batch shape.
-// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<2x2x1x1x1x4xi64> to vector<2x1x1xi64>
-// Global reduction across threads on the 64-bit element type.
-// CHECK: gpu.subgroup_reduce add %{{.*}} cluster(size = 4, stride = 16) : (i64) -> i64

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ReductionConfigUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/SliceUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
@@ -707,6 +708,9 @@ checkDispatchForVectorDistribution(Operation *parentOp) {
 LogicalResult setReductionConfig(IREE::GPU::TargetAttr target,
                                  mlir::FunctionOpInterface entryPoint,
                                  Operation *op) {
+  if (!target) {
+    return failure();
+  }
   MLIRContext *context = op->getContext();
 
   if (!isa<linalg::LinalgOp>(op) && !isa<IREE::LinalgExt::ArgCompareOp>(op)) {
@@ -780,13 +784,27 @@ LogicalResult setReductionConfig(IREE::GPU::TargetAttr target,
     return failure();
   }
 
-  // Reduction distribution only supports 4/8/16/32 bit types now.
-  if (!llvm::is_contained({4, 8, 16, 32}, *bitWidth)) {
+  // Accept power-of-two element widths >= 4; sub-byte element types take
+  // separate code paths. Widths above kShuffleNativeBits additionally
+  // require a backend with a decomposing `gpu.shuffle` lowering. The
+  // effective upper bound is constrained later by `largestLoadSizeInBits`,
+  // not here.
+  if (!llvm::isPowerOf2_64(*bitWidth) || *bitWidth < 4) {
+    return failure();
+  }
+  if (!targetSupportsShuffleBitwidth(target, *bitWidth)) {
     return failure();
   }
 
   const std::optional<int64_t> maxLoadBits = wgp.getMaxLoadInstructionBits();
   const unsigned largestLoadSizeInBits = maxLoadBits.value_or(128);
+
+  // Guard divide-by-zero: `threadLoads = largestLoadSizeInBits / *bitWidth`
+  // becomes 0 when the element is wider than a single load instruction,
+  // and is then used as a divisor in the subgroup-divisibility loop below.
+  if (*bitWidth > largestLoadSizeInBits) {
+    return failure();
+  }
 
   unsigned threadLoads = largestLoadSizeInBits / *bitWidth;
   if (!hasDynamicReductionDim) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/config_vector_distribute_sm80.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/config_vector_distribute_sm80.mlir
@@ -60,3 +60,75 @@ func.func @matmul_256x256x256_f16_f16() {
 // CHECK-LABEL: func.func @matmul_256x256x256_f16_f16()
 // CHECK:       linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:                mma_kind = #iree_gpu.mma_layout<NV_MMA_SYNC_F16_16x8x16_F16>
+
+// -----
+
+// f64 reduction on sm_80: only AMDGPU has a `gpu.shuffle` lowering that
+// decomposes wider element types into 32-bit chunks, so the gate (positive
+// `target.isAMD()` check) rejects 64-bit on sm_80 and the dispatch must NOT
+// pick VectorDistribute. Once the NVVM lowering grows the same support
+// (llvm/llvm-project#197080, cf. the AMD precedent at
+// llvm/llvm-project#136320), the gate can broaden to include sm_*.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @reduction_f64_sm80_no_vector_distribute() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f64
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xf64>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf64>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xf64>> -> tensor<8x4096xf64>
+  %3 = tensor.empty() : tensor<8xf64>
+  %4 = linalg.fill ins(%cst : f64) outs(%3 : tensor<8xf64>) -> tensor<8xf64>
+  %5 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                         affine_map<(d0, d1) -> (d0)>],
+        iterator_types = ["parallel", "reduction"]}
+      ins(%2 : tensor<8x4096xf64>) outs(%4 : tensor<8xf64>) {
+      ^bb0(%in: f64, %out: f64):
+        %6 = arith.addf %in, %out : f64
+        linalg.yield %6 : f64
+      } -> tensor<8xf64>
+  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf64>>
+  return
+}
+
+// CHECK-LABEL: func.func @reduction_f64_sm80_no_vector_distribute
+// CHECK-NOT:   pipeline = #iree_gpu.pipeline<VectorDistribute>
+
+// -----
+
+// i48 (non-power-of-two) reduction: the bitwidth gate's power-of-two check
+// rejects this independent of the target, so VectorDistribute must NOT be
+// chosen. Co-located with the f64 fallback test rather than the AMDGPU file
+// because the property under test is target-independent.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @reduction_i48_falls_back() {
+  %c0 = arith.constant 0 : index
+  %czero = arith.constant 0 : i48
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xi48>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi48>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xi48>> -> tensor<8x4096xi48>
+  %3 = tensor.empty() : tensor<8xi48>
+  %4 = linalg.fill ins(%czero : i48) outs(%3 : tensor<8xi48>) -> tensor<8xi48>
+  %5 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                         affine_map<(d0, d1) -> (d0)>],
+        iterator_types = ["parallel", "reduction"]}
+      ins(%2 : tensor<8x4096xi48>) outs(%4 : tensor<8xi48>) {
+      ^bb0(%in: i48, %out: i48):
+        %6 = arith.addi %in, %out : i48
+        linalg.yield %6 : i48
+      } -> tensor<8xi48>
+  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xi48> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi48>>
+  return
+}
+
+// CHECK-LABEL: func.func @reduction_i48_falls_back
+// CHECK-NOT:   pipeline = #iree_gpu.pipeline<VectorDistribute>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "config_vector_distribute_reduction_gfx942.mlir",
             "config_vector_distribute_reduction_gfx950.mlir",
             "configure_buffer_instructions.mlir",
+            "gpu_nested_layout_vector_distribution_wide_shuffle.mlir",
             "pipeline_argcompare_tile_and_fuse.mlir",
             "pipeline_argcompare_vector_distribute.mlir",
             "pipeline_direct_conv_tile_and_fuse.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_lit_test_suite(
     "config_vector_distribute_reduction_gfx942.mlir"
     "config_vector_distribute_reduction_gfx950.mlir"
     "configure_buffer_instructions.mlir"
+    "gpu_nested_layout_vector_distribution_wide_shuffle.mlir"
     "pipeline_argcompare_tile_and_fuse.mlir"
     "pipeline_argcompare_vector_distribute.mlir"
     "pipeline_direct_conv_tile_and_fuse.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_argcompare.mlir
@@ -321,3 +321,80 @@ func.func @argcompare_1d_rank_to_scalar_f32(
 // CHECK-LABEL: func.func @argcompare_1d_rank_to_scalar_f32
 // CHECK:         iree_linalg_ext.arg_compare
 // CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{thread = [0], workgroup = [0]}>
+
+// -----
+
+// 1d f64 arg_compare on gfx942: AMDGPU, so 64-bit passes the bitwidth gate
+// and reaches VectorDistribute.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_1d_f64() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf64>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f64>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xf64>> -> tensor<4096xf64>
+  %4 = tensor.empty() : tensor<f64>
+  %5 = tensor.empty() : tensor<i32>
+  %6:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%3 : tensor<4096xf64>)
+    outs(%4, %5 : tensor<f64>, tensor<i32>) {
+    ^bb0(%a: f64, %b: f64):
+      %cmp = arith.cmpf ogt, %a, %b : f64
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<f64>, tensor<i32>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [], sizes = [], strides = [] : tensor<f64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<f64>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [], sizes = [], strides = [] : tensor<i32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i32>>
+  return
+}
+
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
+// CHECK-LABEL: func.func @argcompare_1d_f64
+// CHECK:         iree_linalg_ext.arg_compare
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:        partial_reduction
+// CHECK-SAME:        workgroup
+
+// -----
+
+// 1d i64 arg_compare on gfx942: same gate, integer path.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_1d_i64() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xi64>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i64>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [4096], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4096xi64>> -> tensor<4096xi64>
+  %4 = tensor.empty() : tensor<i64>
+  %5 = tensor.empty() : tensor<i32>
+  %6:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%3 : tensor<4096xi64>)
+    outs(%4, %5 : tensor<i64>, tensor<i32>) {
+    ^bb0(%a: i64, %b: i64):
+      %cmp = arith.cmpi sgt, %a, %b : i64
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<i64>, tensor<i32>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [], sizes = [], strides = [] : tensor<i64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i64>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [], sizes = [], strides = [] : tensor<i32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<i32>>
+  return
+}
+
+// CHECK:       #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
+// CHECK-LABEL: func.func @argcompare_1d_i64
+// CHECK:         iree_linalg_ext.arg_compare
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:        partial_reduction
+// CHECK-SAME:        workgroup

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -717,3 +717,39 @@ func.func @reduction_i128() {
 // CHECK-SAME:      lowering_config = #iree_gpu.lowering_config
 // CHECK-SAME:        partial_reduction
 // CHECK-SAME:        workgroup
+
+// -----
+
+// i256 reduction on gfx942: exercises the divide-by-zero guard in
+// `setReductionVectorDistributionConfig`. With largestLoadSizeInBits == 128
+// on gfx942, `*bitWidth (256) > largestLoadSizeInBits (128)` triggers the
+// early failure, so the reduction config is not set and VectorDistribute is
+// not selected.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @reduction_i256() {
+  %c0 = arith.constant 0 : index
+  %czero = arith.constant 0 : i256
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xi256>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi256>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xi256>> -> tensor<8x4096xi256>
+  %3 = tensor.empty() : tensor<8xi256>
+  %4 = linalg.fill ins(%czero : i256) outs(%3 : tensor<8xi256>) -> tensor<8xi256>
+  %5 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                         affine_map<(d0, d1) -> (d0)>],
+        iterator_types = ["parallel", "reduction"]}
+      ins(%2 : tensor<8x4096xi256>) outs(%4 : tensor<8xi256>) {
+      ^bb0(%in: i256, %out: i256):
+        %6 = arith.addi %in, %out : i256
+        linalg.yield %6 : i256
+      } -> tensor<8xi256>
+  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xi256> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi256>>
+  return
+}
+
+// CHECK-LABEL: func.func @reduction_i256
+// CHECK-NOT:     pipeline = #iree_gpu.pipeline<VectorDistribute>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute_reduction_gfx942.mlir
@@ -603,3 +603,117 @@ func.func @reordered_post_reduction_consumer() {
 // CHECK-SAME:               serial = [128, 0],
 // CHECK-SAME:               subgroup_basis = {{\[}}[1, 1], [0, 1]{{\]}},
 // CHECK-SAME:               thread = [2, 0]
+
+// -----
+
+// f64 reduction on gfx942: AMDGPU, so 64-bit passes the bitwidth gate and
+// reaches VectorDistribute.
+
+// CHECK: #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @reduction_f64() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f64
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xf64>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf64>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xf64>> -> tensor<8x4096xf64>
+  %3 = tensor.empty() : tensor<8xf64>
+  %4 = linalg.fill ins(%cst : f64) outs(%3 : tensor<8xf64>) -> tensor<8xf64>
+  %5 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                         affine_map<(d0, d1) -> (d0)>],
+        iterator_types = ["parallel", "reduction"]}
+      ins(%2 : tensor<8x4096xf64>) outs(%4 : tensor<8xf64>) {
+      ^bb0(%in: f64, %out: f64):
+        %6 = arith.addf %in, %out : f64
+        linalg.yield %6 : f64
+      } -> tensor<8xf64>
+  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xf64>>
+  return
+}
+
+// CHECK-LABEL: func.func @reduction_f64
+// CHECK:         linalg.generic
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:        partial_reduction
+// CHECK-SAME:        workgroup
+
+// -----
+
+// Same as above but with i64 element type.
+
+// CHECK: #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @reduction_i64() {
+  %c0 = arith.constant 0 : index
+  %czero = arith.constant 0 : i64
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xi64>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi64>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xi64>> -> tensor<8x4096xi64>
+  %3 = tensor.empty() : tensor<8xi64>
+  %4 = linalg.fill ins(%czero : i64) outs(%3 : tensor<8xi64>) -> tensor<8xi64>
+  %5 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                         affine_map<(d0, d1) -> (d0)>],
+        iterator_types = ["parallel", "reduction"]}
+      ins(%2 : tensor<8x4096xi64>) outs(%4 : tensor<8xi64>) {
+      ^bb0(%in: i64, %out: i64):
+        %6 = arith.addi %in, %out : i64
+        linalg.yield %6 : i64
+      } -> tensor<8xi64>
+  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xi64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi64>>
+  return
+}
+
+// CHECK-LABEL: func.func @reduction_i64
+// CHECK:         linalg.generic
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:        partial_reduction
+// CHECK-SAME:        workgroup
+
+// -----
+
+// i128 reduction on gfx942: AMDGPU, so 128-bit passes the bitwidth gate and
+// reaches VectorDistribute. The ROCDL lowering decomposes 128-bit shuffles
+// into four 32-bit chunks.
+
+// CHECK: #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @reduction_i128() {
+  %c0 = arith.constant 0 : index
+  %czero = arith.constant 0 : i128
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xi128>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi128>>
+  %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4096xi128>> -> tensor<8x4096xi128>
+  %3 = tensor.empty() : tensor<8xi128>
+  %4 = linalg.fill ins(%czero : i128) outs(%3 : tensor<8xi128>) -> tensor<8xi128>
+  %5 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                         affine_map<(d0, d1) -> (d0)>],
+        iterator_types = ["parallel", "reduction"]}
+      ins(%2 : tensor<8x4096xi128>) outs(%4 : tensor<8xi128>) {
+      ^bb0(%in: i128, %out: i128):
+        %6 = arith.addi %in, %out : i128
+        linalg.yield %6 : i128
+      } -> tensor<8xi128>
+  iree_tensor_ext.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xi128> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8xi128>>
+  return
+}
+
+// CHECK-LABEL: func.func @reduction_i128
+// CHECK:         linalg.generic
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:        partial_reduction
+// CHECK-SAME:        workgroup

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/gpu_nested_layout_vector_distribution_wide_shuffle.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/gpu_nested_layout_vector_distribution_wide_shuffle.mlir
@@ -1,0 +1,212 @@
+// RUN: iree-opt --iree-transform-dialect-interpreter --iree-gpu-test-target=gfx942 --split-input-file --canonicalize -mlir-print-local-scope --cse %s | FileCheck %s
+
+// AMDGPU-only nested-layout vector distribution cases. These exercise paths
+// gated on `targetSupportsShuffleBitwidth` returning true for >32-bit element
+// types, which today requires an AMD target with a decomposing `gpu.shuffle`
+// lowering. Target-agnostic cases (<=32-bit elements) live in the per-op
+// distribution test files (multi_reduce, argcompare, scan).
+
+// f64 vector.multi_reduction on AMDGPU: passes the bitwidth gate, so the
+// pattern fires and emits `gpu.subgroup_reduce ... : (f64) -> f64`.
+
+#nested_f64 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 2],
+  outer_tile = [1, 1],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
+
+  subgroup_strides = [1, 1],
+  thread_strides = [1, 16]
+>
+
+func.func @reduce_f64_1d_dim(%arg0: vector<32x32xf64>, %arg1: vector<32xf64>) -> vector<32xf64> {
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested_f64) : vector<32x32xf64>
+  %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<32x32xf64> to vector<32xf64>
+  return %0 : vector<32xf64>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduce_f64_1d_dim
+// Local reduction on the distributed batch shape.
+// CHECK: vector.multi_reduction <maximumf>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<2x2x1x1x1x4xf64> to vector<2x1x1xf64>
+// Cross-thread reduction on the 64-bit element type.
+// CHECK: gpu.subgroup_reduce maximumf %{{.*}} cluster(size = 4, stride = 16) : (f64) -> f64
+
+// -----
+
+// i64 vector.multi_reduction on AMDGPU: parallel to @reduce_f64_1d_dim,
+// exercises the same 64-bit shuffle gate for an integer reduction kind.
+
+#nested_i64 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 2],
+  outer_tile = [1, 1],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
+
+  subgroup_strides = [1, 1],
+  thread_strides = [1, 16]
+>
+
+func.func @reduce_i64_1d_dim(%arg0: vector<32x32xi64>, %arg1: vector<32xi64>) -> vector<32xi64> {
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested_i64) : vector<32x32xi64>
+  %0 = vector.multi_reduction <add>, %arg0l, %arg1 [1] : vector<32x32xi64> to vector<32xi64>
+  return %0 : vector<32xi64>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduce_i64_1d_dim
+// Local reduction on the distributed batch shape.
+// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<2x2x1x1x1x4xi64> to vector<2x1x1xi64>
+// Cross-thread reduction on the 64-bit element type.
+// CHECK: gpu.subgroup_reduce add %{{.*}} cluster(size = 4, stride = 16) : (i64) -> i64
+
+// -----
+
+// i128 vector.multi_reduction on AMDGPU: targetSupportsShuffleBitwidth has no
+// upper bound on AMD, and the ROCDL gpu.shuffle lowering generically
+// decomposes wide values into i32 ds_bpermute chunks. The pattern fires and
+// emits `gpu.subgroup_reduce ... : (i128) -> i128`, which lowers to four
+// 32-bit shuffles.
+
+#nested_i128 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 2],
+  outer_tile = [1, 1],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
+
+  subgroup_strides = [1, 1],
+  thread_strides = [1, 16]
+>
+
+func.func @reduce_i128_1d_dim(%arg0: vector<32x32xi128>, %arg1: vector<32xi128>) -> vector<32xi128> {
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested_i128) : vector<32x32xi128>
+  %0 = vector.multi_reduction <add>, %arg0l, %arg1 [1] : vector<32x32xi128> to vector<32xi128>
+  return %0 : vector<32xi128>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reduce_i128_1d_dim
+// Local reduction on the distributed batch shape.
+// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1, 3, 5] : vector<2x2x1x1x1x4xi128> to vector<2x1x1xi128>
+// Cross-thread reduction on the 128-bit element type.
+// CHECK: gpu.subgroup_reduce add %{{.*}} cluster(size = 4, stride = 16) : (i128) -> i128
+
+// -----
+
+// i64 arg_compare on AMDGPU: passes the bitwidth gate. The commutative
+// comparator selects the ballot path: subgroup_reduce on i64 + a single
+// i32 shuffle for the winning lane index.
+
+#layout_1d_thread_only = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile = [1],
+  outer_tile = [1],
+  thread_tile = [64],
+  element_tile = [1],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+#layout_0d_thread_only = #iree_vector_ext.nested_layout<
+  subgroup_tile = [],
+  batch_tile = [],
+  outer_tile = [],
+  thread_tile = [],
+  element_tile = [],
+
+  subgroup_strides = [],
+  thread_strides   = []
+>
+
+// CHECK-LABEL: func @argcompare_i64
+// CHECK-NOT: iree_vector_ext.arg_compare
+// CHECK: gpu.subgroup_reduce maxsi {{.*}} : (i64) -> i64
+// CHECK: gpu.shuffle idx {{.*}} : i32
+func.func @argcompare_i64(
+    %input: vector<64xi64>,
+    %input_idx: vector<64xi32>,
+    %init_val: vector<i64>,
+    %init_idx: vector<i32>) -> (vector<i64>, vector<i32>) {
+  %v = iree_vector_ext.to_layout %input to layout(#layout_1d_thread_only) : vector<64xi64>
+  %i = iree_vector_ext.to_layout %input_idx to layout(#layout_1d_thread_only) : vector<64xi32>
+  %iv = iree_vector_ext.to_layout %init_val to layout(#layout_0d_thread_only) : vector<i64>
+  %ii = iree_vector_ext.to_layout %init_idx to layout(#layout_0d_thread_only) : vector<i32>
+  %res:2 = iree_vector_ext.arg_compare dimension(0)
+      ins(%v, %i : vector<64xi64>, vector<64xi32>)
+      inits(%iv, %ii : vector<i64>, vector<i32>) {
+    ^bb0(%a: i64, %b: i64):
+      %cmp = arith.cmpi sgt, %a, %b : i64
+      iree_vector_ext.yield %cmp : i1
+  } -> vector<i64>, vector<i32>
+  return %res#0, %res#1 : vector<i64>, vector<i32>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+// Carve-out: 64-bit scan on gfx942. Even though the AMDGPU target accepts
+// >32-bit shuffles for reduction/arg_compare, scan is intentionally kept on
+// the 32-bit ceiling. The pattern must NOT fire here: the original
+// `vector.scan` survives and no `iree_gpu.subgroup_scan` is emitted.
+
+#layout_scan_f64 = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1],
+  batch_tile    = [1],
+  outer_tile    = [1],
+  thread_tile   = [4],
+  element_tile  = [4],
+
+  subgroup_strides = [1],
+  thread_strides   = [1]
+>
+
+// CHECK-LABEL: @scan_f64_gfx942_carve_out
+func.func @scan_f64_gfx942_carve_out(%src: vector<16xf64>, %init: vector<f64>) -> (vector<16xf64>, vector<f64>) {
+  %src_l = iree_vector_ext.to_layout %src to layout(#layout_scan_f64) : vector<16xf64>
+  %out:2 = vector.scan <add>, %src_l, %init {inclusive = true, reduction_dim = 0 : i64}
+    : vector<16xf64>, vector<f64>
+  return %out#0, %out#1 : vector<16xf64>, vector<f64>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK: vector.scan
+// CHECK-NOT: iree_gpu.subgroup_scan

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_argcompare_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_argcompare_vector_distribute.mlir
@@ -70,3 +70,60 @@ func.func @argcompare_argmax() attributes {hal.executable.target = #executable_t
 //     CHECK: %[[RESULT_IDX_VEC:.+]] = vector.broadcast %[[RESULT_IDX]] : i32 to vector<1xi32>
 //     CHECK: vector.transfer_write %[[RESULT_VAL]]
 //     CHECK: vector.transfer_write %[[RESULT_IDX_VEC]]
+
+// -----
+
+// i64 arg_compare on gfx942: commutative comparator picks the ballot path,
+// emitting `gpu.subgroup_reduce maxsi : (i64) -> i64` + `gpu.shuffle idx`.
+
+#executable_target_rocm = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#config_i64 = #iree_gpu.lowering_config<{
+  workgroup = [1, 0],
+  partial_reduction = [0, 256],
+  thread = [0, 4],
+  subgroup_basis = [[1, 1], [0, 1]],
+  lane_basis = [[1, 64], [0, 1]]
+}>
+
+#translation_i64 = #iree_codegen.translation_info<
+  pipeline = #iree_gpu.pipeline<VectorDistribute>
+  workgroup_size = [64, 1, 1]
+  subgroup_size = 64, {
+    gpu_pipeline_options = #iree_gpu.pipeline_options<
+      no_reduce_shared_memory_bank_conflicts = false,
+      use_igemm_convolution = false>
+  }>
+
+#pipeline_layout_i64 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+
+func.func @argcompare_argmax_i64() attributes {hal.executable.target = #executable_target_rocm, translation_info = #translation_i64} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout_i64) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x256xi64>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout_i64) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1xi64>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout_i64) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1xi32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 256], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x256xi64>> -> tensor<1x256xi64>
+  %4 = tensor.empty() : tensor<1xi64>
+  %5 = tensor.empty() : tensor<1xi32>
+  %6:2 = iree_linalg_ext.arg_compare {lowering_config = #config_i64} dimension(1) ins(%3 : tensor<1x256xi64>) outs(%4, %5 : tensor<1xi64>, tensor<1xi32>) {
+    ^bb0(%a: i64, %b: i64):
+      %cmp = arith.cmpi sgt, %a, %b : i64
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<1xi64>, tensor<1xi32>
+  iree_tensor_ext.dispatch.tensor.store %6#0, %1, offsets = [0], sizes = [1], strides = [1] : tensor<1xi64> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1xi64>>
+  iree_tensor_ext.dispatch.tensor.store %6#1, %2, offsets = [0], sizes = [1], strides = [1] : tensor<1xi32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<1xi32>>
+  return
+}
+
+// CHECK-LABEL: func.func @argcompare_argmax_i64
+// Vectorized compare+select over the element tile (4 elements).
+// CHECK:         arith.cmpi sgt, %{{.*}}, %{{.*}} : vector<1x1x1x1x1x4xi64>
+// Thread reduction: subgroup_reduce on i64 (decomposed downstream by ROCDL).
+// CHECK:         gpu.subgroup_reduce maxsi {{.*}} : (i64) -> i64
+// Ballot to find winning lane.
+// CHECK:         gpu.ballot
+// Index broadcast via gpu.shuffle idx.
+// CHECK:         gpu.shuffle idx

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -1323,6 +1323,14 @@ bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target) {
   return chipset->majorVersion == 9 && chipset->minorVersion >= 5;
 }
 
+bool targetSupportsShuffleBitwidth(IREE::GPU::TargetAttr target,
+                                   unsigned bitwidth) {
+  if (bitwidth <= kShuffleNativeBits) {
+    return true;
+  }
+  return target && target.isAMD();
+}
+
 void addConfigGPUTarget(MLIRContext *context,
                         IREE::GPU::TargetAttr gpuTargetAttr,
                         SmallVectorImpl<NamedAttribute> &config) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -24,11 +24,12 @@ namespace mlir::iree_compiler {
 static constexpr int32_t kNumGPUDims = 3;
 static constexpr int32_t kWarpSize = 32;
 
-// `gpu.shuffle` natively supports up to 32-bit element types. Wider values
-// must be decomposed by the backend's lowering, which today only ROCDL does
-// (cf. llvm/llvm-project#136320). NVVM tracking is at
-// llvm/llvm-project#197080. See `targetSupportsShuffleBitwidth`.
-static constexpr unsigned kShuffleNativeBits = 32;
+// Universally-safe ceiling for `gpu.shuffle`-based codegen: at this width or
+// below, every backend's `gpu.shuffle` lowering emits working code. Wider
+// values rely on the backend decomposing them, which today only ROCDL does
+// (cf. llvm/llvm-project#136320; NVVM tracking at llvm/llvm-project#197080).
+// See `targetSupportsShuffleBitwidth`.
+constexpr unsigned kShuffleNativeBits = 32;
 
 //===----------------------------------------------------------------------===//
 // GPU processor IDs and sizes

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -24,6 +24,12 @@ namespace mlir::iree_compiler {
 static constexpr int32_t kNumGPUDims = 3;
 static constexpr int32_t kWarpSize = 32;
 
+// `gpu.shuffle` natively supports up to 32-bit element types. Wider values
+// must be decomposed by the backend's lowering, which today only ROCDL does
+// (cf. llvm/llvm-project#136320). NVVM tracking is at
+// llvm/llvm-project#197080. See `targetSupportsShuffleBitwidth`.
+static constexpr unsigned kShuffleNativeBits = 32;
+
 //===----------------------------------------------------------------------===//
 // GPU processor IDs and sizes
 //===----------------------------------------------------------------------===//
@@ -333,6 +339,13 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 /// Check if the target architecture supports global load DMA.
 /// Returns true only for CDNA4+ (gfx950+) architectures.
 bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target);
+
+/// True if `gpu.shuffle` on `bitwidth`-bit elements is supported by `target`.
+/// Widths up to `kShuffleNativeBits` are universally supported; wider widths
+/// require a backend that decomposes them (today only AMDGPU). A null
+/// `target` is treated conservatively (reject wide shuffles).
+bool targetSupportsShuffleBitwidth(IREE::GPU::TargetAttr target,
+                                   unsigned bitwidth);
 
 // Methods to retrieve information association with `configuration` field
 // of `hal.executable.target` attribute used commonly in GPU codegen pipelines.

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -164,9 +164,15 @@ iree_check_single_backend_test_suite(
         "dynamic_gather_attention.mlir",
         "linalg_ops_dynamic.mlir",
         "split_reduction_using_tiling.mlir",
+        "vector_distribute_64bit_amdgpu.mlir",
     ],
     compiler_flags = [
         "--iree-opt-level=O3",
+        # vector_distribute_64bit_amdgpu.mlir relies on f64 reaching codegen;
+        # the default f64->f32 demotion would silently turn it into the f32
+        # case. Note: this flag is sticky for the whole suite — any future
+        # f64-touching test added here will also skip demotion.
+        "--iree-input-demote-f64-to-f32=false",
     ],
     driver = "hip",
     tags = [

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -164,14 +164,34 @@ iree_check_single_backend_test_suite(
         "dynamic_gather_attention.mlir",
         "linalg_ops_dynamic.mlir",
         "split_reduction_using_tiling.mlir",
+    ],
+    compiler_flags = [
+        "--iree-opt-level=O3",
+    ],
+    driver = "hip",
+    tags = [
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-amd",
+    ],
+    target_backend = "rocm",
+)
+
+# Isolated suite so `--iree-input-demote-f64-to-f32=false` only applies to the
+# 64-bit-element vector distribution test and does not bleed into unrelated
+# tests in `check_regression_hip`.
+iree_check_single_backend_test_suite(
+    name = "check_regression_vector_distribute_64bit_hip",
+    timeout = "moderate",
+    srcs = [
         "vector_distribute_64bit_amdgpu.mlir",
     ],
     compiler_flags = [
         "--iree-opt-level=O3",
-        # vector_distribute_64bit_amdgpu.mlir relies on f64 reaching codegen;
-        # the default f64->f32 demotion would silently turn it into the f32
-        # case. Note: this flag is sticky for the whole suite — any future
-        # f64-touching test added here will also skip demotion.
+        # The test relies on f64 reaching codegen; the default f64->f32
+        # demotion would silently turn it into the f32 case.
         "--iree-input-demote-f64-to-f32=false",
     ],
     driver = "hip",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -180,6 +180,26 @@ iree_check_single_backend_test_suite(
     "dynamic_gather_attention.mlir"
     "linalg_ops_dynamic.mlir"
     "split_reduction_using_tiling.mlir"
+  TARGET_BACKEND
+    "rocm"
+  DRIVER
+    "hip"
+  COMPILER_FLAGS
+    "--iree-opt-level=O3"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-amd"
+  TIMEOUT
+    300
+)
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_regression_vector_distribute_64bit_hip
+  SRCS
     "vector_distribute_64bit_amdgpu.mlir"
   TARGET_BACKEND
     "rocm"

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -180,12 +180,14 @@ iree_check_single_backend_test_suite(
     "dynamic_gather_attention.mlir"
     "linalg_ops_dynamic.mlir"
     "split_reduction_using_tiling.mlir"
+    "vector_distribute_64bit_amdgpu.mlir"
   TARGET_BACKEND
     "rocm"
   DRIVER
     "hip"
   COMPILER_FLAGS
     "--iree-opt-level=O3"
+    "--iree-input-demote-f64-to-f32=false"
   LABELS
     "noasan"
     "nomsan"

--- a/tests/e2e/regression/vector_distribute_64bit_amdgpu.mlir
+++ b/tests/e2e/regression/vector_distribute_64bit_amdgpu.mlir
@@ -1,0 +1,76 @@
+// 64-bit reduction and arg_compare on AMDGPU through VectorDistribute.
+
+// f64 sum reduction. 8 rows of 256 ones each: each row sums to 256.0.
+func.func @reduction_f64_sum() {
+  %in = util.unfoldable_constant dense<1.0> : tensor<8x256xf64>
+  %cst = arith.constant 0.0 : f64
+  %init = tensor.empty() : tensor<8xf64>
+  %fill = linalg.fill ins(%cst : f64) outs(%init : tensor<8xf64>) -> tensor<8xf64>
+  %result = linalg.generic {indexing_maps = [
+    affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%in : tensor<8x256xf64>) outs(%fill : tensor<8xf64>) {
+    ^bb0(%a: f64, %b: f64):
+      %2 = arith.addf %a, %b : f64
+      linalg.yield %2 : f64
+    } -> tensor<8xf64>
+  check.expect_eq_const(%result, dense<256.0> : tensor<8xf64>) : tensor<8xf64>
+  return
+}
+
+// i64 arg_compare (argmax). Length-256 input is a subgroup-compatible size
+// that selects VectorDistribute (small lengths land on TileAndFuse and skip
+// the wide-shuffle path entirely). All elements are 1 except index 100 = 7,
+// so the maximum is 7 at index 100. Putting the max at a non-last index
+// catches a buggy "always returns the last lane" reducer.
+func.func @argcompare_i64_argmax() {
+  %ones = util.unfoldable_constant dense<1> : tensor<256xi64>
+  %c7_i64 = arith.constant 7 : i64
+  %c100 = arith.constant 100 : index
+  %in_i64 = tensor.insert %c7_i64 into %ones[%c100] : tensor<256xi64>
+  %int_min = arith.constant -9223372036854775808 : i64
+  %c0 = arith.constant 0 : i32
+  %init_v_empty = tensor.empty() : tensor<i64>
+  %init_i_empty = tensor.empty() : tensor<i32>
+  %init_v = linalg.fill ins(%int_min : i64) outs(%init_v_empty : tensor<i64>) -> tensor<i64>
+  %init_i = linalg.fill ins(%c0 : i32) outs(%init_i_empty : tensor<i32>) -> tensor<i32>
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%in_i64 : tensor<256xi64>)
+    outs(%init_v, %init_i : tensor<i64>, tensor<i32>) {
+    ^bb0(%a: i64, %b: i64):
+      %cmp = arith.cmpi sgt, %a, %b : i64
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<i64>, tensor<i32>
+  check.expect_eq_const(%res#0, dense<7> : tensor<i64>) : tensor<i64>
+  check.expect_eq_const(%res#1, dense<100> : tensor<i32>) : tensor<i32>
+  return
+}
+
+// f64 arg_compare (argmax). Same shape and rationale as @argcompare_i64_argmax
+// on the floating-point path: 256 elements of 1.0 with 7.0 at index 100. The
+// value seed (-1.0) is smaller than every input so the first comparison
+// establishes the running max.
+func.func @argcompare_f64_argmax() {
+  %ones = util.unfoldable_constant dense<1.0> : tensor<256xf64>
+  %c7_f64 = arith.constant 7.0 : f64
+  %c100 = arith.constant 100 : index
+  %in_f64 = tensor.insert %c7_f64 into %ones[%c100] : tensor<256xf64>
+  %seed = arith.constant -1.0 : f64
+  %c0 = arith.constant 0 : i32
+  %init_v_empty = tensor.empty() : tensor<f64>
+  %init_i_empty = tensor.empty() : tensor<i32>
+  %init_v = linalg.fill ins(%seed : f64) outs(%init_v_empty : tensor<f64>) -> tensor<f64>
+  %init_i = linalg.fill ins(%c0 : i32) outs(%init_i_empty : tensor<i32>) -> tensor<i32>
+  %res:2 = iree_linalg_ext.arg_compare
+    dimension(0)
+    ins(%in_f64 : tensor<256xf64>)
+    outs(%init_v, %init_i : tensor<f64>, tensor<i32>) {
+    ^bb0(%a: f64, %b: f64):
+      %cmp = arith.cmpf ogt, %a, %b : f64
+      iree_linalg_ext.yield %cmp : i1
+  } -> tensor<f64>, tensor<i32>
+  check.expect_eq_const(%res#0, dense<7.0> : tensor<f64>) : tensor<f64>
+  check.expect_eq_const(%res#1, dense<100> : tensor<i32>) : tensor<i32>
+  return
+}


### PR DESCRIPTION
The upstream PR  [`llvm-project#136320`](https://github.com/llvm/llvm-project/pull/136320) removed the 32-bit constraint from `GPUToROCDL`'s `gpu.shuffle` lowering by decomposing wider values into 32-bit chunks via  LLVM::decomposeValue` / `LLVM::composeValue`. With that lowering in place, the IREE-side 32-bit ceiling was unnecessarily restrictive.     

This PR relaxes the 32-bit element-bitwidth ceiling that prevented `vector.multi_reduction` and `iree_linalg_ext.arg_compare` from compiling through the VectorDistribute pipeline on AMDGPU.  After this PR, AMD targets accept power-of-two element widths above 32 bits.

Assisted-by:  [Claude Code](https://claude.ai/code)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    