### PR TITLE
[Codegen][AMDGPU] Pattern match transfer_read+transpose to global_transpose_load for RDNA4

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
@@ -917,31 +917,28 @@ struct TransferReadTransposeToGlobalTransposeLoad final
         rewriter, loc, resultVecType, src, transferOp.getIndices());
 
     // Compute corrected write indices for contiguous K writes:
-    //   N_new = N_base + K_single % N      (lane's N position within N_base
-    //   group) K_new = (K_single // N) * N        (K-group base, aligned to N)
-    // Write vector<1xNxT> at [N_new, K_new] → alloc_8[N_new, K_new..K_new+N-1]
-    // This is contiguous K in alloc_8[N, K] (K is inner) — no subview needed.
+    // Compute corrected write indices for contiguous K writes.
+    // Delinearize K_single into [K_group, K_offset] where K_group = K_single /
+    // N and K_offset = K_single % N. Then:
+    //   N_new = N_base + K_offset   (lane's N position within the N-group)
+    //   K_new = K_group * N         (K-group base, aligned to N)
     ValueRange writeIndices = writeOp.getIndices();
     assert(writeIndices.size() == 2 && "expected 2D write");
-    Value nBase = writeIndices[0];   // N_group * N
-    Value kSingle = writeIndices[1]; // K lane value (0..K_total-1)
+    Value nBase = writeIndices[0];
+    Value kSingle = writeIndices[1];
 
-    AffineExpr dn = rewriter.getAffineDimExpr(0);
-    AffineExpr dk = rewriter.getAffineDimExpr(1);
-    AffineMap nNewMap = AffineMap::get(2, 0, dn + dk % N);
-    AffineMap kNewMap = AffineMap::get(2, 0, (dk.floorDiv(N)) * N);
+    Value nVal = arith::ConstantIndexOp::create(rewriter, loc, N);
+    auto delinOp = affine::AffineDelinearizeIndexOp::create(
+        rewriter, loc, kSingle, SmallVector<Value>{nVal},
+        /*hasOuterBound=*/false);
+    Value kGroup = delinOp.getResult(0);
+    Value kOffset = delinOp.getResult(1);
+    Value nNew = arith::AddIOp::create(rewriter, loc, nBase, kOffset);
+    Value kNew = arith::MulIOp::create(rewriter, loc, kGroup, nVal);
 
-    Value nNew = affine::AffineApplyOp::create(rewriter, loc, nNewMap,
-                                               ValueRange{nBase, kSingle});
-    Value kNew = affine::AffineApplyOp::create(rewriter, loc, kNewMap,
-                                               ValueRange{nBase, kSingle});
-
-    VectorType writeVecType = VectorType::get({1, N}, elemType);
-    Value castResult = vector::ShapeCastOp::create(rewriter, loc, writeVecType,
-                                                   trLoad.getResult());
-    vector::TransferWriteOp::create(rewriter, loc, castResult,
+    vector::TransferWriteOp::create(rewriter, loc, trLoad.getResult(),
                                     writeOp.getBase(), ValueRange{nNew, kNew},
-                                    SmallVector<bool>{true, true});
+                                    SmallVector<bool>{true});
     rewriter.eraseOp(writeOp);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
@@ -18,6 +19,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -34,6 +36,7 @@ namespace {
 
 constexpr int64_t kTransposeLoadLaneGroupSize = 16;
 constexpr amdgpu::Chipset kGfx950 = amdgpu::Chipset(9, 5, 0);
+constexpr amdgpu::Chipset kGfx1200 = amdgpu::Chipset(12, 0, 0);
 constexpr llvm::StringLiteral kPassLocalHintAttr = "__pass_local_hint";
 
 //===----------------------------------------------------------------------===//
@@ -752,6 +755,199 @@ struct TransferReadToTransposeLoad final
 };
 
 //===----------------------------------------------------------------------===//
+// Global Transfer Read + Transpose to Global Transpose Load Pattern
+//===----------------------------------------------------------------------===//
+
+/// Returns true if the memref memory space is a flat global (not workgroup,
+/// not fat_raw_buffer). Accepts no memory space, gpu::Global, integer 0/1,
+/// or #hal.descriptor_type<storage_buffer>.
+static bool isGlobalMemorySpace(Attribute memSpace) {
+  if (!memSpace) {
+    return false;
+  }
+  if (auto gpuAttr = dyn_cast<gpu::AddressSpaceAttr>(memSpace)) {
+    return gpuAttr.getValue() == gpu::AddressSpace::Global;
+  }
+  if (isa<IREE::HAL::DescriptorTypeAttr>(memSpace)) {
+    return true;
+  }
+  return false;
+}
+
+/// Returns the required vector size (number of elements in the transposed
+/// dimension) for global_transpose_load given an element type, or nullopt if
+/// unsupported.
+static std::optional<int64_t>
+getGlobalTransposeLoadVectorSize(Type elementType) {
+  unsigned bits = elementType.getIntOrFloatBitWidth();
+  switch (bits) {
+  case 8:
+  case 16:
+    return 8;
+  default:
+    return std::nullopt;
+  }
+}
+
+/// Matches:
+///   %read = vector.transfer_read %src[%row, %col] : memref<..., global>,
+///                                                   vector<Nx1xT>
+///   %result = vector.transpose %read, [1, 0] : vector<Nx1xT> to vector<1xNxT>
+///
+/// and replaces with:
+///   %cast = memref.memory_space_cast %src : ... to memref<..., global>
+///   %tr   = amdgpu.global_transpose_load %cast[%row, %col]
+///                   : memref<..., global> -> vector<NxT>
+///   %result = vector.shape_cast %tr : vector<NxT> to vector<1xNxT>
+///
+/// Only fires on gfx1250+ targets.
+struct TransferReadTransposeToGlobalTransposeLoad final
+    : OpRewritePattern<vector::TransposeOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(vector::TransposeOp transposeOp,
+                                PatternRewriter &rewriter) const override {
+    // Must be a simple [1, 0] transpose (2D).
+    ArrayRef<int64_t> perm = transposeOp.getPermutation();
+    if (perm.size() != 2 || perm[0] != 1 || perm[1] != 0) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "not a 2D [1,0] transpose");
+    }
+
+    // Input to transpose must be a transfer_read.
+    auto transferOp =
+        transposeOp.getVector().getDefiningOp<vector::TransferReadOp>();
+    if (!transferOp) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "not fed by transfer_read");
+    }
+
+    // Source memref must be flat global (not workgroup, not fat_raw_buffer).
+    auto memrefType = cast<MemRefType>(transferOp.getBase().getType());
+    if (!isGlobalMemorySpace(memrefType.getMemorySpace())) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "source is not flat global memory");
+    }
+
+    // With (K-outer, N-inner) iteration in the linalg.generic copy, N is the
+    // vectorized inner dimension.  The transfer_read reads 8 contiguous
+    // N-elements per lane, giving vector<1xNxT> (1 K row, N contiguous cols).
+    //   vector<1x8xT>  [K_dim=1, N_dim=8]
+    // After the software transpose [1,0] this becomes vector<8x1xT> [N,K],
+    // which is written to alloc_8[N_base, K_single] along N (stride-8 write).
+    // global_load_tr replaces the N read: each of 8 consecutive lanes provides
+    // its own K-row address, the hardware transposes (8×8 block transpose),
+    // and the result is written with the corrected stride-8 subview.
+    VectorType readType = transferOp.getVectorType();
+    if (readType.getRank() != 2 || readType.getDimSize(0) != 1) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "expected vector<1xNxT> from read");
+    }
+
+    // Check element type and expected N (number of contiguous N elements read).
+    Type elemType = readType.getElementType();
+    std::optional<int64_t> expectedN =
+        getGlobalTransposeLoadVectorSize(elemType);
+    if (!expectedN) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "unsupported element type");
+    }
+    if (readType.getDimSize(1) != *expectedN) {
+      return rewriter.notifyMatchFailure(
+          transposeOp,
+          "vector inner dim does not match global_transpose_load size");
+    }
+
+    // Must be in_bounds.
+    ArrayAttr inBounds = transferOp.getInBounds();
+    if (!inBounds || !llvm::all_of(inBounds.getAsRange<BoolAttr>(),
+                                   [](BoolAttr b) { return b.getValue(); })) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "transfer_read not in_bounds");
+    }
+
+    // Permutation map must be identity (no broadcast).
+    if (!transferOp.getPermutationMap().isIdentity()) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "non-identity permutation map");
+    }
+
+    Location loc = transposeOp.getLoc();
+
+    // Cast memref to gpu::AddressSpace::Global if needed so that
+    // amdgpu.global_transpose_load verifier is satisfied.
+    Value src = transferOp.getBase();
+    auto globalSpace = gpu::AddressSpaceAttr::get(rewriter.getContext(),
+                                                  gpu::AddressSpace::Global);
+    if (memrefType.getMemorySpace() != globalSpace) {
+      auto globalMemrefType =
+          MemRefType::get(memrefType.getShape(), memrefType.getElementType(),
+                          memrefType.getLayout(), globalSpace);
+      src = memref::MemorySpaceCastOp::create(rewriter, loc, globalMemrefType,
+                                              src);
+    }
+
+    // The transpose result must have exactly one use: a transfer_write to
+    // workgroup memory at [N_base, K_single] with vector<8x1>.
+    // With the K-inner tiling (UseGlobalTransposeLoadAttr, (N-outer, K-inner)
+    // linalg.generic), global_load_tr's 8-lane wave-level 8×8 transpose means
+    // lane K_single's result[i] = B[K_group_base+i, N_base + K_single%N].
+    // This should be written to alloc_8[N_base + K_single%N, K_group_base..N-1]
+    // as vector<1x8> (contiguous K) — no subview needed.
+    if (!transposeOp->hasOneUse()) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "transpose result has multiple uses");
+    }
+    auto writeOp =
+        dyn_cast<vector::TransferWriteOp>(*transposeOp->user_begin());
+    if (!writeOp) {
+      return rewriter.notifyMatchFailure(
+          transposeOp, "transpose not consumed by transfer_write");
+    }
+    auto writeDst = cast<MemRefType>(writeOp.getBase().getType());
+    if (!hasSharedMemoryAddressSpace(writeDst)) {
+      return rewriter.notifyMatchFailure(
+          transposeOp, "write destination is not workgroup memory");
+    }
+
+    // Emit amdgpu.global_transpose_load.
+    int64_t N = *expectedN;
+    auto resultVecType = VectorType::get({N}, elemType);
+    auto trLoad = amdgpu::GlobalTransposeLoadOp::create(
+        rewriter, loc, resultVecType, src, transferOp.getIndices());
+
+    // Compute corrected write indices for contiguous K writes:
+    //   N_new = N_base + K_single % N      (lane's N position within N_base
+    //   group) K_new = (K_single // N) * N        (K-group base, aligned to N)
+    // Write vector<1xNxT> at [N_new, K_new] → alloc_8[N_new, K_new..K_new+N-1]
+    // This is contiguous K in alloc_8[N, K] (K is inner) — no subview needed.
+    ValueRange writeIndices = writeOp.getIndices();
+    assert(writeIndices.size() == 2 && "expected 2D write");
+    Value nBase = writeIndices[0];   // N_group * N
+    Value kSingle = writeIndices[1]; // K lane value (0..K_total-1)
+
+    AffineExpr dn = rewriter.getAffineDimExpr(0);
+    AffineExpr dk = rewriter.getAffineDimExpr(1);
+    AffineMap nNewMap = AffineMap::get(2, 0, dn + dk % N);
+    AffineMap kNewMap = AffineMap::get(2, 0, (dk.floorDiv(N)) * N);
+
+    Value nNew = affine::AffineApplyOp::create(rewriter, loc, nNewMap,
+                                               ValueRange{nBase, kSingle});
+    Value kNew = affine::AffineApplyOp::create(rewriter, loc, kNewMap,
+                                               ValueRange{nBase, kSingle});
+
+    VectorType writeVecType = VectorType::get({1, N}, elemType);
+    Value castResult = vector::ShapeCastOp::create(rewriter, loc, writeVecType,
+                                                   trLoad.getResult());
+    vector::TransferWriteOp::create(rewriter, loc, castResult,
+                                    writeOp.getBase(), ValueRange{nNew, kNew},
+                                    SmallVector<bool>{true, true});
+    rewriter.eraseOp(writeOp);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//
 
@@ -768,36 +964,53 @@ struct ROCDLLoadToTransposeLoadPass final
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
 
-    // Check if target supports transpose_load (currently gfx950 only)
     IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
     if (!target) {
       return;
     }
     FailureOr<amdgpu::Chipset> chipset =
         amdgpu::Chipset::parse(target.getArch());
-    if (failed(chipset) || *chipset != kGfx950) {
+    if (failed(chipset)) {
+      return;
+    }
+
+    bool isGfx950 = (*chipset == kGfx950);
+    bool isRDNA4 = chipset->majorVersion == 12 && chipset->minorVersion <= 1;
+
+    if (!isGfx950 && !isRDNA4) {
       return;
     }
 
     IRRewriter rewriter(funcOp.getContext());
 
-    // Phase 1: Seed hints on gpu.thread_id ops
-    std::optional<SmallVector<int64_t>> workgroupSize =
-        getWorkgroupSize(funcOp);
-    if (workgroupSize) {
-      seedThreadIdHints(funcOp, rewriter, *workgroupSize);
+    RewritePatternSet patterns(funcOp.getContext());
+
+    if (isGfx950) {
+      // Seed hints on gpu.thread_id ops for LDS transpose load.
+      std::optional<SmallVector<int64_t>> workgroupSize =
+          getWorkgroupSize(funcOp);
+      if (workgroupSize) {
+        seedThreadIdHints(funcOp, rewriter, *workgroupSize);
+      }
+      // Propagate hints and lower transfer_reads via greedy patterns.
+      patterns
+          .add<PropagateHintThroughDelinearize, TransferReadToTransposeLoad>(
+              funcOp.getContext());
     }
 
-    // Phase 2: Propagate hints and lower transfer_reads via greedy patterns
-    RewritePatternSet patterns(funcOp.getContext());
-    patterns.add<PropagateHintThroughDelinearize, TransferReadToTransposeLoad>(
-        funcOp.getContext());
+    if (isRDNA4) {
+      // Global memory transpose load: match vector<1x8> transfer_read +
+      // transpose [1,0] → vector<8x1> from flat global memory and replace
+      // with amdgpu.global_transpose_load.
+      patterns.add<TransferReadTransposeToGlobalTransposeLoad>(
+          funcOp.getContext());
+    }
 
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
 
-    // Phase 3: Remove pass-local index_hint ops for IR cleanliness
+    // Remove pass-local index_hint ops for IR cleanliness (gfx950 path).
     funcOp.walk([&](IREE::Codegen::IndexHintOp hintOp) {
       if (hintOp->hasAttr(kPassLocalHintAttr)) {
         rewriter.replaceAllUsesWith(hintOp.getResult(), hintOp.getOperand());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -62,6 +62,7 @@ iree_lit_test_suite(
             "reduction_pipeline_rocm.mlir",
             "reduction_pipeline_softmax_rocm.mlir",
             "reuse_shared_memory_allocs.mlir",
+            "rocdl_global_transpose_load.mlir",
             "rocdl_load_to_transpose_load.mlir",
             "rocdl_pipeline_test.mlir",
             "sort_pipeline_test.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_lit_test_suite(
     "reduction_pipeline_rocm.mlir"
     "reduction_pipeline_softmax_rocm.mlir"
     "reuse_shared_memory_allocs.mlir"
+    "rocdl_global_transpose_load.mlir"
     "rocdl_load_to_transpose_load.mlir"
     "rocdl_pipeline_test.mlir"
     "sort_pipeline_test.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_global_transpose_load.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_global_transpose_load.mlir
@@ -1,0 +1,139 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 \
+// RUN:   --pass-pipeline='builtin.module(func.func(iree-rocdl-load-to-transpose-load))' \
+// RUN:   %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN:   --pass-pipeline='builtin.module(func.func(iree-rocdl-load-to-transpose-load))' \
+// RUN:   %s | FileCheck %s --check-prefix=CHECK-NO-RDNA4
+
+// -----
+
+// BF16 with explicit gpu global address space.
+
+// CHECK-DAG: #[[N_MAP:.*]] = affine_map<(d0, d1) -> (d0 + d1 mod 8)>
+// CHECK-DAG: #[[K_MAP:.*]] = affine_map<(d0, d1) -> ((d1 floordiv 8) * 8)>
+// CHECK-LABEL: func.func @global_transpose_load_bf16
+// CHECK-SAME:    %[[N_BASE:[A-Za-z0-9]+]]: index, %[[K_SINGLE:[A-Za-z0-9]+]]: index
+// CHECK-NOT: vector.transpose
+// CHECK:     %[[TR:.*]] = amdgpu.global_transpose_load
+// CHECK-SAME:   : memref<128x64xbf16, #gpu.address_space<global>> -> vector<8xbf16>
+// CHECK:     %[[N_NEW:.*]] = affine.apply #[[N_MAP]](%[[N_BASE]], %[[K_SINGLE]])
+// CHECK:     %[[K_NEW:.*]] = affine.apply #[[K_MAP]](%[[N_BASE]], %[[K_SINGLE]])
+// CHECK:     %[[CAST:.*]] = vector.shape_cast %[[TR]] : vector<8xbf16> to vector<1x8xbf16>
+// CHECK:     vector.transfer_write %[[CAST]], {{.*}}[%[[N_NEW]], %[[K_NEW]]]
+
+// CHECK-NO-RDNA4-LABEL: func.func @global_transpose_load_bf16
+// CHECK-NO-RDNA4-NOT: amdgpu.global_transpose_load
+// CHECK-NO-RDNA4: vector.transpose
+func.func @global_transpose_load_bf16(
+    %src: memref<128x64xbf16, #gpu.address_space<global>>,
+    %dst: memref<8x64xbf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : bf16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xbf16, #gpu.address_space<global>>, vector<1x8xbf16>
+  %1 = vector.transpose %0, [1, 0] : vector<1x8xbf16> to vector<8x1xbf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<8x1xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// F16 with explicit gpu global address space.
+
+// CHECK-LABEL: func.func @global_transpose_load_f16
+// CHECK-NOT: vector.transpose
+// CHECK: amdgpu.global_transpose_load {{.*}} -> vector<8xf16>
+// CHECK-NO-RDNA4-LABEL: func.func @global_transpose_load_f16
+// CHECK-NO-RDNA4-NOT: amdgpu.global_transpose_load
+func.func @global_transpose_load_f16(
+    %src: memref<128x64xf16, #gpu.address_space<global>>,
+    %dst: memref<8x64xf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xf16, #gpu.address_space<global>>, vector<1x8xf16>
+  %1 = vector.transpose %0, [1, 0] : vector<1x8xf16> to vector<8x1xf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<8x1xf16>, memref<8x64xf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// HAL storage buffer (descriptor_type) source — cast to global before load.
+
+// CHECK-LABEL: func.func @global_transpose_load_hal_buffer
+// CHECK-NOT: vector.transpose
+// CHECK: memref.memory_space_cast {{.*}} : memref<128x64xbf16, #hal.descriptor_type<storage_buffer>> to memref<128x64xbf16, #gpu.address_space<global>>
+// CHECK: amdgpu.global_transpose_load
+// CHECK-NO-RDNA4-LABEL: func.func @global_transpose_load_hal_buffer
+// CHECK-NO-RDNA4-NOT: amdgpu.global_transpose_load
+func.func @global_transpose_load_hal_buffer(
+    %src: memref<128x64xbf16, #hal.descriptor_type<storage_buffer>>,
+    %dst: memref<8x64xbf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : bf16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xbf16, #hal.descriptor_type<storage_buffer>>, vector<1x8xbf16>
+  %1 = vector.transpose %0, [1, 0] : vector<1x8xbf16> to vector<8x1xbf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<8x1xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// No transform: source is workgroup memory (not global).
+// CHECK-LABEL: func.func @no_transform_workgroup_src
+// CHECK-NOT: amdgpu.global_transpose_load
+// CHECK: vector.transpose
+func.func @no_transform_workgroup_src(
+    %src: memref<128x64xbf16, #gpu.address_space<workgroup>>,
+    %dst: memref<8x64xbf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : bf16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xbf16, #gpu.address_space<workgroup>>, vector<1x8xbf16>
+  %1 = vector.transpose %0, [1, 0] : vector<1x8xbf16> to vector<8x1xbf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<8x1xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// No transform: source has no address space (not a recognized global).
+// CHECK-LABEL: func.func @no_transform_no_memspace
+// CHECK-NOT: amdgpu.global_transpose_load
+// CHECK: vector.transpose
+func.func @no_transform_no_memspace(
+    %src: memref<128x64xbf16>,
+    %dst: memref<8x64xbf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : bf16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xbf16>, vector<1x8xbf16>
+  %1 = vector.transpose %0, [1, 0] : vector<1x8xbf16> to vector<8x1xbf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<8x1xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// No transform: wrong read shape (vector<8x1> instead of vector<1x8>).
+// CHECK-LABEL: func.func @no_transform_wrong_shape
+// CHECK-NOT: amdgpu.global_transpose_load
+func.func @no_transform_wrong_shape(
+    %src: memref<128x64xbf16, #gpu.address_space<global>>,
+    %dst: memref<8x64xbf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : bf16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xbf16, #gpu.address_space<global>>, vector<8x1xbf16>
+  %1 = vector.transpose %0, [1, 0] : vector<8x1xbf16> to vector<1x8xbf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<1x8xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_global_transpose_load.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_global_transpose_load.mlir
@@ -9,17 +9,19 @@
 
 // BF16 with explicit gpu global address space.
 
-// CHECK-DAG: #[[N_MAP:.*]] = affine_map<(d0, d1) -> (d0 + d1 mod 8)>
-// CHECK-DAG: #[[K_MAP:.*]] = affine_map<(d0, d1) -> ((d1 floordiv 8) * 8)>
 // CHECK-LABEL: func.func @global_transpose_load_bf16
 // CHECK-SAME:    %[[N_BASE:[A-Za-z0-9]+]]: index, %[[K_SINGLE:[A-Za-z0-9]+]]: index
 // CHECK-NOT: vector.transpose
+// CHECK:     %[[N_VAL:.*]] = arith.constant 8 : index
 // CHECK:     %[[TR:.*]] = amdgpu.global_transpose_load
 // CHECK-SAME:   : memref<128x64xbf16, #gpu.address_space<global>> -> vector<8xbf16>
-// CHECK:     %[[N_NEW:.*]] = affine.apply #[[N_MAP]](%[[N_BASE]], %[[K_SINGLE]])
-// CHECK:     %[[K_NEW:.*]] = affine.apply #[[K_MAP]](%[[N_BASE]], %[[K_SINGLE]])
-// CHECK:     %[[CAST:.*]] = vector.shape_cast %[[TR]] : vector<8xbf16> to vector<1x8xbf16>
-// CHECK:     vector.transfer_write %[[CAST]], {{.*}}[%[[N_NEW]], %[[K_NEW]]]
+// Delinearize K_single into [K_group, K_offset]: K_group = K_single / 8, K_offset = K_single % 8
+// CHECK:     %[[DELIN:.*]]:2 = affine.delinearize_index %[[K_SINGLE]] into (8)
+// CHECK:     %[[N_NEW:.*]] = arith.addi %[[N_BASE]], %[[DELIN]]#1
+// CHECK:     %[[K_NEW:.*]] = arith.muli %[[DELIN]]#0, %[[N_VAL]]
+// N_new = N_base + K_offset, K_new = K_group * N — contiguous K writes.
+// CHECK:     vector.transfer_write %[[TR]], {{.*}}[%[[N_NEW]], %[[K_NEW]]]
+// CHECK-SAME:   {in_bounds = [true]} : vector<8xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
 
 // CHECK-NO-RDNA4-LABEL: func.func @global_transpose_load_bf16
 // CHECK-NO-RDNA4-NOT: amdgpu.global_transpose_load


### PR DESCRIPTION
Part of #24454.

## Summary

Add `TransferReadTransposeToGlobalTransposeLoad` pattern to `ROCDLLoadToTransposeLoad`
that recognizes the IR produced by K-inner tiled copy promotions on RDNA4:

```
%0 = vector.transfer_read %src[%k, %n], %cst : memref<..., global>, vector<1x8xT>
%1 = vector.transpose %0, [1, 0]             : vector<1x8xT> to vector<8x1xT>
vector.transfer_write %1, %dst[%n, %k]       : vector<8x1xT>, memref<..., workgroup>
```

and replaces it with `amdgpu.global_transpose_load` on gfx1200+ targets.

The `global_load_tr_b128` hardware instruction performs an 8×8 wave-level
cross-lane transpose: 8 consecutive lanes each read a row of 8 N-elements,
and the hardware transposes the result so each lane holds a K-direction slice.
The write indices are recomputed so the output goes to the correct location
in the shared memory allocation with contiguous K access:
- `N_new = N_base + K_single % N`
- `K_new = (K_single floordiv N) * N`

The pass now dispatches to the gfx950 path (LDS transpose, existing) and
the gfx1200+ path (global transpose, new) independently.
