### PR TITLE
Register IndexedAccessOpInterface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
@@ -48,6 +48,7 @@
 #include "mlir/Dialect/Transform/LoopExtension/LoopExtension.h"
 #include "mlir/Dialect/Vector/IR/ValueBoundsOpInterfaceImpl.h"
 #include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
+#include "mlir/Dialect/Vector/Transforms/IndexedAccessOpInterfaceImpl.h"
 #include "mlir/Dialect/Vector/Transforms/SubsetOpInterfaceImpl.h"
 
 namespace mlir::iree_compiler {
@@ -123,6 +124,7 @@ void registerCodegenInterfaces(DialectRegistry &registry) {
   tensor::registerTransformDialectExtension(registry);
   tensor::registerValueBoundsOpInterfaceExternalModels(registry);
   transform::registerLoopExtension(registry);
+  vector::registerIndexedAccessOpInterfaceExternalModels(registry);
   vector::registerSubsetOpInterfaceExternalModels(registry);
   vector::registerTransformDialectExtension(registry);
   vector::registerValueBoundsOpInterfaceExternalModels(registry);


### PR DESCRIPTION
IndexedAccessOpInterface was missing from the set of registered interfaces. Working on #24134 revealed this is missing. I believe it is possible to not use this, but at the moment I don't see why it shouldn't be used. 