### PR TITLE
[Codegen] Split StableHLO/JAX select-style argmax reductions

### DIFF
--- a/compiler/plugins/target/ROCM/test/config_ukernel_argmax_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/test/config_ukernel_argmax_gfx942.mlir
@@ -40,7 +40,7 @@ func.func @argmax_4d_unit_parallel_f32i64(%arg0 : tensor<1x1x1x?xf32>) -> tensor
   %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<1x1x1xf32>) -> tensor<1x1x1xf32>
   %4:2 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%arg0 : tensor<1x1x1x?xf32>) outs(%3, %1 : tensor<1x1x1xf32>, tensor<1x1x1xi64>) {
   ^bb0(%in: f32, %out: f32, %out_0: i64):
-    %5 = linalg.index 1 : index
+    %5 = linalg.index 3 : index
     %6 = arith.index_cast %5 : index to i64
     %7 = arith.maximumf %in, %out : f32
     %8 = arith.cmpf ogt, %in, %out : f32

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -387,55 +387,6 @@ splitReduction(RewriterBase &rewriter, LinalgExt::TopkOp topkOp,
   return success();
 }
 
-struct ArgmaxCombinerOps {
-  Operation *maxOp = nullptr;    // arith.maximumf
-  Operation *selectOp = nullptr; // arith.select
-  Operation *cmpOp = nullptr;    // arith.cmpf
-};
-
-// Matches the combiner pattern in a linalg.generic argmax-style reduction:
-// Example MLIR:
-// %4:2 = linalg.generic {
-//     indexing_maps = [...],
-//     iterator_types = ["parallel", "reduction"]
-//   } ins(%arg0 : tensor<?x128xbf16>) outs(%1, %3 : tensor<?xbf16>,
-//   tensor<?xi64>) {
-// ^bb0(%in: bf16, %out: bf16, %out_0: i64):
-//   %5 = linalg.index 1 : index
-//   %6 = arith.index_cast %5 : index to i64
-//   %7 = arith.maximumf %in, %out : bf16
-//   %8 = arith.cmpf ogt, %in, %out : bf16
-//   %9 = arith.select %8, %6, %out_0 : i64
-//   linalg.yield %7, %9 : bf16, i64
-// } -> (tensor<?xbf16>, tensor<?xi64>)
-//
-// This function extracts the `arith.maximumf`, `arith.cmpf`, and `arith.select`
-// operations from the body to facilitate transformations such as split
-// reduction.
-static ArgmaxCombinerOps collectArgmaxCombinerOps(linalg::GenericOp genericOp) {
-  assert(isArgmaxOp(genericOp) && "expected operation to be an argmax op");
-
-  auto yieldOp = cast<linalg::YieldOp>(genericOp.getBody()->getTerminator());
-
-  // Extract max value producer: arith.maximumf.
-  Value maxResult = yieldOp.getOperand(0);
-  auto maxOp = cast<arith::MaximumFOp>(maxResult.getDefiningOp());
-
-  // Extract index result producer: arith.select.
-  Value indexResult = yieldOp.getOperand(1);
-  auto selectOp = cast<arith::SelectOp>(indexResult.getDefiningOp());
-
-  // Extract the condition of the select, expected to be arith.cmpf with
-  // predicate OGT.
-  auto cmpOp = cast<arith::CmpFOp>(selectOp.getCondition().getDefiningOp());
-
-  ArgmaxCombinerOps ops;
-  ops.maxOp = maxOp;
-  ops.selectOp = selectOp;
-  ops.cmpOp = cmpOp;
-  return ops;
-}
-
 static Value expandValue(OpBuilder &builder, Location loc, Value value,
                          RankedTensorType expandedType) {
   RankedTensorType originalType = cast<RankedTensorType>(value.getType());
@@ -521,7 +472,8 @@ static Value getSplitReductionInit(OpBuilder &builder, Location loc,
 FailureOr<linalg::SplitReductionResult>
 splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
                      linalg::ControlSplitReductionFn controlSplitReductionFn) {
-  assert(isArgmaxOp(genericOp) && "expected operation to be an argmax op");
+  std::optional<ArgmaxKind> argmaxKind = getArgmaxKind(genericOp);
+  assert(argmaxKind && "expected operation to be an argmax op");
 
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(genericOp);
@@ -568,13 +520,43 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
                                        "compared to intermediate tensor size");
   }
 
-  ArgmaxCombinerOps combinerOps = collectArgmaxCombinerOps(genericOp);
-  Operation *reductionOp = combinerOps.maxOp;
-  std::optional<TypedAttr> identity = arith::getNeutralElement(reductionOp);
-  if (!identity.has_value()) {
+  auto valueType =
+      dyn_cast<FloatType>(genericOp.getRegionOutputArgs()[0].getType());
+  if (!valueType) {
     return rewriter.notifyMatchFailure(
         genericOp, "Unknown identity value for the reduction");
   }
+  auto identity = FloatAttr::get(
+      valueType, APFloat::getInf(valueType.getFloatSemantics(), true));
+
+  bool selectStyleArgmax = *argmaxKind == ArgmaxKind::StableHloSelectStyle;
+
+  auto buildArgmaxCombiner = [](OpBuilder &b, Location loc, Value val,
+                                Value idx, Value outVal, Value outIdx,
+                                bool selectStyleArgmax) {
+    if (!selectStyleArgmax) {
+      Value maxVal = arith::MaximumFOp::create(b, loc, val, outVal);
+      Value cmp =
+          arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
+      Value selIdx = arith::SelectOp::create(b, loc, cmp, idx, outIdx);
+      return std::pair<Value, Value>{maxVal, selIdx};
+    }
+
+    Value greater =
+        arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
+    Value isNan =
+        arith::CmpFOp::create(b, loc, arith::CmpFPredicate::UNE, val, val);
+    Value valueCond = arith::OrIOp::create(b, loc, greater, isNan);
+    Value equal =
+        arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OEQ, val, outVal);
+    Value lowerIndex =
+        arith::CmpIOp::create(b, loc, arith::CmpIPredicate::slt, idx, outIdx);
+    Value tieCond = arith::AndIOp::create(b, loc, equal, lowerIndex);
+    Value indexCond = arith::OrIOp::create(b, loc, valueCond, tieCond);
+    Value maxVal = arith::SelectOp::create(b, loc, valueCond, val, outVal);
+    Value selIdx = arith::SelectOp::create(b, loc, indexCond, idx, outIdx);
+    return std::pair<Value, Value>{maxVal, selIdx};
+  };
 
   SmallVector<Value> newInputs;
   for (OpOperand *operand : genericOp.getDpsInputOperands()) {
@@ -611,7 +593,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
   OpOperand *indexInit = genericOp.getDpsInitOperand(1);
   // Value identity.
   Value identityValue =
-      getSplitReductionInit(rewriter, loc, valueInit->get(), *identity,
+      getSplitReductionInit(rewriter, loc, valueInit->get(), identity,
                             outputDimSize, insertSplitIndex);
   // Index identity.
   Type indexElemType = genericOp.getRegionOutputArgs()[1].getType();
@@ -638,17 +620,16 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
     }
   }
 
-  // Step 1: Create a a structurally strict argmax that performs a partial
-  // reduction over the split (tile) dimension. The argmax matches the pattern
-  // expected by isArgmaxOp (maximumf, cmpf, select with index from
-  // linalg.index). The result yields the local maximum values and their
+  // Step 1: Create an argmax that performs a partial reduction over the split
+  // (tile) dimension. The result yields the local maximum values and their
   // corresponding local indices within each tile. These local indices will be
   // adjusted to global indices in step 2.
   auto partialArgmax = linalg::GenericOp::create(
       rewriter, loc,
       TypeRange{identityValue.getType(), identityIndex.getType()}, newInputs,
       ValueRange{identityValue, identityIndex}, newMaps, newIteratorTypes,
-      [reductionDim](OpBuilder &b, Location loc, ValueRange args) {
+      [reductionDim, selectStyleArgmax,
+       buildArgmaxCombiner](OpBuilder &b, Location loc, ValueRange args) {
         Value in = args[0];
         Value outVal = args[1];
         Value outIdx = args[2];
@@ -669,11 +650,8 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
           inCast = arith::TruncFOp::create(b, loc, outVal.getType(), in);
         }
 
-        Value maxVal = arith::MaximumFOp::create(b, loc, inCast, outVal);
-        Value cmp = arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT,
-                                          inCast, outVal);
-        Value selIdx =
-            arith::SelectOp::create(b, loc, cmp, reductionIdx, outIdx);
+        auto [maxVal, selIdx] = buildArgmaxCombiner(
+            b, loc, inCast, reductionIdx, outVal, outIdx, selectStyleArgmax);
         linalg::YieldOp::create(b, loc, ValueRange{maxVal, selIdx});
       });
 
@@ -703,8 +681,8 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
       rewriter, loc, genericOp.getResultTypes(),
       ValueRange{partialArgmax.getResult(0), partialArgmax.getResult(1)},
       genericOp.getDpsInits(), finalReductionMaps, reductionIteratorTypes,
-      [combinerOps, tileSize, insertSplitDimension](OpBuilder &b, Location loc,
-                                                    ValueRange inputs) {
+      [tileSize, insertSplitDimension, selectStyleArgmax,
+       buildArgmaxCombiner](OpBuilder &b, Location loc, ValueRange inputs) {
         Value val = inputs[0];
         Value local = inputs[1];
         Value outVal = inputs[2];
@@ -716,15 +694,9 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
         }
         // gidx = outer * ratio + local.
         Value gidx = arith::AddIOp::create(b, loc, offset, local);
-        Operation *clonedMax = b.clone(*combinerOps.maxOp);
-        clonedMax->setOperands({val, outVal});
-        Operation *clonedCmp = b.clone(*combinerOps.cmpOp);
-        clonedCmp->setOperands({val, outVal});
-        Operation *clonedSel = b.clone(*combinerOps.selectOp);
-        clonedSel->setOperands({clonedCmp->getResult(0), gidx, outIdx});
-        linalg::YieldOp::create(
-            b, loc,
-            ValueRange{clonedMax->getResult(0), clonedSel->getResult(0)});
+        auto [maxVal, selIdx] = buildArgmaxCombiner(b, loc, val, gidx, outVal,
+                                                    outIdx, selectStyleArgmax);
+        linalg::YieldOp::create(b, loc, ValueRange{maxVal, selIdx});
       });
 
   rewriter.replaceOp(genericOp, finalReduction.getResults());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -22,6 +22,8 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include <utility>
+
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
 #define GEN_PASS_DEF_TOPKSPLITREDUCTIONPASS
@@ -469,6 +471,38 @@ static Value getSplitReductionInit(OpBuilder &builder, Location loc,
   return linalg::FillOp::create(builder, loc, identityVal, empty).getResult(0);
 }
 
+static std::pair<Value, Value> buildArgmaxCombiner(OpBuilder &b, Location loc,
+                                                   ArgmaxKind kind, Value val,
+                                                   Value idx, Value outVal,
+                                                   Value outIdx) {
+  // Split reduction creates new reductions over local and global indices, so
+  // rebuild the recognized argmax semantics instead of cloning the original
+  // combiner ops. This intentionally drops operation attributes such as
+  // arith fast-math flags, which is conservative for the newly generated ops.
+  if (kind == ArgmaxKind::Canonical) {
+    Value maxVal = arith::MaximumFOp::create(b, loc, val, outVal);
+    Value cmp =
+        arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
+    Value selIdx = arith::SelectOp::create(b, loc, cmp, idx, outIdx);
+    return {maxVal, selIdx};
+  }
+
+  Value greater =
+      arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
+  Value isNan =
+      arith::CmpFOp::create(b, loc, arith::CmpFPredicate::UNE, val, val);
+  Value valueCond = arith::OrIOp::create(b, loc, greater, isNan);
+  Value equal =
+      arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OEQ, val, outVal);
+  Value lowerIndex =
+      arith::CmpIOp::create(b, loc, arith::CmpIPredicate::slt, idx, outIdx);
+  Value tieCond = arith::AndIOp::create(b, loc, equal, lowerIndex);
+  Value indexCond = arith::OrIOp::create(b, loc, valueCond, tieCond);
+  Value maxVal = arith::SelectOp::create(b, loc, valueCond, val, outVal);
+  Value selIdx = arith::SelectOp::create(b, loc, indexCond, idx, outIdx);
+  return {maxVal, selIdx};
+}
+
 FailureOr<linalg::SplitReductionResult>
 splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
                      linalg::ControlSplitReductionFn controlSplitReductionFn) {
@@ -521,42 +555,11 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
   }
 
   auto valueType =
-      dyn_cast<FloatType>(genericOp.getRegionOutputArgs()[0].getType());
-  if (!valueType) {
-    return rewriter.notifyMatchFailure(
-        genericOp, "Unknown identity value for the reduction");
-  }
-  auto identity = FloatAttr::get(
-      valueType, APFloat::getInf(valueType.getFloatSemantics(), true));
-
-  bool selectStyleArgmax = *argmaxKind == ArgmaxKind::StableHloSelectStyle;
-
-  auto buildArgmaxCombiner = [](OpBuilder &b, Location loc, Value val,
-                                Value idx, Value outVal, Value outIdx,
-                                bool selectStyleArgmax) {
-    if (!selectStyleArgmax) {
-      Value maxVal = arith::MaximumFOp::create(b, loc, val, outVal);
-      Value cmp =
-          arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
-      Value selIdx = arith::SelectOp::create(b, loc, cmp, idx, outIdx);
-      return std::pair<Value, Value>{maxVal, selIdx};
-    }
-
-    Value greater =
-        arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
-    Value isNan =
-        arith::CmpFOp::create(b, loc, arith::CmpFPredicate::UNE, val, val);
-    Value valueCond = arith::OrIOp::create(b, loc, greater, isNan);
-    Value equal =
-        arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OEQ, val, outVal);
-    Value lowerIndex =
-        arith::CmpIOp::create(b, loc, arith::CmpIPredicate::slt, idx, outIdx);
-    Value tieCond = arith::AndIOp::create(b, loc, equal, lowerIndex);
-    Value indexCond = arith::OrIOp::create(b, loc, valueCond, tieCond);
-    Value maxVal = arith::SelectOp::create(b, loc, valueCond, val, outVal);
-    Value selIdx = arith::SelectOp::create(b, loc, indexCond, idx, outIdx);
-    return std::pair<Value, Value>{maxVal, selIdx};
-  };
+      cast<FloatType>(genericOp.getRegionOutputArgs()[0].getType());
+  auto identity =
+      FloatAttr::get(valueType, APFloat::getInf(valueType.getFloatSemantics(),
+                                                /*Negative=*/true));
+  ArgmaxKind kind = *argmaxKind;
 
   SmallVector<Value> newInputs;
   for (OpOperand *operand : genericOp.getDpsInputOperands()) {
@@ -628,8 +631,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
       rewriter, loc,
       TypeRange{identityValue.getType(), identityIndex.getType()}, newInputs,
       ValueRange{identityValue, identityIndex}, newMaps, newIteratorTypes,
-      [reductionDim, selectStyleArgmax,
-       buildArgmaxCombiner](OpBuilder &b, Location loc, ValueRange args) {
+      [reductionDim, kind](OpBuilder &b, Location loc, ValueRange args) {
         Value in = args[0];
         Value outVal = args[1];
         Value outIdx = args[2];
@@ -651,7 +653,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
         }
 
         auto [maxVal, selIdx] = buildArgmaxCombiner(
-            b, loc, inCast, reductionIdx, outVal, outIdx, selectStyleArgmax);
+            b, loc, kind, inCast, reductionIdx, outVal, outIdx);
         linalg::YieldOp::create(b, loc, ValueRange{maxVal, selIdx});
       });
 
@@ -681,8 +683,8 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
       rewriter, loc, genericOp.getResultTypes(),
       ValueRange{partialArgmax.getResult(0), partialArgmax.getResult(1)},
       genericOp.getDpsInits(), finalReductionMaps, reductionIteratorTypes,
-      [tileSize, insertSplitDimension, selectStyleArgmax,
-       buildArgmaxCombiner](OpBuilder &b, Location loc, ValueRange inputs) {
+      [tileSize, insertSplitDimension, kind](OpBuilder &b, Location loc,
+                                             ValueRange inputs) {
         Value val = inputs[0];
         Value local = inputs[1];
         Value outVal = inputs[2];
@@ -694,8 +696,8 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
         }
         // gidx = outer * ratio + local.
         Value gidx = arith::AddIOp::create(b, loc, offset, local);
-        auto [maxVal, selIdx] = buildArgmaxCombiner(b, loc, val, gidx, outVal,
-                                                    outIdx, selectStyleArgmax);
+        auto [maxVal, selIdx] =
+            buildArgmaxCombiner(b, loc, kind, val, gidx, outVal, outIdx);
         linalg::YieldOp::create(b, loc, ValueRange{maxVal, selIdx});
       });
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -22,8 +22,6 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#include <utility>
-
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
 #define GEN_PASS_DEF_TOPKSPLITREDUCTIONPASS
@@ -477,43 +475,51 @@ static void setPreservedAttrs(Operation *op, DictionaryAttr attrs) {
   }
 }
 
-static std::pair<Value, Value>
-buildArgmaxCombiner(OpBuilder &b, Location loc, const ArgmaxCombinerInfo &info,
-                    Value val, Value idx, Value outVal, Value outIdx) {
+struct ArgmaxCombinerResults {
+  Value maxValue;
+  Value selectedIndex;
+};
+
+static ArgmaxCombinerResults buildArgmaxCombiner(OpBuilder &b, Location loc,
+                                                 const ArgmaxCombinerInfo &info,
+                                                 Value val, Value idx,
+                                                 Value outVal, Value outIdx) {
   // Split reduction creates new reductions over local and global indices, so
   // rebuild the recognized argmax semantics instead of cloning the original
   // combiner ops. Preserve the matched combiner attributes explicitly so
   // frontend flags such as arith fast-math follow the regenerated ops.
   if (info.kind == ArgmaxKind::Canonical) {
     auto maxOp = arith::MaximumFOp::create(b, loc, val, outVal);
-    setPreservedAttrs(maxOp, info.maximumAttrs);
+    setPreservedAttrs(maxOp.getOperation(), info.maximumAttrs);
     auto cmpOp =
         arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
-    setPreservedAttrs(cmpOp, info.greaterThanCmpAttrs);
+    setPreservedAttrs(cmpOp.getOperation(), info.greaterThanCmpAttrs);
     auto selectOp = arith::SelectOp::create(b, loc, cmpOp, idx, outIdx);
-    setPreservedAttrs(selectOp, info.indexSelectAttrs);
-    return {maxOp, selectOp};
+    setPreservedAttrs(selectOp.getOperation(), info.indexSelectAttrs);
+    return {/*maxValue=*/maxOp.getResult(),
+            /*selectedIndex=*/selectOp.getResult()};
   }
 
   auto greater =
       arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
-  setPreservedAttrs(greater, info.greaterThanCmpAttrs);
+  setPreservedAttrs(greater.getOperation(), info.greaterThanCmpAttrs);
   auto isNan =
       arith::CmpFOp::create(b, loc, arith::CmpFPredicate::UNE, val, val);
-  setPreservedAttrs(isNan, info.isNanCmpAttrs);
+  setPreservedAttrs(isNan.getOperation(), info.isNanCmpAttrs);
   Value valueCond = arith::OrIOp::create(b, loc, greater, isNan);
   auto equal =
       arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OEQ, val, outVal);
-  setPreservedAttrs(equal, info.equalCmpAttrs);
+  setPreservedAttrs(equal.getOperation(), info.equalCmpAttrs);
   Value lowerIndex =
       arith::CmpIOp::create(b, loc, arith::CmpIPredicate::slt, idx, outIdx);
   Value tieCond = arith::AndIOp::create(b, loc, equal, lowerIndex);
   Value indexCond = arith::OrIOp::create(b, loc, valueCond, tieCond);
   auto valueSelect = arith::SelectOp::create(b, loc, valueCond, val, outVal);
-  setPreservedAttrs(valueSelect, info.valueSelectAttrs);
+  setPreservedAttrs(valueSelect.getOperation(), info.valueSelectAttrs);
   auto indexSelect = arith::SelectOp::create(b, loc, indexCond, idx, outIdx);
-  setPreservedAttrs(indexSelect, info.indexSelectAttrs);
-  return {valueSelect, indexSelect};
+  setPreservedAttrs(indexSelect.getOperation(), info.indexSelectAttrs);
+  return {/*maxValue=*/valueSelect.getResult(),
+          /*selectedIndex=*/indexSelect.getResult()};
 }
 
 FailureOr<linalg::SplitReductionResult>
@@ -521,7 +527,11 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
                      linalg::ControlSplitReductionFn controlSplitReductionFn) {
   std::optional<ArgmaxCombinerInfo> argmaxInfo =
       getArgmaxCombinerInfo(genericOp);
-  assert(argmaxInfo && "expected operation to be an argmax op");
+  if (!argmaxInfo) {
+    return rewriter.notifyMatchFailure(
+        genericOp, "operation is not a recognized argmax pattern");
+  }
+  ArgmaxCombinerInfo info = *argmaxInfo;
 
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(genericOp);
@@ -568,12 +578,24 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
                                        "compared to intermediate tensor size");
   }
 
-  auto valueType =
-      cast<FloatType>(genericOp.getRegionOutputArgs()[0].getType());
-  auto identity =
-      FloatAttr::get(valueType, APFloat::getInf(valueType.getFloatSemantics(),
-                                                /*Negative=*/true));
-  ArgmaxCombinerInfo info = *argmaxInfo;
+  std::optional<TypedAttr> identity;
+  if (info.kind == ArgmaxKind::Canonical) {
+    identity = arith::getNeutralElement(info.maximumOp);
+    if (!identity) {
+      return rewriter.notifyMatchFailure(
+          genericOp, "unknown identity value for the reduction");
+    }
+  } else {
+    auto valueType =
+        dyn_cast<FloatType>(genericOp.getRegionOutputArgs()[0].getType());
+    if (!valueType) {
+      return rewriter.notifyMatchFailure(
+          genericOp, "expected floating point value output for argmax");
+    }
+    identity =
+        FloatAttr::get(valueType, APFloat::getInf(valueType.getFloatSemantics(),
+                                                  /*Negative=*/true));
+  }
 
   SmallVector<Value> newInputs;
   for (OpOperand *operand : genericOp.getDpsInputOperands()) {
@@ -610,7 +632,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
   OpOperand *indexInit = genericOp.getDpsInitOperand(1);
   // Value identity.
   Value identityValue =
-      getSplitReductionInit(rewriter, loc, valueInit->get(), identity,
+      getSplitReductionInit(rewriter, loc, valueInit->get(), *identity,
                             outputDimSize, insertSplitIndex);
   // Index identity.
   Type indexElemType = genericOp.getRegionOutputArgs()[1].getType();
@@ -666,9 +688,10 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
           inCast = arith::TruncFOp::create(b, loc, outVal.getType(), in);
         }
 
-        auto [maxVal, selIdx] = buildArgmaxCombiner(
+        ArgmaxCombinerResults results = buildArgmaxCombiner(
             b, loc, info, inCast, reductionIdx, outVal, outIdx);
-        linalg::YieldOp::create(b, loc, ValueRange{maxVal, selIdx});
+        linalg::YieldOp::create(
+            b, loc, ValueRange{results.maxValue, results.selectedIndex});
       });
 
   // Step 2: Final reduction that computes global indices and selects the one
@@ -710,9 +733,10 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
         }
         // gidx = outer * ratio + local.
         Value gidx = arith::AddIOp::create(b, loc, offset, local);
-        auto [maxVal, selIdx] =
+        ArgmaxCombinerResults results =
             buildArgmaxCombiner(b, loc, info, val, gidx, outVal, outIdx);
-        linalg::YieldOp::create(b, loc, ValueRange{maxVal, selIdx});
+        linalg::YieldOp::create(
+            b, loc, ValueRange{results.maxValue, results.selectedIndex});
       });
 
   rewriter.replaceOp(genericOp, finalReduction.getResults());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -471,43 +471,57 @@ static Value getSplitReductionInit(OpBuilder &builder, Location loc,
   return linalg::FillOp::create(builder, loc, identityVal, empty).getResult(0);
 }
 
-static std::pair<Value, Value> buildArgmaxCombiner(OpBuilder &b, Location loc,
-                                                   ArgmaxKind kind, Value val,
-                                                   Value idx, Value outVal,
-                                                   Value outIdx) {
+static void setPreservedAttrs(Operation *op, DictionaryAttr attrs) {
+  if (attrs) {
+    op->setAttrs(attrs);
+  }
+}
+
+static std::pair<Value, Value>
+buildArgmaxCombiner(OpBuilder &b, Location loc, const ArgmaxCombinerInfo &info,
+                    Value val, Value idx, Value outVal, Value outIdx) {
   // Split reduction creates new reductions over local and global indices, so
   // rebuild the recognized argmax semantics instead of cloning the original
-  // combiner ops. This intentionally drops operation attributes such as
-  // arith fast-math flags, which is conservative for the newly generated ops.
-  if (kind == ArgmaxKind::Canonical) {
-    Value maxVal = arith::MaximumFOp::create(b, loc, val, outVal);
-    Value cmp =
+  // combiner ops. Preserve the matched combiner attributes explicitly so
+  // frontend flags such as arith fast-math follow the regenerated ops.
+  if (info.kind == ArgmaxKind::Canonical) {
+    auto maxOp = arith::MaximumFOp::create(b, loc, val, outVal);
+    setPreservedAttrs(maxOp, info.maximumAttrs);
+    auto cmpOp =
         arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
-    Value selIdx = arith::SelectOp::create(b, loc, cmp, idx, outIdx);
-    return {maxVal, selIdx};
+    setPreservedAttrs(cmpOp, info.greaterThanCmpAttrs);
+    auto selectOp = arith::SelectOp::create(b, loc, cmpOp, idx, outIdx);
+    setPreservedAttrs(selectOp, info.indexSelectAttrs);
+    return {maxOp, selectOp};
   }
 
-  Value greater =
+  auto greater =
       arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OGT, val, outVal);
-  Value isNan =
+  setPreservedAttrs(greater, info.greaterThanCmpAttrs);
+  auto isNan =
       arith::CmpFOp::create(b, loc, arith::CmpFPredicate::UNE, val, val);
+  setPreservedAttrs(isNan, info.isNanCmpAttrs);
   Value valueCond = arith::OrIOp::create(b, loc, greater, isNan);
-  Value equal =
+  auto equal =
       arith::CmpFOp::create(b, loc, arith::CmpFPredicate::OEQ, val, outVal);
+  setPreservedAttrs(equal, info.equalCmpAttrs);
   Value lowerIndex =
       arith::CmpIOp::create(b, loc, arith::CmpIPredicate::slt, idx, outIdx);
   Value tieCond = arith::AndIOp::create(b, loc, equal, lowerIndex);
   Value indexCond = arith::OrIOp::create(b, loc, valueCond, tieCond);
-  Value maxVal = arith::SelectOp::create(b, loc, valueCond, val, outVal);
-  Value selIdx = arith::SelectOp::create(b, loc, indexCond, idx, outIdx);
-  return {maxVal, selIdx};
+  auto valueSelect = arith::SelectOp::create(b, loc, valueCond, val, outVal);
+  setPreservedAttrs(valueSelect, info.valueSelectAttrs);
+  auto indexSelect = arith::SelectOp::create(b, loc, indexCond, idx, outIdx);
+  setPreservedAttrs(indexSelect, info.indexSelectAttrs);
+  return {valueSelect, indexSelect};
 }
 
 FailureOr<linalg::SplitReductionResult>
 splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
                      linalg::ControlSplitReductionFn controlSplitReductionFn) {
-  std::optional<ArgmaxKind> argmaxKind = getArgmaxKind(genericOp);
-  assert(argmaxKind && "expected operation to be an argmax op");
+  std::optional<ArgmaxCombinerInfo> argmaxInfo =
+      getArgmaxCombinerInfo(genericOp);
+  assert(argmaxInfo && "expected operation to be an argmax op");
 
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(genericOp);
@@ -559,7 +573,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
   auto identity =
       FloatAttr::get(valueType, APFloat::getInf(valueType.getFloatSemantics(),
                                                 /*Negative=*/true));
-  ArgmaxKind kind = *argmaxKind;
+  ArgmaxCombinerInfo info = *argmaxInfo;
 
   SmallVector<Value> newInputs;
   for (OpOperand *operand : genericOp.getDpsInputOperands()) {
@@ -631,7 +645,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
       rewriter, loc,
       TypeRange{identityValue.getType(), identityIndex.getType()}, newInputs,
       ValueRange{identityValue, identityIndex}, newMaps, newIteratorTypes,
-      [reductionDim, kind](OpBuilder &b, Location loc, ValueRange args) {
+      [reductionDim, info](OpBuilder &b, Location loc, ValueRange args) {
         Value in = args[0];
         Value outVal = args[1];
         Value outIdx = args[2];
@@ -653,7 +667,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
         }
 
         auto [maxVal, selIdx] = buildArgmaxCombiner(
-            b, loc, kind, inCast, reductionIdx, outVal, outIdx);
+            b, loc, info, inCast, reductionIdx, outVal, outIdx);
         linalg::YieldOp::create(b, loc, ValueRange{maxVal, selIdx});
       });
 
@@ -683,7 +697,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
       rewriter, loc, genericOp.getResultTypes(),
       ValueRange{partialArgmax.getResult(0), partialArgmax.getResult(1)},
       genericOp.getDpsInits(), finalReductionMaps, reductionIteratorTypes,
-      [tileSize, insertSplitDimension, kind](OpBuilder &b, Location loc,
+      [tileSize, insertSplitDimension, info](OpBuilder &b, Location loc,
                                              ValueRange inputs) {
         Value val = inputs[0];
         Value local = inputs[1];
@@ -697,7 +711,7 @@ splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,
         // gidx = outer * ratio + local.
         Value gidx = arith::AddIOp::create(b, loc, offset, local);
         auto [maxVal, selIdx] =
-            buildArgmaxCombiner(b, loc, kind, val, gidx, outVal, outIdx);
+            buildArgmaxCombiner(b, loc, info, val, gidx, outVal, outIdx);
         linalg::YieldOp::create(b, loc, ValueRange{maxVal, selIdx});
       });
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -1309,31 +1309,22 @@ static bool isCurrentMaxValue(Value value, Value outVal) {
   return stripFloatCast(value) == outVal;
 }
 
-static bool matchFloatCompare(Value value, arith::CmpFPredicate predicate,
-                              Value lhs, Value rhs) {
+static arith::CmpFOp matchFloatCompare(Value value,
+                                       arith::CmpFPredicate predicate,
+                                       Value lhs, Value rhs) {
   auto cmpOp = value.getDefiningOp<arith::CmpFOp>();
   if (!cmpOp || cmpOp.getPredicate() != predicate) {
-    return false;
+    return nullptr;
   }
-  return stripFloatCast(cmpOp->getOperand(0)) == lhs &&
-         stripFloatCast(cmpOp->getOperand(1)) == rhs;
+  if (stripFloatCast(cmpOp->getOperand(0)) != lhs ||
+      stripFloatCast(cmpOp->getOperand(1)) != rhs) {
+    return nullptr;
+  }
+  return cmpOp;
 }
 
-template <typename OpTy>
-static bool matchCommutativeBinary(Value value,
-                                   llvm::function_ref<bool(Value)> matchLhs,
-                                   llvm::function_ref<bool(Value)> matchRhs) {
-  auto op = value.getDefiningOp<OpTy>();
-  if (!op) {
-    return false;
-  }
-  Value lhs = op->getOperand(0);
-  Value rhs = op->getOperand(1);
-  return (matchLhs(lhs) && matchRhs(rhs)) || (matchLhs(rhs) && matchRhs(lhs));
-}
-
-static bool matchCanonicalArgmax(linalg::GenericOp genericOp,
-                                 unsigned reductionDim) {
+static std::optional<ArgmaxCombinerInfo>
+matchCanonicalArgmax(linalg::GenericOp genericOp, unsigned reductionDim) {
   Block *body = genericOp.getBody();
   Value inVal = body->getArgument(0);
   Value outVal = body->getArgument(1);
@@ -1342,30 +1333,133 @@ static bool matchCanonicalArgmax(linalg::GenericOp genericOp,
 
   auto maxOp = yieldOp.getOperand(0).getDefiningOp<arith::MaximumFOp>();
   if (!maxOp) {
-    return false;
+    return std::nullopt;
   }
   Value maxLhs = maxOp->getOperand(0);
   Value maxRhs = maxOp->getOperand(1);
   if (!((isIncomingValue(maxLhs, inVal) && isCurrentMaxValue(maxRhs, outVal)) ||
         (isIncomingValue(maxRhs, inVal) &&
          isCurrentMaxValue(maxLhs, outVal)))) {
-    return false;
+    return std::nullopt;
   }
 
   auto indexSelect = yieldOp.getOperand(1).getDefiningOp<arith::SelectOp>();
   if (!indexSelect) {
-    return false;
+    return std::nullopt;
   }
-  if (!matchFloatCompare(indexSelect.getCondition(), arith::CmpFPredicate::OGT,
-                         inVal, outVal)) {
-    return false;
+  arith::CmpFOp greaterThan = matchFloatCompare(
+      indexSelect.getCondition(), arith::CmpFPredicate::OGT, inVal, outVal);
+  if (!greaterThan) {
+    return std::nullopt;
   }
-  return isCurrentReductionIndex(indexSelect.getTrueValue(), reductionDim) &&
-         indexSelect.getFalseValue() == outIdx;
+  if (!isCurrentReductionIndex(indexSelect.getTrueValue(), reductionDim) ||
+      indexSelect.getFalseValue() != outIdx) {
+    return std::nullopt;
+  }
+
+  return ArgmaxCombinerInfo{
+      /*kind=*/ArgmaxKind::Canonical,
+      /*maximumAttrs=*/maxOp->getAttrDictionary(),
+      /*greaterThanCmpAttrs=*/greaterThan->getAttrDictionary(),
+      /*isNanCmpAttrs=*/{},
+      /*equalCmpAttrs=*/{},
+      /*valueSelectAttrs=*/{},
+      /*indexSelectAttrs=*/indexSelect->getAttrDictionary()};
 }
 
-static bool matchStableHloSelectStyleArgmax(linalg::GenericOp genericOp,
-                                            unsigned reductionDim) {
+static std::optional<std::pair<arith::CmpFOp, arith::CmpFOp>>
+matchStableHloValueCondition(Value value, Value inVal, Value outVal) {
+  auto op = value.getDefiningOp<arith::OrIOp>();
+  if (!op) {
+    return std::nullopt;
+  }
+
+  auto matchGreaterThan = [&](Value value) {
+    return matchFloatCompare(value, arith::CmpFPredicate::OGT, inVal, outVal);
+  };
+  auto matchInputIsNan = [&](Value value) {
+    return matchFloatCompare(value, arith::CmpFPredicate::UNE, inVal, inVal);
+  };
+
+  arith::CmpFOp lhsGreaterThan = matchGreaterThan(op->getOperand(0));
+  arith::CmpFOp rhsIsNan = matchInputIsNan(op->getOperand(1));
+  if (lhsGreaterThan && rhsIsNan) {
+    return std::make_pair(lhsGreaterThan, rhsIsNan);
+  }
+
+  arith::CmpFOp rhsGreaterThan = matchGreaterThan(op->getOperand(1));
+  arith::CmpFOp lhsIsNan = matchInputIsNan(op->getOperand(0));
+  if (rhsGreaterThan && lhsIsNan) {
+    return std::make_pair(rhsGreaterThan, lhsIsNan);
+  }
+
+  return std::nullopt;
+}
+
+static bool matchLowerIndex(Value value, unsigned reductionDim, Value outIdx) {
+  auto cmpOp = value.getDefiningOp<arith::CmpIOp>();
+  if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::slt) {
+    return false;
+  }
+  return isCurrentReductionIndex(cmpOp->getOperand(0), reductionDim) &&
+         cmpOp->getOperand(1) == outIdx;
+}
+
+static std::optional<arith::CmpFOp>
+matchStableHloTieCondition(Value value, unsigned reductionDim, Value inVal,
+                           Value outVal, Value outIdx) {
+  auto op = value.getDefiningOp<arith::AndIOp>();
+  if (!op) {
+    return std::nullopt;
+  }
+
+  auto matchEqual = [&](Value value) {
+    return matchFloatCompare(value, arith::CmpFPredicate::OEQ, inVal, outVal);
+  };
+
+  arith::CmpFOp lhsEqual = matchEqual(op->getOperand(0));
+  if (lhsEqual && matchLowerIndex(op->getOperand(1), reductionDim, outIdx)) {
+    return lhsEqual;
+  }
+
+  arith::CmpFOp rhsEqual = matchEqual(op->getOperand(1));
+  if (rhsEqual && matchLowerIndex(op->getOperand(0), reductionDim, outIdx)) {
+    return rhsEqual;
+  }
+
+  return std::nullopt;
+}
+
+static std::optional<arith::CmpFOp>
+matchStableHloIndexCondition(Value value, unsigned reductionDim, Value inVal,
+                             Value outVal, Value outIdx) {
+  auto op = value.getDefiningOp<arith::OrIOp>();
+  if (!op) {
+    return std::nullopt;
+  }
+
+  auto lhsValueCondition =
+      matchStableHloValueCondition(op->getOperand(0), inVal, outVal);
+  auto rhsTieCondition = matchStableHloTieCondition(
+      op->getOperand(1), reductionDim, inVal, outVal, outIdx);
+  if (lhsValueCondition && rhsTieCondition) {
+    return rhsTieCondition;
+  }
+
+  auto rhsValueCondition =
+      matchStableHloValueCondition(op->getOperand(1), inVal, outVal);
+  auto lhsTieCondition = matchStableHloTieCondition(
+      op->getOperand(0), reductionDim, inVal, outVal, outIdx);
+  if (rhsValueCondition && lhsTieCondition) {
+    return lhsTieCondition;
+  }
+
+  return std::nullopt;
+}
+
+static std::optional<ArgmaxCombinerInfo>
+matchStableHloSelectStyleArgmax(linalg::GenericOp genericOp,
+                                unsigned reductionDim) {
   Block *body = genericOp.getBody();
   Value inVal = body->getArgument(0);
   Value outVal = body->getArgument(1);
@@ -1375,51 +1469,41 @@ static bool matchStableHloSelectStyleArgmax(linalg::GenericOp genericOp,
   auto valueSelect = yieldOp.getOperand(0).getDefiningOp<arith::SelectOp>();
   auto indexSelect = yieldOp.getOperand(1).getDefiningOp<arith::SelectOp>();
   if (!valueSelect || !indexSelect) {
-    return false;
+    return std::nullopt;
   }
   if (!isIncomingValue(valueSelect.getTrueValue(), inVal) ||
       !isCurrentMaxValue(valueSelect.getFalseValue(), outVal)) {
-    return false;
+    return std::nullopt;
   }
   if (!isCurrentReductionIndex(indexSelect.getTrueValue(), reductionDim) ||
       indexSelect.getFalseValue() != outIdx) {
-    return false;
+    return std::nullopt;
   }
 
-  auto matchGreaterThan = [&](Value value) {
-    return matchFloatCompare(value, arith::CmpFPredicate::OGT, inVal, outVal);
-  };
-  auto matchInputIsNan = [&](Value value) {
-    return matchFloatCompare(value, arith::CmpFPredicate::UNE, inVal, inVal);
-  };
-  auto matchValueCondition = [&](Value value) {
-    return matchCommutativeBinary<arith::OrIOp>(value, matchGreaterThan,
-                                                matchInputIsNan);
-  };
-  auto matchEqual = [&](Value value) {
-    return matchFloatCompare(value, arith::CmpFPredicate::OEQ, inVal, outVal);
-  };
-  auto matchLowerIndex = [&](Value value) {
-    auto cmpOp = value.getDefiningOp<arith::CmpIOp>();
-    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::slt) {
-      return false;
-    }
-    return isCurrentReductionIndex(cmpOp->getOperand(0), reductionDim) &&
-           cmpOp->getOperand(1) == outIdx;
-  };
-  auto matchTieCondition = [&](Value value) {
-    return matchCommutativeBinary<arith::AndIOp>(value, matchEqual,
-                                                 matchLowerIndex);
-  };
-
-  if (!matchValueCondition(valueSelect.getCondition())) {
-    return false;
+  auto valueCmpOps =
+      matchStableHloValueCondition(valueSelect.getCondition(), inVal, outVal);
+  if (!valueCmpOps) {
+    return std::nullopt;
   }
-  return matchCommutativeBinary<arith::OrIOp>(
-      indexSelect.getCondition(), matchValueCondition, matchTieCondition);
+
+  std::optional<arith::CmpFOp> equalCmpOp = matchStableHloIndexCondition(
+      indexSelect.getCondition(), reductionDim, inVal, outVal, outIdx);
+  if (!equalCmpOp) {
+    return std::nullopt;
+  }
+
+  return ArgmaxCombinerInfo{
+      /*kind=*/ArgmaxKind::StableHloSelectStyle,
+      /*maximumAttrs=*/{},
+      /*greaterThanCmpAttrs=*/valueCmpOps->first->getAttrDictionary(),
+      /*isNanCmpAttrs=*/valueCmpOps->second->getAttrDictionary(),
+      /*equalCmpAttrs=*/(*equalCmpOp)->getAttrDictionary(),
+      /*valueSelectAttrs=*/valueSelect->getAttrDictionary(),
+      /*indexSelectAttrs=*/indexSelect->getAttrDictionary()};
 }
 
-std::optional<ArgmaxKind> getArgmaxKind(linalg::GenericOp genericOp) {
+std::optional<ArgmaxCombinerInfo>
+getArgmaxCombinerInfo(linalg::GenericOp genericOp) {
   // Check for 2 results(value, index), and 1 input
   if (genericOp.getNumDpsInits() != 2) {
     return std::nullopt;
@@ -1457,11 +1541,21 @@ std::optional<ArgmaxKind> getArgmaxKind(linalg::GenericOp genericOp) {
   genericOp.getReductionDims(reductionDims);
   unsigned reductionDim = reductionDims[0];
 
-  if (matchCanonicalArgmax(genericOp, reductionDim)) {
-    return ArgmaxKind::Canonical;
+  if (std::optional<ArgmaxCombinerInfo> info =
+          matchCanonicalArgmax(genericOp, reductionDim)) {
+    return info;
   }
-  if (matchStableHloSelectStyleArgmax(genericOp, reductionDim)) {
-    return ArgmaxKind::StableHloSelectStyle;
+  if (std::optional<ArgmaxCombinerInfo> info =
+          matchStableHloSelectStyleArgmax(genericOp, reductionDim)) {
+    return info;
+  }
+  return std::nullopt;
+}
+
+std::optional<ArgmaxKind> getArgmaxKind(linalg::GenericOp genericOp) {
+  if (std::optional<ArgmaxCombinerInfo> info =
+          getArgmaxCombinerInfo(genericOp)) {
+    return info->kind;
   }
   return std::nullopt;
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -1283,25 +1283,161 @@ bool isaHorizontallyFusedContraction(Operation *op) {
   return true;
 }
 
-bool isArgmaxOp(linalg::GenericOp genericOp) {
-  // Check for 2 results(value, index), and 1 input
-  if (genericOp.getNumDpsInits() != 2) {
+static Value stripFloatCast(Value value) {
+  if (auto extOp = value.getDefiningOp<arith::ExtFOp>()) {
+    return extOp.getIn();
+  }
+  if (auto truncOp = value.getDefiningOp<arith::TruncFOp>()) {
+    return truncOp.getIn();
+  }
+  return value;
+}
+
+static bool isCurrentReductionIndex(Value value, unsigned reductionDim) {
+  if (auto castOp = value.getDefiningOp<arith::IndexCastOp>()) {
+    value = castOp.getIn();
+  }
+  auto indexOp = value.getDefiningOp<linalg::IndexOp>();
+  return indexOp && indexOp.getDim() == reductionDim;
+}
+
+static bool isIncomingValue(Value value, Value inVal) {
+  return stripFloatCast(value) == inVal;
+}
+
+static bool isCurrentMaxValue(Value value, Value outVal) {
+  return stripFloatCast(value) == outVal;
+}
+
+static bool matchFloatCompare(Value value, arith::CmpFPredicate predicate,
+                              Value lhs, Value rhs) {
+  auto cmpOp = value.getDefiningOp<arith::CmpFOp>();
+  if (!cmpOp || cmpOp.getPredicate() != predicate) {
+    return false;
+  }
+  return stripFloatCast(cmpOp->getOperand(0)) == lhs &&
+         stripFloatCast(cmpOp->getOperand(1)) == rhs;
+}
+
+template <typename OpTy>
+static bool matchCommutativeBinary(Value value,
+                                   llvm::function_ref<bool(Value)> matchLhs,
+                                   llvm::function_ref<bool(Value)> matchRhs) {
+  auto op = value.getDefiningOp<OpTy>();
+  if (!op) {
+    return false;
+  }
+  Value lhs = op->getOperand(0);
+  Value rhs = op->getOperand(1);
+  return (matchLhs(lhs) && matchRhs(rhs)) || (matchLhs(rhs) && matchRhs(lhs));
+}
+
+static bool matchCanonicalArgmax(linalg::GenericOp genericOp,
+                                 unsigned reductionDim) {
+  Block *body = genericOp.getBody();
+  Value inVal = body->getArgument(0);
+  Value outVal = body->getArgument(1);
+  Value outIdx = body->getArgument(2);
+  auto yieldOp = cast<linalg::YieldOp>(body->getTerminator());
+
+  auto maxOp = yieldOp.getOperand(0).getDefiningOp<arith::MaximumFOp>();
+  if (!maxOp) {
+    return false;
+  }
+  Value maxLhs = maxOp->getOperand(0);
+  Value maxRhs = maxOp->getOperand(1);
+  if (!((isIncomingValue(maxLhs, inVal) && isCurrentMaxValue(maxRhs, outVal)) ||
+        (isIncomingValue(maxRhs, inVal) &&
+         isCurrentMaxValue(maxLhs, outVal)))) {
     return false;
   }
 
-  if (genericOp.getNumDpsInputs() != 1) {
+  auto indexSelect = yieldOp.getOperand(1).getDefiningOp<arith::SelectOp>();
+  if (!indexSelect) {
     return false;
+  }
+  if (!matchFloatCompare(indexSelect.getCondition(), arith::CmpFPredicate::OGT,
+                         inVal, outVal)) {
+    return false;
+  }
+  return isCurrentReductionIndex(indexSelect.getTrueValue(), reductionDim) &&
+         indexSelect.getFalseValue() == outIdx;
+}
+
+static bool matchStableHloSelectStyleArgmax(linalg::GenericOp genericOp,
+                                            unsigned reductionDim) {
+  Block *body = genericOp.getBody();
+  Value inVal = body->getArgument(0);
+  Value outVal = body->getArgument(1);
+  Value outIdx = body->getArgument(2);
+  auto yieldOp = cast<linalg::YieldOp>(body->getTerminator());
+
+  auto valueSelect = yieldOp.getOperand(0).getDefiningOp<arith::SelectOp>();
+  auto indexSelect = yieldOp.getOperand(1).getDefiningOp<arith::SelectOp>();
+  if (!valueSelect || !indexSelect) {
+    return false;
+  }
+  if (!isIncomingValue(valueSelect.getTrueValue(), inVal) ||
+      !isCurrentMaxValue(valueSelect.getFalseValue(), outVal)) {
+    return false;
+  }
+  if (!isCurrentReductionIndex(indexSelect.getTrueValue(), reductionDim) ||
+      indexSelect.getFalseValue() != outIdx) {
+    return false;
+  }
+
+  auto matchGreaterThan = [&](Value value) {
+    return matchFloatCompare(value, arith::CmpFPredicate::OGT, inVal, outVal);
+  };
+  auto matchInputIsNan = [&](Value value) {
+    return matchFloatCompare(value, arith::CmpFPredicate::UNE, inVal, inVal);
+  };
+  auto matchValueCondition = [&](Value value) {
+    return matchCommutativeBinary<arith::OrIOp>(value, matchGreaterThan,
+                                                matchInputIsNan);
+  };
+  auto matchEqual = [&](Value value) {
+    return matchFloatCompare(value, arith::CmpFPredicate::OEQ, inVal, outVal);
+  };
+  auto matchLowerIndex = [&](Value value) {
+    auto cmpOp = value.getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::slt) {
+      return false;
+    }
+    return isCurrentReductionIndex(cmpOp->getOperand(0), reductionDim) &&
+           cmpOp->getOperand(1) == outIdx;
+  };
+  auto matchTieCondition = [&](Value value) {
+    return matchCommutativeBinary<arith::AndIOp>(value, matchEqual,
+                                                 matchLowerIndex);
+  };
+
+  if (!matchValueCondition(valueSelect.getCondition())) {
+    return false;
+  }
+  return matchCommutativeBinary<arith::OrIOp>(
+      indexSelect.getCondition(), matchValueCondition, matchTieCondition);
+}
+
+std::optional<ArgmaxKind> getArgmaxKind(linalg::GenericOp genericOp) {
+  // Check for 2 results(value, index), and 1 input
+  if (genericOp.getNumDpsInits() != 2) {
+    return std::nullopt;
+  }
+
+  if (genericOp.getNumDpsInputs() != 1) {
+    return std::nullopt;
   }
 
   // Argmax will require 1D reduction.
   if (genericOp.getNumReductionLoops() != 1) {
-    return false;
+    return std::nullopt;
   }
 
   // TODO: Add better affine map checks.
   auto indexingMaps = genericOp.getIndexingMapsArray();
   if (!indexingMaps[0].isIdentity()) {
-    return false;
+    return std::nullopt;
   }
 
   // Check that initial value is negative Infinite.
@@ -1310,80 +1446,28 @@ bool isArgmaxOp(linalg::GenericOp genericOp) {
   Value initVal = genericOp.getDpsInitOperand(0)->get();
   auto fillOp = initVal.getDefiningOp<linalg::FillOp>();
   if (!fillOp) {
-    return false;
+    return std::nullopt;
   }
   Value fillVal = fillOp.getDpsInputOperand(0)->get();
   if (!matchPattern(fillVal, m_NegInfFloat())) {
-    return false;
+    return std::nullopt;
   }
 
-  // Work back from linalg.yield and check body of genericOp.
-  // The genericOp should yield the result of an arith.select,
-  // preceded by an arith.cmpf, arith.maximumf, and arith.extui
-  auto yieldOp = cast<linalg::YieldOp>(genericOp.getBody()->getTerminator());
-  Value producerOutput;
-  Operation *producer;
+  SmallVector<unsigned> reductionDims;
+  genericOp.getReductionDims(reductionDims);
+  unsigned reductionDim = reductionDims[0];
 
-  // Producer of linalg.yield 1st arg is arith.maximumf
-  {
-    producerOutput = yieldOp->getOperand(0);
-    producer = producerOutput.getDefiningOp();
-    if (!producer || producer->getNumOperands() == 0) {
-      return false;
-    }
-    if (!matchPattern(producer, m_Op<arith::MaximumFOp>())) {
-      return false;
-    }
+  if (matchCanonicalArgmax(genericOp, reductionDim)) {
+    return ArgmaxKind::Canonical;
   }
-
-  // Producer of linalg.yield op 2nd arg is arith.select
-  // TODO: Add check that select is selecting between linalg.index and index of
-  // current max.
-  {
-    producerOutput = yieldOp->getOperand(1);
-    producer = producerOutput.getDefiningOp();
-    if (!producer || producer->getNumOperands() == 0) {
-      return false;
-    }
-    if (!matchPattern(producer, m_Op<arith::SelectOp>())) {
-      return false;
-    }
-    auto selectOp = cast<arith::SelectOp>(producerOutput.getDefiningOp());
-    Value trueVal = selectOp.getTrueValue();
-    if (auto castOp = trueVal.getDefiningOp<arith::IndexCastOp>()) {
-      trueVal = castOp.getIn();
-    }
-
-    // Ensure the true value is directly produced by linalg.index.
-    auto indexOp = trueVal.getDefiningOp<linalg::IndexOp>();
-    if (!indexOp) {
-      return false;
-    }
+  if (matchStableHloSelectStyleArgmax(genericOp, reductionDim)) {
+    return ArgmaxKind::StableHloSelectStyle;
   }
+  return std::nullopt;
+}
 
-  // Producer of arith.select op is arith.cmpf
-  {
-    producerOutput = producer->getOperand(0);
-    producer = producerOutput.getDefiningOp();
-    if (!producer || producer->getNumOperands() == 0) {
-      return false;
-    }
-    auto producerCmpFOp = dyn_cast<arith::CmpFOp>(producer);
-    if (!producerCmpFOp ||
-        producerCmpFOp.getPredicate() != arith::CmpFPredicate::OGT) {
-      return false;
-    }
-
-    // Check that in and out of cmpf are loop variables.
-    // Currently first operand is disabled because it may be mixed type
-    // which would lead it to be extf(%arg0).
-    // TODO: Add better mixed type support check.
-    if (producer->getOperand(1) != genericOp.getBody()->getArgument(1)) {
-      return false;
-    }
-  }
-
-  return true;
+bool isArgmaxOp(linalg::GenericOp genericOp) {
+  return getArgmaxKind(genericOp).has_value();
 }
 
 bool hasOnlyScalarInputs(linalg::GenericOp linalgOp) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -1283,7 +1283,7 @@ bool isaHorizontallyFusedContraction(Operation *op) {
   return true;
 }
 
-static Value stripFloatCast(Value value) {
+static Value stripFloatExtTrunc(Value value) {
   if (auto extOp = value.getDefiningOp<arith::ExtFOp>()) {
     return extOp.getIn();
   }
@@ -1302,11 +1302,11 @@ static bool isCurrentReductionIndex(Value value, unsigned reductionDim) {
 }
 
 static bool isIncomingValue(Value value, Value inVal) {
-  return stripFloatCast(value) == inVal;
+  return stripFloatExtTrunc(value) == inVal;
 }
 
 static bool isCurrentMaxValue(Value value, Value outVal) {
-  return stripFloatCast(value) == outVal;
+  return stripFloatExtTrunc(value) == outVal;
 }
 
 static arith::CmpFOp matchFloatCompare(Value value,
@@ -1316,12 +1316,17 @@ static arith::CmpFOp matchFloatCompare(Value value,
   if (!cmpOp || cmpOp.getPredicate() != predicate) {
     return nullptr;
   }
-  if (stripFloatCast(cmpOp->getOperand(0)) != lhs ||
-      stripFloatCast(cmpOp->getOperand(1)) != rhs) {
+  if (stripFloatExtTrunc(cmpOp->getOperand(0)) != lhs ||
+      stripFloatExtTrunc(cmpOp->getOperand(1)) != rhs) {
     return nullptr;
   }
   return cmpOp;
 }
+
+struct StableHloValueConditionOps {
+  arith::CmpFOp greaterThan;
+  arith::CmpFOp isNan;
+};
 
 static std::optional<ArgmaxCombinerInfo>
 matchCanonicalArgmax(linalg::GenericOp genericOp, unsigned reductionDim) {
@@ -1359,6 +1364,7 @@ matchCanonicalArgmax(linalg::GenericOp genericOp, unsigned reductionDim) {
 
   return ArgmaxCombinerInfo{
       /*kind=*/ArgmaxKind::Canonical,
+      /*maximumOp=*/maxOp,
       /*maximumAttrs=*/maxOp->getAttrDictionary(),
       /*greaterThanCmpAttrs=*/greaterThan->getAttrDictionary(),
       /*isNanCmpAttrs=*/{},
@@ -1367,7 +1373,7 @@ matchCanonicalArgmax(linalg::GenericOp genericOp, unsigned reductionDim) {
       /*indexSelectAttrs=*/indexSelect->getAttrDictionary()};
 }
 
-static std::optional<std::pair<arith::CmpFOp, arith::CmpFOp>>
+static std::optional<StableHloValueConditionOps>
 matchStableHloValueCondition(Value value, Value inVal, Value outVal) {
   auto op = value.getDefiningOp<arith::OrIOp>();
   if (!op) {
@@ -1384,13 +1390,15 @@ matchStableHloValueCondition(Value value, Value inVal, Value outVal) {
   arith::CmpFOp lhsGreaterThan = matchGreaterThan(op->getOperand(0));
   arith::CmpFOp rhsIsNan = matchInputIsNan(op->getOperand(1));
   if (lhsGreaterThan && rhsIsNan) {
-    return std::make_pair(lhsGreaterThan, rhsIsNan);
+    return StableHloValueConditionOps{/*greaterThan=*/lhsGreaterThan,
+                                      /*isNan=*/rhsIsNan};
   }
 
   arith::CmpFOp rhsGreaterThan = matchGreaterThan(op->getOperand(1));
   arith::CmpFOp lhsIsNan = matchInputIsNan(op->getOperand(0));
   if (rhsGreaterThan && lhsIsNan) {
-    return std::make_pair(rhsGreaterThan, lhsIsNan);
+    return StableHloValueConditionOps{/*greaterThan=*/rhsGreaterThan,
+                                      /*isNan=*/lhsIsNan};
   }
 
   return std::nullopt;
@@ -1494,9 +1502,10 @@ matchStableHloSelectStyleArgmax(linalg::GenericOp genericOp,
 
   return ArgmaxCombinerInfo{
       /*kind=*/ArgmaxKind::StableHloSelectStyle,
+      /*maximumOp=*/nullptr,
       /*maximumAttrs=*/{},
-      /*greaterThanCmpAttrs=*/valueCmpOps->first->getAttrDictionary(),
-      /*isNanCmpAttrs=*/valueCmpOps->second->getAttrDictionary(),
+      /*greaterThanCmpAttrs=*/valueCmpOps->greaterThan->getAttrDictionary(),
+      /*isNanCmpAttrs=*/valueCmpOps->isNan->getAttrDictionary(),
       /*equalCmpAttrs=*/(*equalCmpOp)->getAttrDictionary(),
       /*valueSelectAttrs=*/valueSelect->getAttrDictionary(),
       /*indexSelectAttrs=*/indexSelect->getAttrDictionary()};
@@ -1552,16 +1561,8 @@ getArgmaxCombinerInfo(linalg::GenericOp genericOp) {
   return std::nullopt;
 }
 
-std::optional<ArgmaxKind> getArgmaxKind(linalg::GenericOp genericOp) {
-  if (std::optional<ArgmaxCombinerInfo> info =
-          getArgmaxCombinerInfo(genericOp)) {
-    return info->kind;
-  }
-  return std::nullopt;
-}
-
 bool isArgmaxOp(linalg::GenericOp genericOp) {
-  return getArgmaxKind(genericOp).has_value();
+  return getArgmaxCombinerInfo(genericOp).has_value();
 }
 
 bool hasOnlyScalarInputs(linalg::GenericOp linalgOp) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_
 #define IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_
 
+#include <optional>
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/Attributes.h"
@@ -241,6 +242,14 @@ bool isGatherlikeOp(Operation *op);
 /// The expectation is that the LHS is common, and all the operands are
 /// different RHS.
 bool isaHorizontallyFusedContraction(Operation *op);
+
+enum class ArgmaxKind {
+  Canonical,
+  StableHloSelectStyle,
+};
+
+/// Returns the argmax kind represented by the given linalg.generic, if any.
+std::optional<ArgmaxKind> getArgmaxKind(linalg::GenericOp genericOp);
 
 /// Check if a linalg.generic is representing an argmax operation.
 bool isArgmaxOp(linalg::GenericOp genericOp);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -251,6 +251,7 @@ enum class ArgmaxKind {
 
 struct ArgmaxCombinerInfo {
   ArgmaxKind kind;
+  Operation *maximumOp;
   DictionaryAttr maximumAttrs;
   DictionaryAttr greaterThanCmpAttrs;
   DictionaryAttr isNanCmpAttrs;
@@ -263,9 +264,6 @@ struct ArgmaxCombinerInfo {
 /// any.
 std::optional<ArgmaxCombinerInfo>
 getArgmaxCombinerInfo(linalg::GenericOp genericOp);
-
-/// Returns the argmax kind represented by the given linalg.generic, if any.
-std::optional<ArgmaxKind> getArgmaxKind(linalg::GenericOp genericOp);
 
 /// Check if a linalg.generic is representing an argmax operation.
 bool isArgmaxOp(linalg::GenericOp genericOp);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -249,6 +249,21 @@ enum class ArgmaxKind {
   StableHloSelectStyle,
 };
 
+struct ArgmaxCombinerInfo {
+  ArgmaxKind kind;
+  DictionaryAttr maximumAttrs;
+  DictionaryAttr greaterThanCmpAttrs;
+  DictionaryAttr isNanCmpAttrs;
+  DictionaryAttr equalCmpAttrs;
+  DictionaryAttr valueSelectAttrs;
+  DictionaryAttr indexSelectAttrs;
+};
+
+/// Returns the argmax combiner info represented by the given linalg.generic, if
+/// any.
+std::optional<ArgmaxCombinerInfo>
+getArgmaxCombinerInfo(linalg::GenericOp genericOp);
+
 /// Returns the argmax kind represented by the given linalg.generic, if any.
 std::optional<ArgmaxKind> getArgmaxKind(linalg::GenericOp genericOp);
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -7,7 +7,6 @@
 #ifndef IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_
 #define IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_
 
-#include <optional>
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/Attributes.h"
@@ -15,6 +14,8 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
+
+#include <optional>
 
 namespace mlir {
 struct Range;

--- a/compiler/src/iree/compiler/DispatchCreation/test/split_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/split_reduction.mlir
@@ -46,8 +46,8 @@ util.func public @argmax(%arg0: tensor<?x131072xbf16>, %arg1: index) -> tensor<?
   ^bb0(%in: bf16, %out: bf16, %out_0: i64):
     %5 = linalg.index 1 : index
     %6 = arith.index_cast %5 : index to i64
-    %7 = arith.maximumf %in, %out : bf16
-    %8 = arith.cmpf ogt, %in, %out : bf16
+    %7 = arith.maximumf %in, %out fastmath<nnan> : bf16
+    %8 = arith.cmpf ogt, %in, %out fastmath<nnan> : bf16
     %9 = arith.select %8, %6, %out_0 : i64
     linalg.yield %7, %9 : bf16, i64
   } -> (tensor<?xbf16>, tensor<?xi64>)
@@ -81,8 +81,8 @@ util.func public @argmax(%arg0: tensor<?x131072xbf16>, %arg1: index) -> tensor<?
 // CHECK: ^bb0(%[[IN:.+]]: bf16, %[[ACC:.+]]: bf16, %[[IDX:.+]]: i64)
 // CHECK: %[[REDIDX:.+]] = linalg.index 2 : index
 // CHECK: %[[CASTIDX:.+]] = arith.index_cast %[[REDIDX]] : index to i64
-// CHECK: %[[MAXVAL:.+]] = arith.maximumf %[[IN]], %[[ACC]] : bf16
-// CHECK: %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[ACC]] : bf16
+// CHECK: %[[MAXVAL:.+]] = arith.maximumf %[[IN]], %[[ACC]] fastmath<nnan> : bf16
+// CHECK: %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[ACC]] fastmath<nnan> : bf16
 // CHECK: %[[SELIDX:.+]] = arith.select %[[CMP]], %[[CASTIDX]], %[[IDX]] : i64
 // CHECK: linalg.yield %[[MAXVAL]], %[[SELIDX]] : bf16, i64
 
@@ -96,8 +96,8 @@ util.func public @argmax(%arg0: tensor<?x131072xbf16>, %arg1: index) -> tensor<?
 // CHECK: %[[OFFSET:.+]] = arith.muli %[[OUTER]], %[[C128]] : index
 // CHECK: %[[OFFSET_CAST:.+]] = arith.index_cast %[[OFFSET]] : index to i64
 // CHECK: %[[GIDX:.+]] = arith.addi %[[OFFSET_CAST]], %[[I1]] : i64
-// CHECK: %[[MAX2:.+]] = arith.maximumf %[[V1]], %[[V2]] : bf16
-// CHECK: %[[CMP2:.+]] = arith.cmpf ogt, %[[V1]], %[[V2]] : bf16
+// CHECK: %[[MAX2:.+]] = arith.maximumf %[[V1]], %[[V2]] fastmath<nnan> : bf16
+// CHECK: %[[CMP2:.+]] = arith.cmpf ogt, %[[V1]], %[[V2]] fastmath<nnan> : bf16
 // CHECK: %[[SEL2:.+]] = arith.select %[[CMP2]], %[[GIDX]], %[[I2]] : i64
 // CHECK: linalg.yield %[[MAX2]], %[[SEL2]] : bf16, i64
 
@@ -151,10 +151,10 @@ util.func public @argmax_select_style(%arg0: tensor<1x248320xf32>) -> tensor<1xi
   ^bb0(%in: f32, %out: f32, %out_idx: i32):
     %idx = linalg.index 1 : index
     %idx_i32 = arith.index_cast %idx : index to i32
-    %gt = arith.cmpf ogt, %in, %out : f32
-    %nan = arith.cmpf une, %in, %in : f32
+    %gt = arith.cmpf ogt, %in, %out fastmath<contract> : f32
+    %nan = arith.cmpf une, %in, %in fastmath<contract> : f32
     %value_cond = arith.ori %gt, %nan : i1
-    %eq = arith.cmpf oeq, %in, %out : f32
+    %eq = arith.cmpf oeq, %in, %out fastmath<contract> : f32
     %lower_idx = arith.cmpi slt, %idx_i32, %out_idx : i32
     %tie = arith.andi %eq, %lower_idx : i1
     %index_cond = arith.ori %value_cond, %tie : i1
@@ -168,7 +168,13 @@ util.func public @argmax_select_style(%arg0: tensor<1x248320xf32>) -> tensor<1xi
 // CHECK-LABEL:   util.func public @argmax_select_style
 // CHECK:         tensor.expand_shape %arg0 {{\[}}[0], [1, 2]] output_shape [1, 1940, 128] : tensor<1x248320xf32> into tensor<1x1940x128xf32>
 // CHECK:         iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK:         arith.cmpf ogt, {{.*}} fastmath<contract> : f32
+// CHECK:         arith.cmpf une, {{.*}} fastmath<contract> : f32
+// CHECK:         arith.cmpf oeq, {{.*}} fastmath<contract> : f32
 // CHECK:         iterator_types = ["parallel", "reduction"]
+// CHECK:         arith.cmpf ogt, {{.*}} fastmath<contract> : f32
+// CHECK:         arith.cmpf une, {{.*}} fastmath<contract> : f32
+// CHECK:         arith.cmpf oeq, {{.*}} fastmath<contract> : f32
 // CHECK:         util.return
 
 // -----

--- a/compiler/src/iree/compiler/DispatchCreation/test/split_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/split_reduction.mlir
@@ -134,6 +134,150 @@ util.func public @argmax_no_split(%arg0: tensor<?x512xbf16>, %arg1: index) -> te
 
 // -----
 
+util.func public @argmax_select_style(%arg0: tensor<1x248320xf32>) -> tensor<1xi32> {
+  %cst = arith.constant 0xFF800000 : f32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1xf32>) -> tensor<1xf32>
+  %2 = tensor.empty() : tensor<1xi32>
+  %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<1xi32>) -> tensor<1xi32>
+  %4:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg0 : tensor<1x248320xf32>)
+      outs(%1, %3 : tensor<1xf32>, tensor<1xi32>) {
+  ^bb0(%in: f32, %out: f32, %out_idx: i32):
+    %idx = linalg.index 1 : index
+    %idx_i32 = arith.index_cast %idx : index to i32
+    %gt = arith.cmpf ogt, %in, %out : f32
+    %nan = arith.cmpf une, %in, %in : f32
+    %value_cond = arith.ori %gt, %nan : i1
+    %eq = arith.cmpf oeq, %in, %out : f32
+    %lower_idx = arith.cmpi slt, %idx_i32, %out_idx : i32
+    %tie = arith.andi %eq, %lower_idx : i1
+    %index_cond = arith.ori %value_cond, %tie : i1
+    %value = arith.select %value_cond, %in, %out : f32
+    %index = arith.select %index_cond, %idx_i32, %out_idx : i32
+    linalg.yield %value, %index : f32, i32
+  } -> (tensor<1xf32>, tensor<1xi32>)
+  util.return %4#1 : tensor<1xi32>
+}
+
+// CHECK-LABEL:   util.func public @argmax_select_style
+// CHECK:         tensor.expand_shape %arg0 {{\[}}[0], [1, 2]] output_shape [1, 1940, 128] : tensor<1x248320xf32> into tensor<1x1940x128xf32>
+// CHECK:         iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK:         iterator_types = ["parallel", "reduction"]
+// CHECK:         util.return
+
+// -----
+
+util.func public @argmax_select_style_no_nan_no_tie_no_split(%arg0: tensor<1x248320xf32>) -> tensor<1xi32> {
+  %cst = arith.constant 0xFF800000 : f32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1xf32>) -> tensor<1xf32>
+  %2 = tensor.empty() : tensor<1xi32>
+  %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<1xi32>) -> tensor<1xi32>
+  %4:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg0 : tensor<1x248320xf32>)
+      outs(%1, %3 : tensor<1xf32>, tensor<1xi32>) {
+  ^bb0(%in: f32, %out: f32, %out_idx: i32):
+    %idx = linalg.index 1 : index
+    %idx_i32 = arith.index_cast %idx : index to i32
+    %gt = arith.cmpf ogt, %in, %out : f32
+    %value = arith.select %gt, %in, %out : f32
+    %index = arith.select %gt, %idx_i32, %out_idx : i32
+    linalg.yield %value, %index : f32, i32
+  } -> (tensor<1xf32>, tensor<1xi32>)
+  util.return %4#1 : tensor<1xi32>
+}
+
+// CHECK-LABEL:   util.func public @argmax_select_style_no_nan_no_tie_no_split
+// CHECK-NOT:     tensor.expand_shape
+// CHECK:         util.return
+
+// -----
+
+util.func public @argmax_select_style_larger_tie_index_no_split(%arg0: tensor<1x248320xf32>) -> tensor<1xi32> {
+  %cst = arith.constant 0xFF800000 : f32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1xf32>) -> tensor<1xf32>
+  %2 = tensor.empty() : tensor<1xi32>
+  %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<1xi32>) -> tensor<1xi32>
+  %4:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg0 : tensor<1x248320xf32>)
+      outs(%1, %3 : tensor<1xf32>, tensor<1xi32>) {
+  ^bb0(%in: f32, %out: f32, %out_idx: i32):
+    %idx = linalg.index 1 : index
+    %idx_i32 = arith.index_cast %idx : index to i32
+    %gt = arith.cmpf ogt, %in, %out : f32
+    %nan = arith.cmpf une, %in, %in : f32
+    %value_cond = arith.ori %gt, %nan : i1
+    %eq = arith.cmpf oeq, %in, %out : f32
+    %higher_idx = arith.cmpi sgt, %idx_i32, %out_idx : i32
+    %tie = arith.andi %eq, %higher_idx : i1
+    %index_cond = arith.ori %value_cond, %tie : i1
+    %value = arith.select %value_cond, %in, %out : f32
+    %index = arith.select %index_cond, %idx_i32, %out_idx : i32
+    linalg.yield %value, %index : f32, i32
+  } -> (tensor<1xf32>, tensor<1xi32>)
+  util.return %4#1 : tensor<1xi32>
+}
+
+// CHECK-LABEL:   util.func public @argmax_select_style_larger_tie_index_no_split
+// CHECK-NOT:     tensor.expand_shape
+// CHECK:         util.return
+
+// -----
+
+util.func public @argmax_select_style_reversed_index_select_no_split(%arg0: tensor<1x248320xf32>) -> tensor<1xi32> {
+  %cst = arith.constant 0xFF800000 : f32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1xf32>) -> tensor<1xf32>
+  %2 = tensor.empty() : tensor<1xi32>
+  %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<1xi32>) -> tensor<1xi32>
+  %4:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg0 : tensor<1x248320xf32>)
+      outs(%1, %3 : tensor<1xf32>, tensor<1xi32>) {
+  ^bb0(%in: f32, %out: f32, %out_idx: i32):
+    %idx = linalg.index 1 : index
+    %idx_i32 = arith.index_cast %idx : index to i32
+    %gt = arith.cmpf ogt, %in, %out : f32
+    %nan = arith.cmpf une, %in, %in : f32
+    %value_cond = arith.ori %gt, %nan : i1
+    %eq = arith.cmpf oeq, %in, %out : f32
+    %lower_idx = arith.cmpi slt, %idx_i32, %out_idx : i32
+    %tie = arith.andi %eq, %lower_idx : i1
+    %index_cond = arith.ori %value_cond, %tie : i1
+    %value = arith.select %value_cond, %in, %out : f32
+    %index = arith.select %index_cond, %out_idx, %idx_i32 : i32
+    linalg.yield %value, %index : f32, i32
+  } -> (tensor<1xf32>, tensor<1xi32>)
+  util.return %4#1 : tensor<1xi32>
+}
+
+// CHECK-LABEL:   util.func public @argmax_select_style_reversed_index_select_no_split
+// CHECK-NOT:     tensor.expand_shape
+// CHECK:         util.return
+
+// -----
+
 util.func public @argmax_extf(%input: tensor<151936xf16>) -> (tensor<f32>, tensor<i64>) {
   %c0_i64 = arith.constant 0 : i64
   %cst = arith.constant 0xFF800000 : f32

--- a/compiler/src/iree/compiler/DispatchCreation/test/split_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/split_reduction.mlir
@@ -179,6 +179,86 @@ util.func public @argmax_select_style(%arg0: tensor<1x248320xf32>) -> tensor<1xi
 
 // -----
 
+util.func public @argmax_select_style_extf_bf16_to_f32(%arg0: tensor<1x248320xbf16>) -> tensor<1xi32> {
+  %cst = arith.constant 0xFF800000 : f32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1xf32>) -> tensor<1xf32>
+  %2 = tensor.empty() : tensor<1xi32>
+  %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<1xi32>) -> tensor<1xi32>
+  %4:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg0 : tensor<1x248320xbf16>)
+      outs(%1, %3 : tensor<1xf32>, tensor<1xi32>) {
+  ^bb0(%in: bf16, %out: f32, %out_idx: i32):
+    %idx = linalg.index 1 : index
+    %idx_i32 = arith.index_cast %idx : index to i32
+    %in_f32 = arith.extf %in : bf16 to f32
+    %gt = arith.cmpf ogt, %in_f32, %out : f32
+    %nan = arith.cmpf une, %in_f32, %in_f32 : f32
+    %value_cond = arith.ori %gt, %nan : i1
+    %eq = arith.cmpf oeq, %in_f32, %out : f32
+    %lower_idx = arith.cmpi slt, %idx_i32, %out_idx : i32
+    %tie = arith.andi %eq, %lower_idx : i1
+    %index_cond = arith.ori %value_cond, %tie : i1
+    %value = arith.select %value_cond, %in_f32, %out : f32
+    %index = arith.select %index_cond, %idx_i32, %out_idx : i32
+    linalg.yield %value, %index : f32, i32
+  } -> (tensor<1xf32>, tensor<1xi32>)
+  util.return %4#1 : tensor<1xi32>
+}
+
+// CHECK-LABEL:   util.func public @argmax_select_style_extf_bf16_to_f32
+// CHECK:         tensor.expand_shape %arg0 {{\[}}[0], [1, 2]] output_shape [1, 1940, 128] : tensor<1x248320xbf16> into tensor<1x1940x128xbf16>
+// CHECK:         iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK:         arith.extf {{.*}} : bf16 to f32
+// CHECK:         iterator_types = ["parallel", "reduction"]
+// CHECK:         util.return
+
+// -----
+
+util.func public @argmax_select_style_swapped_conditions(%arg0: tensor<1x248320xf32>) -> tensor<1xi32> {
+  %cst = arith.constant 0xFF800000 : f32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1xf32>) -> tensor<1xf32>
+  %2 = tensor.empty() : tensor<1xi32>
+  %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<1xi32>) -> tensor<1xi32>
+  %4:2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+      ins(%arg0 : tensor<1x248320xf32>)
+      outs(%1, %3 : tensor<1xf32>, tensor<1xi32>) {
+  ^bb0(%in: f32, %out: f32, %out_idx: i32):
+    %idx = linalg.index 1 : index
+    %idx_i32 = arith.index_cast %idx : index to i32
+    %gt = arith.cmpf ogt, %in, %out : f32
+    %nan = arith.cmpf une, %in, %in : f32
+    %value_cond = arith.ori %nan, %gt : i1
+    %eq = arith.cmpf oeq, %in, %out : f32
+    %lower_idx = arith.cmpi slt, %idx_i32, %out_idx : i32
+    %tie = arith.andi %lower_idx, %eq : i1
+    %index_cond = arith.ori %tie, %value_cond : i1
+    %value = arith.select %value_cond, %in, %out : f32
+    %index = arith.select %index_cond, %idx_i32, %out_idx : i32
+    linalg.yield %value, %index : f32, i32
+  } -> (tensor<1xf32>, tensor<1xi32>)
+  util.return %4#1 : tensor<1xi32>
+}
+
+// CHECK-LABEL:   util.func public @argmax_select_style_swapped_conditions
+// CHECK:         tensor.expand_shape %arg0 {{\[}}[0], [1, 2]] output_shape [1, 1940, 128] : tensor<1x248320xf32> into tensor<1x1940x128xf32>
+// CHECK:         iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK:         iterator_types = ["parallel", "reduction"]
+// CHECK:         util.return
+
+// -----
+
 util.func public @argmax_select_style_no_nan_no_tie_no_split(%arg0: tensor<1x248320xf32>) -> tensor<1xi32> {
   %cst = arith.constant 0xFF800000 : f32
   %c0_i32 = arith.constant 0 : i32


### PR DESCRIPTION
Problem:
StableHLO/JAX lowers argmax for lm_head vocab reductions as a pair of selects with explicit NaN handling and lower-index tie breaking. The existing split-reduction matcher only recognized the canonical maximumf/cmpf/select form, so large vocab reductions stayed as one wide reduction.

Fix:
Teach the argmax matcher to distinguish canonical and StableHLO/JAX select-style argmax reductions, and preserve the corresponding combiner when splitting. Keep the select-style matcher strict by requiring the `gt || isnan` value condition, the `eq && lower_index` tie condition, and the expected value/index select operands.

Example:
A Qwen `lm_head` argmax over vocab size 248320 can now split into a two-stage reduction over 1940x128 tiles while preserving NaN and lower-index tie semantics. Negative tests ensure similar-looking select reductions with different NaN/tie/index semantics do not split.