### PR TITLE
Reapply "[CPU] Sink down reshapes across packing ops."

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPropagateDataLayout.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPropagateDataLayout.cpp
@@ -174,6 +174,14 @@ void CPUPropagateDataLayoutPass::runOnOperation() {
         }
         return true;
       });
+  // Bubble pack ops through reshape ops so that the reshape can be folded into
+  // the interface tensor store by `populateReshapeToInterfaceTensorPatterns`.
+  linalg::populateDataLayoutPropagationPatterns(
+      patterns, [](OpOperand *operand) -> bool {
+        Operation *producerOp = operand->get().getDefiningOp();
+        return isa_and_nonnull<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(
+            producerOp);
+      });
   if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/propagate_data_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/propagate_data_layout.mlir
@@ -115,3 +115,27 @@ func.func @negative_innermost_dim_is_not_collapsed(%src: tensor<1x3x1x8x16xi32>)
 // CHECK-LABEL: func.func @negative_innermost_dim_is_not_collapsed(
 // CHECK:         tensor.collapse_shape
 // CHECK:         linalg.unpack
+
+// -----
+
+// Bubble up pack through collapse_shape so the pack operates on the
+// uncollapsed shape and the collapse can be folded away later.
+func.func @bubble_up_pack_through_collapse(
+    %src: tensor<3x3x3x320x320xf32>) -> tensor<3200x27x32x1xf32> {
+  %collapsed = tensor.collapse_shape %src [[0, 1, 2], [3, 4]]
+      : tensor<3x3x3x320x320xf32> into tensor<27x102400xf32>
+  %empty = tensor.empty() : tensor<3200x27x32x1xf32>
+  %pack = linalg.pack %collapsed outer_dims_perm = [1, 0]
+      inner_dims_pos = [1, 0] inner_tiles = [32, 1] into %empty
+      : tensor<27x102400xf32> -> tensor<3200x27x32x1xf32>
+  return %pack : tensor<3200x27x32x1xf32>
+}
+// CHECK-LABEL: func.func @bubble_up_pack_through_collapse(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+// CHECK:         %[[PACK:.+]] = linalg.pack %[[SRC]]
+// CHECK-SAME:      outer_dims_perm = [3, 4, 0, 1, 2]
+// CHECK-SAME:      inner_dims_pos = [4, 2] inner_tiles = [32, 1]
+// CHECK-SAME:      : tensor<3x3x3x320x320xf32> -> tensor<320x10x3x3x3x32x1xf32>
+// CHECK:         %[[COLLAPSED:.+]] = tensor.collapse_shape %[[PACK]]
+// CHECK-SAME:      : tensor<320x10x3x3x3x32x1xf32> into tensor<3200x27x32x1xf32>
+// CHECK:         return %[[COLLAPSED]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3483,6 +3483,12 @@ void MultiLoweringConfigGenerator::adjustTileSizesForRootOp() {
   // Adjust root op tiling sizes with non-root op.
   for (auto &[op, vecTileSize] : nonRootOpVecTileSizes) {
     if (isa<linalg::PackOp>(op)) {
+      if (isa<IREE::LinalgExt::OnlineAttentionOp>(rootOperation)) {
+        // Pack tile-size adjustment is mainly for producer/consumer fusion. For
+        // online attention, the downstream pack represents the store-side
+        // layout and should not drive the attention's tiling config.
+        continue;
+      }
       // For pack op, align the distribution tile size and overwrite the
       // vector parallel tile size and scalable flag.
       adjust(op, vecTileSize, IREE::CPU::TilingLevel::DistributionTiles, align);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1250,6 +1250,58 @@ func.func @attention(%4: tensor<20x4096x64xf16>, %5: tensor<20x4096x64xf16>, %6:
       cpu = "generic", cpu_features = "",
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
+#map5 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1)>
+#map6 = affine_map<(d0, d1, d2, d3) -> (d0 * 10 + d2, d1, d3)>
+#map7 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @attention_with_downstream_propagated_pack(
+    %query: tensor<20x4096x64xf16>,
+    %key: tensor<20x4096x64xf16>,
+    %value: tensor<20x4096x64xf16>) -> tensor<2x256x10x64x16x1xf16>
+    attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
+  %scale = arith.constant 0.125 : f16
+  %out = tensor.empty() : tensor<20x4096x64xf32>
+  %stat = tensor.empty() : tensor<20x4096xf32>
+  %zero = arith.constant 0.000000e+00 : f32
+  %neg_inf = arith.constant -3.40282347E+38 : f32
+  %filled_out = linalg.fill ins(%zero : f32) outs(%out : tensor<20x4096x64xf32>) -> tensor<20x4096x64xf32>
+  %filled_max = linalg.fill ins(%neg_inf : f32) outs(%stat : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %filled_sum = linalg.fill ins(%zero : f32) outs(%stat : tensor<20x4096xf32>) -> tensor<20x4096xf32>
+  %attention:3 = iree_linalg_ext.online_attention {indexing_maps = [#map, #map1, #map2, #map3, #map4, #map5, #map5]}
+    ins(%query, %key, %value, %scale : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16)
+    outs(%filled_out, %filled_max, %filled_sum : tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>) {
+  ^bb0(%score: f32):
+    iree_linalg_ext.yield %score : f32
+  } -> tensor<20x4096x64xf32>, tensor<20x4096xf32>, tensor<20x4096xf32>
+  %generic_out = tensor.empty() : tensor<2x4096x10x64xf16>
+  %generic = linalg.generic {indexing_maps = [#map6, #map7], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%attention#0 : tensor<20x4096x64xf32>)
+      outs(%generic_out : tensor<2x4096x10x64xf16>) {
+  ^bb0(%in: f32, %out_elem: f16):
+    %truncated = arith.truncf %in : f32 to f16
+    linalg.yield %truncated : f16
+  } -> tensor<2x4096x10x64xf16>
+  %pack_out = tensor.empty() : tensor<2x256x10x64x16x1xf16>
+  %pack = linalg.pack %generic outer_dims_perm = [0, 1, 2, 3]
+      inner_dims_pos = [1, 3] inner_tiles = [16, 1] into %pack_out
+      : tensor<2x4096x10x64xf16> -> tensor<2x256x10x64x16x1xf16>
+  return %pack : tensor<2x256x10x64x16x1xf16>
+}
+//      CHECK: #[[ATTN_PACK_CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [1, 64, 0, 0, 64], vector_common_parallel = [1, 1, 0, 0, 16], vector_reduction = [0, 0, 0, 1, 0]>
+//      CHECK: func.func @attention_with_downstream_propagated_pack
+//      CHECK: iree_linalg_ext.online_attention
+// CHECK-SAME:   lowering_config = #[[ATTN_PACK_CONFIG]]
+
+// -----
+
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+      cpu = "generic", cpu_features = "",
+      data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+      native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d4)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7, d3)>


### PR DESCRIPTION
The reshape ops are fused because of data-tiling fusion. We should sink down the ops and fuse them into bindings, if possible. If it is not possible, they become MapStoreOp so the sequence of the ops all implement tiling interface.

Both solutions are required, and the revision adds the former optimization to the pass.

The additional change is avoiding tile size adjustment from pack op when the root op is an attention op. It'd break the fusion, because it is not a perfect tiling case. It is intended to leave the pack op outside the fusion, as attention is a big op and we respect its tiling config.

Fixes https://github.com/iree-org/iree/issues/23920