### PR TITLE
[Dispatch Creation] Require all producer uses to be fusable

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -773,6 +773,23 @@ static bool isFusableWithProducer(OpOperand &operand,
   return true;
 }
 
+static bool areAllFusionGroupUsesFusableWithProducer(
+    Operation *producer, const FusionGroup &fusionGroup,
+    const FusionTracker &tracker, FormDispatchRegionsPassOptions const &options,
+    bool fuseWithTruncate) {
+  return llvm::all_of(producer->getUses(), [&](OpOperand &use) {
+    Operation *useOwner = use.getOwner();
+    Operation *useOwnerAtProducerLevel =
+        producer->getBlock()->findAncestorOpInBlock(*useOwner);
+    if (!useOwnerAtProducerLevel ||
+        !fusionGroup.contains(useOwnerAtProducerLevel)) {
+      return true;
+    }
+    return useOwnerAtProducerLevel == useOwner &&
+           isFusableWithProducer(use, tracker, options, fuseWithTruncate);
+  });
+}
+
 /// Starting from the `root` op, traverse the operand use-def chain
 /// in reverse to fuse with producers.
 static void
@@ -802,7 +819,8 @@ fuseRootsWithProducers(MLIRContext *context, Operation *root,
         continue;
       }
 
-      if (!isFusableWithProducer(operand, tracker, options, fuseWithTruncate)) {
+      if (!areAllFusionGroupUsesFusableWithProducer(
+              producer, fusionGroup, tracker, options, fuseWithTruncate)) {
         continue;
       }
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -2510,6 +2510,50 @@ util.func public @no_producer_fusion_with_extract_use_from_above(
 
 // -----
 
+// Producer blocked: it is used both as a normal linalg input and by a
+// tensor.extract nested inside the same root.
+#map = affine_map<(d0, d1) -> (d0, d1)>
+util.func public @no_producer_fusion_with_nested_extract_and_ins_use(
+    %arg0: tensor<4x8xf32>, %arg1: tensor<4x8xf32>)
+    -> tensor<4x8xf32> {
+  %empty = tensor.empty() : tensor<4x8xf32>
+  %producer = linalg.generic {
+      indexing_maps = [#map, #map],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg0 : tensor<4x8xf32>) outs(%empty : tensor<4x8xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %0 = arith.mulf %in, %in : f32
+      linalg.yield %0 : f32
+  } -> tensor<4x8xf32>
+  %root = linalg.generic {
+      indexing_maps = [#map, #map, #map],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%producer, %arg1 : tensor<4x8xf32>, tensor<4x8xf32>)
+      outs(%empty : tensor<4x8xf32>) {
+    ^bb0(%in: f32, %in_1: f32, %out: f32):
+      %idx0 = linalg.index 0 : index
+      %idx1 = linalg.index 1 : index
+      %extracted = tensor.extract %producer[%idx0, %idx1]
+          : tensor<4x8xf32>
+      %0 = arith.addf %in, %in_1 : f32
+      %1 = arith.addf %0, %extracted : f32
+      linalg.yield %1 : f32
+  } -> tensor<4x8xf32>
+  util.return %root : tensor<4x8xf32>
+}
+// CHECK-LABEL: util.func public @no_producer_fusion_with_nested_extract_and_ins_use
+//       CHECK:   %[[PRODUCER:.+]] = flow.dispatch.region
+//       CHECK:     linalg.generic
+//       CHECK:       arith.mulf
+//       CHECK:     flow.return
+//       CHECK:   flow.dispatch.region
+//       CHECK:     linalg.generic
+//  CHECK-SAME:       ins(%[[PRODUCER]]
+//       CHECK:       tensor.extract %[[PRODUCER]]
+//       CHECK:     flow.return
+
+// -----
+
 // Producer blocked: multi-level capture chain (extract → opA → root).
 #map = affine_map<(d0, d1) -> (d0, d1)>
 util.func public @no_fusion_multilevel_region_capture(


### PR DESCRIPTION
Prevents fusion as seen in https://github.com/iree-org/iree/issues/24149 where the producer is used normally by the root but also by a `tensor.extract` inside the root op's body.