### PR TITLE
[Codegen][AMDGPU] Add UseGlobalTransposeLoad promotion attr and operand promotion for RDNA4

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -15,10 +15,12 @@
 #include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -118,6 +120,119 @@ void promoteResult(OpBuilder &builder, Operation *op, Value valToMakeShared) {
   });
 }
 
+/// Traces through tensor.extract_slice ops to find the
+/// iree_codegen.load_from_buffer feeding this value. Returns the slice chain
+/// (outermost first) and the load op, or failure if the pattern isn't matched.
+static FailureOr<std::pair<SmallVector<tensor::ExtractSliceOp>,
+                           IREE::Codegen::LoadFromBufferOp>>
+findLoadFromBuffer(Value v) {
+  SmallVector<tensor::ExtractSliceOp> slices;
+  while (auto sliceOp = v.getDefiningOp<tensor::ExtractSliceOp>()) {
+    slices.push_back(sliceOp);
+    v = sliceOp.getSource();
+  }
+  auto loadOp = v.getDefiningOp<IREE::Codegen::LoadFromBufferOp>();
+  if (!loadOp) {
+    return failure();
+  }
+  return std::make_pair(slices, loadOp);
+}
+
+/// Promotes an operand for global_load_tr by copying to shared memory.
+/// Strips fat_raw_buffer so the copy reads from a flat global pointer
+/// (required by global_load_tr), then creates a linalg.generic that
+/// iterates (K-outer, N-inner) so vectorization produces vector<1x8> reads
+/// — 8 contiguous N-direction elements per lane. This is the access pattern
+/// that global_load_tr_b128 requires.
+/// The matmul's indexing map is updated to read from the transposed [N,K]
+/// shared memory layout.
+Value transposePromoteOperand(OpBuilder &builder, Operation *op,
+                              unsigned index) {
+  OpOperand &operand = op->getOpOperand(index);
+  Location loc = op->getLoc();
+
+  // Strip fat_raw_buffer if present so global_load_tr can use a flat pointer.
+  Value sourceValue = operand.get();
+  auto maybeLoad = findLoadFromBuffer(sourceValue);
+  if (succeeded(maybeLoad)) {
+    auto &[slices, loadOp] = *maybeLoad;
+    if (auto castOp =
+            loadOp.getBuffer().getDefiningOp<amdgpu::FatRawBufferCastOp>()) {
+      OpBuilder::InsertionGuard g(builder);
+      builder.setInsertionPointAfter(loadOp);
+      auto flatMemrefType = cast<MemRefType>(castOp.getSource().getType());
+      auto flatTensorType = RankedTensorType::get(
+          flatMemrefType.getShape(), flatMemrefType.getElementType());
+      Value flatLoad = IREE::Codegen::LoadFromBufferOp::create(
+          builder, loadOp.getLoc(), flatTensorType, castOp.getSource());
+      sourceValue = flatLoad;
+      for (auto sliceOp : llvm::reverse(slices)) {
+        builder.setInsertionPointAfter(sliceOp);
+        sourceValue = tensor::ExtractSliceOp::create(
+            builder, sliceOp.getLoc(), sliceOp.getResultType(), sourceValue,
+            sliceOp.getMixedOffsets(), sliceOp.getMixedSizes(),
+            sliceOp.getMixedStrides());
+      }
+    }
+  }
+
+  auto tensorType = cast<RankedTensorType>(sourceValue.getType());
+  MLIRContext *ctx = op->getContext();
+
+  // Create the transposed output buffer [N, K].
+  SmallVector<OpFoldResult> mixedSizes =
+      tensor::getMixedSizes(builder, loc, sourceValue);
+  SmallVector<OpFoldResult> transposedSizes(mixedSizes.rbegin(),
+                                            mixedSizes.rend());
+  Value empty = tensor::EmptyOp::create(builder, loc, transposedSizes,
+                                        tensorType.getElementType());
+
+  // linalg.generic with (d0=K outer, d1=N inner):
+  //   input  map: (d0, d1) -> (d0, d1)  reads src[k, n]
+  //   output map: (d0, d1) -> (d1, d0)  writes dst[n, k]
+  // With N as the inner (vectorized) dimension, each thread reads
+  // vector<1x8> (8 contiguous N elements at fixed K) — the correct
+  // access pattern for global_load_tr_b128.
+  // Loop iteration order: (d0=N outer, d1=K inner).
+  // With K as the inner (fast-varying per-lane) dimension,
+  // UseGlobalTransposeLoadAttr's tiling [N=vectorSize, K=1] maps K to
+  // linear_dim_0 (fast thread dim): 8 consecutive lanes get 8 consecutive
+  // K rows, which is the correct wave-level setup for global_load_tr.
+  // Each lane reads vector<1x8> (8 contiguous N from its K row). The tag
+  // UseGlobalTransposeLoadAttr drives the thread tiling level sizes.
+  //   input  map (d0=N, d1=K) -> (d1, d0)  reads B[K, N]
+  //   output map (d0=N, d1=K) -> (d0, d1)  writes alloc[N, K]
+  AffineExpr d0 = builder.getAffineDimExpr(0); // N (outer)
+  AffineExpr d1 = builder.getAffineDimExpr(1); // K (inner)
+  AffineMap inputMap = AffineMap::get(2, 0, {d1, d0}, ctx);
+  AffineMap outputMap = AffineMap::get(2, 0, {d0, d1}, ctx);
+  SmallVector<utils::IteratorType> iterTypes(2, utils::IteratorType::parallel);
+
+  auto copyOp = linalg::GenericOp::create(
+      builder, loc, empty.getType(), sourceValue, empty,
+      ArrayRef<AffineMap>{inputMap, outputMap}, iterTypes,
+      [](OpBuilder &b, Location l, ValueRange args) {
+        linalg::YieldOp::create(b, l, args[0]);
+      });
+  // Use UseGlobalTransposeLoadAttr as the lowering config so the tiling pass
+  // produces K-inner thread assignment via getStaticTilingLevelSizes.
+  setLoweringConfig(copyOp, IREE::GPU::UseGlobalTransposeLoadAttr::get(ctx));
+
+  // Update the matmul's indexing map for this operand by reversing its
+  // results to reflect the [N, K] shared memory layout.
+  if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
+    SmallVector<AffineMap> maps(genericOp.getIndexingMapsArray());
+    AffineMap oldMap = maps[index];
+    SmallVector<AffineExpr> results(oldMap.getResults().rbegin(),
+                                    oldMap.getResults().rend());
+    maps[index] = AffineMap::get(oldMap.getNumDims(), oldMap.getNumSymbols(),
+                                 results, ctx);
+    genericOp.setIndexingMapsAttr(builder.getAffineMapArrayAttr(maps));
+  }
+
+  return copyOp.getResult(0);
+}
+
 void promoteOperand(OpBuilder &builder, Operation *op, unsigned index,
                     IREE::GPU::PromotionAttr promotionAttr) {
   auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
@@ -133,9 +248,14 @@ void promoteOperand(OpBuilder &builder, Operation *op, unsigned index,
     // TODO(qedawkins): Move result promotion to attribute interface.
     return promoteResult(builder, op, op->getResult(index));
   }
-  OpOperand &operand = op->getOpOperand(index);
 
-  Value replacement = promotionAttr.promoteOperand(builder, operand);
+  Value replacement;
+  if (isa<IREE::GPU::UseGlobalTransposeLoadAttr>(promotionAttr)) {
+    replacement = transposePromoteOperand(builder, op, index);
+  } else {
+    OpOperand &operand = op->getOpOperand(index);
+    replacement = promotionAttr.promoteOperand(builder, operand);
+  }
   op->setOperand(index, replacement);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -60,6 +60,7 @@ iree_lit_test_suite(
             "gpu_pad_operands.mlir",
             "gpu_pipeline.mlir",
             "gpu_promote_matmul_operands.mlir",
+            "gpu_promote_matmul_operands_global_transpose.mlir",
             "gpu_promotion_analysis.mlir",
             "gpu_reorder_workgroups.mlir",
             "gpu_reorder_workgroups_static.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_lit_test_suite(
     "gpu_pad_operands.mlir"
     "gpu_pipeline.mlir"
     "gpu_promote_matmul_operands.mlir"
+    "gpu_promote_matmul_operands_global_transpose.mlir"
     "gpu_promotion_analysis.mlir"
     "gpu_reorder_workgroups.mlir"
     "gpu_reorder_workgroups_static.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands_global_transpose.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands_global_transpose.mlir
@@ -1,0 +1,91 @@
+// RUN: iree-opt %s --split-input-file \
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands),canonicalize)" \
+// RUN:   | FileCheck %s
+
+// Verify UseGlobalTransposeLoad promotion:
+//   - Creates a linalg.generic copy with K-inner thread mapping
+//     (input map reads B[K,N], output map writes alloc[N,K])
+//   - Tags the copy with #iree_gpu.use_global_transpose_load lowering config
+//   - The matmul RHS is updated to use the promoted (transposed) buffer
+
+// -----
+
+#lowering_config = #iree_gpu.lowering_config<{
+  promote_operands = [1],
+  promotion_types = [#iree_gpu.use_global_transpose_load]}>
+
+// CHECK-LABEL: func.func @transpose_promote_rhs
+// CHECK-SAME:    %[[LHS:[A-Za-z0-9]+]]: tensor<32x64xbf16>
+// CHECK-SAME:    %[[RHS:[A-Za-z0-9]+]]: tensor<64x128xbf16>
+func.func @transpose_promote_rhs(%lhs: tensor<32x64xbf16>,
+                                  %rhs: tensor<64x128xbf16>) -> tensor<32x128xbf16> {
+  %cst = arith.constant 0.0 : bf16
+  %empty = tensor.empty() : tensor<32x128xbf16>
+  %fill = linalg.fill ins(%cst : bf16) outs(%empty : tensor<32x128xbf16>) -> tensor<32x128xbf16>
+  %mm = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                     affine_map<(d0, d1, d2) -> (d2, d1)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel", "reduction"],
+    lowering_config = #lowering_config}
+    ins(%lhs, %rhs : tensor<32x64xbf16>, tensor<64x128xbf16>)
+    outs(%fill : tensor<32x128xbf16>) {
+  ^bb0(%in0: bf16, %in1: bf16, %out0: bf16):
+    %mul = arith.mulf %in0, %in1 : bf16
+    %add = arith.addf %out0, %mul : bf16
+    linalg.yield %add : bf16
+  } -> tensor<32x128xbf16>
+  return %mm : tensor<32x128xbf16>
+}
+
+// The copy linalg.generic has:
+//   input  map: (d0, d1) -> (d1, d0)   reads B[K, N] (K-outer, N-inner)
+//   output map: (d0, d1) -> (d0, d1)   writes alloc[N, K] (N-outer, K-inner)
+// This gives K-inner thread assignment so global_load_tr's 8x8 wave transpose
+// aligns with the thread→lane mapping.
+//
+// The copy has the transposed output shape [N=128, K=64] and K-inner config.
+// CHECK:       tensor.empty() : tensor<128x64xbf16>
+// CHECK:       linalg.generic
+// CHECK-SAME:    ins({{.*}} : tensor<64x128xbf16>)
+// CHECK-SAME:    outs({{.*}} : tensor<128x64xbf16>)
+// CHECK-SAME:    lowering_config = #iree_gpu.use_global_transpose_load
+//
+// The matmul's RHS input is the promoted [N=128, K=64] buffer.
+// CHECK:       linalg.generic
+// CHECK-SAME:    ins({{.*}}, {{.*}} : tensor<32x64xbf16>, tensor<128x64xbf16>)
+
+// -----
+
+// LHS promotion with UseGlobalTransposeLoad (transposedLhs case).
+#lowering_config_lhs = #iree_gpu.lowering_config<{
+  promote_operands = [0],
+  promotion_types = [#iree_gpu.use_global_transpose_load]}>
+
+// CHECK-LABEL: func.func @transpose_promote_lhs
+// CHECK-SAME:    %[[LHS:[A-Za-z0-9]+]]: tensor<64x32xbf16>
+func.func @transpose_promote_lhs(%lhs: tensor<64x32xbf16>,
+                                  %rhs: tensor<64x128xbf16>) -> tensor<32x128xbf16> {
+  %cst = arith.constant 0.0 : bf16
+  %empty = tensor.empty() : tensor<32x128xbf16>
+  %fill = linalg.fill ins(%cst : bf16) outs(%empty : tensor<32x128xbf16>) -> tensor<32x128xbf16>
+  // transposedLhs: LHS is K-outer (K, M) instead of (M, K)
+  %mm = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0)>,
+                     affine_map<(d0, d1, d2) -> (d2, d1)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel", "reduction"],
+    lowering_config = #lowering_config_lhs}
+    ins(%lhs, %rhs : tensor<64x32xbf16>, tensor<64x128xbf16>)
+    outs(%fill : tensor<32x128xbf16>) {
+  ^bb0(%in0: bf16, %in1: bf16, %out0: bf16):
+    %mul = arith.mulf %in0, %in1 : bf16
+    %add = arith.addf %out0, %mul : bf16
+    linalg.yield %add : bf16
+  } -> tensor<32x128xbf16>
+  return %mm : tensor<32x128xbf16>
+}
+
+// CHECK:       linalg.generic
+// CHECK-SAME:    ins({{.*}} : tensor<64x32xbf16>)
+// CHECK-SAME:    lowering_config = #iree_gpu.use_global_transpose_load

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -221,4 +221,44 @@ SmallVector<int64_t> globalLoadDMATileSizes(Operation *op) {
   return tileSizes;
 }
 
+SmallVector<int64_t> globalTransposeLoadTileSizes(Operation *op) {
+  auto funcOp = op->getParentOfType<FunctionOpInterface>();
+  std::optional<SmallVector<int64_t>> workgroupSize = getWorkgroupSize(funcOp);
+  if (!workgroupSize) {
+    return {};
+  }
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+  if (!linalgOp) {
+    return {};
+  }
+
+  SmallVector<int64_t> loopRanges = linalgOp.getStaticLoopRanges();
+  if (loopRanges.size() != 2) {
+    return {};
+  }
+
+  int64_t targetSubgroupSize = getGPUTargetAttr(op).getPreferredSubgroupSize();
+  // Vector size: 8 bf16 elements = 128 bits per lane per global_load_tr call.
+  int64_t elemBits = getElementTypeOrSelf(linalgOp->getResultTypes()[0])
+                         .getIntOrFloatBitWidth();
+  int64_t vectorSize = 128 / elemBits; // 8 for bf16/f16, 16 for i8
+
+  int64_t numThreads = llvm::product_of(*workgroupSize);
+
+  // Tile: [d0=N (outer, step=vectorSize), d1=K (inner, step=1)].
+  // The K axis (d1, step=1) maps to linear_dim_0 (fast thread dim), giving
+  // K-inner wave assignment needed by global_load_tr.
+  int64_t kRange = loopRanges[1]; // K dimension (inner of linalg.generic)
+  int64_t nRange = loopRanges[0]; // N dimension (outer of linalg.generic)
+
+  // Each thread handles vectorSize N-values (vectorized) and 1 K-value.
+  // Total tasks: (nRange / vectorSize) * kRange = numThreads * numIterations.
+  (void)nRange;
+  (void)kRange;
+  (void)numThreads;
+  (void)targetSubgroupSize;
+
+  return {vectorSize, 1}; // [N_step=vectorSize, K_step=1]
+}
+
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.h
@@ -15,6 +15,13 @@ namespace mlir::iree_compiler::IREE::GPU {
 SmallVector<int64_t> deriveThreadTileSizes(Operation *op);
 SmallVector<int64_t> globalLoadDMATileSizes(Operation *op);
 
+/// Returns thread-level tile sizes [N=vectorSize, K=1] for the
+/// global_transpose_load copy. With N as the outer step and K=1 as the inner,
+/// the K axis maps to linear_dim_0 (fast thread dim), giving K-inner wave
+/// assignment. 8 consecutive lanes then get 8 consecutive K rows, which is
+/// required for global_load_tr's wave-level 8x8 cross-lane transpose.
+SmallVector<int64_t> globalTransposeLoadTileSizes(Operation *op);
+
 } // namespace mlir::iree_compiler::IREE::GPU
 
 namespace mlir::iree_compiler {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -3194,6 +3194,33 @@ bool UseGlobalLoadDMAAttr::hasTilingLevel(unsigned level) const {
 }
 
 //===----------------------------------------------------------------------===//
+// UseGlobalTransposeLoadAttr - LoweringConfigAttrInterface
+//===----------------------------------------------------------------------===//
+
+SmallVector<int64_t>
+UseGlobalTransposeLoadAttr::getStaticTilingLevelSizes(unsigned level,
+                                                      Operation *op) const {
+  if (level == llvm::to_underlying(GPU::TilingLevel::Thread)) {
+    return globalTransposeLoadTileSizes(op);
+  }
+  return {};
+}
+
+SmallVector<OpFoldResult>
+UseGlobalTransposeLoadAttr::getTilingLevelSizes(OpBuilder &b, unsigned level,
+                                                Operation *op) const {
+  if (level == llvm::to_underlying(GPU::TilingLevel::Thread)) {
+    SmallVector<int64_t> sizes = globalTransposeLoadTileSizes(op);
+    return getAsIndexOpFoldResult(b.getContext(), sizes);
+  }
+  return {};
+}
+
+bool UseGlobalTransposeLoadAttr::hasTilingLevel(unsigned level) const {
+  return level == llvm::to_underlying(GPU::TilingLevel::Thread);
+}
+
+//===----------------------------------------------------------------------===//
 // PromoteWithCacheSwizzleAttr
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -97,6 +97,36 @@ def IREEGPU_UseGlobalLoadDma :
   let parameters = (ins);
 }
 
+def IREEGPU_UseGlobalTransposeLoad :
+    AttrDef<IREEGPU_Dialect, "UseGlobalTransposeLoad", [
+      DeclareAttrInterfaceMethods<IREECodegen_LoweringConfigAttrInterface, [
+        "getStaticTilingLevelSizes",
+        "getTilingLevelSizes",
+        "hasTilingLevel",
+      ]>,
+      DeclareAttrInterfaceMethods<IREEGPU_PromotionAttr>
+    ]> {
+  let mnemonic = "use_global_transpose_load";
+  let summary = [{
+    Promote an operand using the global memory transpose load instruction.
+  }];
+  let description = [{
+    Promotion attribute indicating that the operand should be loaded from global
+    memory using the `amdgpu.global_transpose_load` instruction, which loads
+    and transposes a matrix tile in a single subgroup operation.
+
+    This is applicable for gfx1200+ targets when the operand's memory layout
+    requires a transpose relative to what the MMA intrinsic expects:
+    - LHS when `transposedLhs` (K is not the innermost dimension)
+    - RHS when `!transposedRhs` (N is not the innermost dimension)
+
+    Supported element types for gfx1200+: i8, f8E5M2FNUZ, f8E4M3FNUZ,
+    f8E5M2, f8E4M3FN, f16, bf16, i16.
+  }];
+  let assemblyFormat = "";
+  let parameters = (ins);
+}
+
 def IREEGPU_PromoteWithCacheSwizzle :
     AttrDef<IREEGPU_Dialect, "PromoteWithCacheSwizzle", [
       DeclareAttrInterfaceMethods<IREEGPU_PromotionAttr, [

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLoadToTransposeLoad.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
@@ -18,6 +19,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -34,6 +36,7 @@ namespace {
 
 constexpr int64_t kTransposeLoadLaneGroupSize = 16;
 constexpr amdgpu::Chipset kGfx950 = amdgpu::Chipset(9, 5, 0);
+constexpr amdgpu::Chipset kGfx1200 = amdgpu::Chipset(12, 0, 0);
 constexpr llvm::StringLiteral kPassLocalHintAttr = "__pass_local_hint";
 
 //===----------------------------------------------------------------------===//
@@ -752,6 +755,203 @@ struct TransferReadToTransposeLoad final
 };
 
 //===----------------------------------------------------------------------===//
+// Global Transfer Read + Transpose to Global Transpose Load Pattern
+//===----------------------------------------------------------------------===//
+
+/// Returns true if the memref memory space is a flat global (not workgroup,
+/// not fat_raw_buffer). Accepts no memory space, gpu::Global, integer 0/1,
+/// or #hal.descriptor_type<storage_buffer>.
+static bool isGlobalMemorySpace(Attribute memSpace) {
+  if (!memSpace) {
+    return true;
+  }
+  if (auto gpuAttr = dyn_cast<gpu::AddressSpaceAttr>(memSpace)) {
+    return gpuAttr.getValue() == gpu::AddressSpace::Global;
+  }
+  if (auto intAttr = dyn_cast<IntegerAttr>(memSpace)) {
+    return intAttr.getInt() == 0 || intAttr.getInt() == 1;
+  }
+  // Accept HAL descriptor_type (flat global binding in IREE).
+  if (isa<IREE::HAL::DescriptorTypeAttr>(memSpace)) {
+    return true;
+  }
+  return false;
+}
+
+/// Returns the required vector size (number of elements in the transposed
+/// dimension) for global_transpose_load given an element type, or nullopt if
+/// unsupported.
+static std::optional<int64_t>
+getGlobalTransposeLoadVectorSize(Type elementType) {
+  unsigned bits = elementType.getIntOrFloatBitWidth();
+  switch (bits) {
+  case 8:
+  case 16:
+    return 8;
+  default:
+    return std::nullopt;
+  }
+}
+
+/// Matches:
+///   %read = vector.transfer_read %src[%row, %col] : memref<..., global>,
+///                                                   vector<Nx1xT>
+///   %result = vector.transpose %read, [1, 0] : vector<Nx1xT> to vector<1xNxT>
+///
+/// and replaces with:
+///   %cast = memref.memory_space_cast %src : ... to memref<..., global>
+///   %tr   = amdgpu.global_transpose_load %cast[%row, %col]
+///                   : memref<..., global> -> vector<NxT>
+///   %result = vector.shape_cast %tr : vector<NxT> to vector<1xNxT>
+///
+/// Only fires on gfx1250+ targets.
+struct TransferReadTransposeToGlobalTransposeLoad final
+    : OpRewritePattern<vector::TransposeOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(vector::TransposeOp transposeOp,
+                                PatternRewriter &rewriter) const override {
+    // Must be a simple [1, 0] transpose (2D).
+    ArrayRef<int64_t> perm = transposeOp.getPermutation();
+    if (perm.size() != 2 || perm[0] != 1 || perm[1] != 0) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "not a 2D [1,0] transpose");
+    }
+
+    // Input to transpose must be a transfer_read.
+    auto transferOp =
+        transposeOp.getVector().getDefiningOp<vector::TransferReadOp>();
+    if (!transferOp) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "not fed by transfer_read");
+    }
+
+    // Source memref must be flat global (not workgroup, not fat_raw_buffer).
+    auto memrefType = cast<MemRefType>(transferOp.getBase().getType());
+    if (!isGlobalMemorySpace(memrefType.getMemorySpace())) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "source is not flat global memory");
+    }
+
+    // With (K-outer, N-inner) iteration in the linalg.generic copy, N is the
+    // vectorized inner dimension.  The transfer_read reads 8 contiguous
+    // N-elements per lane, giving vector<1xNxT> (1 K row, N contiguous cols).
+    //   vector<1x8xT>  [K_dim=1, N_dim=8]
+    // After the software transpose [1,0] this becomes vector<8x1xT> [N,K],
+    // which is written to alloc_8[N_base, K_single] along N (stride-8 write).
+    // global_load_tr replaces the N read: each of 8 consecutive lanes provides
+    // its own K-row address, the hardware transposes (8×8 block transpose),
+    // and the result is written with the corrected stride-8 subview.
+    VectorType readType = transferOp.getVectorType();
+    if (readType.getRank() != 2 || readType.getDimSize(0) != 1) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "expected vector<1xNxT> from read");
+    }
+
+    // Check element type and expected N (number of contiguous N elements read).
+    Type elemType = readType.getElementType();
+    std::optional<int64_t> expectedN =
+        getGlobalTransposeLoadVectorSize(elemType);
+    if (!expectedN) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "unsupported element type");
+    }
+    if (readType.getDimSize(1) != *expectedN) {
+      return rewriter.notifyMatchFailure(
+          transposeOp,
+          "vector inner dim does not match global_transpose_load size");
+    }
+
+    // Must be in_bounds.
+    ArrayAttr inBounds = transferOp.getInBounds();
+    if (!inBounds || !llvm::all_of(inBounds.getAsRange<BoolAttr>(),
+                                   [](BoolAttr b) { return b.getValue(); })) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "transfer_read not in_bounds");
+    }
+
+    // Permutation map must be identity (no broadcast).
+    if (!transferOp.getPermutationMap().isIdentity()) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "non-identity permutation map");
+    }
+
+    Location loc = transposeOp.getLoc();
+
+    // Cast memref to gpu::AddressSpace::Global if needed so that
+    // amdgpu.global_transpose_load verifier is satisfied.
+    Value src = transferOp.getBase();
+    if (memrefType.getMemorySpace()) {
+      auto globalSpace = gpu::AddressSpaceAttr::get(rewriter.getContext(),
+                                                    gpu::AddressSpace::Global);
+      auto globalMemrefType =
+          MemRefType::get(memrefType.getShape(), memrefType.getElementType(),
+                          memrefType.getLayout(), globalSpace);
+      src = memref::MemorySpaceCastOp::create(rewriter, loc, globalMemrefType,
+                                              src);
+    }
+
+    // The transpose result must have exactly one use: a transfer_write to
+    // workgroup memory at [N_base, K_single] with vector<8x1>.
+    // With the K-inner tiling (UseGlobalTransposeLoadAttr, (N-outer, K-inner)
+    // linalg.generic), global_load_tr's 8-lane wave-level 8×8 transpose means
+    // lane K_single's result[i] = B[K_group_base+i, N_base + K_single%N].
+    // This should be written to alloc_8[N_base + K_single%N, K_group_base..N-1]
+    // as vector<1x8> (contiguous K) — no subview needed.
+    if (!transposeOp->hasOneUse()) {
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "transpose result has multiple uses");
+    }
+    auto writeOp =
+        dyn_cast<vector::TransferWriteOp>(*transposeOp->user_begin());
+    if (!writeOp) {
+      return rewriter.notifyMatchFailure(
+          transposeOp, "transpose not consumed by transfer_write");
+    }
+    auto writeDst = cast<MemRefType>(writeOp.getBase().getType());
+    if (!hasSharedMemoryAddressSpace(writeDst)) {
+      return rewriter.notifyMatchFailure(
+          transposeOp, "write destination is not workgroup memory");
+    }
+
+    // Emit amdgpu.global_transpose_load.
+    int64_t N = *expectedN;
+    auto resultVecType = VectorType::get({N}, elemType);
+    auto trLoad = amdgpu::GlobalTransposeLoadOp::create(
+        rewriter, loc, resultVecType, src, transferOp.getIndices());
+
+    // Compute corrected write indices for contiguous K writes:
+    //   N_new = N_base + K_single % N      (lane's N position within N_base
+    //   group) K_new = (K_single // N) * N        (K-group base, aligned to N)
+    // Write vector<1xNxT> at [N_new, K_new] → alloc_8[N_new, K_new..K_new+N-1]
+    // This is contiguous K in alloc_8[N, K] (K is inner) — no subview needed.
+    ValueRange writeIndices = writeOp.getIndices();
+    assert(writeIndices.size() == 2 && "expected 2D write");
+    Value nBase = writeIndices[0];   // N_group * N
+    Value kSingle = writeIndices[1]; // K lane value (0..K_total-1)
+
+    AffineExpr dn = rewriter.getAffineDimExpr(0);
+    AffineExpr dk = rewriter.getAffineDimExpr(1);
+    AffineMap nNewMap = AffineMap::get(2, 0, dn + dk % N);
+    AffineMap kNewMap = AffineMap::get(2, 0, (dk.floorDiv(N)) * N);
+
+    Value nNew = affine::AffineApplyOp::create(rewriter, loc, nNewMap,
+                                               ValueRange{nBase, kSingle});
+    Value kNew = affine::AffineApplyOp::create(rewriter, loc, kNewMap,
+                                               ValueRange{nBase, kSingle});
+
+    VectorType writeVecType = VectorType::get({1, N}, elemType);
+    Value castResult = vector::ShapeCastOp::create(rewriter, loc, writeVecType,
+                                                   trLoad.getResult());
+    vector::TransferWriteOp::create(rewriter, loc, castResult,
+                                    writeOp.getBase(), ValueRange{nNew, kNew},
+                                    SmallVector<bool>{true, true});
+    rewriter.eraseOp(writeOp);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//
 
@@ -768,36 +968,52 @@ struct ROCDLLoadToTransposeLoadPass final
   void runOnOperation() override {
     FunctionOpInterface funcOp = getOperation();
 
-    // Check if target supports transpose_load (currently gfx950 only)
     IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
     if (!target) {
       return;
     }
     FailureOr<amdgpu::Chipset> chipset =
         amdgpu::Chipset::parse(target.getArch());
-    if (failed(chipset) || *chipset != kGfx950) {
+    if (failed(chipset)) {
+      return;
+    }
+
+    bool isGfx950 = (*chipset == kGfx950);
+    bool isRDNA4 = chipset->majorVersion == 12 && chipset->minorVersion <= 1;
+
+    if (!isGfx950 && !isRDNA4) {
       return;
     }
 
     IRRewriter rewriter(funcOp.getContext());
 
-    // Phase 1: Seed hints on gpu.thread_id ops
-    std::optional<SmallVector<int64_t>> workgroupSize =
-        getWorkgroupSize(funcOp);
-    if (workgroupSize) {
-      seedThreadIdHints(funcOp, rewriter, *workgroupSize);
+    RewritePatternSet patterns(funcOp.getContext());
+
+    if (isGfx950) {
+      // Phase 1: Seed hints on gpu.thread_id ops for LDS transpose load.
+      std::optional<SmallVector<int64_t>> workgroupSize =
+          getWorkgroupSize(funcOp);
+      if (workgroupSize) {
+        seedThreadIdHints(funcOp, rewriter, *workgroupSize);
+      }
+      patterns
+          .add<PropagateHintThroughDelinearize, TransferReadToTransposeLoad>(
+              funcOp.getContext());
     }
 
-    // Phase 2: Propagate hints and lower transfer_reads via greedy patterns
-    RewritePatternSet patterns(funcOp.getContext());
-    patterns.add<PropagateHintThroughDelinearize, TransferReadToTransposeLoad>(
-        funcOp.getContext());
+    if (isRDNA4) {
+      // Global memory transpose load: match vector<1x8> transfer_read +
+      // transpose [1,0] → vector<8x1> from flat global memory and replace
+      // with amdgpu.global_transpose_load.
+      patterns.add<TransferReadTransposeToGlobalTransposeLoad>(
+          funcOp.getContext());
+    }
 
     if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
 
-    // Phase 3: Remove pass-local index_hint ops for IR cleanliness
+    // Remove pass-local index_hint ops for IR cleanliness (gfx950 path).
     funcOp.walk([&](IREE::Codegen::IndexHintOp hintOp) {
       if (hintOp->hasAttr(kPassLocalHintAttr)) {
         rewriter.replaceAllUsesWith(hintOp.getResult(), hintOp.getOperand());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -62,6 +62,7 @@ iree_lit_test_suite(
             "reduction_pipeline_rocm.mlir",
             "reduction_pipeline_softmax_rocm.mlir",
             "reuse_shared_memory_allocs.mlir",
+            "rocdl_global_transpose_load.mlir",
             "rocdl_load_to_transpose_load.mlir",
             "rocdl_pipeline_test.mlir",
             "sort_pipeline_test.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_lit_test_suite(
     "reduction_pipeline_rocm.mlir"
     "reduction_pipeline_softmax_rocm.mlir"
     "reuse_shared_memory_allocs.mlir"
+    "rocdl_global_transpose_load.mlir"
     "rocdl_load_to_transpose_load.mlir"
     "rocdl_pipeline_test.mlir"
     "sort_pipeline_test.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_global_transpose_load.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_global_transpose_load.mlir
@@ -1,0 +1,98 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1201 \
+// RUN:   --pass-pipeline='builtin.module(func.func(iree-rocdl-load-to-transpose-load))' \
+// RUN:   %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN:   --pass-pipeline='builtin.module(func.func(iree-rocdl-load-to-transpose-load))' \
+// RUN:   %s | FileCheck %s --check-prefix=CHECK-NO-RDNA4
+
+// Verify that vector.transfer_read + vector.transpose from flat global memory
+// is replaced with amdgpu.global_transpose_load on RDNA4 (gfx1200+), and that
+// the write indices are corrected for contiguous K writes.
+
+// -----
+
+// BF16: vector<1x8xbf16> read + [1,0] transpose → global_transpose_load.
+// The write indices are recomputed from (N_base, K_single):
+//   N_new = N_base + K_single % 8
+//   K_new = (K_single floordiv 8) * 8
+
+// CHECK-LABEL: func.func @global_transpose_load_bf16
+// CHECK-NOT: vector.transpose
+// CHECK:     %[[TR:.*]] = amdgpu.global_transpose_load
+// CHECK-SAME:   : memref<128x64xbf16> -> vector<8xbf16>
+// CHECK:     %[[CAST:.*]] = vector.shape_cast %[[TR]] : vector<8xbf16> to vector<1x8xbf16>
+// CHECK:     vector.transfer_write %[[CAST]]
+
+// CHECK-NO-RDNA4-LABEL: func.func @global_transpose_load_bf16
+// CHECK-NO-RDNA4-NOT: amdgpu.global_transpose_load
+// CHECK-NO-RDNA4: vector.transpose
+func.func @global_transpose_load_bf16(
+    %src: memref<128x64xbf16>,
+    %dst: memref<8x64xbf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : bf16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xbf16>, vector<1x8xbf16>
+  %1 = vector.transpose %0, [1, 0] : vector<1x8xbf16> to vector<8x1xbf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<8x1xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// F16: same pattern works for f16.
+// CHECK-LABEL: func.func @global_transpose_load_f16
+// CHECK-NOT: vector.transpose
+// CHECK: amdgpu.global_transpose_load {{.*}} -> vector<8xf16>
+// CHECK-NO-RDNA4-LABEL: func.func @global_transpose_load_f16
+// CHECK-NO-RDNA4-NOT: amdgpu.global_transpose_load
+func.func @global_transpose_load_f16(
+    %src: memref<128x64xf16>,
+    %dst: memref<8x64xf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : f16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xf16>, vector<1x8xf16>
+  %1 = vector.transpose %0, [1, 0] : vector<1x8xf16> to vector<8x1xf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<8x1xf16>, memref<8x64xf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// No transform: source is workgroup memory (not global).
+// CHECK-LABEL: func.func @no_transform_workgroup_src
+// CHECK-NOT: amdgpu.global_transpose_load
+// CHECK: vector.transpose
+func.func @no_transform_workgroup_src(
+    %src: memref<128x64xbf16, #gpu.address_space<workgroup>>,
+    %dst: memref<8x64xbf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : bf16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xbf16, #gpu.address_space<workgroup>>, vector<1x8xbf16>
+  %1 = vector.transpose %0, [1, 0] : vector<1x8xbf16> to vector<8x1xbf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<8x1xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// No transform: wrong read shape (vector<8x1> instead of vector<1x8>).
+// CHECK-LABEL: func.func @no_transform_wrong_shape
+// CHECK-NOT: amdgpu.global_transpose_load
+func.func @no_transform_wrong_shape(
+    %src: memref<128x64xbf16>,
+    %dst: memref<8x64xbf16, #gpu.address_space<workgroup>>,
+    %n_base: index, %k_single: index) {
+  %cst = arith.constant 0.0 : bf16
+  %0 = vector.transfer_read %src[%k_single, %n_base], %cst {in_bounds = [true, true]}
+      : memref<128x64xbf16>, vector<8x1xbf16>
+  %1 = vector.transpose %0, [1, 0] : vector<8x1xbf16> to vector<1x8xbf16>
+  vector.transfer_write %1, %dst[%n_base, %k_single] {in_bounds = [true, true]}
+      : vector<1x8xbf16>, memref<8x64xbf16, #gpu.address_space<workgroup>>
+  return
+}


### PR DESCRIPTION
Part of #24454. Stacks on #24457 and #24467.

## Summary

Introduces `IREEGPU_UseGlobalTransposeLoad`, a promotion attribute that
drives matmul B-operands (and transposed A-operands) to be loaded via
`global_load_tr` on RDNA4 (gfx1200+).

### New attribute

`UseGlobalTransposeLoadAttr` implements:
- `IREEGPU_PromotionAttr` — hooks into `GPUPromoteMatmulOperands`
- `IREECodegen_LoweringConfigAttrInterface` — provides tiling sizes `[N=8, K=1]`
  (vectorSize × 1, where vectorSize=8 for bf16/f16)

### K-inner operand promotion

A new `transposePromoteOperand` path in `GPUPromoteMatmulOperands` creates
a `linalg.generic` copy with K-inner thread mapping:
- **input map**: `(d0, d1) → (d1, d0)` — reads `B[K, N]` (K-outer, N-inner in memory)
- **output map**: `(d0, d1) → (d0, d1)` — writes `alloc[N, K]` (N-outer, K-inner)

This tiling aligns with `global_load_tr`'s 8×8 wave-level hardware transpose:
8 consecutive lanes each read 8 contiguous N-elements, and the hardware
transposes so each lane holds a K-direction slice. Consecutive lanes → K,
which is exactly what K-inner thread assignment gives.

The copy is tagged with `UseGlobalTransposeLoadAttr` as its lowering config
so `ROCDLLoadToTransposeLoad` (PR 2) can pattern-match and lower it.

`amdgpu.fat_raw_buffer_cast` is stripped before creating the copy because
`global_load_tr` requires a flat global pointer, not a fat buffer descriptor.

### New helpers

- `DerivedConfigUtils`: `globalTransposeLoadTileSizes(op)` returns `{vectorSize, 1}`
- `IREEGPUAttrs`: `UseGlobalTransposeLoadAttr` tiling level implementation

## Test

`gpu_promote_matmul_operands_global_transpose.mlir` verifies:
- RHS promotion: copy gets output shape `[N, K]` (transposed) with `use_global_transpose_load` config
- LHS promotion (transposedLhs): same attribute on the copy