### PR TITLE
[LinalgExt] Classify im2col convolution batch dims as m_pos dims

### DIFF
--- a/compiler/bindings/python/test/api/tuner_api_test.py
+++ b/compiler/bindings/python/test/api/tuner_api_test.py
@@ -346,7 +346,7 @@ def test_igemm_conv_details():
         '"reduction"',
         '"reduction"',
     ]
-    assert details.im2col_output_perm == [2, 1, 3, 0]
+    assert details.im2col_output_perm == [2, 0, 3, 1]
     assert details.filter_reassoc_indices == [[0], [1, 2], [3]]
     assert details.is_output_channel_first
     assert details.conv_to_igemm_dim_map == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 4}

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_masked_inferred.mlir
@@ -954,6 +954,32 @@ func.func @im2col_vectorize_nhwc(
 
 // -----
 
+// Unit-window M dim. This is the shape produced when a convolution batch dim is
+// reclassified as an im2col M dim: the synthetic window metadata is all ones, so
+// the M dim is a contiguous pass-through dim.
+func.func @im2col_vectorize_unit_m_dim(
+    %input: tensor<1x16xf32>
+) -> tensor<1x16x1xf32> {
+  %0 = tensor.empty() : tensor<1x16x1xf32>
+  %1 = iree_linalg_ext.im2col strides = [1] dilations = [1] kernel_size = [1]
+                          offsets = [0, 0, 0] output_sizes = [[1], [16], [1]]
+                          batch_pos = [0] m_pos = [1] k_pos = []
+                          input_k_perm = [0] output_perm = [0, 1, 2]
+                          ins(%input : tensor<1x16xf32>)
+                          outs(%0 : tensor<1x16x1xf32>) -> tensor<1x16x1xf32>
+  return %1 : tensor<1x16x1xf32>
+}
+// CHECK-LABEL: func.func @im2col_vectorize_unit_m_dim
+//  CHECK-SAME:     %[[INPUT:[a-zA-Z0-9_]+]]: tensor<1x16xf32>
+//   CHECK-DAG:   %[[POISON:.+]] = ub.poison : f32
+//   CHECK-NOT:   iree_linalg_ext.im2col
+//       CHECK:   %[[READ:.+]] = vector.transfer_read %[[INPUT]]{{.*}}, %[[POISON]] {in_bounds = [true]} : tensor<1x16xf32>, vector<16xf32>
+//       CHECK:   %[[WRITE_VEC:.+]] = vector.transpose {{.*}} : vector<1x16xf32> to vector<16x1xf32>
+//       CHECK:   %[[FINAL:.+]] = vector.transfer_write %[[WRITE_VEC]], {{.*}} : vector<16x1xf32>, tensor<1x16x1xf32>
+//       CHECK:   return %[[FINAL]] : tensor<1x16x1xf32>
+
+// -----
+
 // Dynamic output shape: vectorization pattern should not match.
 func.func @im2col_no_vectorize_dynamic(
     %input: tensor<2x34x34x640xf32>, %m_size: index, %m_off: index, %k: index

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_vector_tile_sizes.mlir
@@ -755,6 +755,47 @@ func.func @im2col_tile_sizes_nhwc(
 
 // -----
 
+// Im2col: unit-window M dims index the input as contiguous pass-through dims
+// and are vectorizable when they are the innermost input dim.
+
+// CHECK-LABEL: @im2col_tile_sizes_unit_m_dim
+func.func @im2col_tile_sizes_unit_m_dim(
+    %input: tensor<1x16xf32>
+) -> tensor<1x16x1xf32> {
+  %0 = tensor.empty() : tensor<1x16x1xf32>
+  // CHECK: iree_linalg_ext.im2col
+  // CHECK-SAME: iree_codegen.vector_tile_sizes = array<i64: 1, 16, 1>
+  %1 = iree_linalg_ext.im2col strides = [1] dilations = [1] kernel_size = [1]
+                          offsets = [0, 0, 0] output_sizes = [[1], [16], [1]]
+                          batch_pos = [0] m_pos = [1] k_pos = []
+                          input_k_perm = [0] output_perm = [0, 1, 2]
+                          ins(%input : tensor<1x16xf32>)
+                          outs(%0 : tensor<1x16x1xf32>) -> tensor<1x16x1xf32>
+  return %1 : tensor<1x16x1xf32>
+}
+
+// -----
+
+// Im2col: non-unit stride M dims cannot use the unit-window contiguous path.
+
+// CHECK-LABEL: @im2col_tile_sizes_strided_m_dim
+func.func @im2col_tile_sizes_strided_m_dim(
+    %input: tensor<1x32xf32>
+) -> tensor<1x16x1xf32> {
+  %0 = tensor.empty() : tensor<1x16x1xf32>
+  // CHECK: iree_linalg_ext.im2col
+  // CHECK-NOT: iree_codegen.vector_tile_sizes
+  %1 = iree_linalg_ext.im2col strides = [2] dilations = [1] kernel_size = [1]
+                          offsets = [0, 0, 0] output_sizes = [[1], [16], [1]]
+                          batch_pos = [0] m_pos = [1] k_pos = []
+                          input_k_perm = [0] output_perm = [0, 1, 2]
+                          ins(%input : tensor<1x32xf32>)
+                          outs(%0 : tensor<1x16x1xf32>) -> tensor<1x16x1xf32>
+  return %1 : tensor<1x16x1xf32>
+}
+
+// -----
+
 // Im2col: non-vectorizable. input_k_perm = [1, 0] makes the innermost K
 // non-contiguous in the input tensor, so no dimension can be vectorized
 // with a contiguous slice. The analysis should not stamp a tile sizes

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -622,37 +622,34 @@ OnlineAttentionOp::decomposeOperation(OpBuilder &b) {
 
 /// Decomposition implementation for iree_linalg_ext.im2col op.
 /// The im2col op is decomposed into serial loops of `insert->extract->copy`.
-/// The decomposition supports leaving either the `batch` or `K` dimension
-/// untiled when the corresponding slice in the input tensor is contiguous.
-/// If the entire `K` dimension maps to a contiguous slice, the loop over `K`
-/// is left untiled to enable more efficient data transfer. Likewise, if the
-/// `batch` dimension is contiguous, it is left untiled instead. All other
-/// dimensions, including any non-contiguous `batch` or `K`, are tiled to 1.
+/// The decomposition supports leaving a contiguous `batch`, unit-window M,
+/// or K dimension untiled when the corresponding slice in the input tensor is
+/// contiguous. All other dimensions are tiled to 1.
 /// TODO(Max191): Fallback to larger tile sizes instead of immediately tiling K
 ///               dimension to 1 when non-contiguous.
 ///
 /// The simple decomposition (with K tiled to 1) will look like:
 /// ```
 ///   %im2col = iree_linalg_ext.im2col
-///       strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-///       offsets = [0, %m_off, %k_off]
-///       output_sizes = [[2], [32, 32], [3, 3, 640]]
-///       batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-///       input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+///       strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+///       offsets = [%m_off, %k_off]
+///       output_sizes = [[2, 32, 32], [1, 3, 3, 640]]
+///       batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+///       input_k_perm = [0, 1, 2, 3] output_perm = [0, 1]
 ///       ins(%in : tensor<2x34x34x640xf32>)
-///       outs(%out : tensor<2x4x8xf32>) -> tensor<2x4x8xf32>
+///       outs(%out : tensor<4x8xf32>) -> tensor<4x8xf32>
 /// ```
 /// Decomposes to:
 /// ```
-/// scf.for %B = %c0 to %c2 step %c1
-///   scf.for %M = %c0 to %c4 step %c1
-///     scf.for %K = %c0 to %c8 step %c1
-///       %slice = tensor.extract_slice %in[%B, %h, %w, %k] ... to tensor<1xf32>
-///       %copy = linalg.copy ins(%slice) outs(%out)
-///       %insert = tensor.insert_slice %copy into %loop_arg
+/// scf.for %M = %c0 to %c4 step %c1
+///   scf.for %K = %c0 to %c8 step %c1
+///     %slice = tensor.extract_slice %in[%n, %h, %w, %k] ... to tensor<1xf32>
+///     %copy = linalg.copy ins(%slice) outs(%out)
+///     %insert = tensor.insert_slice %copy into %loop_arg
 /// ```
 /// Where the offsets are computed as:
-///   `%h` = `(%m_off + %M) / 32 + ((%k_off + %K) / 640) / 3`
+///   `%n` = `(%m_off + %M) / (32 * 32)`
+///   `%h` = `((%m_off + %M) / 32) mod 32 + ((%k_off + %K) / (3 * 640)) mod 3`
 ///   `%w` = `(%m_off + %M) mod 32 + ((%k_off + %K) / 640) mod 3`
 ///   `%k` = `(%k_off + %K) mod 640`
 ///

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/Im2colUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/Im2colUtils.cpp
@@ -352,6 +352,23 @@ static bool willBeContiguousSlice(OpFoldResult inputSize, OpFoldResult tileSize,
          affineOp.getMap().getResult(0).isMultipleOf(constTileSize.value());
 }
 
+/// Returns true when an M output dim is a contiguous pass-through dim: one
+/// output step corresponds to one input step, with no non-unit window, stride,
+/// or dilation semantics.
+static bool isUnitWindowMOutputDim(Im2colOp im2colOp, int64_t outputDim) {
+  SmallVector<int64_t> mOutputDims = im2colOp.getMOutputDims();
+  auto it = llvm::find(mOutputDims, outputDim);
+  if (it == mOutputDims.end()) {
+    return false;
+  }
+  int64_t idx = it - mOutputDims.begin();
+  SmallVector<OpFoldResult> kernelSizes = im2colOp.getMixedKernelSize();
+  ArrayRef<int64_t> strides = im2colOp.getStrides();
+  ArrayRef<int64_t> dilations = im2colOp.getDilations();
+  return isConstantIntValue(kernelSizes[idx], 1) && strides[idx] == 1 &&
+         dilations[idx] == 1;
+}
+
 std::optional<int64_t>
 chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
                      ArrayRef<Range> iterationDomain,
@@ -397,6 +414,10 @@ chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
   // Check each dim in order from innermost to outermost, and return the first
   // one that is vectorizable.
   for (int64_t outputDimToVectorize : llvm::reverse(vectorizableOutputDims)) {
+    OpFoldResult outputDimSize = iterationDomain[outputDimToVectorize].size;
+    if (isConstantIntValue(outputDimSize, 1)) {
+      continue;
+    }
     // If a K dim is being vectorized, then it is contiguous along either the
     // input channel dimension, or the filter kernel window. If it is contiguous
     // along the kernel window, then the actual inner slice size is equal to the
@@ -430,8 +451,11 @@ chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
       // Use the offset of this specific K dim directly (no linearization).
       offset = offsets[kDimToCanonicalIdx[outputDimToVectorize]];
     } else if (mDimSet.contains(outputDimToVectorize)) {
-      // TODO(Max191): Support vectorization along the M dimension.
-      continue;
+      if (!isUnitWindowMOutputDim(im2colOp, outputDimToVectorize)) {
+        // TODO(Max191): Support vectorizing spatial M dims with non-unit
+        // window, stride, or dilation metadata.
+        continue;
+      }
     }
     // Skip dims with non-zero output low padding. Low padding on the
     // vectorized output dim would require shifting write positions and
@@ -441,7 +465,6 @@ chooseDimToVectorize(OpBuilder &b, Location loc, Im2colOp im2colOp,
       continue;
     }
 
-    OpFoldResult outputDimSize = iterationDomain[outputDimToVectorize].size;
     if (!willBeContiguousSlice(innerSliceSize, outputDimSize, offset,
                                getOffsetDivisibility)) {
       continue;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2796,8 +2796,9 @@ LogicalResult Im2colOp::verify() {
   // Batch output dims: each produces 1 coordinate (batch index).
   //   -> total inner sizes across all batch dims = batchPos.size()
   //
-  // M output dims: collectively produce mPos.size() coordinates
-  //   (spatial output positions, one per spatial dimension).
+  // M output dims: collectively produce mPos.size() coordinates. For
+  // convolution lowering, these include convolution batch and output spatial
+  // positions.
   //   -> total inner sizes across all M dims = mPos.size()
   //
   // K output dims: collectively produce (mPos.size() + kPos.size())

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1412,15 +1412,24 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     #### Attributes
 
     **Convolution metadata** — derived from the original convolution:
-    - `strides`: spatial stride per m_pos dimension.
-    - `dilations`: dilation factor per m_pos dimension.
-    - `kernel_size`: filter kernel extent per m_pos dimension.
+    - `strides`: source-coordinate stride per `m_pos` dimension.
+    - `dilations`: source-coordinate dilation per `m_pos` dimension.
+    - `kernel_size`: filter/window extent per `m_pos` dimension.
 
-    **Dimension mapping** — describes which input dimensions are batch, spatial
-    (M), or reduction (K):
-    - `batch_pos`: input dimensions that are batch (pass-through to output).
-    - `m_pos`: input dimensions that are spatial (indexed by stride/dilation).
-    - `k_pos`: input dimensions that are channels (direct index).
+    Spatial `m_pos` dimensions use the original convolution window metadata.
+    `m_pos` dimensions without a real filter window, such as convolution batch
+    dimensions, use synthetic unit metadata (`stride = dilation = kernel = 1`).
+
+    **Dimension mapping** — describes which input dimensions are GEMM batch,
+    M, or K dimensions:
+    - `batch_pos`: input dimensions that are GEMM batch/pass-through dims.
+      For convolution lowering, this is used for depth/group-like dimensions,
+      not convolution batch dimensions that only index the image/output.
+    - `m_pos`: input dimensions that form GEMM M coordinates. For convolution
+      lowering, this includes convolution batch dimensions and output image
+      dimensions.
+    - `k_pos`: input dimensions that form direct GEMM K coordinates, such as
+      input channel dimensions.
 
     **Indexing**:
     - `offsets`: one offset per output dimension in canonical
@@ -1429,14 +1438,15 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
     - `output_sizes`: nested list of delinearization sizes per output dimension.
       Each entry describes how to delinearize that output dimension back to
       spatial/channel coordinates. For example:
-      `output_sizes = [[2], [32, 32], [3, 3, 640]]` means batch=[2],
-      M delinearizes into [OH=32, OW=32], K delinearizes into [KH=3, KW=3, C=640].
+      `output_sizes = [[2], [32], [32], [1, 3, 3, 640]]` with empty
+      `batch_pos` means M dims delinearize into [N=2], [OH=32], [OW=32], and K
+      delinearizes into [unit N window=1, KH=3, KW=3, C=640].
 
     **Layout permutations**:
     - `input_k_perm`: permutation that maps the delinearized K output dimension
-      coordinates (window offsets from spatial dims and channel indices) to their
-      corresponding input dimension positions. Used when
-      the filter layout differs from the input layout (e.g., input=HWC,
+      coordinates (window offsets from M dims, synthetic unit coordinates, and
+      channel indices) to their corresponding input dimension positions. Used
+      when the filter layout differs from the input layout (e.g., input=HWC,
       filter=CHW requires `input_k_perm = [2, 0, 1]`). The identity permutation
       means the layouts are already aligned.
     - `output_perm`: permutation of the canonical `[Batch, M, K]` order to the
@@ -1460,58 +1470,59 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
 
     #### Semantics
 
-    For each output position `(b, m, k)`, the op computes input coordinates,
-    where `i` indexes over `m_pos` dimensions (spatial) and `j` indexes over
-    `k_pos` dimensions (channel):
+    For each output position, the op computes input coordinates, where `i`
+    indexes over `m_pos` dimensions and `j` indexes over `k_pos` dimensions:
     ```
-      spatial_coord[i] = m_coord[i] * stride[i] + window_offset[i] * dilation[i]
+      m_input_coord[i] = m_coord[i] * stride[i] + window_offset[i] * dilation[i]
       channel_coord[j] = k_coord[j]
     ```
     where `m_coord` and `window_offset`/`k_coord` come from delinearizing the
-    M and K output indices using `output_sizes`.
+    M and K output indices using `output_sizes`. For a convolution batch M dim,
+    the synthetic unit metadata makes `window_offset = 0`, so the input
+    coordinate is the M coordinate directly.
 
     #### Examples
 
     Basic im2col (NHWC conv, 3x3 kernel):
     ```mlir
       %im2col = iree_linalg_ext.im2col
-          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-          offsets = [0, 0, 0]
-          output_sizes = [[2], [32, 32], [3, 3, 640]]
-          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+          strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+          offsets = [0, 0, 0, 0]
+          output_sizes = [[2], [32], [32], [1, 3, 3, 640]]
+          batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2, 3] output_perm = [0, 1, 2, 3]
           ins(%in : tensor<2x34x34x640xf32>)
-          outs(%out : tensor<2x1024x5760xf32>) -> tensor<2x1024x5760xf32>
+          outs(%out : tensor<2x32x32x5760xf32>) -> tensor<2x32x32x5760xf32>
     ```
 
     With input padding (same padding absorbed from tensor.pad):
     ```mlir
       %im2col = iree_linalg_ext.im2col
-          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-          offsets = [0, 0, 0]
-          output_sizes = [[2], [34, 34], [3, 3, 640]]
-          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
+          strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+          offsets = [0, 0, 0, 0]
+          output_sizes = [[2], [34], [34], [1, 3, 3, 640]]
+          batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2, 3] output_perm = [0, 1, 2, 3]
           input_pad_low = [0, 1, 1, 0] input_pad_high = [0, 1, 1, 0]
           pad_value(%cst : f32)
           ins(%in : tensor<2x34x34x640xf32>)
-          outs(%out : tensor<2x1156x5760xf32>) -> tensor<2x1156x5760xf32>
+          outs(%out : tensor<2x34x34x5760xf32>) -> tensor<2x34x34x5760xf32>
     ```
 
     With output-only padding (GEMM alignment, no input padding):
     ```mlir
-      // M valid = 32*32 = 1024; output has 1040 (16 extra M positions filled
-      // with pad_value for GEMM alignment). K valid = 3*3*640 = 5760.
+      // K valid = 1*3*3*640 = 5760; output has 5768 (8 extra K positions
+      // filled with pad_value for GEMM alignment).
       %im2col = iree_linalg_ext.im2col
-          strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-          offsets = [0, 0, 0]
-          output_sizes = [[2], [32, 32], [3, 3, 640]]
-          batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-          input_k_perm = [0, 1, 2] output_perm = [0, 1, 2]
-          output_pad_low = [0, 0, 0] output_pad_high = [0, 16, 0]
+          strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+          offsets = [0, 0, 0, 0]
+          output_sizes = [[2], [32], [32], [1, 3, 3, 640]]
+          batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+          input_k_perm = [0, 1, 2, 3] output_perm = [0, 1, 2, 3]
+          output_pad_low = [0, 0, 0, 0] output_pad_high = [0, 0, 0, 8]
           pad_value(%cst : f32)
           ins(%in : tensor<2x34x34x640xf32>)
-          outs(%out : tensor<2x1040x5760xf32>) -> tensor<2x1040x5760xf32>
+          outs(%out : tensor<2x32x32x5768xf32>) -> tensor<2x32x32x5768xf32>
     ```
   }];
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-linalg-ext-convert-conv-to-im2col-op"
@@ -55,8 +56,8 @@ static SmallVector<NamedAttribute> getPrunedAttributeList(linalg::LinalgOp op) {
   return prunedAttributeList;
 }
 
-// Computes `inputKPerm` that maps the input spatial and channel dimension order
-// to filter's.
+// Computes `inputKPerm` for the real shared K dims before synthetic conv-batch
+// M dims are inserted.
 static SmallVector<int64_t>
 computeInputKPerm(AffineMap inputMap, AffineMap filterMap,
                   const mlir::linalg::ConvolutionDimensions &convDims) {
@@ -89,6 +90,72 @@ computeInputKPerm(AffineMap inputMap, AffineMap filterMap,
     inputKPerm.push_back(std::distance(inputReductionDims.begin(), it));
   }
   return inputKPerm;
+}
+
+/// Returns the first dim in `dims` that `expr` depends on, if any.
+static std::optional<unsigned> findFunctionOfDim(AffineExpr expr,
+                                                 ArrayRef<unsigned> dims) {
+  for (unsigned dim : dims) {
+    if (expr.isFunctionOfDim(dim)) {
+      return dim;
+    }
+  }
+  return std::nullopt;
+}
+
+/// Returns the first result position in `map` that depends on `dim`, if any.
+static std::optional<int64_t> getResultPositionForDim(AffineMap map,
+                                                      unsigned dim) {
+  for (auto [idx, expr] : llvm::enumerate(map.getResults())) {
+    if (expr.isFunctionOfDim(dim)) {
+      return idx;
+    }
+  }
+  return std::nullopt;
+}
+
+/// Expands `input_k_perm` after conv batch dims are reclassified as M dims.
+///
+/// Conv batch dims have synthetic unit kernel-window coordinates prepended to
+/// the K output order. `input_k_perm` maps K output order to input shared-dim
+/// order, so this shifts existing output-order indices by the number of
+/// synthetic dims and inserts each synthetic dim at its input-map position.
+static FailureOr<SmallVector<int64_t>> expandInputKPermForBatchMDims(
+    AffineMap inputMap, ArrayRef<int64_t> inputKPerm,
+    const mlir::linalg::ConvolutionDimensions &convDims) {
+  if (convDims.batch.empty()) {
+    return SmallVector<int64_t>(inputKPerm);
+  }
+
+  SmallVector<int64_t> inverseInputKPerm = invertPermutationVector(inputKPerm);
+  int64_t numSyntheticBatchDims = convDims.batch.size();
+  for (int64_t &outputOrderIndex : inverseInputKPerm) {
+    outputOrderIndex += numSyntheticBatchDims;
+  }
+
+  SmallVector<unsigned> inputKPermDims;
+  llvm::append_range(inputKPermDims, convDims.inputChannel);
+  llvm::append_range(inputKPermDims, convDims.filterLoop);
+  int64_t numSharedDimsSeen = 0;
+  int64_t syntheticOutputIndex = numSyntheticBatchDims;
+
+  for (AffineExpr inputExpr : llvm::reverse(inputMap.getResults())) {
+    if (findFunctionOfDim(inputExpr, convDims.batch)) {
+      inverseInputKPerm.insert(inverseInputKPerm.end() - numSharedDimsSeen,
+                               --syntheticOutputIndex);
+      ++numSharedDimsSeen;
+      continue;
+    }
+    if (findFunctionOfDim(inputExpr, inputKPermDims)) {
+      ++numSharedDimsSeen;
+    }
+  }
+
+  if (syntheticOutputIndex != 0 ||
+      inverseInputKPerm.size() != inputKPerm.size() + numSyntheticBatchDims) {
+    return failure();
+  }
+  return invertPermutationVector(inverseInputKPerm);
 }
 
 namespace {
@@ -125,9 +192,10 @@ using ControlFnTy = std::function<bool(Operation *)>;
 //
 // In general for 2D case with (N, H, W, C) input and (Kh, Kw, C, D) filter
 // and output (N, Ho, Wo, D) the convolution is the following matrix-matrix
-// multiplication (Ho x Wo, Kh x Kw x C) * (Kh x Kw x C, D) for each input in
-// the N batches. For the case where N > 1 its a batched matrxi-matrix
-// multiplication.
+// multiplication ((N x Ho x Wo), Kh x Kw x C) * (Kh x Kw x C, D). The
+// convolution batch dimension only indexes the image/output operands, so it is
+// represented as an M dimension in the im2col/GEMM metadata rather than as a
+// GEMM batch dimension.
 
 class ConvertConvGeneric final
     : public OpInterfaceRewritePattern<linalg::LinalgOp> {
@@ -177,47 +245,56 @@ public:
     AffineMap filterMap = indexingMaps[1];
     AffineMap outputMap = indexingMaps[2];
 
-    SmallVector<OpFoldResult> kernelSizes;
-    for (auto filterLoop : convDims.filterLoop) {
-      std::optional<int64_t> maybeDim = filterMap.getResultPosition(
-          getAffineDimExpr(filterLoop, filterMap.getContext()));
-      if (!maybeDim) {
-        return rewriter.notifyMatchFailure(linalgOp,
-                                           "Failed to infer filter shape.");
-      }
-      kernelSizes.push_back(
-          rewriter.getIndexAttr(filterShape[maybeDim.value()]));
-    }
-
-    // Batch dims for the im2col also include the depth/group dimensions of the
-    // conv.
     SmallVector<int64_t> outputPerm = igemmConvDetails.im2colOutputPerm;
-    auto im2colBatchIterDims =
-        llvm::to_vector(llvm::concat<unsigned>(convDims.depth, convDims.batch));
-    SmallVector<int64_t> batchPos(im2colBatchIterDims.size());
-    for (int64_t convDim : im2colBatchIterDims) {
-      AffineExpr convDimExpr = getAffineDimExpr(convDim, getContext());
-      int64_t im2colInputDim = inputMap.getResultPosition(convDimExpr).value();
-
-      AffineExpr igemmDimExpr = igemmConvDetails.convToIgemmDimMap.at(convDim);
-      int64_t igemmInputDim = igemmConvDetails.getIgemmInputImageMap()
-                                  .getResultPosition(igemmDimExpr)
-                                  .value();
-      batchPos[outputPerm[igemmInputDim]] = im2colInputDim;
-    }
-
+    SmallVector<int64_t> batchPos;
     SmallVector<int64_t> mPos;
     SmallVector<int64_t> mShape;
-    for (auto outputImage : convDims.outputImage) {
-      for (auto [idx, e] : llvm::enumerate(inputMap.getResults())) {
-        if (e.isFunctionOfDim(outputImage)) {
-          mPos.push_back(idx);
-        }
+    SmallVector<int64_t> im2colStrides;
+    SmallVector<int64_t> im2colDilations;
+    SmallVector<OpFoldResult> kernelSizes;
+    int64_t numSyntheticBatchMDims = 0;
+
+    DenseMap<unsigned, int64_t> outputImageDimToIndex;
+    for (auto [idx, dim] : llvm::enumerate(convDims.outputImage)) {
+      outputImageDimToIndex[dim] = idx;
+    }
+
+    for (auto [inputDim, inputExpr] : llvm::enumerate(inputMap.getResults())) {
+      if (findFunctionOfDim(inputExpr, convDims.depth)) {
+        batchPos.push_back(inputDim);
+        continue;
       }
-      for (auto [idx, e] : llvm::enumerate(outputMap.getResults())) {
-        if (e.isFunctionOfDim(outputImage)) {
-          mShape.push_back(outputShape[idx]);
+      if (findFunctionOfDim(inputExpr, convDims.batch)) {
+        mPos.push_back(inputDim);
+        mShape.push_back(inputShape[inputDim]);
+        im2colStrides.push_back(1);
+        im2colDilations.push_back(1);
+        kernelSizes.push_back(rewriter.getIndexAttr(1));
+        ++numSyntheticBatchMDims;
+        continue;
+      }
+      if (std::optional<unsigned> outputImage =
+              findFunctionOfDim(inputExpr, convDims.outputImage)) {
+        std::optional<int64_t> outputDim =
+            getResultPositionForDim(outputMap, *outputImage);
+        if (!outputDim) {
+          return rewriter.notifyMatchFailure(
+              linalgOp, "Failed to infer output image shape.");
         }
+        auto outputImageIt = outputImageDimToIndex.find(*outputImage);
+        int64_t outputImageIndex = outputImageIt->second;
+        unsigned filterLoop = convDims.filterLoop[outputImageIndex];
+        std::optional<int64_t> filterDim = filterMap.getResultPosition(
+            getAffineDimExpr(filterLoop, filterMap.getContext()));
+        if (!filterDim) {
+          return rewriter.notifyMatchFailure(linalgOp,
+                                             "Failed to infer filter shape.");
+        }
+        mPos.push_back(inputDim);
+        mShape.push_back(outputShape[*outputDim]);
+        im2colStrides.push_back(convDims.strides[outputImageIndex]);
+        im2colDilations.push_back(convDims.dilations[outputImageIndex]);
+        kernelSizes.push_back(rewriter.getIndexAttr(filterShape[*filterDim]));
       }
     }
 
@@ -231,9 +308,18 @@ public:
     }
     SmallVector<int64_t> inputKPerm =
         computeInputKPerm(inputMap, filterMap, convDims);
+    FailureOr<SmallVector<int64_t>> expandedInputKPerm =
+        expandInputKPermForBatchMDims(inputMap, inputKPerm, convDims);
+    if (failed(expandedInputKPerm)) {
+      return rewriter.notifyMatchFailure(linalgOp,
+                                         "Failed to expand input K perm.");
+    }
+    inputKPerm = *expandedInputKPerm;
 
     // Build unified offsets and output_sizes for the im2col op.
-    // Canonical output dim order: [batch, M, inputChannel K, filterLoop K].
+    // Canonical output dim order: [batch_pos dims, M, inputChannel K,
+    // filterLoop K]. For convolutions, batch_pos is used for depth-like dims;
+    // convolution batch dims are M dims with synthetic unit window metadata.
     // At conv-to-im2col time all offsets are zero.
 
     // Classify each original filter dim as parallel, inputChannel, or
@@ -259,7 +345,8 @@ public:
 
     // Collect K output dim inner sizes from filter reassociation indices,
     // separated into inputChannel and filterLoop groups. The canonical
-    // im2col output order is: [batch, M, inputChannel K, filterLoop K].
+    // im2col output order is: [batch_pos dims, M, inputChannel K,
+    // filterLoop K].
     SmallVector<SmallVector<int64_t>> inputChannelInnerSizes;
     SmallVector<SmallVector<int64_t>> filterLoopInnerSizes;
     for (const auto &indices : filterReassocIndices) {
@@ -284,25 +371,38 @@ public:
       }
     }
 
-    int64_t numOutputDims = batchPos.size() + mShape.size() +
-                            inputChannelInnerSizes.size() +
-                            filterLoopInnerSizes.size();
+    SmallVector<SmallVector<OpFoldResult>> kOutputSizes;
+    for (const auto &innerSizes : inputChannelInnerSizes) {
+      kOutputSizes.push_back(getAsIndexOpFoldResult(getContext(), innerSizes));
+    }
+    for (const auto &innerSizes : filterLoopInnerSizes) {
+      kOutputSizes.push_back(getAsIndexOpFoldResult(getContext(), innerSizes));
+    }
+    assert(!kOutputSizes.empty() &&
+           "expected at least one K output dim for convolution");
+    if (numSyntheticBatchMDims > 0) {
+      kOutputSizes.front().insert(kOutputSizes.front().begin(),
+                                  numSyntheticBatchMDims,
+                                  rewriter.getIndexAttr(1));
+    }
+
+    int64_t numOutputDims =
+        batchPos.size() + mShape.size() + kOutputSizes.size();
     SmallVector<OpFoldResult> offsets(numOutputDims, rewriter.getIndexAttr(0));
     SmallVector<SmallVector<OpFoldResult>> outputSizes;
     // Batch dims: each has a single inner size.
     for (int64_t dim : batchPos) {
       outputSizes.push_back({rewriter.getIndexAttr(inputShape[dim])});
     }
-    // M dims: each spatial output dim is a separate output dimension.
+    // M dims: each convolution batch or spatial output dim is a separate output
+    // dimension.
     for (int64_t m : mShape) {
       outputSizes.push_back({rewriter.getIndexAttr(m)});
     }
-    // InputChannel K dims first, then filterLoop K dims.
-    for (const auto &innerSizes : inputChannelInnerSizes) {
-      outputSizes.push_back(getAsIndexOpFoldResult(getContext(), innerSizes));
-    }
-    for (const auto &innerSizes : filterLoopInnerSizes) {
-      outputSizes.push_back(getAsIndexOpFoldResult(getContext(), innerSizes));
+    // Synthetic conv-batch unit K coords first, then inputChannel K dims, then
+    // filterLoop K dims.
+    for (const auto &innerSizes : kOutputSizes) {
+      outputSizes.push_back(innerSizes);
     }
 
     auto loc = linalgOp.getLoc();
@@ -327,9 +427,9 @@ public:
                                               inputType.getElementType());
     Value img2ColTensor =
         IREE::LinalgExt::Im2colOp::create(
-            rewriter, loc, input, /*output=*/colTensor, convDims.strides,
-            convDims.dilations, kernelSizes, offsets, outputSizes, batchPos,
-            mPos, kPos, inputKPerm, outputPerm)
+            rewriter, loc, input, /*output=*/colTensor, im2colStrides,
+            im2colDilations, kernelSizes, offsets, outputSizes, batchPos, mPos,
+            kPos, inputKPerm, outputPerm)
             .getResult(0);
 
     Value reshapedFilter = tensor::CollapseShapeOp::create(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -16,10 +16,10 @@ util.func public @conv_2d_nhwc_hwcf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [3, 3, 4]]
-// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [1, 3, 3, 4]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+// CHECK-SAME:   input_k_perm = [0, 1, 2, 3] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
@@ -51,10 +51,10 @@ util.func public @conv_2d_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x16x14x14xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x36x14x14xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4, 3, 3]]
-// CHECK-SAME:   batch_pos = [0] m_pos = [2, 3] k_pos = [1]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 3, 1, 2]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [1, 4, 3, 3]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 2, 3] k_pos = [1]
+// CHECK-SAME:   input_k_perm = [0, 1, 2, 3] output_perm = [0, 3, 1, 2]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x4x16x16xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x36x14x14xf32>) -> tensor<1x36x14x14xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2, 3]] : tensor<16x4x3x3xf32> into tensor<16x36xf32>
@@ -86,10 +86,10 @@ util.func public @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf16>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [3, 3, 4]]
-// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [1, 3, 3, 4]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+// CHECK-SAME:   input_k_perm = [0, 1, 2, 3] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf16>) -> tensor<1x14x14x36xf16>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf16> into tensor<36x16xf16>
@@ -123,10 +123,10 @@ util.func public @conv_strided(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x7x7x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x7x7x36xf16>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [2, 2] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [7], [7], [3, 3, 4]]
-// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
+// CHECK-SAME:   strides = [1, 2, 2] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [7], [7], [1, 3, 3, 4]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+// CHECK-SAME:   input_k_perm = [0, 1, 2, 3] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x7x7x36xf16>) -> tensor<1x7x7x36xf16>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf16> into tensor<36x16xf16>
@@ -161,10 +161,10 @@ util.func public @conv_dilated(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x12x12x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x12x12x36xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [2, 2] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [12], [12], [3, 3, 4]]
-// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 2, 3]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 2, 2] kernel_size = [1, 3, 3]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [12], [12], [1, 3, 3, 4]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+// CHECK-SAME:   input_k_perm = [0, 1, 2, 3] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x12x12x36xf32>) -> tensor<1x12x12x36xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
@@ -201,7 +201,7 @@ util.func public @conv_nhwc_hwfc(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x9x4xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4], [3, 3]]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [1, 4], [3, 3]]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x9x4xf32>) -> tensor<1x14x14x9x4xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1], [2], [3]] : tensor<3x3x16x4xf32> into tensor<9x16x4xf32>
@@ -272,10 +272,10 @@ util.func public @conv_1d_ncw_fcw_transpose_maps(%arg0: tensor<1x8x130xf32>, %ar
 // CHECK:      %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[EMPTY]] : tensor<1x16x128xf32>) -> tensor<1x16x128xf32>
 // CHECK:      %[[EMPTY2:.+]] = tensor.empty() : tensor<1x24x128xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [3]
-// CHECK-SAME:   offsets = [0, 0, 0] output_sizes = {{\[}}[1], [128], [8, 3]]
-// CHECK-SAME:   batch_pos = [0] m_pos = [2] k_pos = [1]
-// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [0, 2, 1]
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [1, 3]
+// CHECK-SAME:   offsets = [0, 0, 0] output_sizes = {{\[}}[1], [128], [1, 8, 3]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 2] k_pos = [1]
+// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 2, 1]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x8x130xf32>)
 // CHECK-SAME:   outs(%[[EMPTY2]] : tensor<1x24x128xf32>) -> tensor<1x24x128xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2]] : tensor<16x8x3xf32> into tensor<16x24xf32>
@@ -313,10 +313,10 @@ util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x26x18x288xf32>, %arg1: tens
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<288x3x3x288xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<6144x3x3x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[288], [3], [3], [16, 24, 16]]
-// CHECK-SAME:   batch_pos = [3] m_pos = [1, 2] k_pos = [0]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [3, 1, 2, 0]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [24, 16, 1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[3], [3], [288], [1, 16, 24, 16]]
+// CHECK-SAME:   batch_pos = [] m_pos = [1, 2, 3] k_pos = [0]
+// CHECK-SAME:   input_k_perm = [3, 0, 1, 2] output_perm = [3, 0, 1, 2]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x26x18x288xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<6144x3x3x288xf32>) -> tensor<6144x3x3x288xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<16x24x16x288xf32> into tensor<6144x288xf32>
@@ -354,10 +354,10 @@ util.func public @conv_2d_hwcn_hwcf(%arg0: tensor<26x18x16x288xf32>, %arg1: tens
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<3x3x288x288xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<3x3x6144x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[288], [3], [3], [24, 16, 16]]
-// CHECK-SAME:   batch_pos = [3] m_pos = [0, 1] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [1, 2, 3, 0]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [24, 16, 1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[3], [3], [288], [1, 24, 16, 16]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1, 3] k_pos = [2]
+// CHECK-SAME:   input_k_perm = [3, 0, 1, 2] output_perm = [0, 1, 3, 2]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<26x18x16x288xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<3x3x6144x288xf32>) -> tensor<3x3x6144x288xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<24x16x16x288xf32> into tensor<6144x288xf32>
@@ -434,10 +434,10 @@ module {
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<16x24x16x96xf32>
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<16x24x16x288xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[16], [16], [24], [3, 96]]
-// CHECK-SAME:   batch_pos = [0, 2] m_pos = [1] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [0, 2, 1, 3]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[16], [24], [16], [1, 1, 3, 96]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+// CHECK-SAME:   input_k_perm = [0, 2, 1, 3] output_perm = [0, 1, 2, 3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<16x26x16x96xf32>)
 // CHECK-SAME:   outs(%[[EMPTY]] : tensor<16x24x16x288xf32>) -> tensor<16x24x16x288xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2]] : tensor<96x3x96xf32> into tensor<96x288xf32>
@@ -464,10 +464,10 @@ util.func public @conv_2d_nhwc_chwf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
 
 // CHECK:      util.func public @conv_2d_nhwc_chwf(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [4], [3, 3]]
-// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
-// CHECK-SAME:   input_k_perm = [2, 0, 1] output_perm = [0, 1, 2, 4, 3]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[1], [14], [14], [1, 4], [3, 3]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1, 2] k_pos = [3]
+// CHECK-SAME:   input_k_perm = [0, 3, 1, 2] output_perm = [0, 1, 2, 4, 3]
 // CHECK-SAME:   ins({{.*}} : tensor<1x16x16x4xf32>)
 // CHECK-SAME:   outs({{.*}} : tensor<1x14x14x9x4xf32>) -> tensor<1x14x14x9x4xf32>
 
@@ -488,10 +488,10 @@ util.func public @conv_1d_nhc_chf(%arg0: tensor<1x3x2xf32>, %arg1: tensor<2x2x2x
 
 // CHECK:      util.func public @conv_1d_nhc_chf(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1] dilations = [1] kernel_size = [2]
-// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [2], [2], [2]]
-// CHECK-SAME:   batch_pos = [0] m_pos = [1] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [1, 0] output_perm = [0, 1, 3, 2]
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [1, 2]
+// CHECK-SAME:   offsets = [0, 0, 0, 0] output_sizes = {{\[}}[1], [2], [1, 2], [2]]
+// CHECK-SAME:   batch_pos = [] m_pos = [0, 1] k_pos = [2]
+// CHECK-SAME:   input_k_perm = [0, 2, 1] output_perm = [0, 1, 3, 2]
 // CHECK-SAME:   ins({{.*}} : tensor<1x3x2xf32>)
 // CHECK-SAME:   outs({{.*}} : tensor<1x2x2x2xf32>) -> tensor<1x2x2x2xf32>
 
@@ -514,10 +514,10 @@ util.func public @conv_2d_no_input_channel(%arg0: tensor<61x93x16x64xbf16>, %arg
 
 // CHECK:      util.func public @conv_2d_no_input_channel(
 // CHECK:        %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [59, 91]
-// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[16], [64], [3], [3], [59, 91]]
-// CHECK-SAME:   batch_pos = [2, 3] m_pos = [0, 1] k_pos = []
-// CHECK-SAME:   input_k_perm = [0, 1] output_perm = [2, 3, 4, 0, 1]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [59, 91, 1]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[16], [3], [3], [64], [1, 59, 91]]
+// CHECK-SAME:   batch_pos = [2] m_pos = [0, 1, 3] k_pos = []
+// CHECK-SAME:   input_k_perm = [2, 0, 1] output_perm = [1, 2, 4, 0, 3]
 // CHECK-SAME:   ins({{.*}} : tensor<61x93x16x64xbf16>)
 // CHECK-SAME:   outs({{.*}} : tensor<3x3x5369x16x64xbf16>) -> tensor<3x3x5369x16x64xbf16>
 // CHECK:        tensor.collapse_shape %{{.*}} {{\[}}[0, 1], [2], [3]] : tensor<59x91x16x56xbf16> into tensor<5369x16x56xbf16>
@@ -543,10 +543,10 @@ util.func public @conv_2d_nhwgc_gfhwc(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
 // CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<2x8x8x7x16xf32>]]
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<2x8x8x7x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[2], [7], [8], [8], [3, 3, 4]]
-// CHECK-SAME:   batch_pos = [0, 3] m_pos = [1, 2] k_pos = [4]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 2, 3, 1, 4]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[7], [2], [8], [8], [1, 3, 3, 4]]
+// CHECK-SAME:   batch_pos = [3] m_pos = [0, 1, 2] k_pos = [4]
+// CHECK-SAME:   input_k_perm = [0, 1, 2, 3] output_perm = [1, 2, 3, 0, 4]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
 // CHECK-SAME:   outs(%[[EMPTY]] : [[LHS_T]]) -> [[LHS_T]]
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[RHS_T:tensor<7x16x36xf32>]]
@@ -577,10 +577,10 @@ util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<2x7x4x10x10xf32>, %arg1: ten
 // CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<2x7x16x8x8xf32>]]
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x36x8x8xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[2], [7], [8], [8], [4, 3, 3]]
-// CHECK-SAME:   batch_pos = [0, 1] m_pos = [3, 4] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 4, 2, 3]
+// CHECK-SAME:   strides = [1, 1, 1] dilations = [1, 1, 1] kernel_size = [1, 3, 3]
+// CHECK-SAME:   offsets = [0, 0, 0, 0, 0] output_sizes = {{\[}}[7], [2], [8], [8], [1, 4, 3, 3]]
+// CHECK-SAME:   batch_pos = [1] m_pos = [0, 3, 4] k_pos = [2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2, 3] output_perm = [1, 0, 4, 2, 3]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
 // CHECK-SAME:   outs(%[[EMPTY]] : [[RHS_T]])
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[LHS_T:tensor<16x7x36xf32>]]
@@ -620,8 +620,8 @@ util.func public @conv_2d_ngchw_fgchw_gnfhw(%arg0: tensor<2x7x4x10x10xf32>, %arg
 // CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<7x2x16x8x8xf32>]]
 // CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x36x8x8xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
-// CHECK-SAME:   batch_pos = [0, 1] m_pos = [3, 4] k_pos = [2]
-// CHECK-SAME:   input_k_perm = [0, 1, 2] output_perm = [0, 1, 4, 2, 3]
+// CHECK-SAME:   batch_pos = [1] m_pos = [0, 3, 4] k_pos = [2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2, 3] output_perm = [1, 0, 4, 2, 3]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
 // CHECK-SAME:   outs(%[[EMPTY]] : [[RHS_T]])
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[LHS_T:tensor<16x7x36xf32>]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -427,9 +427,10 @@ bool isGatherlikeOp(Operation *op) {
 //===---------------------------------------------------------------------===//
 
 /// Classification of IGEMM dims from the image/im2col perspective.
-/// Batch includes both batch and depth (group) dims. M is output spatial
-/// dims. InputChannel and FilterLoop are the two subcategories of reduction
-/// dims. The canonical im2col output order is:
+/// Batch includes depth (group) dims. M includes convolution batch and
+/// output spatial dims.
+/// InputChannel and FilterLoop are the two subcategories of reduction dims.
+/// The canonical im2col output order is:
 ///   [Batch, M, InputChannel, FilterLoop].
 enum class Im2colDimKind {
   Batch,
@@ -463,12 +464,13 @@ static SmallVector<int64_t> computeIm2colOutputPermutation(
   auto classifyIgemmDim = [&](int64_t igemmDim) -> Im2colDimKind {
     ArrayRef<int64_t> convDimGroup = igemmDimToConvDims[igemmDim];
     if (llvm::all_of(convDimGroup, [&](int64_t convDim) {
-          return batchDimSet.contains(convDim) || depthDimSet.contains(convDim);
+          return depthDimSet.contains(convDim);
         })) {
       return Im2colDimKind::Batch;
     }
     if (llvm::all_of(convDimGroup, [&](int64_t convDim) {
-          return outputImageDimSet.contains(convDim);
+          return batchDimSet.contains(convDim) ||
+                 outputImageDimSet.contains(convDim);
         })) {
       return Im2colDimKind::M;
     }


### PR DESCRIPTION
Redefines the classification of convolution dimensions in the im2col op when converting convolution to GEMM + im2col, and fixes a semantic inconsistency with the treatment of convolution batch dims in the im2col op. Batch dims in the convolution only appear in the image operand, so they actually become M dims in the resulting GEMM, but the old classification would place them in the batch_pos list.

This PR fixes the semantic error and puts convolution batch dims into m_pos instead. In order to preserve the consistent handling of m_pos dims in the im2col lowerings and verification, the batch dims are given synthetic filter window metadata (unit strides, dilations, and window size), which simplifies the im2col op lowering and verification implementation. There is no reason the im2col op needs to know that the dim came from a convolution batch dim, since im2col only needs a well defined access pattern, for which this synthetic metadata is sufficient.

Benchmarks were tested locally on MI350, and there is no impact on performance. This is expected, since layouts and the results of codegen do not change, and this is only a change to the im2col metadata.