### PR TITLE
Fix MapLoad for dynamic shapes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -1030,12 +1031,20 @@ static FailureOr<MapLoadOp> foldConsumerIntoMapLoadImpl(
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(consumerOp);
 
-  // Create new dest tensor matching consumer output shape.
+  // Reify against operands since we are about to replace `consumerOp` with
+  // `newMapLoad`, so dim queries on the result would loop back into the new
+  // map_load's destination.
   Value consumerResult = consumerOp->getResult(0);
   Type elementType = getElementTypeOrSelf(consumerResult.getType());
-  SmallVector<OpFoldResult> newSizes =
-      tensor::getMixedSizes(rewriter, loc, consumerResult);
-  Value newDest = tensor::EmptyOp::create(rewriter, loc, newSizes, elementType);
+  FailureOr<SmallVector<OpFoldResult>> newSizes =
+      reifyShapeOfResult(rewriter, consumerOp, /*resultIndex=*/0);
+  if (failed(newSizes)) {
+    return rewriter.notifyMatchFailure(
+        consumerOp,
+        "consumer does not implement ReifyRankedShapedTypeOpInterface");
+  }
+  Value newDest =
+      tensor::EmptyOp::create(rewriter, loc, *newSizes, elementType);
 
   // Clone the map_load with new dest.
   auto newMapLoad = MapLoadOp::create(rewriter, loc, newDest.getType(),
@@ -1122,14 +1131,23 @@ static FailureOr<MapLoadOp> foldReshapeIntoMapLoad(RewriterBase &rewriter,
     return failure();
   }
   Location loc = reshapeOp->getLoc();
-  SmallVector<OpFoldResult> srcDims =
-      tensor::getMixedSizes(rewriter, loc, reshapeOp.getSrc());
-  SmallVector<OpFoldResult> resultDims =
-      tensor::getMixedSizes(rewriter, loc, reshapeOp.getResult());
+  SmallVector<OpFoldResult> srcDims;
+  FailureOr<SmallVector<OpFoldResult>> resultDims;
+  {
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(reshapeOp);
+    srcDims = tensor::getMixedSizes(rewriter, loc, mapLoadOp.getOutput());
+    resultDims = reifyShapeOfResult(rewriter, reshapeOp, /*resultIndex=*/0);
+  }
+  if (failed(resultDims)) {
+    return rewriter.notifyMatchFailure(
+        reshapeOp,
+        "reshape does not implement ReifyRankedShapedTypeOpInterface");
+  }
 
   return foldConsumerIntoMapLoadImpl(
       rewriter, reshapeOp, mapLoadOp,
-      [&rewriter, loc, resultDims,
+      [&rewriter, loc, resultDims = *resultDims,
        srcDims](ArrayRef<BlockArgument> indices) -> SmallVector<Value> {
         SmallVector<Value> indexValues(indices.begin(), indices.end());
         auto linearizeIndexOp = affine::AffineLinearizeIndexOp::create(

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -1031,9 +1031,8 @@ static FailureOr<MapLoadOp> foldConsumerIntoMapLoadImpl(
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(consumerOp);
 
-  // Reify against operands since we are about to replace `consumerOp` with
-  // `newMapLoad`, so dim queries on the result would loop back into the new
-  // map_load's destination.
+  // Reify may emit small helper ops at the insertion point. They dominate the
+  // new `tensor.empty` / `map_load`.
   Value consumerResult = consumerOp->getResult(0);
   Type elementType = getElementTypeOrSelf(consumerResult.getType());
   FailureOr<SmallVector<OpFoldResult>> newSizes =
@@ -1131,14 +1130,12 @@ static FailureOr<MapLoadOp> foldReshapeIntoMapLoad(RewriterBase &rewriter,
     return failure();
   }
   Location loc = reshapeOp->getLoc();
-  SmallVector<OpFoldResult> srcDims;
-  FailureOr<SmallVector<OpFoldResult>> resultDims;
-  {
-    OpBuilder::InsertionGuard g(rewriter);
-    rewriter.setInsertionPoint(reshapeOp);
-    srcDims = tensor::getMixedSizes(rewriter, loc, mapLoadOp.getOutput());
-    resultDims = reifyShapeOfResult(rewriter, reshapeOp, /*resultIndex=*/0);
-  }
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(reshapeOp);
+  SmallVector<OpFoldResult> srcDims =
+      tensor::getMixedSizes(rewriter, loc, mapLoadOp.getOutput());
+  FailureOr<SmallVector<OpFoldResult>> resultDims =
+      reifyShapeOfResult(rewriter, reshapeOp, /*resultIndex=*/0);
   if (failed(resultDims)) {
     return rewriter.notifyMatchFailure(
         reshapeOp,
@@ -1149,6 +1146,7 @@ static FailureOr<MapLoadOp> foldReshapeIntoMapLoad(RewriterBase &rewriter,
       rewriter, reshapeOp, mapLoadOp,
       [&rewriter, loc, resultDims = *resultDims,
        srcDims](ArrayRef<BlockArgument> indices) -> SmallVector<Value> {
+        OpBuilder::InsertionGuard g(rewriter);
         SmallVector<Value> indexValues(indices.begin(), indices.end());
         auto linearizeIndexOp = affine::AffineLinearizeIndexOp::create(
             rewriter, loc, indexValues, resultDims, /*disjoint=*/true);

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_source_layout_transformation.mlir
@@ -624,3 +624,49 @@ func.func @nested_transpose_generic_blocks_mapload(
 //       CHECK:     linalg.generic
 //       CHECK:     linalg.copy
 //   CHECK-NOT:   iree_linalg_ext.map_load
+
+// -----
+
+func.func @dynamic_extract_expand_pad(%buffer : memref<50x32x16xf32>,
+                                      %offset : index,
+                                      %size : index) -> tensor<?x1x1x1x4xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %source = iree_codegen.load_from_buffer %buffer
+      : memref<50x32x16xf32> -> tensor<50x32x16xf32>
+  %slice = tensor.extract_slice %source[%offset, 0, 0] [%size, 32, 16] [1, 1, 1]
+      : tensor<50x32x16xf32> to tensor<?x32x16xf32>
+  %expanded = tensor.expand_shape %slice [[0], [1, 2], [3, 4]]
+      output_shape [%size, 2, 16, 1, 16]
+      : tensor<?x32x16xf32> into tensor<?x2x16x1x16xf32>
+  %subslice = tensor.extract_slice %expanded[0, 0, 0, 0, 0]
+      [%size, 1, 1, 1, 4] [1, 1, 1, 1, 1]
+      : tensor<?x2x16x1x16xf32> to tensor<?x1x1x1x4xf32>
+  %padded = tensor.pad %subslice low[0, 0, 0, 0, 0] high[0, 0, 0, 0, 0] {
+  ^bb0(%i: index, %j: index, %k: index, %l: index, %m: index):
+    tensor.yield %cst : f32
+  } : tensor<?x1x1x1x4xf32> to tensor<?x1x1x1x4xf32>
+  return %padded : tensor<?x1x1x1x4xf32>
+}
+// CHECK-LABEL: @dynamic_extract_expand_pad
+//  CHECK-SAME:     %[[BUFFER:[A-Za-z0-9_]+]]: memref<50x32x16xf32>
+//  CHECK-SAME:     %[[OFFSET:[A-Za-z0-9_]+]]: index
+//  CHECK-SAME:     %[[SIZE:[A-Za-z0-9_]+]]: index
+//   CHECK-DAG:   %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+//       CHECK:   %[[SOURCE:.+]] = iree_codegen.load_from_buffer %[[BUFFER]]
+//       CHECK:   %[[DEST:.+]] = tensor.empty(%[[SIZE]]) : tensor<?x1x1x1x4xf32>
+//       CHECK:   %[[ML:.+]] = iree_linalg_ext.map_load
+//  CHECK-SAME:     %[[SOURCE]] into %[[DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index, %[[IDX4:.+]]: index):
+//       CHECK:     %[[LIN:.+]] = affine.linearize_index disjoint [%[[IDX0]], %[[IDX1]], %[[IDX2]]] by (%[[SIZE]], 2, 16) : index
+//       CHECK:     %[[DELIN:.+]]:2 = affine.delinearize_index %[[LIN]] into (%[[SIZE]], 32) : index, index
+//       CHECK:     %[[ROW:.+]] = arith.addi %[[OFFSET]], %[[DELIN]]#0
+//       CHECK:     iree_linalg_ext.yield %[[ROW]], %[[DELIN]]#1, %[[IDX4]], %[[CST]] : index, index, index, f32
+//       CHECK:   } : tensor<50x32x16xf32> into tensor<?x1x1x1x4xf32> -> tensor<?x1x1x1x4xf32>
+//   CHECK-NOT:   iree_linalg_ext.map_load
+//       CHECK:   return %[[ML]] : tensor<?x1x1x1x4xf32>
+// FOLD-LABEL: @dynamic_extract_expand_pad
+//   FOLD-NOT:   tensor.dim
+//       FOLD:   %[[FOLD_DEST:.+]] = tensor.empty(%{{.+}}) : tensor<?x1x1x1x4xf32>
+//       FOLD:   %[[FOLD_ML:.+]] = iree_linalg_ext.map_load {{.*}} into %[[FOLD_DEST]]
+//   FOLD-NOT:   iree_linalg_ext.map_load
+//       FOLD:   return %[[FOLD_ML]]


### PR DESCRIPTION
`combine-source-layout-transformation` was building each new `map_load`'s `tensor.empty` destination with `tensor::getMixedSizes(consumer.getResult())`.
For a dynamically-shaped consumer (e.g. `extract_slice → expand_shape →
extract_slice → pad`), once the consumer was replaced by the new `map_load`, the materialized `tensor.dim %consumer_result, i` queries silently became `tensor.dim %new_map_load, i` and fed the very `tensor.empty` driving that `map_load`'s destination : yielding both an SSA dominance violation and a self-referential cycle (`tensor.empty(tensor.dim(%new_ml, 0))` with `%new_ml
= map_load ... into %that_empty`).

This PR fixes the above by routing all such size queries through reifyShapeOfResult, so dynamic dims are expressed in terms of the consumer op's *operands* and never the result that's about to be replaced.

Fixes #24461.