### PR TITLE
[Python] Preserve device-local buffer uploads

### DIFF
--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -215,8 +215,7 @@ py::object HalAllocator::AllocateBufferCopy(
   PyBufferReleaser py_view_releaser(py_view);
 
   iree_hal_buffer_params_t params = {0};
-  // TODO: Should not require host visible :(
-  params.type = memory_type | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  params.type = memory_type;
   params.usage = allowed_usage;
 
   iree_hal_buffer_t* hal_buffer = nullptr;
@@ -231,7 +230,7 @@ py::object HalAllocator::AllocateBufferCopy(
           IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
     }
   }
-  CheckApiStatus(status, "Failed to allocate device visible buffer");
+  CheckApiStatus(status, "Failed to allocate buffer copy");
 
   if (!raw_element_type) {
     return py::cast(HalBuffer::StealFromRawPtr(hal_buffer),

--- a/runtime/bindings/python/invoke.cc
+++ b/runtime/bindings/python/invoke.cc
@@ -216,8 +216,8 @@ class InvokeStatics {
 
             retained_bv = c.allocator().AllocateBufferCopy(
                 IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-                IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING,
-                c.device(), host_array, hal_element_type);
+                IREE_HAL_BUFFER_USAGE_DEFAULT, c.device(), host_array,
+                hal_element_type);
             bv = py::cast<HalBufferView*>(retained_bv);
           }
 
@@ -420,8 +420,7 @@ class InvokeStatics {
 
       // Put it on the device.
       py::object retained_bv = c.allocator().AllocateBufferCopy(
-          IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-          IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING,
+          IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL, IREE_HAL_BUFFER_USAGE_DEFAULT,
           c.device(), host_array, hal_element_type);
       HalBufferView* bv = py::cast<HalBufferView*>(retained_bv);
 

--- a/runtime/bindings/python/iree/runtime/array_interop.py
+++ b/runtime/bindings/python/iree/runtime/array_interop.py
@@ -267,7 +267,7 @@ def asdevicearray(
     *,
     implicit_host_transfer: bool = False,
     memory_type=MemoryType.DEVICE_LOCAL,
-    allowed_usage=(BufferUsage.DEFAULT | BufferUsage.MAPPING),
+    allowed_usage=BufferUsage.DEFAULT,
     element_type: Optional[HalElementType] = None,
 ) -> DeviceArray:
     """Helper to create a DeviceArray from an arbitrary array like.
@@ -276,8 +276,10 @@ def asdevicearray(
     a device as the first argument. This may not be the best mechanism for
     getting a DeviceArray, depending on your use case, but it is reliable
     and simple. This function may make a defensive copy or cause implicit
-    transfers to satisfy the request. If this is important to you, then a lower
-    level API is likely more appropriate.
+    transfers to satisfy the request. The default creates a device-local buffer;
+    callers that require direct host mapping should request a host-visible
+    memory type and mapping usage explicitly. If this is important to you, then
+    a lower level API is likely more appropriate.
 
     Note that additional flags `memory_type`, `allowed_usage` and `element_type`
     are only hints if creating a new DeviceArray. If `a` is already a DeviceArray,

--- a/runtime/bindings/python/iree/runtime/function.py
+++ b/runtime/bindings/python/iree/runtime/function.py
@@ -289,10 +289,10 @@ ABI_TYPE_TO_DTYPE = {
     "i1": np.bool_,
 }
 
-# When we get an ndarray as an argument and are implicitly mapping it to a
+# When we get an ndarray as an argument and are implicitly converting it to a
 # buffer view, flags for doing so.
 IMPLICIT_BUFFER_ARG_MEMORY_TYPE = MemoryType.DEVICE_LOCAL
-IMPLICIT_BUFFER_ARG_USAGE = BufferUsage.DEFAULT | BufferUsage.MAPPING
+IMPLICIT_BUFFER_ARG_USAGE = BufferUsage.DEFAULT
 
 
 def _is_ndarray_descriptor(desc):

--- a/runtime/bindings/python/tests/array_interop_test.py
+++ b/runtime/bindings/python/tests/array_interop_test.py
@@ -55,6 +55,26 @@ class DeviceHalTest(unittest.TestCase):
         np.testing.assert_array_equal(cp, init_ary)
         self.assertTrue(ary.is_host_accessible)
 
+    def testCudaDeviceLocalAsDeviceArrayMemoryType(self):
+        try:
+            device = iree.runtime.get_device("cuda")
+        except Exception as e:
+            self.skipTest(f"CUDA device unavailable: {e}")
+
+        init_ary = np.zeros([3, 4], dtype=np.float32) + 2
+        ary = iree.runtime.asdevicearray(
+            device,
+            init_ary,
+            memory_type=iree.runtime.MemoryType.DEVICE_LOCAL,
+            allowed_usage=iree.runtime.BufferUsage.DEFAULT,
+        )
+        memory_type = ary._buffer_view.get_buffer().memory_type()
+        self.assertTrue(memory_type & int(iree.runtime.MemoryType.DEVICE_LOCAL))
+        self.assertFalse(memory_type & int(iree.runtime.MemoryType.HOST_LOCAL))
+
+        cp = ary.to_host()
+        np.testing.assert_array_equal(cp, init_ary)
+
     def testOverrideDtype(self):
         init_ary = np.zeros([3, 4], dtype=np.int32) + 2
         buffer_view = self.allocator.allocate_buffer_copy(

--- a/runtime/bindings/python/tests/function_test.py
+++ b/runtime/bindings/python/tests/function_test.py
@@ -456,6 +456,37 @@ class FunctionTest(unittest.TestCase):
             "<VmVariantList(1): [HalBufferView(2:0x20000011)]>", repr(invoked_arg_list)
         )
 
+    def testCudaImplicitNdArrayArgMemoryType(self):
+        try:
+            device = rt.get_device("cuda")
+        except Exception as e:
+            self.skipTest(f"CUDA device unavailable: {e}")
+
+        arg_array = np.zeros([3, 4], dtype=np.float32)
+        invoked_buffer_view = None
+
+        def invoke(arg_list, ret_list):
+            nonlocal invoked_buffer_view
+            invoked_buffer_view = arg_list.get_as_object(0, rt.HalBufferView)
+
+        vm_context = MockVmContext(invoke)
+        vm_function = MockVmFunction(
+            reflection={
+                "iree.abi": json.dumps(
+                    {
+                        "a": [["ndarray", "f32", 3, 4]],
+                        "r": [],
+                    }
+                )
+            }
+        )
+        invoker = FunctionInvoker(vm_context, device, vm_function)
+        _ = invoker(arg_array)
+
+        memory_type = invoked_buffer_view.get_buffer().memory_type()
+        self.assertTrue(memory_type & int(rt.MemoryType.DEVICE_LOCAL))
+        self.assertFalse(memory_type & int(rt.MemoryType.HOST_LOCAL))
+
     def testDeviceArrayArg(self):
         # Note that since the device array is set up to disallow implicit host
         # transfers, this also verifies that no accidental/automatic transfers


### PR DESCRIPTION
Problem:
- Python ndarray arguments and `asdevicearray` uploads requested device-local memory, but also requested `IREE_HAL_BUFFER_USAGE_MAPPING` and forced `IREE_HAL_MEMORY_TYPE_HOST_VISIBLE` in `AllocateBufferCopy`.
- `IREE_HAL_BUFFER_USAGE_MAPPING` means the final HAL buffer may be mapped by the host; it is not required for uploading host data into a device buffer.
- On CUDA and other discrete GPU backends, requiring host-visible mapping can prevent the allocator from choosing true device-local memory.

Fix:
- Allocate buffer copies with the requested memory type instead of forcing host-visible memory.
- Drop mapping usage from implicit ndarray and `asdevicearray` uploads, so the default path creates device-local dispatch buffers.
- Callers that need direct host mapping can still request host-visible memory and mapping usage explicitly.

Example:
- Passing a NumPy array as a function argument now uploads it with `iree_hal_device_transfer_h2d` into a `DEVICE_LOCAL` buffer instead of creating a host-visible, mappable buffer.
- The buffer remains usable for dispatch storage and transfer, while explicit host reads can still copy the data back with `to_host()`.