### PR TITLE
[Codegen] Fold masked transfer_read/write in loops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -435,12 +435,11 @@ private:
     auto readConversion = IREE::Util::HoistableConversionOp::create(
         rewriter, readOp.getLoc(), kTransferReadTag, kTransferWriteTag,
         TypeRange{readOp.getVectorType()}, ValueRange{candidate.iterArg},
-        [&](OpBuilder &builder, Location loc, ValueRange args) {
-          Value read = vector::TransferReadOp::create(
-              builder, loc, readOp.getVectorType(), args[0],
-              readOp.getIndices(), readOp.getPermutationMap(),
-              readOp.getPadding(), readOp.getMask(), readOp.getInBoundsAttr());
-          return SmallVector<Value>{read};
+        [&](OpBuilder &builder, Location, ValueRange args) {
+          auto clonedRead = cast<vector::TransferReadOp>(
+              builder.clone(*readOp.getOperation()));
+          clonedRead.getBaseMutable().assign(args[0]);
+          return SmallVector<Value>{clonedRead.getResult()};
         });
 
     TypedValue<VectorType> mask = readOp.getMask();
@@ -456,14 +455,12 @@ private:
     auto writeConversion = IREE::Util::HoistableConversionOp::create(
         rewriter, writeOp.getLoc(), kTransferWriteTag, kTransferReadTag,
         TypeRange{writeOp.getResult().getType()}, ValueRange{carriedValue},
-        [&](OpBuilder &builder, Location loc, ValueRange args) {
-          Value write =
-              vector::TransferWriteOp::create(
-                  builder, loc, args[0], candidate.initArg,
-                  writeOp.getIndices(), writeOp.getPermutationMapAttr(),
-                  writeOp.getMask(), writeOp.getInBoundsAttr())
-                  .getResult();
-          return SmallVector<Value>{write};
+        [&](OpBuilder &builder, Location, ValueRange args) {
+          auto clonedWrite = cast<vector::TransferWriteOp>(
+              builder.clone(*writeOp.getOperation()));
+          clonedWrite.getValueToStoreMutable().assign(args[0]);
+          clonedWrite.getBaseMutable().assign(candidate.initArg);
+          return SmallVector<Value>{clonedWrite.getResult()};
         });
 
     rewriter.replaceOp(writeOp, writeConversion.getResult(0));

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -898,11 +898,8 @@ canonicalizeLoopCarriedTransferState(mlir::FunctionOpInterface funcOp,
   }
   {
     RewritePatternSet patterns(context);
-    // This intentionally runs independent of fold-identity-slices: it only
-    // retargets transfer reads through identity slices to unblock transfer
-    // folding and does not generally erase identity slice ops.
-    patterns.add<FoldTransferWriteChain, FoldTransferReadOfIdentitySlice,
-                 FoldTransferRAW, FoldTransferReadOfEmptyTensor>(context);
+    patterns.add<FoldTransferWriteChain, FoldTransferRAW,
+                 FoldTransferReadOfEmptyTensor>(context);
     vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return failure();
@@ -988,6 +985,9 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   patterns.add<PromoteLoopCarriedTransferIterArg>(context);
   scf::ForOp::getCanonicalizationPatterns(patterns, context);
   vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
+  // Run after subset hoisting so retargeting reads through identity slices
+  // does not create direct tensor iter_arg uses that block subset matching.
+  patterns.add<FoldTransferReadOfIdentitySlice>(context);
   if (foldIdentitySlices) {
     patterns.add<CastLikeExtractSliceOpFolder>(context);
     patterns.add<CastLikeInsertSliceOpFolder>(context);

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -443,13 +443,13 @@ private:
           return SmallVector<Value>{read};
         });
 
+    TypedValue<VectorType> mask = readOp.getMask();
+    Value pad = readOp.getPadding();
     for (vector::TransferReadOp read : candidate.reads) {
       rewriter.replaceOp(read, readConversion.getResult(0));
     }
 
     vector::TransferWriteOp writeOp = candidate.write;
-    TypedValue<VectorType> mask = readOp.getMask();
-    Value pad = readOp.getPadding();
     rewriter.setInsertionPoint(writeOp);
     Value carriedValue = getLoopCarriedTransferValue(
         rewriter, writeOp.getLoc(), mask, pad, writeOp.getVector());

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -236,12 +236,43 @@ hasOnlyLoopInvariantOperandsExcept(LoopLikeOpInterface loopLike, Operation *op,
   });
 }
 
+static bool areEquivalentMasks(Value lhs, Value rhs) {
+  if (lhs == rhs) {
+    return true;
+  }
+  if (!lhs || !rhs || lhs.getType() != rhs.getType()) {
+    return false;
+  }
+  auto lhsCreateMask = lhs.getDefiningOp<vector::CreateMaskOp>();
+  auto rhsCreateMask = rhs.getDefiningOp<vector::CreateMaskOp>();
+  return lhsCreateMask && rhsCreateMask &&
+         lhsCreateMask.getOperands() == rhsCreateMask.getOperands();
+}
+
+static bool
+areEquivalentTransferAccesses(Type lhsVectorType, ValueRange lhsIndices,
+                              AffineMap lhsPermutationMap, Value lhsMask,
+                              Type rhsVectorType, ValueRange rhsIndices,
+                              AffineMap rhsPermutationMap, Value rhsMask) {
+  return lhsVectorType == rhsVectorType && lhsIndices == rhsIndices &&
+         lhsPermutationMap == rhsPermutationMap &&
+         areEquivalentMasks(lhsMask, rhsMask);
+}
+
 static bool areEquivalentTransferReadWrite(vector::TransferReadOp readOp,
                                            vector::TransferWriteOp writeOp) {
-  return readOp.getType() == writeOp.getVector().getType() &&
-         readOp.getIndices() == writeOp.getIndices() &&
-         readOp.getPermutationMap() == writeOp.getPermutationMap() &&
-         readOp.getMask() == writeOp.getMask();
+  return areEquivalentTransferAccesses(
+      readOp.getType(), readOp.getIndices(), readOp.getPermutationMap(),
+      readOp.getMask(), writeOp.getVector().getType(), writeOp.getIndices(),
+      writeOp.getPermutationMap(), writeOp.getMask());
+}
+
+static bool areEquivalentTransferWrites(vector::TransferWriteOp lhs,
+                                        vector::TransferWriteOp rhs) {
+  return areEquivalentTransferAccesses(
+      lhs.getVector().getType(), lhs.getIndices(), lhs.getPermutationMap(),
+      lhs.getMask(), rhs.getVector().getType(), rhs.getIndices(),
+      rhs.getPermutationMap(), rhs.getMask());
 }
 
 static Value getLoopCarriedTransferValue(OpBuilder &builder,
@@ -428,6 +459,128 @@ private:
   }
 };
 
+/// Fold tensor.dim of a loop-carried tensor iter_arg back to the loop init
+/// tensor when the yielded value is only a chain of shape-preserving
+/// vector.transfer_write ops.
+///
+/// This normalizes masks built from loop-carried tensor dims before transfer
+/// folding runs. Without this, equivalent masks may remain structurally
+/// different because one is based on the init tensor and another is based on
+/// the iter_arg.
+///
+/// ```mlir
+/// %r = scf.for ... iter_args(%acc = %init) -> tensor<?xf32> {
+///   %d = tensor.dim %acc, %c0 : tensor<?xf32>
+///   %m = vector.create_mask %d : vector<4xi1>
+///   %next = vector.transfer_write %v, %acc[%c0], %m
+///   scf.yield %next : tensor<?xf32>
+/// }
+/// ```
+///
+/// becomes:
+///
+/// ```mlir
+/// %r = scf.for ... iter_args(%acc = %init) -> tensor<?xf32> {
+///   %d = tensor.dim %init, %c0 : tensor<?xf32>
+///   %m = vector.create_mask %d : vector<4xi1>
+///   %next = vector.transfer_write %v, %acc[%c0], %m
+///   scf.yield %next : tensor<?xf32>
+/// }
+/// ```
+struct FoldDimOfShapePreservingTransferIterArg final
+    : OpRewritePattern<tensor::DimOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(tensor::DimOp dimOp,
+                                PatternRewriter &rewriter) const override {
+    auto iterArg = dyn_cast<BlockArgument>(dimOp.getSource());
+    if (!iterArg) {
+      return failure();
+    }
+    auto forOp = dyn_cast<scf::ForOp>(iterArg.getOwner()->getParentOp());
+    if (!forOp) {
+      return failure();
+    }
+    OpOperand *initArg = forOp.getTiedLoopInit(iterArg);
+    if (!initArg || !isShapePreservingTransferWriteChain(forOp, iterArg)) {
+      return failure();
+    }
+
+    rewriter.modifyOpInPlace(
+        dimOp, [&]() { dimOp.getSourceMutable().assign(initArg->get()); });
+    return success();
+  }
+
+private:
+  bool isShapePreservingTransferWriteChain(scf::ForOp forOp,
+                                           BlockArgument iterArg) const {
+    OpOperand *yieldedValue = forOp.getTiedLoopYieldedValue(iterArg);
+    if (!yieldedValue) {
+      return false;
+    }
+    Value value = yieldedValue->get();
+    while (true) {
+      if (value == iterArg) {
+        return true;
+      }
+      auto writeOp = value.getDefiningOp<vector::TransferWriteOp>();
+      if (!writeOp || !writeOp.hasPureTensorSemantics()) {
+        return false;
+      }
+      value = writeOp.getBase();
+    }
+  }
+};
+
+/// Fold transfer_write chains where a later write overwrites the same tensor
+/// slice as an earlier write. For equal masks, masked-off lanes are preserved
+/// from the original base by both writes, so the earlier write is not needed
+/// for the later result.
+///
+/// This handles structurally equivalent masks that upstream WAW folding does
+/// not recognize after CSE/canonicalization fail to make the mask SSA value the
+/// same.
+///
+/// ```mlir
+/// %m0 = vector.create_mask %d : vector<4xi1>
+/// %w0 = vector.transfer_write %v0, %t[%c0], %m0
+/// %m1 = vector.create_mask %d : vector<4xi1>
+/// %w1 = vector.transfer_write %v1, %w0[%c0], %m1
+/// ```
+///
+/// becomes:
+///
+/// ```mlir
+/// %m1 = vector.create_mask %d : vector<4xi1>
+/// %w1 = vector.transfer_write %v1, %t[%c0], %m1
+/// ```
+struct FoldTransferWriteChain final
+    : OpRewritePattern<vector::TransferWriteOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
+                                PatternRewriter &rewriter) const override {
+    if (!writeOp.hasPureTensorSemantics() || writeOp.hasOutOfBoundsDim()) {
+      return failure();
+    }
+    auto previousWriteOp =
+        writeOp.getBase().getDefiningOp<vector::TransferWriteOp>();
+    if (!previousWriteOp || !previousWriteOp.hasPureTensorSemantics() ||
+        previousWriteOp.hasOutOfBoundsDim() ||
+        !areEquivalentTransferWrites(writeOp, previousWriteOp)) {
+      return failure();
+    }
+
+    rewriter.modifyOpInPlace(writeOp, [&]() {
+      writeOp.getBaseMutable().assign(previousWriteOp.getBase());
+    });
+    if (previousWriteOp->use_empty()) {
+      rewriter.eraseOp(previousWriteOp);
+    }
+    return success();
+  }
+};
+
 namespace {
 struct CastLikeExtractSliceOpFolder final
     : OpRewritePattern<tensor::ExtractSliceOp> {
@@ -456,6 +609,78 @@ struct CastLikeInsertSliceOpFolder final
     }
     rewriter.replaceOp(sliceOp, sliceOp.getSource());
     return success();
+  }
+};
+
+/// Retarget vector.transfer_read through an identity tensor slice.
+///
+/// This is narrower than the general identity-slice folder: it only updates the
+/// transfer_read base and only for zero-offset, unit-stride slices with
+/// identical source/result types. The purpose is to unblock transfer folding in
+/// cleanup phases that intentionally do not run the general
+/// fold-identity-slices patterns.
+///
+/// ```mlir
+/// %slice = tensor.extract_slice %t[0] [%d] [1]
+///     : tensor<?xf32> to tensor<?xf32>
+/// %r = vector.transfer_read %slice[%c0], %pad
+///     : tensor<?xf32>, vector<4xf32>
+/// ```
+///
+/// becomes:
+///
+/// ```mlir
+/// %r = vector.transfer_read %t[%c0], %pad
+///     : tensor<?xf32>, vector<4xf32>
+/// ```
+///
+/// The same rewrite applies to identity tensor.insert_slice results, replacing
+/// the read base with the inserted source tensor.
+struct FoldTransferReadOfIdentitySlice final
+    : OpRewritePattern<vector::TransferReadOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
+    if (!readOp.hasPureTensorSemantics()) {
+      return failure();
+    }
+    Value source = getIdentitySliceSource(readOp.getBase());
+    if (!source) {
+      return failure();
+    }
+    rewriter.modifyOpInPlace(readOp,
+                             [&]() { readOp.getBaseMutable().assign(source); });
+    return success();
+  }
+
+private:
+  bool isIdentityExtractSliceOp(tensor::ExtractSliceOp extractSliceOp) const {
+    return tensor::isCastLikeExtractSliceOp(extractSliceOp) &&
+           extractSliceOp.getSourceType() == extractSliceOp.getResultType() &&
+           extractSliceOp.hasZeroOffset() && extractSliceOp.hasUnitStride();
+  }
+
+  bool isIdentityInsertSliceOp(tensor::InsertSliceOp insertSliceOp) const {
+    return tensor::isCastLikeInsertSliceOp(insertSliceOp) &&
+           insertSliceOp.getSourceType() == insertSliceOp.getResultType() &&
+           insertSliceOp.hasZeroOffset() && insertSliceOp.hasUnitStride();
+  }
+
+  Value getIdentitySliceSource(Value value) const {
+    if (auto extractSliceOp = value.getDefiningOp<tensor::ExtractSliceOp>()) {
+      if (isIdentityExtractSliceOp(extractSliceOp)) {
+        return extractSliceOp.getSource();
+      }
+      return {};
+    }
+    if (auto insertSliceOp = value.getDefiningOp<tensor::InsertSliceOp>()) {
+      if (isIdentityInsertSliceOp(insertSliceOp)) {
+        return insertSliceOp.getSource();
+      }
+      return {};
+    }
+    return {};
   }
 };
 
@@ -540,7 +765,7 @@ struct FoldTransferRAW : OpRewritePattern<vector::TransferReadOp> {
     // When wMask is absent (unmasked write) or wMask == rMask (original is
     // never accessed), this simplifies to just valToStore.
     Value inner = valToStore;
-    bool needsOriginal = wMask && wMask != rMask;
+    bool needsOriginal = wMask && !areEquivalentMasks(wMask, rMask);
     if (needsOriginal) {
       Value originalRead = vector::TransferReadOp::create(
           rewriter, readOp.getLoc(), readOp.getType(), writeOp.getBase(),
@@ -655,6 +880,50 @@ struct FoldTransferReadOfEmptyTensor
 };
 } // namespace
 
+static LogicalResult
+canonicalizeLoopCarriedTransferState(mlir::FunctionOpInterface funcOp,
+                                     MLIRContext *context) {
+  // Keep dim/shape cleanup separate from transfer cleanup. FoldTransferRAW is
+  // not reversible: if it runs before masks based on loop-carried tensor dims
+  // are normalized to the loop init shape, it may conservatively materialize an
+  // extra read of the original tensor and block later iter_arg promotion.
+  {
+    RewritePatternSet patterns(context);
+    patterns.add<FoldDimOfShapePreservingTransferIterArg>(context);
+    tensor::DimOp::getCanonicalizationPatterns(patterns, context);
+    tensor::EmptyOp::getCanonicalizationPatterns(patterns, context);
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+      return failure();
+    }
+  }
+  {
+    RewritePatternSet patterns(context);
+    // This intentionally runs independent of fold-identity-slices: it only
+    // retargets transfer reads through identity slices to unblock transfer
+    // folding and does not generally erase identity slice ops.
+    patterns.add<FoldTransferWriteChain, FoldTransferReadOfIdentitySlice,
+                 FoldTransferRAW, FoldTransferReadOfEmptyTensor>(context);
+    vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+static LogicalResult
+canonicalizeAndPromoteLoopCarriedTransferState(mlir::FunctionOpInterface funcOp,
+                                               MLIRContext *context) {
+  if (failed(canonicalizeLoopCarriedTransferState(funcOp, context))) {
+    return failure();
+  }
+  moveLoopInvariantCodeFromGuaranteedLoops(funcOp);
+
+  RewritePatternSet promotionPatterns(context);
+  promotionPatterns.add<PromoteLoopCarriedTransferIterArg>(context);
+  return applyPatternsGreedily(funcOp, std::move(promotionPatterns));
+}
+
 // Find the earliest insertion point in the block for the given operation.
 static Operation *getEarliestInsertionPointInsideBlock(Block *block,
                                                        Operation *op) {
@@ -689,14 +958,9 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
     extractSliceOp->moveAfter(latestInsertionPoint);
   });
 
-  moveLoopInvariantCodeFromGuaranteedLoops(funcOp);
-  LDBG() << "after hoisting loop invariant code\n" << funcOp << "\n";
-
   // Run the vector transfer-specific promotion before generic subset hoisting
   // so masked transfer loops get the required per-iteration padding semantics.
-  RewritePatternSet promotionPatterns(context);
-  promotionPatterns.add<PromoteLoopCarriedTransferIterArg>(context);
-  if (failed(applyPatternsGreedily(funcOp, std::move(promotionPatterns)))) {
+  if (failed(canonicalizeAndPromoteLoopCarriedTransferState(funcOp, context))) {
     return signalPassFailure();
   }
   LDBG() << "after early promoting loop carried vector transfers" << funcOp;
@@ -712,8 +976,15 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   });
   LDBG() << "after hoisting subset loop invariant tensors" << funcOp;
 
+  if (failed(canonicalizeAndPromoteLoopCarriedTransferState(funcOp, context))) {
+    return signalPassFailure();
+  }
+  LDBG() << "after late promoting loop carried vector transfers" << funcOp;
+
   RewritePatternSet patterns(context);
   populateVectorTransferTensorSliceTransforms(patterns);
+  // Keep the final promotion pattern in this general cleanup because its
+  // transfer/slice folds can expose additional loop-carried transfers.
   patterns.add<PromoteLoopCarriedTransferIterArg>(context);
   scf::ForOp::getCanonicalizationPatterns(patterns, context);
   vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -6,6 +6,8 @@
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
@@ -28,6 +30,10 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
 
 namespace {
+
+static constexpr StringLiteral kTransferReadTag = "loop_carried_transfer_read";
+static constexpr StringLiteral kTransferWriteTag =
+    "loop_carried_transfer_write";
 
 class OptimizeTensorInsertExtractSlicesPass final
     : public impl::OptimizeTensorInsertExtractSlicesPassBase<
@@ -283,18 +289,15 @@ static bool areEquivalentTransferWrites(vector::TransferWriteOp lhs,
       rhs.getPermutationMap(), rhs.getMask());
 }
 
-static Value getLoopCarriedTransferValue(OpBuilder &builder,
-                                         vector::TransferReadOp readOp,
+static Value getLoopCarriedTransferValue(OpBuilder &builder, Location loc,
+                                         TypedValue<VectorType> mask, Value pad,
                                          Value valueToStore) {
-  TypedValue<VectorType> mask = readOp.getMask();
   if (!mask) {
     return valueToStore;
   }
-  Value pad = readOp.getPadding();
   Value padVector = vector::BroadcastOp::create(
       builder, pad.getLoc(), cast<VectorType>(valueToStore.getType()), pad);
-  return arith::SelectOp::create(builder, readOp.getLoc(), mask, valueToStore,
-                                 padVector);
+  return arith::SelectOp::create(builder, loc, mask, valueToStore, padVector);
 }
 
 /// Promote a tensor iter_arg to a vector iter_arg when the tensor is only
@@ -320,40 +323,68 @@ static Value getLoopCarriedTransferValue(OpBuilder &builder,
 /// lanes, transfer_read returns padding, while transfer_write preserves the
 /// tensor. A generic subset hoist would carry `%new` directly, which is only
 /// equivalent for unmasked transfers.
-struct HoistLoopCarriedTransferIterArg final : OpRewritePattern<scf::ForOp> {
+struct MarkHoistableLoopCarriedTransferIterArg final
+    : OpRewritePattern<vector::TransferWriteOp> {
   using Base::Base;
 
-  LogicalResult matchAndRewrite(scf::ForOp forOp,
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
                                 PatternRewriter &rewriter) const override {
-    for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i < e; ++i) {
-      std::optional<HoistableTransferIterArg> candidate =
-          getHoistableTransferIterArg(forOp, i);
-      if (candidate) {
-        return hoistLoopCarriedTransferIterArg(rewriter, forOp, *candidate);
-      }
+    std::optional<HoistableTransferIterArg> candidate =
+        getHoistableTransferIterArg(writeOp);
+    if (!candidate) {
+      return failure();
     }
-    return failure();
+    return markLoopCarriedTransferIterArgHoistable(rewriter, *candidate);
   }
 
 private:
   struct HoistableTransferIterArg {
-    unsigned index;
+    BlockArgument iterArg;
+    Value initArg;
     vector::TransferWriteOp write;
     SmallVector<vector::TransferReadOp> reads;
   };
 
   std::optional<HoistableTransferIterArg>
-  getHoistableTransferIterArg(scf::ForOp forOp, unsigned index) const {
-    LoopLikeOpInterface loopLike =
-        cast<LoopLikeOpInterface>(forOp.getOperation());
-    BlockArgument iterArg = forOp.getRegionIterArg(index);
-    Value yielded = forOp.getYieldedValues()[index];
-    auto writeOp = yielded.getDefiningOp<vector::TransferWriteOp>();
-    if (!writeOp || !writeOp.hasPureTensorSemantics() ||
-        writeOp.getBase() != iterArg || writeOp.hasOutOfBoundsDim() ||
-        !writeOp->hasOneUse()) {
+  getHoistableTransferIterArg(vector::TransferWriteOp writeOp) const {
+    auto loopLike =
+        dyn_cast_if_present<LoopLikeOpInterface>(writeOp->getParentOp());
+    if (!loopLike || !writeOp.hasPureTensorSemantics() ||
+        writeOp.hasOutOfBoundsDim() || !writeOp->hasOneUse()) {
       return std::nullopt;
     }
+
+    auto yieldedMutable = loopLike.getYieldedValuesMutable();
+    if (!yieldedMutable) {
+      return std::nullopt;
+    }
+
+    std::optional<unsigned> index;
+    for (auto [i, yieldOperand] : llvm::enumerate(*yieldedMutable)) {
+      if (yieldOperand.get() == writeOp.getResult()) {
+        index = i;
+        break;
+      }
+    }
+    if (!index) {
+      return std::nullopt;
+    }
+
+    BlockArgument iterArg = loopLike.getRegionIterArgs()[*index];
+    OpOperand *initArg = loopLike.getTiedLoopInit(iterArg);
+    if (!initArg || writeOp.getBase() != iterArg) {
+      return std::nullopt;
+    }
+    // Avoid marking inner loops whose init is carried by an enclosing loop:
+    // the conversion body would capture that outer iter_arg and can become
+    // self-referential when the conversion is hoisted through the outer loop.
+    if (auto initBlockArg = dyn_cast<BlockArgument>(initArg->get())) {
+      if (dyn_cast_if_present<LoopLikeOpInterface>(
+              initBlockArg.getOwner()->getParentOp())) {
+        return std::nullopt;
+      }
+    }
+
     if (!hasOnlyLoopInvariantOperandsExcept(
             loopLike, writeOp,
             {&writeOp.getValueToStoreMutable(), &writeOp.getBaseMutable()})) {
@@ -386,83 +417,56 @@ private:
     if (reads.empty()) {
       return std::nullopt;
     }
-    return HoistableTransferIterArg{index, writeOp, reads};
+    return HoistableTransferIterArg{iterArg, initArg->get(), writeOp, reads};
   }
 
-  LogicalResult
-  hoistLoopCarriedTransferIterArg(PatternRewriter &rewriter, scf::ForOp forOp,
-                                  HoistableTransferIterArg candidate) const {
-    unsigned oldNumIterArgs = forOp.getNumRegionIterArgs();
-    unsigned oldNumResults = forOp.getNumResults();
-    Value originalInitArg = forOp.getInitArgs()[candidate.index];
+  LogicalResult markLoopCarriedTransferIterArgHoistable(
+      PatternRewriter &rewriter, HoistableTransferIterArg candidate) const {
     OpBuilder::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(forOp);
-
-    // Create a transfer_read before the loop to read the vector value from the
-    // tensor that was the loop argument so far.
     vector::TransferReadOp readOp = candidate.reads.front();
-    Value initVector = vector::TransferReadOp::create(
-        rewriter, readOp.getLoc(), readOp.getVectorType(), originalInitArg,
-        readOp.getIndices(), readOp.getPermutationMap(), readOp.getPadding(),
-        readOp.getMask(), readOp.getInBoundsAttr());
-
-    // Inside the loop, build the new yield value by broadcasting the padding
-    // value and selecting based on the mask. This is only necessary if the
-    // reads and writes are masked.
-    NewYieldValuesFn newYieldValuesFn =
-        [&](OpBuilder &builder, Location,
-            ArrayRef<BlockArgument>) -> SmallVector<Value> {
-      vector::TransferReadOp readOp = candidate.reads.front();
-      return {getLoopCarriedTransferValue(builder, readOp,
-                                          candidate.write.getVector())};
-    };
-
-    // Build the new for-loop with an additional vector-typed loop-carried
-    // value. The original tensor-typed loop-carried value will be removed by
-    // canonicalization later on.
-    FailureOr<LoopLikeOpInterface> newLoopLike =
-        forOp.replaceWithAdditionalYields(
-            rewriter, ValueRange(initVector),
-            /*replaceInitOperandUsesInLoop=*/false, newYieldValuesFn);
-    if (failed(newLoopLike)) {
-      return failure();
-    }
-    scf::ForOp newForOp = cast<scf::ForOp>(newLoopLike->getOperation());
-
-    // The new vector-typed loop-carried value carries the semantics now.
-    // Rewrite the yield such that the original tensor-typed value stops
-    // evolving inside the loop and will be cleaned up by canonicalization.
-    auto yieldOp = cast<scf::YieldOp>(newForOp.getBody()->getTerminator());
-    rewriter.modifyOpInPlace(yieldOp, [&]() {
-      yieldOp->setOperand(candidate.index,
-                          newForOp.getRegionIterArg(candidate.index));
-    });
-
-    // If there are any uses of the original tensor-typed loop-carried value
-    // after the loop, insert a transfer_write with the new vector-typed value
-    // and replace all uses.
-    rewriter.setInsertionPointAfter(newForOp);
-    Value tensorLoopResult = newForOp.getResult(candidate.index);
-    if (!tensorLoopResult.use_empty()) {
-      vector::TransferWriteOp writeOp = candidate.write;
-      Value tensorReplacement =
-          vector::TransferWriteOp::create(
-              rewriter, writeOp.getLoc(), newForOp.getResult(oldNumResults),
-              originalInitArg, writeOp.getIndices(),
-              writeOp.getPermutationMapAttr(), writeOp.getMask(),
-              writeOp.getInBoundsAttr())
-              .getResult();
-      rewriter.replaceAllUsesWith(tensorLoopResult, tensorReplacement);
+    Operation *insertionPoint = readOp.getOperation();
+    for (vector::TransferReadOp candidateRead : candidate.reads) {
+      if (candidateRead->isBeforeInBlock(insertionPoint)) {
+        insertionPoint = candidateRead.getOperation();
+      }
     }
 
-    // Replace all uses of the transfer_read inside the loop with the new
-    // vector-typed loop-carried value.
-    BlockArgument promotedIterArg = newForOp.getRegionIterArg(oldNumIterArgs);
-    for (vector::TransferReadOp readOp : candidate.reads) {
-      rewriter.replaceOp(readOp, promotedIterArg);
+    rewriter.setInsertionPoint(insertionPoint);
+    auto readConversion = IREE::Util::HoistableConversionOp::create(
+        rewriter, readOp.getLoc(), kTransferReadTag, kTransferWriteTag,
+        TypeRange{readOp.getVectorType()}, ValueRange{candidate.iterArg},
+        [&](OpBuilder &builder, Location loc, ValueRange args) {
+          Value read = vector::TransferReadOp::create(
+              builder, loc, readOp.getVectorType(), args[0],
+              readOp.getIndices(), readOp.getPermutationMap(),
+              readOp.getPadding(), readOp.getMask(), readOp.getInBoundsAttr());
+          return SmallVector<Value>{read};
+        });
+
+    for (vector::TransferReadOp read : candidate.reads) {
+      rewriter.replaceOp(read, readConversion.getResult(0));
     }
-    // Remove the old write.
-    rewriter.eraseOp(candidate.write);
+
+    vector::TransferWriteOp writeOp = candidate.write;
+    TypedValue<VectorType> mask = readOp.getMask();
+    Value pad = readOp.getPadding();
+    rewriter.setInsertionPoint(writeOp);
+    Value carriedValue = getLoopCarriedTransferValue(
+        rewriter, writeOp.getLoc(), mask, pad, writeOp.getVector());
+    auto writeConversion = IREE::Util::HoistableConversionOp::create(
+        rewriter, writeOp.getLoc(), kTransferWriteTag, kTransferReadTag,
+        TypeRange{writeOp.getResult().getType()}, ValueRange{carriedValue},
+        [&](OpBuilder &builder, Location loc, ValueRange args) {
+          Value write =
+              vector::TransferWriteOp::create(
+                  builder, loc, args[0], candidate.initArg,
+                  writeOp.getIndices(), writeOp.getPermutationMapAttr(),
+                  writeOp.getMask(), writeOp.getInBoundsAttr())
+                  .getResult();
+          return SmallVector<Value>{write};
+        });
+
+    rewriter.replaceOp(writeOp, writeConversion.getResult(0));
 
     return success();
   }
@@ -926,8 +930,11 @@ canonicalizeAndHoistLoopCarriedTransferState(mlir::FunctionOpInterface funcOp,
   moveLoopInvariantCodeFromGuaranteedLoops(funcOp);
 
   RewritePatternSet hoistingPatterns(context);
-  hoistingPatterns.add<HoistLoopCarriedTransferIterArg>(context);
-  return applyPatternsGreedily(funcOp, std::move(hoistingPatterns));
+  hoistingPatterns.add<MarkHoistableLoopCarriedTransferIterArg>(context);
+  if (failed(applyPatternsGreedily(funcOp, std::move(hoistingPatterns)))) {
+    return failure();
+  }
+  return IREE::Util::eliminateHoistableConversions(funcOp);
 }
 
 // Find the earliest insertion point in the block for the given operation.
@@ -989,9 +996,9 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
 
   RewritePatternSet patterns(context);
   populateVectorTransferTensorSliceTransforms(patterns);
-  // Keep the final hoisting pattern in this general cleanup because its
+  // Keep the final hoisting marker in this general cleanup because its
   // transfer/slice folds can expose additional loop-carried transfers.
-  patterns.add<HoistLoopCarriedTransferIterArg>(context);
+  patterns.add<MarkHoistableLoopCarriedTransferIterArg>(context);
   scf::ForOp::getCanonicalizationPatterns(patterns, context);
   vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
   // Run after subset hoisting so retargeting reads through identity slices
@@ -1006,6 +1013,9 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   // TODO: consider upstreaming.
   patterns.add<FoldTransferRAW, FoldTransferReadOfEmptyTensor>(context);
   if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+    return signalPassFailure();
+  }
+  if (failed(IREE::Util::eliminateHoistableConversions(funcOp))) {
     return signalPassFailure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -225,6 +225,209 @@ void hoistSubsetWithLoopInvariantTensor(RewriterBase &rewriter,
   }
 }
 
+static bool
+hasOnlyLoopInvariantOperandsExcept(LoopLikeOpInterface loopLike, Operation *op,
+                                   ArrayRef<OpOperand *> allowedOperands) {
+  return llvm::all_of(op->getOpOperands(), [&](OpOperand &operand) {
+    if (llvm::is_contained(allowedOperands, &operand)) {
+      return true;
+    }
+    return loopLike.isDefinedOutsideOfLoop(operand.get());
+  });
+}
+
+static bool areEquivalentTransferReadWrite(vector::TransferReadOp readOp,
+                                           vector::TransferWriteOp writeOp) {
+  return readOp.getType() == writeOp.getVector().getType() &&
+         readOp.getIndices() == writeOp.getIndices() &&
+         readOp.getPermutationMap() == writeOp.getPermutationMap() &&
+         readOp.getMask() == writeOp.getMask();
+}
+
+static Value getLoopCarriedTransferValue(OpBuilder &builder,
+                                         vector::TransferReadOp readOp,
+                                         Value valueToStore) {
+  TypedValue<VectorType> mask = readOp.getMask();
+  if (!mask) {
+    return valueToStore;
+  }
+  Value pad = readOp.getPadding();
+  Value padVector = vector::BroadcastOp::create(
+      builder, pad.getLoc(), cast<VectorType>(valueToStore.getType()), pad);
+  return arith::SelectOp::create(builder, readOp.getLoc(), mask, valueToStore,
+                                 padVector);
+}
+
+/// Promote a tensor iter_arg to a vector iter_arg when the tensor is only
+/// accessed through equivalent transfer_read/transfer_write ops.
+///
+///   %loop = scf.for ... iter_args(%t = %init) -> tensor<...> {
+///     %old = vector.transfer_read %t[%c0], %pad, %mask
+///     %new = arith.addf %old, %step
+///     %next = vector.transfer_write %new, %t[%c0], %mask
+///     scf.yield %next
+///   }
+///
+/// becomes:
+///
+///   %init_vec = vector.transfer_read %init[%c0], %pad, %mask
+///   %loop = scf.for ... iter_args(%v = %init_vec) -> vector<...> {
+///     %new = arith.addf %v, %step
+///     %yield = arith.select %mask, %new, splat(%pad)
+///     scf.yield %yield
+///   }
+///
+/// The select is the important masked-transfer semantics. For masked-off
+/// lanes, transfer_read returns padding, while transfer_write preserves the
+/// tensor. A generic subset hoist would carry `%new` directly, which is only
+/// equivalent for unmasked transfers.
+struct PromoteLoopCarriedTransferIterArg final : OpRewritePattern<scf::ForOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i < e; ++i) {
+      auto candidate = getPromotableTransferIterArg(forOp, i);
+      if (candidate) {
+        return promoteLoopCarriedTransferIterArg(rewriter, forOp, *candidate);
+      }
+    }
+    return failure();
+  }
+
+private:
+  struct PromotableTransferIterArg {
+    unsigned index;
+    vector::TransferWriteOp write;
+    SmallVector<vector::TransferReadOp> reads;
+  };
+
+  std::optional<PromotableTransferIterArg>
+  getPromotableTransferIterArg(scf::ForOp forOp, unsigned index) const {
+    LoopLikeOpInterface loopLike =
+        cast<LoopLikeOpInterface>(forOp.getOperation());
+    BlockArgument iterArg = forOp.getRegionIterArg(index);
+    Value yielded = forOp.getYieldedValues()[index];
+    auto writeOp = yielded.getDefiningOp<vector::TransferWriteOp>();
+    if (!writeOp || !writeOp.hasPureTensorSemantics() ||
+        writeOp.getBase() != iterArg || writeOp.hasOutOfBoundsDim() ||
+        !writeOp->hasOneUse()) {
+      return std::nullopt;
+    }
+    if (!hasOnlyLoopInvariantOperandsExcept(
+            loopLike, writeOp,
+            {&writeOp.getValueToStoreMutable(), &writeOp.getBaseMutable()})) {
+      return std::nullopt;
+    }
+
+    SmallVector<vector::TransferReadOp> reads;
+    for (Operation *user : iterArg.getUsers()) {
+      if (user == writeOp.getOperation()) {
+        continue;
+      }
+      auto readOp = dyn_cast<vector::TransferReadOp>(user);
+      if (!readOp || !readOp.hasPureTensorSemantics() ||
+          readOp.getBase() != iterArg || readOp.hasOutOfBoundsDim()) {
+        return std::nullopt;
+      }
+      if (!areEquivalentTransferReadWrite(readOp, writeOp)) {
+        return std::nullopt;
+      }
+      if (!reads.empty() && readOp.getPadding() != reads.front().getPadding()) {
+        return std::nullopt;
+      }
+      if (!hasOnlyLoopInvariantOperandsExcept(loopLike, readOp,
+                                              {&readOp.getBaseMutable()})) {
+        return std::nullopt;
+      }
+      reads.push_back(readOp);
+    }
+
+    if (reads.empty()) {
+      return std::nullopt;
+    }
+    return PromotableTransferIterArg{index, writeOp, reads};
+  }
+
+  LogicalResult
+  promoteLoopCarriedTransferIterArg(PatternRewriter &rewriter, scf::ForOp forOp,
+                                    PromotableTransferIterArg candidate) const {
+    unsigned oldNumIterArgs = forOp.getNumRegionIterArgs();
+    unsigned oldNumResults = forOp.getNumResults();
+    Value originalInitArg = forOp.getInitArgs()[candidate.index];
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(forOp);
+
+    // Create a transfer_read before the loop to read the vector value from the
+    // tensor that was the loop argument so far.
+    vector::TransferReadOp readOp = candidate.reads.front();
+    Value initVector = vector::TransferReadOp::create(
+        rewriter, readOp.getLoc(), readOp.getVectorType(), originalInitArg,
+        readOp.getIndices(), readOp.getPermutationMap(), readOp.getPadding(),
+        readOp.getMask(), readOp.getInBoundsAttr());
+
+    // Inside the loop, build the new yield value by broadcasting the padding
+    // value and selecting based on the mask. This is only necessary if the
+    // reads and writes are masked.
+    NewYieldValuesFn newYieldValuesFn =
+        [&](OpBuilder &builder, Location,
+            ArrayRef<BlockArgument>) -> SmallVector<Value> {
+      vector::TransferReadOp readOp = candidate.reads.front();
+      return {getLoopCarriedTransferValue(builder, readOp,
+                                          candidate.write.getVector())};
+    };
+
+    // Build the new for-loop with an additional vector-typed loop-carried
+    // value. The original tensor-typed loop-carried value will be removed by
+    // canonicalization later on.
+    FailureOr<LoopLikeOpInterface> newLoopLike =
+        forOp.replaceWithAdditionalYields(
+            rewriter, ValueRange(initVector),
+            /*replaceInitOperandUsesInLoop=*/false, newYieldValuesFn);
+    if (failed(newLoopLike)) {
+      return failure();
+    }
+    scf::ForOp newForOp = cast<scf::ForOp>(newLoopLike->getOperation());
+
+    // The new vector-typed loop-carried value carries the semantics now.
+    // Rewrite the yield such that the original tensor-typed value stops
+    // evolving inside the loop and will be cleaned up by canonicalization.
+    auto yieldOp = cast<scf::YieldOp>(newForOp.getBody()->getTerminator());
+    rewriter.modifyOpInPlace(yieldOp, [&]() {
+      yieldOp->setOperand(candidate.index,
+                          newForOp.getRegionIterArg(candidate.index));
+    });
+
+    // If there are any uses of the original tensor-typed loop-carried value
+    // after the loop, insert a transfer_write with the new vector-typed value
+    // and replace all uses.
+    rewriter.setInsertionPointAfter(newForOp);
+    Value tensorLoopResult = newForOp.getResult(candidate.index);
+    if (!tensorLoopResult.use_empty()) {
+      vector::TransferWriteOp writeOp = candidate.write;
+      Value tensorReplacement =
+          vector::TransferWriteOp::create(
+              rewriter, writeOp.getLoc(), newForOp.getResult(oldNumResults),
+              originalInitArg, writeOp.getIndices(),
+              writeOp.getPermutationMapAttr(), writeOp.getMask(),
+              writeOp.getInBoundsAttr())
+              .getResult();
+      rewriter.replaceAllUsesWith(tensorLoopResult, tensorReplacement);
+    }
+
+    // Replace all uses of the transfer_read inside the loop with the new
+    // vector-typed loop-carried value.
+    BlockArgument promotedIterArg = newForOp.getRegionIterArg(oldNumIterArgs);
+    for (vector::TransferReadOp readOp : candidate.reads) {
+      rewriter.replaceOp(readOp, promotedIterArg);
+    }
+    // Remove the old write.
+    rewriter.eraseOp(candidate.write);
+
+    return success();
+  }
+};
+
 namespace {
 struct CastLikeExtractSliceOpFolder final
     : OpRewritePattern<tensor::ExtractSliceOp> {
@@ -474,6 +677,7 @@ static Operation *getEarliestInsertionPointInsideBlock(Block *block,
 void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(funcOp->getContext());
+  MLIRContext *context = &getContext();
 
   // TODO: This is a temporary hack enabled for bufferization to
   // get rid of empty buffers.
@@ -488,6 +692,15 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   moveLoopInvariantCodeFromGuaranteedLoops(funcOp);
   LDBG() << "after hoisting loop invariant code\n" << funcOp << "\n";
 
+  // Run the vector transfer-specific promotion before generic subset hoisting
+  // so masked transfer loops get the required per-iteration padding semantics.
+  RewritePatternSet promotionPatterns(context);
+  promotionPatterns.add<PromoteLoopCarriedTransferIterArg>(context);
+  if (failed(applyPatternsGreedily(funcOp, std::move(promotionPatterns)))) {
+    return signalPassFailure();
+  }
+  LDBG() << "after early promoting loop carried vector transfers" << funcOp;
+
   // TODO: walking in some reverse / inside-out order would be more efficient
   // and would capture more cases.
   funcOp.walk(
@@ -499,9 +712,9 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   });
   LDBG() << "after hoisting subset loop invariant tensors" << funcOp;
 
-  MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   populateVectorTransferTensorSliceTransforms(patterns);
+  patterns.add<PromoteLoopCarriedTransferIterArg>(context);
   scf::ForOp::getCanonicalizationPatterns(patterns, context);
   vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
   if (foldIdentitySlices) {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -37,9 +37,6 @@ class OptimizeTensorInsertExtractSlicesPass final
       OptimizeTensorInsertExtractSlicesPassBase;
 
 public:
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<scf::SCFDialect, vector::VectorDialect>();
-  }
   void runOnOperation() override;
 };
 
@@ -245,8 +242,13 @@ static bool areEquivalentMasks(Value lhs, Value rhs) {
   }
   auto lhsCreateMask = lhs.getDefiningOp<vector::CreateMaskOp>();
   auto rhsCreateMask = rhs.getDefiningOp<vector::CreateMaskOp>();
-  return lhsCreateMask && rhsCreateMask &&
-         lhsCreateMask.getOperands() == rhsCreateMask.getOperands();
+  if (lhsCreateMask && rhsCreateMask) {
+    return lhsCreateMask.getOperands() == rhsCreateMask.getOperands();
+  }
+  auto lhsConstantMask = lhs.getDefiningOp<vector::ConstantMaskOp>();
+  auto rhsConstantMask = rhs.getDefiningOp<vector::ConstantMaskOp>();
+  return lhsConstantMask && rhsConstantMask &&
+         lhsConstantMask.getMaskDimSizes() == rhsConstantMask.getMaskDimSizes();
 }
 
 static bool
@@ -261,6 +263,9 @@ areEquivalentTransferAccesses(Type lhsVectorType, ValueRange lhsIndices,
 
 static bool areEquivalentTransferReadWrite(vector::TransferReadOp readOp,
                                            vector::TransferWriteOp writeOp) {
+  if (readOp.isMasked() || writeOp.isMasked()) {
+    return false;
+  }
   return areEquivalentTransferAccesses(
       readOp.getType(), readOp.getIndices(), readOp.getPermutationMap(),
       readOp.getMask(), writeOp.getVector().getType(), writeOp.getIndices(),
@@ -269,6 +274,9 @@ static bool areEquivalentTransferReadWrite(vector::TransferReadOp readOp,
 
 static bool areEquivalentTransferWrites(vector::TransferWriteOp lhs,
                                         vector::TransferWriteOp rhs) {
+  if (lhs.isMasked() || rhs.isMasked()) {
+    return false;
+  }
   return areEquivalentTransferAccesses(
       lhs.getVector().getType(), lhs.getIndices(), lhs.getPermutationMap(),
       lhs.getMask(), rhs.getVector().getType(), rhs.getIndices(),
@@ -312,29 +320,30 @@ static Value getLoopCarriedTransferValue(OpBuilder &builder,
 /// lanes, transfer_read returns padding, while transfer_write preserves the
 /// tensor. A generic subset hoist would carry `%new` directly, which is only
 /// equivalent for unmasked transfers.
-struct PromoteLoopCarriedTransferIterArg final : OpRewritePattern<scf::ForOp> {
+struct HoistLoopCarriedTransferIterArg final : OpRewritePattern<scf::ForOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
     for (unsigned i = 0, e = forOp.getNumRegionIterArgs(); i < e; ++i) {
-      auto candidate = getPromotableTransferIterArg(forOp, i);
+      std::optional<HoistableTransferIterArg> candidate =
+          getHoistableTransferIterArg(forOp, i);
       if (candidate) {
-        return promoteLoopCarriedTransferIterArg(rewriter, forOp, *candidate);
+        return hoistLoopCarriedTransferIterArg(rewriter, forOp, *candidate);
       }
     }
     return failure();
   }
 
 private:
-  struct PromotableTransferIterArg {
+  struct HoistableTransferIterArg {
     unsigned index;
     vector::TransferWriteOp write;
     SmallVector<vector::TransferReadOp> reads;
   };
 
-  std::optional<PromotableTransferIterArg>
-  getPromotableTransferIterArg(scf::ForOp forOp, unsigned index) const {
+  std::optional<HoistableTransferIterArg>
+  getHoistableTransferIterArg(scf::ForOp forOp, unsigned index) const {
     LoopLikeOpInterface loopLike =
         cast<LoopLikeOpInterface>(forOp.getOperation());
     BlockArgument iterArg = forOp.getRegionIterArg(index);
@@ -377,12 +386,12 @@ private:
     if (reads.empty()) {
       return std::nullopt;
     }
-    return PromotableTransferIterArg{index, writeOp, reads};
+    return HoistableTransferIterArg{index, writeOp, reads};
   }
 
   LogicalResult
-  promoteLoopCarriedTransferIterArg(PatternRewriter &rewriter, scf::ForOp forOp,
-                                    PromotableTransferIterArg candidate) const {
+  hoistLoopCarriedTransferIterArg(PatternRewriter &rewriter, scf::ForOp forOp,
+                                  HoistableTransferIterArg candidate) const {
     unsigned oldNumIterArgs = forOp.getNumRegionIterArgs();
     unsigned oldNumResults = forOp.getNumResults();
     Value originalInitArg = forOp.getInitArgs()[candidate.index];
@@ -909,16 +918,16 @@ canonicalizeLoopCarriedTransferState(mlir::FunctionOpInterface funcOp,
 }
 
 static LogicalResult
-canonicalizeAndPromoteLoopCarriedTransferState(mlir::FunctionOpInterface funcOp,
-                                               MLIRContext *context) {
+canonicalizeAndHoistLoopCarriedTransferState(mlir::FunctionOpInterface funcOp,
+                                             MLIRContext *context) {
   if (failed(canonicalizeLoopCarriedTransferState(funcOp, context))) {
     return failure();
   }
   moveLoopInvariantCodeFromGuaranteedLoops(funcOp);
 
-  RewritePatternSet promotionPatterns(context);
-  promotionPatterns.add<PromoteLoopCarriedTransferIterArg>(context);
-  return applyPatternsGreedily(funcOp, std::move(promotionPatterns));
+  RewritePatternSet hoistingPatterns(context);
+  hoistingPatterns.add<HoistLoopCarriedTransferIterArg>(context);
+  return applyPatternsGreedily(funcOp, std::move(hoistingPatterns));
 }
 
 // Find the earliest insertion point in the block for the given operation.
@@ -955,12 +964,12 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
     extractSliceOp->moveAfter(latestInsertionPoint);
   });
 
-  // Run the vector transfer-specific promotion before generic subset hoisting
+  // Run the vector transfer-specific hoisting before generic subset hoisting
   // so masked transfer loops get the required per-iteration padding semantics.
-  if (failed(canonicalizeAndPromoteLoopCarriedTransferState(funcOp, context))) {
+  if (failed(canonicalizeAndHoistLoopCarriedTransferState(funcOp, context))) {
     return signalPassFailure();
   }
-  LDBG() << "after early promoting loop carried vector transfers" << funcOp;
+  LDBG() << "after early hoisting loop carried vector transfers" << funcOp;
 
   // TODO: walking in some reverse / inside-out order would be more efficient
   // and would capture more cases.
@@ -973,16 +982,16 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   });
   LDBG() << "after hoisting subset loop invariant tensors" << funcOp;
 
-  if (failed(canonicalizeAndPromoteLoopCarriedTransferState(funcOp, context))) {
+  if (failed(canonicalizeAndHoistLoopCarriedTransferState(funcOp, context))) {
     return signalPassFailure();
   }
-  LDBG() << "after late promoting loop carried vector transfers" << funcOp;
+  LDBG() << "after late hoisting loop carried vector transfers" << funcOp;
 
   RewritePatternSet patterns(context);
   populateVectorTransferTensorSliceTransforms(patterns);
-  // Keep the final promotion pattern in this general cleanup because its
+  // Keep the final hoisting pattern in this general cleanup because its
   // transfer/slice folds can expose additional loop-carried transfers.
-  patterns.add<PromoteLoopCarriedTransferIterArg>(context);
+  patterns.add<HoistLoopCarriedTransferIterArg>(context);
   scf::ForOp::getCanonicalizationPatterns(patterns, context);
   vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
   // Run after subset hoisting so retargeting reads through identity slices

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -19,6 +19,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "llvm/ADT/DenseMap.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -663,6 +663,10 @@ def OptimizeTensorInsertExtractSlicesPass
     Option<"foldIdentitySlices", "fold-identity-slices", "bool", "false",
            "Enable folding of identity tensor.*_slice ops.">
   ];
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::ub::UBDialect"
+  ];
 }
 
 def HoistInnerTiledAccReshapesPass :

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -665,6 +665,7 @@ def OptimizeTensorInsertExtractSlicesPass
   ];
   let dependentDialects = [
     "::mlir::arith::ArithDialect",
+    "iree_compiler::IREE::Util::UtilDialect",
     "::mlir::ub::UBDialect"
   ];
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
@@ -19,6 +19,100 @@ func.func @fold_extract_slice_consumer_into_xfer_write(%arg0: vector<1x64x128xf1
 
 // -----
 
+func.func @promote_loop_carried_masked_transfer(%mask: vector<4xi1>) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %pad = arith.constant 0.0 : f32
+  %zero = arith.constant dense<0.0> : vector<4xf32>
+  %one = arith.constant dense<1.0> : vector<4xf32>
+  %empty = tensor.empty() : tensor<4xf32>
+  %init = vector.transfer_write %zero, %empty[%c0], %mask {in_bounds = [true]} : vector<4xf32>, tensor<4xf32>
+  %loop = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %init) -> tensor<4xf32> {
+    %old = vector.transfer_read %acc[%c0], %pad, %mask {in_bounds = [true]} : tensor<4xf32>, vector<4xf32>
+    %new = arith.addf %old, %one : vector<4xf32>
+    %next = vector.transfer_write %new, %acc[%c0], %mask {in_bounds = [true]} : vector<4xf32>, tensor<4xf32>
+    scf.yield %next : tensor<4xf32>
+  }
+  %result = vector.transfer_read %loop[%c0], %pad, %mask {in_bounds = [true]} : tensor<4xf32>, vector<4xf32>
+  return %result : vector<4xf32>
+}
+
+// CHECK-LABEL: func.func @promote_loop_carried_masked_transfer
+// CHECK:         %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+// CHECK:         %[[LOOP:.+]] = scf.for {{.*}} iter_args(%[[ACC:.+]] = %[[ZERO]]) -> (vector<4xf32>) {
+// CHECK:           %[[NEW:.+]] = arith.addf %[[ACC]]
+// CHECK:           %[[YIELD:.+]] = arith.select {{.*}}, %[[NEW]], %[[ZERO]]
+// CHECK:           scf.yield %[[YIELD]] : vector<4xf32>
+// CHECK:         }
+// CHECK:         %[[RESULT:.+]] = arith.select {{.*}}, %[[LOOP]], %[[ZERO]]
+// CHECK:         return %[[RESULT]]
+
+// -----
+
+func.func @promote_loop_carried_masked_transfer_multiple_reads(%mask: vector<4xi1>) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %pad = arith.constant 0.0 : f32
+  %zero = arith.constant dense<0.0> : vector<4xf32>
+  %one = arith.constant dense<1.0> : vector<4xf32>
+  %empty = tensor.empty() : tensor<4xf32>
+  %init = vector.transfer_write %zero, %empty[%c0], %mask {in_bounds = [true]} : vector<4xf32>, tensor<4xf32>
+  %loop = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %init) -> tensor<4xf32> {
+    %old0 = vector.transfer_read %acc[%c0], %pad, %mask {in_bounds = [true]} : tensor<4xf32>, vector<4xf32>
+    %old1 = vector.transfer_read %acc[%c0], %pad, %mask {in_bounds = [true]} : tensor<4xf32>, vector<4xf32>
+    %sum = arith.addf %old0, %old1 : vector<4xf32>
+    %new = arith.addf %sum, %one : vector<4xf32>
+    %next = vector.transfer_write %new, %acc[%c0], %mask {in_bounds = [true]} : vector<4xf32>, tensor<4xf32>
+    scf.yield %next : tensor<4xf32>
+  }
+  %result = vector.transfer_read %loop[%c0], %pad, %mask {in_bounds = [true]} : tensor<4xf32>, vector<4xf32>
+  return %result : vector<4xf32>
+}
+
+// CHECK-LABEL: func.func @promote_loop_carried_masked_transfer_multiple_reads
+// CHECK:         %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+// CHECK:         %[[LOOP:.+]] = scf.for {{.*}} iter_args(%[[ACC:.+]] = %[[ZERO]]) -> (vector<4xf32>) {
+// CHECK-NOT:       vector.transfer_read
+// CHECK:           %[[SUM:.+]] = arith.addf %[[ACC]], %[[ACC]]
+// CHECK:           %[[NEW:.+]] = arith.addf %[[SUM]]
+// CHECK:           %[[YIELD:.+]] = arith.select {{.*}}, %[[NEW]], %[[ZERO]]
+// CHECK:           scf.yield %[[YIELD]] : vector<4xf32>
+// CHECK:         }
+// CHECK:         %[[RESULT:.+]] = arith.select {{.*}}, %[[LOOP]], %[[ZERO]]
+// CHECK:         return %[[RESULT]]
+
+// -----
+
+func.func @negative_promote_loop_carried_out_of_bounds_transfer() -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %pad = arith.constant 0.0 : f32
+  %zero = arith.constant dense<0.0> : vector<4xf32>
+  %one = arith.constant dense<1.0> : vector<4xf32>
+  %empty = tensor.empty() : tensor<1xf32>
+  %init = vector.transfer_write %zero, %empty[%c0] : vector<4xf32>, tensor<1xf32>
+  %loop = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %init) -> tensor<1xf32> {
+    %old0 = vector.transfer_read %acc[%c0], %pad : tensor<1xf32>, vector<4xf32>
+    %old1 = vector.transfer_read %acc[%c0], %pad : tensor<1xf32>, vector<4xf32>
+    %sum = arith.addf %old0, %old1 : vector<4xf32>
+    %new = arith.addf %sum, %one : vector<4xf32>
+    %next = vector.transfer_write %new, %acc[%c0] : vector<4xf32>, tensor<1xf32>
+    scf.yield %next : tensor<1xf32>
+  }
+  %result = vector.transfer_read %loop[%c0], %pad : tensor<1xf32>, vector<4xf32>
+  return %result : vector<4xf32>
+}
+
+// CHECK-LABEL: func.func @negative_promote_loop_carried_out_of_bounds_transfer
+// CHECK:         scf.for {{.*}} iter_args(%{{.*}} = %{{.*}}) -> (tensor<1xf32>) {
+// CHECK:           vector.transfer_read %{{.*}} : tensor<1xf32>, vector<4xf32>
+// CHECK:           vector.transfer_write %{{.*}} : vector<4xf32>, tensor<1xf32>
+
+// -----
+
 // Test the case where we write out of bounds because large index
 func.func @fold_extract_slice_consumer_into_xfer_write_2(%arg0: vector<1x64x128xf16>, %arg1: index) -> tensor<1x?x128xf16> {
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-optimize-tensor-insert-extract-slices{fold-identity-slices=true}))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-optimize-tensor-insert-extract-slices{fold-identity-slices=false}))" --split-input-file %s | FileCheck %s --check-prefix=NOIDENTITY
 
 func.func @fold_extract_slice_consumer_into_xfer_write(%arg0: vector<1x64x128xf16>, %arg1: index) -> tensor<1x?x128xf16> {
   %c0 = arith.constant 0 : index
@@ -82,6 +83,171 @@ func.func @promote_loop_carried_masked_transfer_multiple_reads(%mask: vector<4xi
 // CHECK:         }
 // CHECK:         %[[RESULT:.+]] = arith.select {{.*}}, %[[LOOP]], %[[ZERO]]
 // CHECK:         return %[[RESULT]]
+
+// -----
+
+func.func @promote_loop_carried_masked_transfer_write_chain(%size: index) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %pad = arith.constant 0.0 : f32
+  %zero = arith.constant dense<0.0> : vector<4xf32>
+  %one = arith.constant dense<1.0> : vector<4xf32>
+  %empty = tensor.empty(%size) : tensor<?xf32>
+  %init_mask = vector.create_mask %size : vector<4xi1>
+  %init = vector.transfer_write %zero, %empty[%c0], %init_mask {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+  %loop = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %init) -> tensor<?xf32> {
+    %dim = tensor.dim %acc, %c0 : tensor<?xf32>
+    %mask = vector.create_mask %dim : vector<4xi1>
+    %old = vector.transfer_read %acc[%c0], %pad, %mask {in_bounds = [true]} : tensor<?xf32>, vector<4xf32>
+    %scaled = arith.addf %old, %one : vector<4xf32>
+    %write0 = vector.transfer_write %scaled, %acc[%c0], %mask {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+    %read0 = vector.transfer_read %write0[%c0], %pad, %init_mask {in_bounds = [true]} : tensor<?xf32>, vector<4xf32>
+    %updated = arith.addf %read0, %one : vector<4xf32>
+    %write1 = vector.transfer_write %updated, %write0[%c0], %init_mask {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+    %read1 = vector.transfer_read %write1[%c0], %pad, %mask {in_bounds = [true]} : tensor<?xf32>, vector<4xf32>
+    %updated2 = arith.addf %read1, %one : vector<4xf32>
+    %write2 = vector.transfer_write %updated2, %write1[%c0], %mask {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+    scf.yield %write2 : tensor<?xf32>
+  }
+  %result = vector.transfer_read %loop[%c0], %pad, %init_mask {in_bounds = [true]} : tensor<?xf32>, vector<4xf32>
+  return %result : vector<4xf32>
+}
+
+// CHECK-LABEL: func.func @promote_loop_carried_masked_transfer_write_chain
+// CHECK:         %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+// CHECK:         %[[LOOP:.+]] = scf.for {{.*}} iter_args(%[[ACC:.+]] = %[[ZERO]]) -> (vector<4xf32>) {
+// CHECK-NOT:       tensor.dim
+// CHECK-NOT:       vector.transfer_read
+// CHECK-NOT:       vector.transfer_write
+// CHECK:           arith.addf
+// CHECK-NOT:       tensor.dim
+// CHECK-NOT:       vector.transfer_read
+// CHECK-NOT:       vector.transfer_write
+// CHECK:           arith.select
+// CHECK-NOT:       tensor.dim
+// CHECK-NOT:       vector.transfer_read
+// CHECK-NOT:       vector.transfer_write
+// CHECK:           scf.yield {{.*}} : vector<4xf32>
+// CHECK:         }
+// CHECK:         return
+
+// -----
+
+func.func @fold_dim_of_shape_preserving_transfer_iter_arg(%size: index, %vec: vector<4xf32>) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %empty = tensor.empty(%size) : tensor<?xf32>
+  %init_mask = vector.create_mask %size : vector<4xi1>
+  %init = vector.transfer_write %vec, %empty[%c0], %init_mask {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+  %loop = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %init) -> tensor<?xf32> {
+    %dim = tensor.dim %acc, %c0 : tensor<?xf32>
+    %loop_mask = vector.create_mask %dim : vector<4xi1>
+    %next = vector.transfer_write %vec, %acc[%c0], %loop_mask {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+    scf.yield %next : tensor<?xf32>
+  }
+  return %loop : tensor<?xf32>
+}
+
+// CHECK-LABEL: func.func @fold_dim_of_shape_preserving_transfer_iter_arg
+// CHECK-SAME:    %[[SIZE:[a-zA-Z0-9]+]]
+// CHECK-NOT:     tensor.dim
+// CHECK:         vector.create_mask %[[SIZE]]
+// CHECK:         scf.for
+// CHECK-NOT:     tensor.dim
+// CHECK:         vector.transfer_write
+// CHECK:         scf.yield
+// CHECK:         return
+
+// -----
+
+func.func @fold_transfer_write_chain_equivalent_masks(%t: tensor<?xf32>, %size: index) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %one = arith.constant dense<1.0> : vector<4xf32>
+  %two = arith.constant dense<2.0> : vector<4xf32>
+  %mask0 = vector.create_mask %size : vector<4xi1>
+  %write0 = vector.transfer_write %one, %t[%c0], %mask0 {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+  %mask1 = vector.create_mask %size : vector<4xi1>
+  %write1 = vector.transfer_write %two, %write0[%c0], %mask1 {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+  return %write1 : tensor<?xf32>
+}
+
+// CHECK-LABEL: func.func @fold_transfer_write_chain_equivalent_masks
+// CHECK-SAME:    %[[T:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[TWO:.+]] = arith.constant dense<2.000000e+00> : vector<4xf32>
+// CHECK-NOT:     dense<1.000000e+00>
+// CHECK:         %[[WRITE:.+]] = vector.transfer_write %[[TWO]], %[[T]]
+// CHECK:         return %[[WRITE]]
+
+// -----
+
+func.func @negative_fold_transfer_write_chain_non_equivalent_masks(%t: tensor<?xf32>, %size0: index, %size1: index) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %one = arith.constant dense<1.0> : vector<4xf32>
+  %two = arith.constant dense<2.0> : vector<4xf32>
+  %mask0 = vector.create_mask %size0 : vector<4xi1>
+  %write0 = vector.transfer_write %one, %t[%c0], %mask0 {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+  %mask1 = vector.create_mask %size1 : vector<4xi1>
+  %write1 = vector.transfer_write %two, %write0[%c0], %mask1 {in_bounds = [true]} : vector<4xf32>, tensor<?xf32>
+  return %write1 : tensor<?xf32>
+}
+
+// CHECK-LABEL: func.func @negative_fold_transfer_write_chain_non_equivalent_masks
+// CHECK-DAG:     %[[ONE:.+]] = arith.constant dense<1.000000e+00> : vector<4xf32>
+// CHECK-DAG:     %[[TWO:.+]] = arith.constant dense<2.000000e+00> : vector<4xf32>
+// CHECK:         %[[WRITE0:.+]] = vector.transfer_write %[[ONE]]
+// CHECK:         %[[WRITE1:.+]] = vector.transfer_write %[[TWO]], %[[WRITE0]]
+// CHECK:         return %[[WRITE1]]
+
+// -----
+
+func.func @fold_transfer_read_of_identity_extract_slice(%t: tensor<?xf32>) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f32
+  %dim = tensor.dim %t, %c0 : tensor<?xf32>
+  %slice = tensor.extract_slice %t[0] [%dim] [1] : tensor<?xf32> to tensor<?xf32>
+  %read = vector.transfer_read %slice[%c0], %pad {in_bounds = [true]} : tensor<?xf32>, vector<4xf32>
+  return %read : vector<4xf32>
+}
+
+// NOIDENTITY-LABEL: func.func @fold_transfer_read_of_identity_extract_slice
+// NOIDENTITY-SAME:    %[[T:[a-zA-Z0-9]+]]
+// NOIDENTITY-NOT:     tensor.extract_slice
+// NOIDENTITY:         %[[READ:.+]] = vector.transfer_read %[[T]]
+// NOIDENTITY:         return %[[READ]]
+
+// -----
+
+func.func @negative_fold_transfer_read_of_offset_extract_slice(%t: tensor<?xf32>, %size: index) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f32
+  %slice = tensor.extract_slice %t[1] [%size] [1] : tensor<?xf32> to tensor<?xf32>
+  %read = vector.transfer_read %slice[%c0], %pad {in_bounds = [true]} : tensor<?xf32>, vector<4xf32>
+  return %read : vector<4xf32>
+}
+
+// NOIDENTITY-LABEL: func.func @negative_fold_transfer_read_of_offset_extract_slice
+// NOIDENTITY-SAME:    %[[T:[a-zA-Z0-9]+]]
+// NOIDENTITY:         %[[C1:.+]] = arith.constant 1 : index
+// NOIDENTITY:         %[[READ:.+]] = vector.transfer_read %[[T]][%[[C1]]]
+// NOIDENTITY:         return %[[READ]]
+
+// -----
+
+func.func @fold_transfer_read_of_identity_insert_slice(%src: tensor<4xf32>, %dst: tensor<4xf32>) -> vector<4xf32> {
+  %c0 = arith.constant 0 : index
+  %pad = arith.constant 0.0 : f32
+  %inserted = tensor.insert_slice %src into %dst[0] [4] [1] : tensor<4xf32> into tensor<4xf32>
+  %read = vector.transfer_read %inserted[%c0], %pad {in_bounds = [true]} : tensor<4xf32>, vector<4xf32>
+  return %read : vector<4xf32>
+}
+
+// NOIDENTITY-LABEL: func.func @fold_transfer_read_of_identity_insert_slice
+// NOIDENTITY-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+// NOIDENTITY-NOT:     tensor.insert_slice
+// NOIDENTITY:         %[[READ:.+]] = vector.transfer_read %[[SRC]]
+// NOIDENTITY:         return %[[READ]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
@@ -134,6 +134,36 @@ func.func @promote_loop_carried_masked_transfer_write_chain(%size: index) -> vec
 
 // -----
 
+func.func @nested_loop_carried_transfer_from_enclosing_iter_arg() -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %pad = arith.constant 0.0 : f32
+  %zero = arith.constant dense<0.0> : vector<4xf32>
+  %one = arith.constant dense<1.0> : vector<4xf32>
+  %empty = tensor.empty() : tensor<4xf32>
+  %init = vector.transfer_write %zero, %empty[%c0] {in_bounds = [true]} : vector<4xf32>, tensor<4xf32>
+  %outer = scf.for %i = %c0 to %c4 step %c1 iter_args(%outer_acc = %init) -> tensor<4xf32> {
+    %inner = scf.for %j = %c0 to %c4 step %c1 iter_args(%inner_acc = %outer_acc) -> tensor<4xf32> {
+      %old = vector.transfer_read %inner_acc[%c0], %pad {in_bounds = [true]} : tensor<4xf32>, vector<4xf32>
+      %new = arith.addf %old, %one : vector<4xf32>
+      %next = vector.transfer_write %new, %inner_acc[%c0] {in_bounds = [true]} : vector<4xf32>, tensor<4xf32>
+      scf.yield %next : tensor<4xf32>
+    }
+    scf.yield %inner : tensor<4xf32>
+  }
+  return %outer : tensor<4xf32>
+}
+
+// CHECK-LABEL: func.func @nested_loop_carried_transfer_from_enclosing_iter_arg
+// CHECK:         %[[OUTER:.+]] = scf.for {{.*}} iter_args(%[[OUTER_ARG:.+]] = {{.*}}) -> (vector<4xf32>) {
+// CHECK:           %[[INNER:.+]] = scf.for {{.*}} iter_args(%[[INNER_ARG:.+]] = %[[OUTER_ARG]]) -> (vector<4xf32>) {
+// CHECK:             arith.addf %[[INNER_ARG]]
+// CHECK:           scf.yield %[[INNER]]
+// CHECK:         vector.transfer_write %[[OUTER]]
+
+// -----
+
 func.func @fold_dim_of_shape_preserving_transfer_iter_arg(%size: index, %vec: vector<4xf32>) -> tensor<?xf32> {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index


### PR DESCRIPTION
Add pattern to fold pairs of masked `transfer_read` and `transfer_write` inside loops. Also adds additional patterns that simplify the operation chain inside the loop body through folding to enable the main folding.

This contributes towards https://github.com/iree-org/iree/issues/24221.

Assisted-by: Codex