### PR TITLE
[Codegen][CPU] Fix lowerGenericScalarToVectorContract for rank-N inner tiles.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -793,46 +793,37 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   }
 }
 
-/// Returns `v` with trailing unit dims stripped, down to but not below
-/// rank `minRank`. Emits a `vector.shape_cast` if any dim is stripped;
-/// returns `v` unchanged otherwise.
-static Value dropTrailingUnitDims(OpBuilder &builder, Location loc, Value v,
-                                  int64_t minRank) {
-  auto vt = cast<VectorType>(v.getType());
-  ArrayRef<int64_t> shape = vt.getShape();
-  int64_t newRank = shape.size();
-  while (newRank > minRank && shape[newRank - 1] == 1) {
-    --newRank;
-  }
-  if (newRank == static_cast<int64_t>(shape.size())) {
-    return v;
-  }
-  auto flatTy = VectorType::get(shape.take_front(newRank), vt.getElementType());
-  return vector::ShapeCastOp::create(builder, loc, flatTy, v);
-}
-
 /// Lowers a `DataTiledMMAAttr` whose intrinsic is one of the
 /// `MMA_GENERIC_SCALAR_1x1x1_REG*` cases directly to a single
-/// `vector.contract`. Since the intrinsic's tile shape is 1×1×1, the
-/// operand tiles after applying `intrinsics_m` / `intrinsics_n` /
-/// `intrinsics_k` are simple row-major (M, K)/(N, K)/(M, N) matmul
-/// tiles — no swizzle-based distribution is needed.
+/// `vector.contract`. Since the intrinsic's tile shape is 1×1×1, the only
+/// non-unit dims in each operand tile come from `intrinsics_{m,n,k}`, and
+/// the `Codegen::expand`/`fixupSwizzle` machinery places them in row-major
+/// (M, K) / (N, K) / (M, N) order. Collapse to that rank-2 form with
+/// `vector.shape_cast` regardless of where the non-unit dim(s) sit in the
+/// operand tile, then `shape_cast` the contract result back to the ACC
+/// tile's original shape so callers downstream see the expected type.
 static LogicalResult lowerGenericScalarToVectorContract(
     OpBuilder &builder, Location loc, IREE::CPU::DataTiledMMAAttr attr,
     ValueRange inputs, ValueRange outputs, SmallVectorImpl<Value> &results) {
   assert(isGenericScalar(attr.getIntrinsic()) &&
          "lowerGenericScalarToVectorContract only handles "
          "MMA_GENERIC_SCALAR_1x1x1_REG* intrinsics");
-  // The 1×1×1 base intrinsic means every non-unit dim in the operand tile
-  // came from `intrinsics_{m,n,k}` and is a `Codegen::TileSwizzle`
-  // `CrossIntrinsic` dim, which `Codegen::expand` placed at the start of
-  // its `expandShape` group and at memory slot 0. So all the unit dims end
-  // up at trailing positions of the per-operand tile; drop them to get the
-  // rank-2 (M, K)/(N, K)/(M, N) shape `vector.contract` expects below.
-  Value lhs = dropTrailingUnitDims(builder, loc, inputs[0], /*minRank=*/2);
-  Value rhs = dropTrailingUnitDims(builder, loc, inputs[1], /*minRank=*/2);
-  Value acc = dropTrailingUnitDims(builder, loc, outputs[0], /*minRank=*/2);
-  Type accElem = cast<VectorType>(acc.getType()).getElementType();
+  int64_t M = attr.getIntrinsicsM();
+  int64_t N = attr.getIntrinsicsN();
+  int64_t K = attr.getIntrinsicsK();
+  auto reshape = [&](Value v, ArrayRef<int64_t> targetShape) -> Value {
+    auto vt = cast<VectorType>(v.getType());
+    auto targetTy = VectorType::get(targetShape, vt.getElementType());
+    if (vt == targetTy) {
+      return v;
+    }
+    return vector::ShapeCastOp::create(builder, loc, targetTy, v);
+  };
+  Value lhs = reshape(inputs[0], {M, K});
+  Value rhs = reshape(inputs[1], {N, K});
+  auto accTy = cast<VectorType>(outputs[0].getType());
+  Value acc = reshape(outputs[0], {M, N});
+  Type accElem = accTy.getElementType();
   // For the generic intrinsic, ACC is always at least as wide as LHS/RHS,
   // and they're either all float or all integer (the cost model only picks
   // this intrinsic when element types are mutually consistent that way).
@@ -865,9 +856,10 @@ static LogicalResult lowerGenericScalarToVectorContract(
   // `iree_codegen.inner_tiled` op's own indexing maps for CPU.
   vector::IteratorType par = vector::IteratorType::parallel;
   vector::IteratorType red = vector::IteratorType::reduction;
-  results.push_back(vector::ContractionOp::create(
+  Value contractResult = vector::ContractionOp::create(
       builder, loc, lhs, rhs, acc, MapList{{m, k}, {n, k}, {m, n}},
-      ArrayRef<vector::IteratorType>{par, par, red}));
+      ArrayRef<vector::IteratorType>{par, par, red});
+  results.push_back(reshape(contractResult, accTy.getShape()));
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -214,6 +214,51 @@ module attributes { transform.with_named_sequence } {
 
 // -----
 
+// Generic-scalar with `intrinsics_n = 1` (narrow N): the ACC operand
+// arrives as rank-3 `vector<4x1x1xf32>` rather than the rank-2 `(M, N)`
+// form `vector.contract` consumes. The non-unit M dim is at position 0,
+// and the trailing two unit dims come from the swizzle's `Internal(1)`
+// placeholders for the K-side and N-side of the 1×1×1 base intrinsic.
+// The lowering must `shape_cast` the rank-3 operand into the rank-2
+// `(M, N)` shape for the contract, then `shape_cast` the contract result
+// back to the original rank-3 ACC type so the inner_tiled op's result
+// type is preserved downstream.
+
+#contraction_accesses_n = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_generic_narrow_n_f32(
+    %lhs: vector<4x1xf32>, %rhs: vector<1x1xf32>, %acc: vector<4x1x1xf32>)
+    -> vector<4x1x1xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_n,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 4, lhs_type = f32, rhs_type = f32, acc_type = f32>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<4x1xf32>, vector<1x1xf32> into vector<4x1x1xf32>
+  return %0 : vector<4x1x1xf32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_generic_narrow_n_f32
+//       CHECK:   %[[ACC_2D:.+]] = vector.shape_cast %{{.+}} : vector<4x1x1xf32> to vector<4x1xf32>
+//       CHECK:   %[[RES_2D:.+]] = vector.contract
+//  CHECK-SAME:     %{{.+}}, %{{.+}}, %[[ACC_2D]] : vector<4x1xf32>, vector<1x1xf32> into vector<4x1xf32>
+//       CHECK:   vector.shape_cast %[[RES_2D]] : vector<4x1xf32> to vector<4x1x1xf32>
+
+// -----
+
 // AVX-512 16×1×1 f32 (M↔N-swapped orientation of 1×16×1) with intrinsics_m=2,
 // intrinsics_n=4. The narrow side is RHS, so broadcast widens RHS 1→16; FMA
 // is LHS/RHS-symmetric so the call args don't swap.


### PR DESCRIPTION
After #24455 attaches the per-operand swizzle to the encoder info, the `inner_tiled` op for the generic-scalar 1×1×1 MMA family receives operands whose non-unit dim (size = `intrinsics_{m,n,k}`) can sit at any position in the rank-N tile, not just at the start. The previous `dropTrailingUnitDims` reduction relied on non-unit dims being leading, so e.g. an LHS tile of shape `vector<1x1x4x1x1xf32>` (intrinsics_m=4 with N=K=1) collapsed to rank-3 `vector<1x1x4>` instead of the rank-2 `(M, K)` shape `vector.contract` needs — and the wrapper code then emitted a malformed `vector.broadcast` of `vector<4x1>` into `vector<1x1x4x1x1>` to glue the result back to the inner_tiled's output tile.

Switch to a `vector.shape_cast` directly to the canonical `(M, K) / (N, K) / (M, N)` rank-2 shape: by construction (1×1×1 base intrinsic) every non-unit dim contributing to an operand tile came from an `intrinsics_*` cross-intrinsic factor, so the total element count of each operand is exactly `intrinsics_m * intrinsics_k` (etc.) and the shape_cast is element-preserving. `shape_cast` the contract result back to the inner_tiled op's original ACC tile shape so verification matches downstream.

Progress towards #24323.