### PR TITLE
[Codegen] Register vector `IndexedAccessOpInterface` external models

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
@@ -48,6 +48,7 @@
 #include "mlir/Dialect/Transform/LoopExtension/LoopExtension.h"
 #include "mlir/Dialect/Vector/IR/ValueBoundsOpInterfaceImpl.h"
 #include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
+#include "mlir/Dialect/Vector/Transforms/IndexedAccessOpInterfaceImpl.h"
 #include "mlir/Dialect/Vector/Transforms/SubsetOpInterfaceImpl.h"
 
 namespace mlir::iree_compiler {
@@ -123,6 +124,7 @@ void registerCodegenInterfaces(DialectRegistry &registry) {
   tensor::registerTransformDialectExtension(registry);
   tensor::registerValueBoundsOpInterfaceExternalModels(registry);
   transform::registerLoopExtension(registry);
+  vector::registerIndexedAccessOpInterfaceExternalModels(registry);
   vector::registerSubsetOpInterfaceExternalModels(registry);
   vector::registerTransformDialectExtension(registry);
   vector::registerValueBoundsOpInterfaceExternalModels(registry);


### PR DESCRIPTION
we need to call `vector::registerIndexedAccessOpInterfaceExternalModels`, from `mlir::registerAllDialects` so we ca properly populate index calculation.

This manifested as numeric mismatches in `e2e_batch_matmul_cdna4_coalesced_dma_bf16_rocm_hip` after the LLVM bump in #24409.