### PR TITLE
[Codegen] Fix duplicateTensorEmptyOps past-end iterator on zero-use ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir
@@ -1,5 +1,15 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-eliminate-empty-tensors))" %s | FileCheck %s
 
+// Don't choke on empty tensors with no uses.
+func.func @zero_use_empty_eliminated() {
+  %unused = tensor.empty() : tensor<4xf32>
+  return
+}
+
+// CHECK-LABEL: @zero_use_empty_eliminated
+// CHECK-NOT: tensor.empty
+// CHECK: return
+
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -342,6 +342,12 @@ LogicalResult duplicateTensorEmptyOps(OpBuilder &b, tensor::EmptyOp emptyOp) {
   b.setInsertionPoint(emptyOp);
   SmallVector<OpOperand *> uses = llvm::map_to_vector(
       emptyOp->getUses(), [](OpOperand &use) { return &use; });
+  // Keep the original op for the first use; clone for the rest. If the empty
+  // op has zero or one uses there's nothing to duplicate, and `std::next` on
+  // an empty vector's begin is past-end UB.
+  if (uses.size() < 2) {
+    return success();
+  }
   for (auto use : llvm::make_range(std::next(uses.begin()), uses.end())) {
     auto newOp = cast<tensor::EmptyOp>(b.clone(*emptyOp.getOperation()));
     Operation *user = use->getOwner();


### PR DESCRIPTION
EliminateEmptyTensors was crashing in duplicateTensorEmptyOps when there were empty tensors with no uses in the IR. We don't expect to see empty tensors with no uses in the IR, but if there happen to be any, then the pass should not crash. This PR fixes the issue and handles no-use empty tensors gracefully.