### PR TITLE
[LLVMGPU] Handle single-workgroup scatter dispatches

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/VerifyWorkgroupDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VerifyWorkgroupDistribution.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "mlir/IR/Visitors.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -19,6 +20,29 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+static bool isWorkgroupForall(scf::ForallOp forallOp) {
+  return forallOpHasMappingType<IREE::Codegen::WorkgroupMappingAttr,
+                                IREE::LinalgExt::SplitReductionMappingAttr>(
+      forallOp);
+}
+
+static bool hasAtMostOneStaticIteration(scf::ForallOp forallOp) {
+  for (auto [lb, ub, step] : llvm::zip_equal(forallOp.getMixedLowerBound(),
+                                             forallOp.getMixedUpperBound(),
+                                             forallOp.getMixedStep())) {
+    std::optional<int64_t> lbVal = getConstantIntValue(lb);
+    std::optional<int64_t> ubVal = getConstantIntValue(ub);
+    std::optional<int64_t> stepVal = getConstantIntValue(step);
+    if (!lbVal || !ubVal || !stepVal || *stepVal <= 0) {
+      return false;
+    }
+    if (*ubVal - *lbVal > *stepVal) {
+      return false;
+    }
+  }
+  return true;
+}
+
 struct VerifyWorkgroupDistributionPass final
     : impl::VerifyWorkgroupDistributionPassBase<
           VerifyWorkgroupDistributionPass> {
@@ -26,19 +50,19 @@ struct VerifyWorkgroupDistributionPass final
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
 
-    WalkResult hasForall = funcOp.walk([&](scf::ForallOp forallOp) {
-      if (forallOpHasMappingType<IREE::Codegen::WorkgroupMappingAttr,
-                                 IREE::LinalgExt::SplitReductionMappingAttr>(
-              forallOp)) {
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    });
+    WalkResult hasMultiWorkgroupForall =
+        funcOp.walk([&](scf::ForallOp forallOp) {
+          if (isWorkgroupForall(forallOp) &&
+              !hasAtMostOneStaticIteration(forallOp)) {
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        });
 
-    // Without a workgroup level forall, either this is a single workgroup
+    // Without a multi-workgroup level forall, either this is a single workgroup
     // dispatch, in which case no verification is needed, or this is already
     // distributed in which case verification is no longer possible.
-    if (!hasForall.wasInterrupted()) {
+    if (!hasMultiWorkgroupForall.wasInterrupted()) {
       return;
     }
 
@@ -48,9 +72,7 @@ struct VerifyWorkgroupDistributionPass final
     WalkResult res = funcOp.walk<WalkOrder::PreOrder>([&](Operation *op) {
       if (auto forallOp = dyn_cast<scf::ForallOp>(op)) {
         // Skip ops contained within forall ops with workgroup mappings.
-        if (forallOpHasMappingType<IREE::Codegen::WorkgroupMappingAttr,
-                                   IREE::LinalgExt::SplitReductionMappingAttr>(
-                forallOp)) {
+        if (isWorkgroupForall(forallOp)) {
           return WalkResult::skip();
         }
       }

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_workgroup_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_workgroup_distribution.mlir
@@ -14,6 +14,17 @@ func.func @write_outside_workgroup_forall(%i: i32, %out: memref<32xi32, #hal.des
 
 // -----
 
+// CHECK-LABEL: func @write_outside_single_workgroup_forall
+func.func @write_outside_single_workgroup_forall(%i: i32, %out: memref<32xi32, #hal.descriptor_type<storage_buffer>>) {
+  scf.forall (%arg0) = (0) to (32) step (32) {
+  } {mapping = [#iree_codegen.workgroup_mapping<x>]}
+  %c0 = arith.constant 0 : index
+  memref.store %i, %out[%c0] : memref<32xi32, #hal.descriptor_type<storage_buffer>>
+  return
+}
+
+// -----
+
 // CHECK-LABEL: func @non_workgroup_write_outside_workgroup_forall
 func.func @non_workgroup_write_outside_workgroup_forall(
   %i: i32, %out: memref<32xi32, #hal.descriptor_type<storage_buffer>>, %out2: memref<32xi32>) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -1704,7 +1704,17 @@ LogicalResult setScatterLoweringConfig(IREE::GPU::TargetAttr target,
     // If the inner most slice is a single element then we have to bail out.
     // TODO: Support this case.
     if (!hasNonUnitInnerSlice) {
-      return failure();
+      if (llvm::any_of(loopBounds, ShapedType::isDynamic)) {
+        return failure();
+      }
+      TileSizesListType tileSizes = {loopBounds};
+      std::array<int64_t, 3> workgroupSize = {2 * flatWorkgroupSize, 1, 1};
+      auto loweringConfig = IREE::Codegen::LoweringConfigAttr::get(
+          scatter.getContext(), tileSizes);
+      return setOpConfigAndEntryPointFnTranslation(
+          entryPoint, scatter, loweringConfig,
+          getGPUTranslationInfo(op->getContext(), LoweringPipeline::Distribute,
+                                workgroupSize, flatWorkgroupSize));
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -532,7 +532,7 @@ func.func @only_scattered_dim(%arg0: tensor<48xf32>,
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<Distribute> workgroup_size = [128, 1, 1] subgroup_size = 64
 
 //       CHECK:   linalg_ext.scatter {{.*}}lowering_config = #iree_codegen.lowering_config
-//  CHECK-SAME:     tile_sizes = {{\[}}[128]]
+//  CHECK-SAME:     tile_sizes = {{\[}}[48]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -469,3 +469,34 @@ func.func @matmul_f16() attributes {hal.executable.target = #executable_target_c
 // SM80-COUNT-64: nvvm.mma.sync{{.*}}shape = #nvvm.shape<m = 16, n = 8, k = 16>
 //     SM80-NOT:     nvvm.mma.sync
 //         SM80:     llvm.return
+
+// -----
+
+#executable_target_cuda = #hal.executable.target<"cuda", "cuda-nvptx-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @scatter_update_only_indexed_dim() attributes {hal.executable.target = #executable_target_cuda} {
+  %c0 = arith.constant 0 : index
+  %original = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1x1xf32>>
+  %updates = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11x1x1xf32>>
+  %indices = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi32>>
+  %output = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1x1xf32>>
+  %original_t = iree_tensor_ext.dispatch.tensor.load %original, offsets = [0, 0, 0], sizes = [32, 1, 1], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1x1xf32>> -> tensor<32x1x1xf32>
+  %updates_t = iree_tensor_ext.dispatch.tensor.load %updates, offsets = [0, 0, 0], sizes = [11, 1, 1], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11x1x1xf32>> -> tensor<11x1x1xf32>
+  %indices_t = iree_tensor_ext.dispatch.tensor.load %indices, offsets = [0], sizes = [11], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi32>> -> tensor<11xi32>
+  %scatter = iree_linalg_ext.scatter dimension_map = [0] unique_indices(true) ins(%updates_t, %indices_t : tensor<11x1x1xf32>, tensor<11xi32>) outs(%original_t : tensor<32x1x1xf32>) {
+  ^bb0(%update: f32, %old: f32):
+    iree_linalg_ext.yield %update : f32
+  } -> tensor<32x1x1xf32>
+  iree_tensor_ext.dispatch.tensor.store %scatter, %output, offsets = [0, 0, 0], sizes = [32, 1, 1], strides = [1, 1, 1] : tensor<32x1x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1x1xf32>>
+  return
+}
+
+//       CHECK-LABEL: llvm.func @scatter_update_only_indexed_dim
+//             CHECK:   llvm.store
+//        SM80-LABEL: llvm.func @scatter_update_only_indexed_dim
+//              SM80:   llvm.store


### PR DESCRIPTION
Problem:
- A scatter like `tensor<32x1x1xf32>` updated by `tensor<11x1x1xf32>` with `tensor<11xi32>` indices only updates indexed dimensions and has a unit inner slice.
- LLVMGPU scatter configuration previously failed this shape because it required a non-unit inner slice before selecting a lowering strategy.
- The workgroup distribution verifier also treated statically single-iteration workgroup forall loops as multi-workgroup dispatches, which rejected the copy-back pattern used by functional scatter lowering.

Fix:
- Configure this scatter shape with the Distribute pipeline and a tile that covers the full iteration domain, keeping the original-output copy and the update loop in one workgroup.
- Treat statically single-iteration workgroup forall loops as single-workgroup dispatches in the verifier.

Example:
- For `original: tensor<32x1x1xf32>`, `updates: tensor<11x1x1xf32>`, and `indices: tensor<11xi32>`, lower `out[indices[i], 0, 0] = updates[i, 0, 0]` as a single-workgroup scatter instead of failing configuration.