### PR TITLE
[Codegen] Avoid consumer fusion through scatter ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_fuse_and_hoist_forall.mlir
@@ -187,6 +187,31 @@ func.func @forall_fuse_then_hoist_with_fill(%3: tensor<128x128xf16>, %4: tensor<
 
 // -----
 
+func.func @do_not_consumer_fuse_scatter(%arg0: tensor<2x1x2x256xf32>,
+                                        %arg1: tensor<2xi32>,
+                                        %arg2: tensor<256x1x2x256xf32>) -> tensor<256x1x2x256xf32> {
+  %empty = tensor.empty() : tensor<2x1x2x256xf32>
+  %0 = scf.forall (%arg3) in (2) shared_outs(%arg4 = %empty) -> (tensor<2x1x2x256xf32>) {
+    %2 = tensor.extract_slice %arg0[%arg3, 0, 0, 0] [1, 1, 2, 256] [1, 1, 1, 1] : tensor<2x1x2x256xf32> to tensor<1x1x2x256xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %2 into %arg4[%arg3, 0, 0, 0] [1, 1, 2, 256] [1, 1, 1, 1] : tensor<1x1x2x256xf32> into tensor<2x1x2x256xf32>
+    }
+  }
+  %1 = iree_linalg_ext.scatter dimension_map = [0] unique_indices(false)
+    ins(%0, %arg1 : tensor<2x1x2x256xf32>, tensor<2xi32>) outs(%arg2 : tensor<256x1x2x256xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32):
+    iree_linalg_ext.yield %arg3 : f32
+  } -> tensor<256x1x2x256xf32>
+  return %1 : tensor<256x1x2x256xf32>
+}
+
+// CHECK-LABEL: func @do_not_consumer_fuse_scatter(
+//       CHECK:   %[[PRODUCER:.+]] = scf.forall
+//       CHECK:   iree_linalg_ext.scatter
+//  CHECK-SAME:     ins(%[[PRODUCER]],
+
+// -----
+
 func.func @multi_hoist_and_fuse_trailing_stuff(%2: tensor<128x128xf16>) -> tensor<128x128xf16> {
   %c4 = arith.constant 4 : index
   %c128 = arith.constant 128 : index

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.cpp
@@ -49,6 +49,11 @@ struct FuseTilableForallConsumers final
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
   LogicalResult matchAndRewrite(TilingInterface tilableOp,
                                 PatternRewriter &rewriter) const override {
+    if (isa<IREE::LinalgExt::ScatterOp>(*tilableOp)) {
+      return rewriter.notifyMatchFailure(
+          tilableOp, "scatter consumer fusion is not supported");
+    }
+
     // Currently consumer fusion requires DPS, and we don't want to fuse through
     // inits anyway.
     auto dpsOp = dyn_cast<DestinationStyleOpInterface>(*tilableOp);


### PR DESCRIPTION
Problem:
The forall consumer-fusion pattern can try to fuse through linalg_ext.scatter. The generic tiling helper may partially mutate IR before reporting failure for scatter consumers, which can make the greedy fuse/hoist pass fail to converge.

Fix:
Do not run the forall consumer-fusion pattern on linalg_ext.scatter. Direct scatter fusion needs scatter-specific legality checks because scatter writes to runtime-indexed locations, carries an outs tensor, and must preserve copy/update/writeback and combiner semantics.

Example:
Keep a scatter consuming a forall result outside this fusion path. A focused regression covers this case and prevents the generic fusion path from partially mutating the IR.