### PR TITLE
[CI][vulkan] Pin test_onnx_models::amdgpu_vulkan_rdna3 to shark10.

### DIFF
--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -166,7 +166,11 @@ jobs:
             runs-on: [Linux, X64, gfx1201, persistent-cache]
           - name: amdgpu_vulkan_rdna3
             config-file: onnx_models_gpu_vulkan.json
-            runs-on: [Linux, X64, rdna3, persistent-cache]
+            # TODO(#24464): Remove `shark10-ci` label. There are vulkan driver
+            # issues on shark55. Note that the test is passing on shark01 as
+            # well. shark10-ci is picked because it's what the previous config
+            # was.
+            runs-on: [Linux, X64, rdna3, persistent-cache, shark10-ci]
 
           # NVIDIA GPU
           # TODO(#18238): migrate to new runner cluster


### PR DESCRIPTION
It is a partial revert of https://github.com/iree-org/iree/commit/00593ea3cb4258ac03972634f65a4f613275b86f

The job is passing on [shark01](https://github.com/iree-org/iree/actions/runs/25759270717/job/75658473454) and shark10 (original default), but not shark55: https://github.com/iree-org/iree/actions/runs/25762938040/job/75669682119