### PR TITLE
[Codegen][GPU] Verify per-allocation swizzle hint consistency

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREECodegenFoldMemRefAliasOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREECodegenFoldMemRefAliasOps.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/AMDGPU/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -30,6 +31,7 @@ public:
 
     RewritePatternSet patterns(&getContext());
     memref::populateFoldMemRefAliasOpPatterns(patterns);
+    amdgpu::populateAmdgpuFoldMemRefOpsPatterns(patterns);
     (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/ReinsertSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReinsertSwizzleHints.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/PatternMatch.h"
@@ -112,14 +113,16 @@ void ReinsertSwizzleHintsPass::runOnOperation() {
   IRRewriter rewriter(funcOp->getContext());
   DenseMap<Value, IREE::Codegen::SwizzleAttrInterface> swizzleCache;
 
-  // For each vector.load/store whose base traces to a swizzled alloc, wrap the
-  // base with collapse_shape -> swizzle_hint -> expand_shape.
+  // For each vector.load/store/gather_to_lds whose base traces to a swizzled
+  // alloc, wrap the base with collapse_shape -> swizzle_hint -> expand_shape.
   funcOp.walk([&](Operation *op) {
     Value base;
     if (auto loadOp = dyn_cast<vector::LoadOp>(op)) {
       base = loadOp.getBase();
     } else if (auto storeOp = dyn_cast<vector::StoreOp>(op)) {
       base = storeOp.getBase();
+    } else if (auto gatherOp = dyn_cast<amdgpu::GatherToLDSOp>(op)) {
+      base = gatherOp.getDst();
     } else {
       return;
     }
@@ -134,6 +137,8 @@ void ReinsertSwizzleHintsPass::runOnOperation() {
       loadOp.getBaseMutable().assign(wrapped);
     } else if (auto storeOp = dyn_cast<vector::StoreOp>(op)) {
       storeOp.getBaseMutable().assign(wrapped);
+    } else if (auto gatherOp = dyn_cast<amdgpu::GatherToLDSOp>(op)) {
+      gatherOp.getDstMutable().assign(wrapped);
     }
   });
 

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -10,11 +10,12 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
-#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 
 namespace mlir::iree_compiler {
 
@@ -155,13 +156,53 @@ verifyFlatContiguousSwizzleHintOp(IREE::Codegen::SwizzleHintOp hintOp) {
   return success();
 }
 
-/// Resolves all hints. Walks all direct users and splits them into loads and
-/// stores. If any user is not a swizzle-able load or store, bail out and
-/// silently drop the optimization hint.
-static void resolveHintOp(RewriterBase &rewriter,
-                          IREE::Codegen::SwizzleHintOp hintOp) {
-  SmallVector<vector::LoadOp> loads;
-  SmallVector<vector::StoreOp> stores;
+/// Traces a memref value backward through defining ops and loop
+/// iter_args/results to find the root memref.alloc.
+static memref::AllocOp traceToAllocation(Value val) {
+  DenseSet<Value> visited;
+  SmallVector<Value> worklist = {val};
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    if (!visited.insert(current).second) {
+      continue;
+    }
+    Operation *defOp = current.getDefiningOp();
+    if (!defOp) {
+      auto blockArg = cast<BlockArgument>(current);
+      auto loopOp =
+          dyn_cast<LoopLikeOpInterface>(blockArg.getOwner()->getParentOp());
+      if (!loopOp) {
+        continue;
+      }
+      if (OpOperand *init = loopOp.getTiedLoopInit(blockArg)) {
+        worklist.push_back(init->get());
+      }
+    } else if (auto allocOp = dyn_cast<memref::AllocOp>(defOp)) {
+      return allocOp;
+    } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(defOp)) {
+      if (OpOperand *init = loopOp.getTiedLoopInit(cast<OpResult>(current))) {
+        worklist.push_back(init->get());
+      }
+    } else {
+      for (Value operand : defOp->getOperands()) {
+        if (isa<MemRefType>(operand.getType())) {
+          worklist.push_back(operand);
+        }
+      }
+    }
+  }
+  return nullptr;
+}
+
+struct SwizzleState {
+  bool resolvable = true;
+  bool hasGatherToLds = false;
+};
+
+/// Verifies the users of a swizzle hint and returns its swizzle state.
+/// Emits a diagnostic for any unsupported user.
+static SwizzleState verifyHintUsers(IREE::Codegen::SwizzleHintOp hintOp) {
+  SwizzleState state;
   int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
   for (Operation *user : hintOp->getUsers()) {
     if (auto load = dyn_cast<vector::LoadOp>(user)) {
@@ -169,9 +210,8 @@ static void resolveHintOp(RewriterBase &rewriter,
       // Guard on zero rank loads and loads not divisible by the access width.
       if (loadType.getRank() != 1 ||
           loadType.getShape()[0] % accessWidth != 0) {
-        return;
+        state.resolvable = false;
       }
-      loads.push_back(load);
       continue;
     }
     if (auto store = dyn_cast<vector::StoreOp>(user)) {
@@ -179,30 +219,32 @@ static void resolveHintOp(RewriterBase &rewriter,
       // Guard on zero rank stores and stores not divisible by the access width.
       if (storeType.getRank() != 1 ||
           storeType.getShape()[0] % accessWidth != 0) {
-        return;
+        state.resolvable = false;
       }
-      stores.push_back(store);
       continue;
     }
-    // Gather_to_lds destination-side swizzle is handled by
-    // AMDGPULowerCoalescedDMAToGatherLDS, which applies the inverse swizzle
-    // to source indices. Treat gather_to_lds and view-like ops as transparent
-    // users that pass through the swizzled allocation.
-    if (isa<amdgpu::GatherToLDSOp, ViewLikeOpInterface>(user)) {
+    if (isa<amdgpu::GatherToLDSOp>(user)) {
+      state.hasGatherToLds = true;
       continue;
     }
-    // Throw if we can't rewrite all users.
-    hintOp.emitError() << "unsupported SwizzleHintOp user: " << user;
-    return;
+    hintOp.emitError() << "unsupported SwizzleHintOp user: " << *user;
+    state.resolvable = false;
   }
+  return state;
+}
 
-  for (vector::LoadOp load : loads) {
-    rewriter.setInsertionPoint(load);
-    swizzleLoad(rewriter, load, hintOp);
-  }
-  for (vector::StoreOp store : stores) {
-    rewriter.setInsertionPoint(store);
-    swizzleStore(rewriter, store, hintOp);
+/// Rewrites all load/store users of a resolved swizzle hint with swizzled
+/// offsets. Only call after verifyHintUsers returned a resolvable state.
+static void resolveHintOp(RewriterBase &rewriter,
+                          IREE::Codegen::SwizzleHintOp hintOp) {
+  for (Operation *user : llvm::make_early_inc_range(hintOp->getUsers())) {
+    if (auto load = dyn_cast<vector::LoadOp>(user)) {
+      rewriter.setInsertionPoint(load);
+      swizzleLoad(rewriter, load, hintOp);
+    } else if (auto store = dyn_cast<vector::StoreOp>(user)) {
+      rewriter.setInsertionPoint(store);
+      swizzleStore(rewriter, store, hintOp);
+    }
   }
 }
 
@@ -214,15 +256,54 @@ void ResolveSwizzleHintsPass::runOnOperation() {
   funcOp.walk(
       [&](IREE::Codegen::SwizzleHintOp hint) { hintOps.push_back(hint); });
 
-  // Swizzle all load/store uses of the hint ops if possible. If we can't
-  // guarantee all accesses of a particular hint are swizzled, this will
-  // silently pass through for that hint.
-  IRRewriter rewriter(funcOp->getContext());
+  // Verify resolvability of each hint and group results by alloc, since hints
+  // sharing an alloc must be resolved or dropped together.
+  DenseMap<Value, SwizzleState> allocToSwizzleState;
+  DenseMap<Operation *, Value> swizzleOpToAlloc;
+
   for (IREE::Codegen::SwizzleHintOp hintOp : hintOps) {
     if (failed(verifyFlatContiguousSwizzleHintOp(hintOp))) {
       return signalPassFailure();
     }
-    resolveHintOp(rewriter, hintOp);
+    // Hints normally trace to a memref.alloc. BlockArgument only occurs in lit
+    // tests.
+    Value alloc;
+    if (memref::AllocOp allocOp = traceToAllocation(hintOp.getOperand())) {
+      alloc = allocOp.getResult();
+    } else {
+      assert(isa<BlockArgument>(hintOp.getOperand()) &&
+             "hint operand without alloc should be a function argument");
+      alloc = hintOp.getOperand();
+    }
+    swizzleOpToAlloc[hintOp] = alloc;
+
+    SwizzleState hintState = verifyHintUsers(hintOp);
+    SwizzleState &state = allocToSwizzleState[alloc];
+    state.resolvable &= hintState.resolvable;
+    state.hasGatherToLds |= hintState.hasGatherToLds;
+  }
+
+  // gather_to_lds is a special case: its swizzle is already resolved before
+  // this pass runs, so we cannot silently drop it here.
+  for (auto &[alloc, state] : allocToSwizzleState) {
+    memref::AllocOp allocOp = alloc.getDefiningOp<memref::AllocOp>();
+    if (!allocOp) {
+      continue;
+    }
+    if (!state.resolvable && state.hasGatherToLds) {
+      allocOp.emitError()
+          << "alloc has gather_to_lds users; all swizzle hints must resolve";
+      return signalPassFailure();
+    }
+  }
+
+  // Resolve hints.
+  IRRewriter rewriter(funcOp->getContext());
+  for (IREE::Codegen::SwizzleHintOp hintOp : hintOps) {
+    Value alloc = swizzleOpToAlloc[hintOp];
+    if (allocToSwizzleState[alloc].resolvable) {
+      resolveHintOp(rewriter, hintOp);
+    }
   }
 
   // Drop all hints.

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -166,9 +166,7 @@ static memref::AllocOp traceToAllocation(Value val) {
     if (!visited.insert(current).second) {
       continue;
     }
-    Operation *defOp = current.getDefiningOp();
-    if (!defOp) {
-      auto blockArg = cast<BlockArgument>(current);
+    if (auto blockArg = dyn_cast<BlockArgument>(current)) {
       auto loopOp =
           dyn_cast<LoopLikeOpInterface>(blockArg.getOwner()->getParentOp());
       if (!loopOp) {
@@ -177,14 +175,14 @@ static memref::AllocOp traceToAllocation(Value val) {
       if (OpOperand *init = loopOp.getTiedLoopInit(blockArg)) {
         worklist.push_back(init->get());
       }
-    } else if (auto allocOp = dyn_cast<memref::AllocOp>(defOp)) {
+    } else if (auto allocOp = current.getDefiningOp<memref::AllocOp>()) {
       return allocOp;
-    } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(defOp)) {
+    } else if (auto loopOp = current.getDefiningOp<LoopLikeOpInterface>()) {
       if (OpOperand *init = loopOp.getTiedLoopInit(cast<OpResult>(current))) {
         worklist.push_back(init->get());
       }
     } else {
-      for (Value operand : defOp->getOperands()) {
+      for (Value operand : current.getDefiningOp()->getOperands()) {
         if (isa<MemRefType>(operand.getType())) {
           worklist.push_back(operand);
         }

--- a/compiler/src/iree/compiler/Codegen/Common/test/reinsert_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reinsert_swizzle_hints.mlir
@@ -118,3 +118,21 @@ func.func @trace_through_scf_for() -> vector<8xbf16> {
 //       CHECK:   %[[H2:.+]] = iree_codegen.swizzle_hint %[[C2]][#iree_codegen.xor_shuffle<128, 8>]
 //       CHECK:   %[[E2:.+]] = memref.expand_shape %[[H2]] {{\[\[}}0, 1{{\]\]}}
 //       CHECK:   vector.load %[[E2]]
+
+// -----
+
+func.func @gather_to_lds_2d(%src: memref<8x128xbf16>) {
+  %alloc = memref.alloc() {iree_codegen.swizzle = #iree_codegen.xor_shuffle<128, 8>}
+    : memref<8x128xbf16, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  amdgpu.gather_to_lds %src[%c0, %c0], %alloc[%c0, %c0]
+    : vector<8xbf16>, memref<8x128xbf16>, memref<8x128xbf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// CHECK-LABEL: func @gather_to_lds_2d
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<8x128xbf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[COLLAPSED:.+]] = memref.collapse_shape %[[ALLOC]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   %[[HINT:.+]] = iree_codegen.swizzle_hint %[[COLLAPSED]][#iree_codegen.xor_shuffle<128, 8>]
+//       CHECK:   %[[EXPANDED:.+]] = memref.expand_shape %[[HINT]] {{\[\[}}0, 1{{\]\]}}
+//       CHECK:   amdgpu.gather_to_lds %{{.+}}[%{{.+}}, %{{.+}}], %[[EXPANDED]][%{{.+}}, %{{.+}}]

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -388,3 +388,17 @@ func.func @gather_to_lds_inconsistent_error(%global: memref<2048xf32>) {
   %v = vector.load %1[%c0] : memref<2048xf32, #gpu.address_space<workgroup>>, vector<5xf32>
   return
 }
+
+// -----
+
+// View-like ops between a swizzle_hint and its load/store user are no longer
+// transparent: ResolveSwizzleHints expects them to have been folded away.
+func.func @swizzle_hint_viewlike_user_error() -> vector<4xf32> {
+  %alloc = memref.alloc() : memref<2048xf32>
+  %c0 = arith.constant 0 : index
+  // expected-error @+1 {{unsupported SwizzleHintOp user}}
+  %0 = iree_codegen.swizzle_hint %alloc[#iree_codegen.rotate_rows<64, 4>] : memref<2048xf32>
+  %1 = memref.expand_shape %0 [[0, 1]] output_shape [32, 64] : memref<2048xf32> into memref<32x64xf32>
+  %2 = vector.load %1[%c0, %c0] : memref<32x64xf32>, vector<4xf32>
+  return %2 : vector<4xf32>
+}

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -353,3 +353,38 @@ func.func @swizzle_hint_non_contiguous_memref_error() -> vector<4xf32> {
   %1 = vector.load %0[%offset, %offset] : memref<32x64xf32, strided<[2, 1], offset: 0>>, vector<4xf32>
   return %1: vector<4xf32>
 }
+
+// -----
+
+// When one hint is not resolvable and no gather_to_lds is present, the whole
+// alloc's hints are softly dropped (no swizzle applied to any access).
+func.func @soft_drop_inconsistent_no_gather(%vec: vector<4xf32>) -> (vector<4xf32>, vector<5xf32>) {
+  %alloc = memref.alloc() : memref<2048xf32>
+  %c0 = arith.constant 0 : index
+  %0 = iree_codegen.swizzle_hint %alloc[#iree_codegen.rotate_rows<64, 4>] : memref<2048xf32>
+  %v1 = vector.load %0[%c0] : memref<2048xf32>, vector<4xf32>
+  %1 = iree_codegen.swizzle_hint %alloc[#iree_codegen.rotate_rows<64, 4>] : memref<2048xf32>
+  %v2 = vector.load %1[%c0] : memref<2048xf32>, vector<5xf32>
+  return %v1, %v2 : vector<4xf32>, vector<5xf32>
+}
+
+// CHECK-LABEL: func @soft_drop_inconsistent_no_gather
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc()
+//       CHECK:   %[[V1:.+]] = vector.load %[[ALLOC]]
+//       CHECK:   %[[V2:.+]] = vector.load %[[ALLOC]]
+//       CHECK:   return %[[V1]], %[[V2]]
+
+// -----
+
+// When gather_to_lds is present on a swizzled alloc, all hints must resolve.
+// Here the load hint is not resolvable (width 5), so this is a hard error.
+func.func @gather_to_lds_inconsistent_error(%global: memref<2048xf32>) {
+  // expected-error @+1 {{alloc has gather_to_lds users; all swizzle hints must resolve}}
+  %alloc = memref.alloc() : memref<2048xf32, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %0 = iree_codegen.swizzle_hint %alloc[#iree_codegen.rotate_rows<64, 4>] : memref<2048xf32, #gpu.address_space<workgroup>>
+  amdgpu.gather_to_lds %global[%c0], %0[%c0] : vector<4xf32>, memref<2048xf32>, memref<2048xf32, #gpu.address_space<workgroup>>
+  %1 = iree_codegen.swizzle_hint %alloc[#iree_codegen.rotate_rows<64, 4>] : memref<2048xf32, #gpu.address_space<workgroup>>
+  %v = vector.load %1[%c0] : memref<2048xf32, #gpu.address_space<workgroup>>, vector<5xf32>
+  return
+}


### PR DESCRIPTION
`ResolveSwizzleHints` silently drops any hint whose users it can't rewrite (unsupported user op, vector type not divisible by the access width, etc.). This is fine in isolation but breaks down when multiple hints point to the same alloc:
- **Case 1 — alloc with multiple `swizzle_hint` users**: dropping only the subset that can't be resolved leaves some accesses swizzled and others not. That corrupts data on the alloc.
- **Case 2 — alloc with an `amdgpu.gather_to_lds` user**: gather_to_lds is already lowered (by `AMDGPULowerCoalescedDMAToGatherLDS` or `AMDGPULowerAsyncDMA`) to write its
  destination in the swizzled layout. Any silent drop on a reader of that alloc would read garbage.
  
 In this PR, `ResolveSwizzleHints` is refactored to verify hints per allocation.
 - Group hints by their alloc and aggregate per-alloc resolvability plus whether the alloc has a `gather_to_lds` user.
- If the alloc has a `gather_to_lds` user and any hint is unresolvable, emit a hard error (solves case 2).
- Otherwise, if any hint on the alloc is unresolvable, all hints on that alloc drop together (solves case 1).

Two small changes are also needed for the verification above to land cleanly:
- **`ReinsertSwizzleHints`**: also reinsert a `swizzle_hint` on the destination of `amdgpu.gather_to_lds`. The hint is effectively a no-op at resolve time, but reinserting it restores the pre-absorb state and lets the per-alloc check above see the gather_to_lds user.
- **`IREECodegenFoldMemRefAliasOps`**: also run `amdgpu::populateAmdgpuFoldMemRefOpsPatterns` to fold `memref.expand_shape`/`memref.subview` into `amdgpu.gather_to_lds`.

Note: `swizzle_hint` ops reach `ResolveSwizzleHints` via two paths today: absorb + reinsert (#24000, #24001) and direct. The longer-term plan is to resolve swizzling directly on the `memref.alloc` instead of on `swizzle_hint` ops (https://github.com/iree-org/iree/pull/24001#discussion_r3051860902). This is left as a follow-up to keep the verification change in this PR incremental.

Assisted-by: Cursor (Claude)
  