### PR TITLE
[tokenizer] Return RESOURCE_EXHAUSTED when feed's output buffer is full

### DIFF
--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -2780,16 +2780,28 @@ iree_status_t iree_tokenizer_encode_state_feed(
   *out_bytes_consumed = original_chunk_size - chunk.size;
   *out_token_count = total_tokens;
 
-  // Detect deadlock: input remains but no progress was made. With partial
-  // segment handling this should not happen in practice — the pump enters
-  // partial mode when the ring is full with no segment boundaries, and BPE's
-  // frozen token theorem guarantees progress. This can only fire if the ring
-  // buffer is smaller than max_token_length (configuration error).
+  // Detect no-progress: input remains but feed() produced nothing.
+  // Disambiguate by the caller-supplied output capacity:
+  //   - capacity 0: the outer iree_tokenizer_encode loop has filled
+  //     the parent buffer; sub_output.capacity = output.capacity -
+  //     total_tokens reached 0 with input still pending. Caller
+  //     needs a bigger buffer (RESOURCE_EXHAUSTED).
+  //   - capacity > 0: pump had room and still didn't advance. A
+  //     real pump-invariant violation (ring smaller than
+  //     max_token_length, or a regression in partial-segment
+  //     handling). Surface as INTERNAL so the bug is loud.
   if (iree_status_is_ok(status) && chunk.size > 0 && *out_bytes_consumed == 0 &&
       total_tokens == 0) {
+    if (output.capacity == 0) {
+      return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "encode: output buffer full with input remaining "
+                              "(pending_input=%" PRIhsz " bytes)",
+                              chunk.size);
+    }
     return iree_make_status(
         IREE_STATUS_INTERNAL,
-        "encode deadlock: no progress despite partial segment handling "
+        "encode pump invariant violated: no progress with output room "
+        "and no pending pipeline data "
         "(logical_capacity=%" PRIhsz " bytes, used=%" PRIhsz
         " bytes, pending_input=%" PRIhsz " bytes, has_partial=%" PRIu32 ")",
         state->capacity_mask + 1, state->write_position - state->read_position,

--- a/runtime/src/iree/tokenizer/tokenizer_encode_test.cc
+++ b/runtime/src/iree/tokenizer/tokenizer_encode_test.cc
@@ -6418,6 +6418,53 @@ TEST_F(TokenizerEncodeOverflowTest,
   iree_tokenizer_free(tokenizer);
 }
 
+// Regression: feed() must return RESOURCE_EXHAUSTED (not INTERNAL) when its
+// caller-provided output capacity is exhausted with input still pending.
+//
+// Coverage gap this fills: BatchEncodeOutputBufferTooSmall ("abcde" → 2-token
+// buffer) drains all 5 bytes in ONE feed() call (small enough that the pump
+// consumes the whole segment in one pass); the outer loop then exits because
+// text.size == 0 and the exhaustion fires from finalize(), not feed(). To
+// reach feed()'s no-progress check the input must be long enough that the
+// outer loop iterates multiple times — bytes still pending after the caller's
+// output capacity is reached. 1000 chars × 100-token buffer guarantees that.
+TEST_F(TokenizerEncodeOverflowTest, BatchEncodeReportsExhaustedOnFullOutput) {
+  ScopedVocabBuilder vocab_builder;
+  for (int i = 0; i < 26; ++i) {
+    char token_str[2] = {(char)('a' + i), '\0'};
+    vocab_builder.AddToken(i, token_str);
+  }
+  ScopedVocab vocab = vocab_builder.Build();
+
+  ScopedBuilder builder;
+  iree_tokenizer_builder_set_segmenter(builder.get(),
+                                       CreateWhitespaceSegmenter());
+  iree_tokenizer_builder_set_model(builder.get(),
+                                   CreateBPEModelIgnoreMerges(vocab.get()));
+  iree_tokenizer_builder_set_vocab(builder.get(), vocab.release());
+  iree_tokenizer_t* tokenizer = BuildTokenizer(builder.get());
+  ASSERT_NE(tokenizer, nullptr);
+
+  // Long input (each char is a separate token after whitespace segmentation).
+  std::string input(1000, 'a');
+  // Output capacity smaller than required token count - mid-stream the
+  // outer encode() loop will give feed() a sub_output with capacity == 0
+  // and the deadlock check would previously fire as INTERNAL.
+  std::vector<iree_tokenizer_token_id_t> token_ids(100);
+  iree_host_size_t token_count = 0;
+  iree_status_t status = iree_tokenizer_encode(
+      tokenizer,
+      iree_make_string_view(input.data(),
+                            static_cast<iree_host_size_t>(input.size())),
+      IREE_TOKENIZER_ENCODE_FLAG_NONE,
+      iree_tokenizer_make_token_output(token_ids.data(), NULL, NULL,
+                                       token_ids.size()),
+      iree_allocator_system(), &token_count);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, status);
+
+  iree_tokenizer_free(tokenizer);
+}
+
 // Streaming encode finalize with insufficient capacity for suffix.
 // Feed "ab" (produces [BOS, 0, 1]), then finalize with capacity 0 for EOS.
 TEST_F(TokenizerEncodeOverflowTest, FinalizeOutputBufferTooSmallForSuffix) {


### PR DESCRIPTION
`iree_tokenizer_encode_state_feed`'s no-progress check returned `IREE_STATUS_INTERNAL` for what is usually just an output-buffer overflow. The outer `iree_tokenizer_encode` loop slices output via `sub_output.capacity = output.capacity - total_tokens`; once the caller's buffer is full, the next iteration hands feed() a zero- capacity sub-output with text.size > 0, the partial-segment fallback short-circuits on `output->capacity > total_tokens`, and the pump produces nothing.

Disambiguate by output capacity:
  - `output.capacity == 0`: the outer loop has filled the parent buffer. Caller needs a bigger buffer. RESOURCE_EXHAUSTED.
  - `output.capacity > 0`: pump had room and still made no progress. A real pump-invariant violation (ring smaller than max_token_length, regression in partial-segment handling). Surface as INTERNAL.

Why existing tests missed this: `BatchEncodeOutputBufferTooSmall` encodes "abcde" with a 2-token output buffer. The pump consumes all 5 bytes in ONE feed() call, so text.size hits 0 after one iteration and the outer loop exits. The exhaustion then fires from finalize() — a separate code path at tokenizer.c:2937. To reach feed()'s no-progress check the outer loop must iterate at least once more after total_tokens == output.capacity, which requires the input to be long enough that one feed() call can't drain it. The new regression test (1000 chars into a 100-token buffer) guarantees that condition.

Verification:
  - Tokenizer unit suite: 65/65 passing.
  - HuggingFace smoketest (`huggingface_smoketest.py`, dev mode, 200+ models incl. BERT/GPT2/Llama/Gemma/Falcon/T5/XLM-R/ DeBERTa/sentence-transformers/luke/Qwen): 1667/1667 passing.
  - Tiktoken smoketest (`tiktoken_smoketest.py`, cl100k_base, o200k_base, r50k_base, p50k_base): 76/76 passing.