### PR TITLE
[Codegen][CPU] Fix DataTiledMMAAttr::getUndistributedTileTypes to honor swizzle permutation.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -609,21 +609,6 @@ DataTiledMMAAttr::verifyIndexingMaps(ArrayRef<AffineMap> maps) const {
   return linalg::inferContractionDims(maps);
 }
 
-/// Returns a pair where the first element is the element count of the group and
-/// the second element is whether the group contains a scalable dimension.
-static std::pair<int64_t, bool>
-getVectorAxisSizeAndScalability(ArrayRef<Codegen::TileSwizzle::Dim> group) {
-  using Dim = Codegen::TileSwizzle::Dim;
-  int64_t size = 1;
-  bool scalable = false;
-  for (const Dim &d : group) {
-    size *= d.size();
-    scalable |= d.kind() == Dim::Kind::Internal &&
-                d.symbolicMultiplier() != Dim::SymbolicMultiplier::One;
-  }
-  return {size, scalable};
-}
-
 void DataTiledMMAAttr::getUndistributedTileTypes(
     SmallVectorImpl<VectorType> &result) const {
   MLIRContext *ctx = getContext();
@@ -633,25 +618,9 @@ void DataTiledMMAAttr::getUndistributedTileTypes(
     return;
   }
   auto [aType, bType, cType] = getABCElementTypes(ctx, *this);
-  // Each operand's swizzle encodes its tile shape as (outer physical dim,
-  // inner physical dim) in expandShape[0], expandShape[1]. This mirrors GPU's
-  // DataTiledMMA, where the tile types encode the layout directly and no
-  // separate `permutations` attribute is needed on `inner_tiled`. LHS is
-  // (M, K), RHS is (N, K), and ACC is (M, N) for non-transposed intrinsics
-  // and (N, M) for transposed ones; that transposition is baked into the ACC
-  // swizzle itself (see getIntrinsicSwizzle), so we can query all three
-  // operands uniformly here.
-  auto tileType = [&](Codegen::TileSwizzle swizzle, Type elemType) {
-    auto [outer, outerScalable] =
-        getVectorAxisSizeAndScalability(swizzle.expandShape()[0]);
-    auto [inner, innerScalable] =
-        getVectorAxisSizeAndScalability(swizzle.expandShape()[1]);
-    bool scalable[] = {outerScalable, innerScalable};
-    return VectorType::get({outer, inner}, elemType, scalable);
-  };
-  result.assign({tileType(getSwizzle(*this, 0), aType),
-                 tileType(getSwizzle(*this, 1), bType),
-                 tileType(getSwizzle(*this, 2), cType)});
+  result.assign({Codegen::getTileVectorType(getSwizzle(*this, 0), aType),
+                 Codegen::getTileVectorType(getSwizzle(*this, 1), bType),
+                 Codegen::getTileVectorType(getSwizzle(*this, 2), cType)});
 }
 
 void DataTiledMMAAttr::getDistributedTileTypes(
@@ -778,6 +747,24 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   }
 }
 
+/// Returns `v` with trailing unit dims stripped, down to but not below
+/// rank `minRank`. Emits a `vector.shape_cast` if any dim is stripped;
+/// returns `v` unchanged otherwise.
+static Value dropTrailingUnitDims(OpBuilder &builder, Location loc, Value v,
+                                  int64_t minRank) {
+  auto vt = cast<VectorType>(v.getType());
+  ArrayRef<int64_t> shape = vt.getShape();
+  int64_t newRank = shape.size();
+  while (newRank > minRank && shape[newRank - 1] == 1) {
+    --newRank;
+  }
+  if (newRank == static_cast<int64_t>(shape.size())) {
+    return v;
+  }
+  auto flatTy = VectorType::get(shape.take_front(newRank), vt.getElementType());
+  return vector::ShapeCastOp::create(builder, loc, flatTy, v);
+}
+
 /// Lowers a `DataTiledMMAAttr` whose intrinsic is one of the
 /// `MMA_GENERIC_SCALAR_1x1x1_REG*` cases directly to a single
 /// `vector.contract`. Since the intrinsic's tile shape is 1×1×1, the
@@ -790,9 +777,15 @@ static LogicalResult lowerGenericScalarToVectorContract(
   assert(isGenericScalar(attr.getIntrinsic()) &&
          "lowerGenericScalarToVectorContract only handles "
          "MMA_GENERIC_SCALAR_1x1x1_REG* intrinsics");
-  Value lhs = inputs[0];
-  Value rhs = inputs[1];
-  Value acc = outputs[0];
+  // The 1×1×1 base intrinsic means every non-unit dim in the operand tile
+  // came from `intrinsics_{m,n,k}` and is a `Codegen::TileSwizzle`
+  // `CrossIntrinsic` dim, which `Codegen::expand` placed at the start of
+  // its `expandShape` group and at memory slot 0. So all the unit dims end
+  // up at trailing positions of the per-operand tile; drop them to get the
+  // rank-2 (M, K)/(N, K)/(M, N) shape `vector.contract` expects below.
+  Value lhs = dropTrailingUnitDims(builder, loc, inputs[0], /*minRank=*/2);
+  Value rhs = dropTrailingUnitDims(builder, loc, inputs[1], /*minRank=*/2);
+  Value acc = dropTrailingUnitDims(builder, loc, outputs[0], /*minRank=*/2);
   Type accElem = cast<VectorType>(acc.getType()).getElementType();
   // For the generic intrinsic, ACC is always at least as wide as LHS/RHS,
   // and they're either all float or all integer (the cost model only picks

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/invalid.mlir
@@ -91,7 +91,7 @@ func.func @cpu_inner_tiled_f32_avx512_missing_intrinsics_m(
 ]
 func.func @cpu_inner_tiled_element_type_mismatch(
     %lhs: tensor<1x1x16x1xf16>, %rhs: tensor<1x1x16x1xf16>, %acc: tensor<1x1x16x16xf32>) -> tensor<1x1x16x16xf32> {
-  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #0 inner tile 'tensor<16x1xf16>' is incompatible with expected MMA tile type 'vector<16x1xf32>'}}
+  // expected-error @+1 {{'iree_codegen.inner_tiled' op operand #0 inner tile 'tensor<16x1xf16>' is incompatible with expected MMA tile type 'vector<16x1x1xf32>'}}
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
@@ -55,15 +55,15 @@ func.func @cpu_avx512_1x16x1_f32(
 ]
 // MMA_X86_AVX512_1x16x1_F32_F16_CASTF32, intrinsics 1x2x1 -> M=1,N=2,K=1
 func.func @cpu_avx512_1x16x1_f16_castf32(
-    %lhs: vector<1x1x1xf16>, %rhs: vector<1x2x32xf16>, %acc: vector<1x2x32xf32>)
-    -> vector<1x2x32xf32> {
+    %lhs: vector<1x1x1x1xf16>, %rhs: vector<1x2x2x16xf16>, %acc: vector<1x2x2x16xf32>)
+    -> vector<1x2x2x16xf32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F16_CASTF32, intrinsics_n = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<1x1x1xf16>, vector<1x2x32xf16> into vector<1x2x32xf32>
-  return %0 : vector<1x2x32xf32>
+  } : vector<1x1x1x1xf16>, vector<1x2x2x16xf16> into vector<1x2x2x16xf32>
+  return %0 : vector<1x2x2x16xf32>
 }
 // CHECK-LABEL: func @cpu_avx512_1x16x1_f16_castf32
 //       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
@@ -78,14 +78,14 @@ func.func @cpu_avx512_1x16x1_f16_castf32(
 ]
 // MMA_X86_AVX512FP16_1x32x1_F16_F16, intrinsics 1x1x2
 func.func @cpu_avx512fp16_1x32x1_f16(
-    %lhs: vector<1x2x1x2xf16>, %rhs: vector<2x1x32x2xf16>, %acc: vector<1x1x1x32xf16>)
+    %lhs: vector<1x2x1x2xf16>, %rhs: vector<2x1x2x32xf16>, %acc: vector<1x1x1x32xf16>)
     -> vector<1x1x1x32xf16> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512FP16_1x32x1_F16_F16, intrinsics_k = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<1x2x1x2xf16>, vector<2x1x32x2xf16> into vector<1x1x1x32xf16>
+  } : vector<1x2x1x2xf16>, vector<2x1x2x32xf16> into vector<1x1x1x32xf16>
   return %0 : vector<1x1x1x32xf16>
 }
 // CHECK-LABEL: func @cpu_avx512fp16_1x32x1_f16
@@ -101,15 +101,15 @@ func.func @cpu_avx512fp16_1x32x1_f16(
 ]
 // MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics 2x2x1
 func.func @cpu_avx512bf16_1x16x2_bf16(
-    %lhs: vector<2x1x2x2xbf16>, %rhs: vector<1x2x32x2xbf16>, %acc: vector<2x2x2x32xf32>)
-    -> vector<2x2x2x32xf32> {
+    %lhs: vector<2x1x2x2xbf16>, %rhs: vector<1x2x2x16x2xbf16>, %acc: vector<2x2x2x2x16xf32>)
+    -> vector<2x2x2x2x16xf32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512BF16_1x16x2_F32_BF16, intrinsics_m = 2, intrinsics_n = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<2x1x2x2xbf16>, vector<1x2x32x2xbf16> into vector<2x2x2x32xf32>
-  return %0 : vector<2x2x2x32xf32>
+  } : vector<2x1x2x2xbf16>, vector<1x2x2x16x2xbf16> into vector<2x2x2x2x16xf32>
+  return %0 : vector<2x2x2x2x16xf32>
 }
 // CHECK-LABEL: func @cpu_avx512bf16_1x16x2_bf16
 //       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
@@ -124,15 +124,15 @@ func.func @cpu_avx512bf16_1x16x2_bf16(
 ]
 // MMA_X86_AVX512_1x16x2_I32_I16, intrinsics 1x4x1
 func.func @cpu_avx512_1x16x2_i32_i16(
-    %lhs: vector<1x1x1x2xi16>, %rhs: vector<1x4x64x2xi16>, %acc: vector<1x4x1x64xi32>)
-    -> vector<1x4x1x64xi32> {
+    %lhs: vector<1x1x1x2xi16>, %rhs: vector<1x4x4x16x2xi16>, %acc: vector<1x4x4x16xi32>)
+    -> vector<1x4x4x16xi32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I16, intrinsics_n = 4>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<1x1x1x2xi16>, vector<1x4x64x2xi16> into vector<1x4x1x64xi32>
-  return %0 : vector<1x4x1x64xi32>
+  } : vector<1x1x1x2xi16>, vector<1x4x4x16x2xi16> into vector<1x4x4x16xi32>
+  return %0 : vector<1x4x4x16xi32>
 }
 // CHECK-LABEL: func @cpu_avx512_1x16x2_i32_i16
 //       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
@@ -147,14 +147,14 @@ func.func @cpu_avx512_1x16x2_i32_i16(
 ]
 // MMA_X86_AVX512VNNI_1x16x2_I32_I16, intrinsics 2x1x2
 func.func @cpu_avx512vnni_1x16x2_i32_i16(
-    %lhs: vector<2x2x2x4xi16>, %rhs: vector<2x1x16x4xi16>, %acc: vector<2x1x2x16xi32>)
+    %lhs: vector<2x2x2x2x2xi16>, %rhs: vector<2x1x2x16x2xi16>, %acc: vector<2x1x2x16xi32>)
     -> vector<2x1x2x16xi32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I16, intrinsics_m = 2, intrinsics_k = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<2x2x2x4xi16>, vector<2x1x16x4xi16> into vector<2x1x2x16xi32>
+  } : vector<2x2x2x2x2xi16>, vector<2x1x2x16x2xi16> into vector<2x1x2x16xi32>
   return %0 : vector<2x1x2x16xi32>
 }
 // CHECK-LABEL: func @cpu_avx512vnni_1x16x2_i32_i16
@@ -170,14 +170,14 @@ func.func @cpu_avx512vnni_1x16x2_i32_i16(
 ]
 // MMA_X86_AVX512_1x16x2_I32_I8_CASTI16, intrinsics 1x1x4
 func.func @cpu_avx512_1x16x2_i32_i8(
-    %lhs: vector<1x4x1x8xi8>, %rhs: vector<4x1x16x8xi8>, %acc: vector<1x1x1x16xi32>)
+    %lhs: vector<1x4x4x2xi8>, %rhs: vector<4x1x4x16x2xi8>, %acc: vector<1x1x1x16xi32>)
     -> vector<1x1x1x16xi32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x2_I32_I8_CASTI16, intrinsics_k = 4>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<1x4x1x8xi8>, vector<4x1x16x8xi8> into vector<1x1x1x16xi32>
+  } : vector<1x4x4x2xi8>, vector<4x1x4x16x2xi8> into vector<1x1x1x16xi32>
   return %0 : vector<1x1x1x16xi32>
 }
 // CHECK-LABEL: func @cpu_avx512_1x16x2_i32_i8
@@ -193,14 +193,14 @@ func.func @cpu_avx512_1x16x2_i32_i8(
 ]
 // MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16, intrinsics 4x1x2
 func.func @cpu_avx512vnni_1x16x2_i32_i8(
-    %lhs: vector<4x2x4x4xi8>, %rhs: vector<2x1x16x4xi8>, %acc: vector<4x1x4x16xi32>)
+    %lhs: vector<4x2x4x2x2xi8>, %rhs: vector<2x1x2x16x2xi8>, %acc: vector<4x1x4x16xi32>)
     -> vector<4x1x4x16xi32> {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = #contraction_accesses,
     iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16, intrinsics_m = 4, intrinsics_k = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : vector<4x2x4x4xi8>, vector<2x1x16x4xi8> into vector<4x1x4x16xi32>
+  } : vector<4x2x4x2x2xi8>, vector<2x1x2x16x2xi8> into vector<4x1x4x16xi32>
   return %0 : vector<4x1x4x16xi32>
 }
 // CHECK-LABEL: func @cpu_avx512vnni_1x16x2_i32_i8

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.cpp
@@ -77,4 +77,26 @@ sliceSwizzledShape(const TileSwizzle &swizzle,
   return shape;
 }
 
+VectorType
+getTileVectorType(const TileSwizzle &swizzle, Type elemType,
+                  llvm::function_ref<bool(TileSwizzle::Dim)> keepSize) {
+  using Dim = TileSwizzle::Dim;
+  SmallVector<int64_t> shape = sliceSwizzledShape(swizzle, keepSize);
+  SmallVector<bool> scalable;
+  for (const auto &group : swizzle.expandShape()) {
+    for (const Dim &d : group) {
+      scalable.push_back(d.kind() == Dim::Kind::Internal &&
+                         d.symbolicMultiplier() !=
+                             Dim::SymbolicMultiplier::One);
+    }
+  }
+  applyPermutationToVector(scalable, swizzle.permutation());
+  return VectorType::get(shape, elemType, scalable);
+}
+
+VectorType getTileVectorType(const TileSwizzle &swizzle, Type elemType) {
+  return getTileVectorType(swizzle, elemType,
+                           [](TileSwizzle::Dim) { return true; });
+}
+
 } // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
@@ -218,6 +218,18 @@ SmallVector<int64_t>
 sliceSwizzledShape(const TileSwizzle &swizzle,
                    llvm::function_ref<bool(TileSwizzle::Dim)> predicate);
 
+/// Returns the VectorType corresponding to `swizzle` with element type
+/// `elemType`. The shape is `sliceSwizzledShape(swizzle, keepSize)` — i.e.
+/// every dim of `expandShape` in `swizzle.permutation()` order, with dims
+/// for which `keepSize` returns false collapsed to size 1. A dim with a
+/// non-`One` symbolic multiplier maps to a scalable axis.
+VectorType
+getTileVectorType(const TileSwizzle &swizzle, Type elemType,
+                  llvm::function_ref<bool(TileSwizzle::Dim)> keepSize);
+/// Convenience overload of the above for when every dim is kept at its
+/// full size.
+VectorType getTileVectorType(const TileSwizzle &swizzle, Type elemType);
+
 /// Pushes `dim` to the front of `swizzle.expandShape[srcIdx]`, and updates
 /// `swizzle.permutation` accordingly.
 void expand(TileSwizzle &swizzle, size_t srcIdx, TileSwizzle::Dim dim);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.cpp
@@ -54,15 +54,8 @@ void DataTiledMMAInterfaceAttr::getUndistributedTileTypes(
   SmallVector<Type> elementTypes;
   getElementTypes(elementTypes);
   for (auto [i, elementType] : llvm::enumerate(elementTypes)) {
-    TileSwizzle swizzle = getTileSwizzle(i);
-    SmallVector<int64_t> shape;
-    for (TileSwizzle::ExpandShapeDimVectorType group : swizzle.expandShape()) {
-      for (TileSwizzle::Dim d : group) {
-        shape.push_back(d.size());
-      }
-    }
-    applyPermutationToVector(shape, swizzle.permutation());
-    result.push_back(VectorType::get(shape, elementType));
+    result.push_back(
+        Codegen::getTileVectorType(getTileSwizzle(i), elementType));
   }
 }
 
@@ -70,14 +63,11 @@ void DataTiledMMAInterfaceAttr::getDistributedTileTypes(
     SmallVectorImpl<VectorType> &result) {
   SmallVector<Type> elementTypes;
   getElementTypes(elementTypes);
-  auto getShape = [=](unsigned operandIndex) {
-    return Codegen::sliceSwizzledShape(
-        getTileSwizzle(operandIndex), [](TileSwizzle::Dim d) {
-          return d.kind() != TileSwizzle::Dim::Kind::CrossThread;
-        });
-  };
   for (auto [i, elementType] : llvm::enumerate(elementTypes)) {
-    result.push_back(VectorType::get(getShape(i), elementType));
+    result.push_back(Codegen::getTileVectorType(
+        getTileSwizzle(i), elementType, [](TileSwizzle::Dim d) {
+          return d.kind() != TileSwizzle::Dim::Kind::CrossThread;
+        }));
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -303,17 +303,24 @@ static bool getEnableInnerTiledFromConfig(DictionaryAttr config) {
 }
 
 /// Returns the matmul {M, N, K} tile shape covered by a CPU DataTiledMMAAttr.
-/// Derived directly from `getUndistributedTileTypes`: LHS is M×K (always) and
-/// RHS is N×K (always), regardless of the `transposed_intrinsic` flag. The
-/// ACC layout varies (M×N row-major vs. N×M column-major for transposed
-/// intrinsics), so we derive M and N from the LHS and RHS tiles instead.
+/// The swizzle's `expandShape` is partitioned per its convention (see
+/// `getIntrinsicSwizzle`): LHS is `[M dims, K dims]`, RHS is `[N dims, K
+/// dims]`. So M is the product of LHS group 0, K is the product of LHS
+/// group 1, and N is the product of RHS group 0. Unlike reading from the
+/// vector tile type, this works regardless of the swizzle's permutation.
 static IREE::Codegen::TileMxNxK getTileMxNxK(IREE::CPU::DataTiledMMAAttr mma) {
-  SmallVector<VectorType> tiles;
-  mma.getUndistributedTileTypes(tiles);
-  assert(tiles.size() == 3 && "Expected LHS, RHS, ACC tile types");
-  ArrayRef<int64_t> lhsShape = tiles[0].getShape();
-  ArrayRef<int64_t> rhsShape = tiles[1].getShape();
-  return IREE::Codegen::TileMxNxK{lhsShape[0], rhsShape[0], lhsShape[1]};
+  auto groupProduct = [](ArrayRef<IREE::Codegen::TileSwizzle::Dim> group) {
+    int64_t product = 1;
+    for (const auto &d : group) {
+      product *= d.size();
+    }
+    return product;
+  };
+  IREE::Codegen::TileSwizzle lhsSwizzle = IREE::CPU::getSwizzle(mma, 0);
+  IREE::Codegen::TileSwizzle rhsSwizzle = IREE::CPU::getSwizzle(mma, 1);
+  return IREE::Codegen::TileMxNxK{groupProduct(lhsSwizzle.expandShape()[0]),
+                                  groupProduct(rhsSwizzle.expandShape()[0]),
+                                  groupProduct(lhsSwizzle.expandShape()[1])};
 }
 
 /// Returns the set of `+feature` strings that must all be present in the

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1768,7 +1768,7 @@ func.func @gather(%source: tensor<16x8x32x128xf16>, %indices: tensor<4xi64>, %ou
 // parallel iter dims to 1 and `vector_reduction` collapses the K
 // reduction iter dim to 1. Distribution is parallel-only (M, N).
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "+avx512f", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
-func.func @inner_tiled_avx512_1x16x1_f32(%lhs: tensor<2x4x2x1xf32>, %rhs: tensor<2x4x32x1xf32>, %acc: tensor<2x2x2x32xf32>) -> tensor<2x2x2x32xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
+func.func @inner_tiled_avx512_1x16x1_f32(%lhs: tensor<2x4x2x1xf32>, %rhs: tensor<2x4x2x16xf32>, %acc: tensor<2x2x2x2x16xf32>) -> tensor<2x2x2x2x16xf32> attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
   %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
     indexing_maps = [
       affine_map<(d0, d1, d2) -> (d0, d2)>,
@@ -1780,8 +1780,8 @@ func.func @inner_tiled_avx512_1x16x1_f32(%lhs: tensor<2x4x2x1xf32>, %rhs: tensor
                       #linalg.iterator_type<reduction>],
     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 2, intrinsics_n = 2>,
     semantics = #iree_cpu.mma_semantics<>
-  } : tensor<2x4x2x1xf32>, tensor<2x4x32x1xf32> into tensor<2x2x2x32xf32>
-  return %0 : tensor<2x2x2x32xf32>
+  } : tensor<2x4x2x1xf32>, tensor<2x4x2x16xf32> into tensor<2x2x2x2x16xf32>
+  return %0 : tensor<2x2x2x2x16xf32>
 }
 //   CHECK-DAG: #[[INNER_TILED_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0], vector_common_parallel = [1, 1, 0], vector_reduction = [0, 0, 1]>
 //   CHECK-DAG: #[[INNER_TILED_TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<Mmt4dTilingExpert>>


### PR DESCRIPTION
The swizzle's `permutation` is ground truth for memory layout — for pre-transposed intrinsics with both `intrinsics_m > 1` and `intrinsics_n > 1` on the ACC, the `Codegen::expand` insertion order produces a non-identity permutation that interleaves M and N dims, and that interleaved order is what the encoding materialization actually lays out in memory.

`DataTiledMMAAttr::getUndistributedTileTypes` was silently ignoring that permutation: it returned `(prod(expandShape[0]), prod(expandShape[1]))` — operand-natural row-major — which contradicted the swizzle's stated memory order. The mismatch was dormant when the permutation happened to be identity (all pre-pretransposed intrinsics) but produces wrong tile types for the M↔N-swapped enum values that the next branch in this stack introduces, and is the root cause of the RDNA4 regression that took down #24404.

Fix: lift the per-dim walk into a new shared utility `Codegen::getTileVectorType(swizzle, elemType[, keepSize])` in `IREECodegenTypes`. The shape is `sliceSwizzledShape(swizzle, keepSize)` — every dim of `expandShape` in `swizzle.permutation()` order, with optional per-dim masking to size 1. A dim with a non-`One` symbolic multiplier maps to a scalable axis. CPU's `DataTiledMMAAttr::getUndistributedTileTypes` and GPU's `DataTiledMMAInterfaceAttr::{getUndistributedTileTypes,getDistributedTileTypes}` now all go through it (the GPU distributed variant passes a `d.kind() != CrossThread` mask to fold thread-distribution factors to size-1 axes).

For trivial CPU cases (every `expandShape` group is a single dim — the only configuration `fixupSwizzle` leaves after the base intrinsic build, where `intrinsics_{m,n,k}` haven't yet been expanded in) the result is the same rank-2 `(outer, inner)` shape CPU historically returned. For non-identity permutations introduced by combined `intrinsics_m` and `intrinsics_n` unrolling on ACC, the rank grows because the permutation interleaves M and N dims and there's no rank-2 collapse that faithfully represents the memory layout — and that's the whole point: the tile type now matches what's actually in memory.

`getTileMxNxK` in `CPUEncodingExternalModels.cpp` previously read M, N, K positionally from the tile vector shape, which is wrong once the permutation is honored (M can be spread across multiple dims and interleaved with N). It now goes through the LHS/RHS `TileSwizzle`s directly: M is the product of LHS `expandShape[0]`, K is the product of LHS `expandShape[1]`, N is the product of RHS `expandShape[0]` — the per-operand `[M, K]` / `[N, K]` group partition is what `getIntrinsicSwizzle` establishes by construction, regardless of how the permutation later orders dims in memory.

Test fallout in this branch is limited to `invalid.mlir` (one expected error string updated to reflect the rank increase from honoring the permutation on a 16×1 LHS); other CPU lit tests on origin/main use trivial unrollings that keep the rank-2 shape.

Progress towards https://github.com/iree-org/iree/issues/24323.