### PR TITLE
[Codegen] Skip swizzle transpose when permutation is a no-op modulo unit dims.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -507,6 +507,94 @@ getReassociationIndices(int outerDims,
   return result;
 }
 
+/// Returns true when the swizzle's `permutation` only reorders unit dims
+/// relative to non-unit dims, i.e. it preserves the relative order of all
+/// non-unit dims. In that case the unpermuted and permuted inner-tile shapes
+/// have the same linearized memory layout, so the `linalg.transpose` that the
+/// pack/unpack lowering would otherwise emit moves no data.
+static bool isSwizzlePermutationLayoutNoOp(const TileSwizzle &swizzle) {
+  SmallVector<int64_t> expandedTileShape =
+      IREE::Codegen::getExpandedTileShape(swizzle.expandShape());
+  // `swizzle.permutation()[i]` is the unpermuted `expandedTileShape` index of
+  // the dim landing at permuted position `i`. Unit dims span no memory, so
+  // only the non-unit dims matter: the layout is preserved iff they keep
+  // their source order, i.e. `srcDim` increases across just the non-unit dims.
+  int64_t prevNonUnitSrc = -1;
+  for (int64_t srcDim : swizzle.permutation()) {
+    if (expandedTileShape[srcDim] == 1) {
+      continue;
+    }
+    if (srcDim < prevNonUnitSrc) {
+      return false;
+    }
+    prevNonUnitSrc = srcDim;
+  }
+  return true;
+}
+
+/// Tries to build the reassociation for the single reshape that replaces the
+/// swizzle's expand_shape + transpose when the transpose is a layout no-op:
+/// from the packed shape (outer + `innerTileSizes`) to the permuted-inner
+/// shape (outer + `applyPermutation(expandedTileShape, permutation)`).
+///
+/// The permuted-inner shape keeps the swizzle's unit dims: it is the
+/// materialized encoding type fixed by `getEncodingInfo`, which the reshape
+/// must match exactly for dialect conversion. Dropping unit dims is not a
+/// choice this lowering can make locally.
+///
+/// Intended to be called only when `isSwizzlePermutationLayoutNoOp(swizzle)`,
+/// but that predicate is not sufficient: it guarantees the linearized layout
+/// is preserved, but a layout-no-op transpose isn't always expressible as a
+/// single reshape. Specifically, a later group's non-unit dim can land
+/// positionally before an earlier (all-unit) group's content, leaving no
+/// valid ascending-order reassociation. Returns `failure()` in that case so
+/// the caller falls back to the general expand + transpose lowering.
+static FailureOr<SmallVector<ReassociationIndices>>
+getSwizzleFoldedReassociation(int outerDims, ArrayRef<int64_t> innerTileSizes,
+                              const TileSwizzle &swizzle) {
+  SmallVector<int64_t> permutedInnerShape =
+      IREE::Codegen::getExpandedTileShape(swizzle.expandShape());
+  applyPermutationToVector(permutedInnerShape, swizzle.permutation());
+
+  SmallVector<ReassociationIndices> result;
+  for (int i = 0; i < outerDims; ++i) {
+    result.push_back({i});
+  }
+  int targetIdx = 0;
+  for (int64_t innerSize : innerTileSizes) {
+    ReassociationIndices group;
+    int64_t accum = 1;
+    // Grow the slice until its product reaches `innerSize`. `do/while` (not
+    // `while`) consumes at least one dim, so `innerSize == 1` slices aren't
+    // empty. Fail if a single dim overshoots `innerSize` (a later group's
+    // non-unit dim positioned before this group's content) or we run out of
+    // dims.
+    do {
+      if (targetIdx >= static_cast<int>(permutedInnerShape.size())) {
+        return failure();
+      }
+      group.push_back(outerDims + targetIdx);
+      accum *= permutedInnerShape[targetIdx];
+      ++targetIdx;
+    } while (accum < innerSize);
+    if (accum != innerSize) {
+      return failure();
+    }
+    result.push_back(std::move(group));
+  }
+  // Trailing unit dims (after the last non-unit dim) go to the last slice.
+  // Absorbing them per-slice instead would let an earlier slice eat unit dims
+  // that a later, all-unit packed dim still needs.
+  while (targetIdx < static_cast<int>(permutedInnerShape.size())) {
+    if (permutedInnerShape[targetIdx] != 1) {
+      return failure();
+    }
+    result.back().push_back(outerDims + targetIdx);
+    ++targetIdx;
+  }
+  return result;
+}
+
 /// Convert iree_linalg_ext.set_encoding op to pack + tile swizzling ops. We use
 /// expand_shape + linalg.transpose to represent a tile swizzling op.
 struct SetEncodingOpLoweringConversion
@@ -536,9 +624,38 @@ struct SetEncodingOpLoweringConversion
     }
 
     Location loc = encodingOp.getLoc();
-
-    // Create expand_shape op to tile the innermost two dimensions.
     int origRank = encodingOp.getSourceType().getRank();
+
+    // Final shape after the swizzle is applied: outer dims + permuted
+    // expand-shape inner tile.
+    SmallVector<int64_t> permutedInnerShape =
+        getExpandedTileShape(encodingInfo.swizzle->expandShape());
+    applyPermutationToVector(permutedInnerShape,
+                             encodingInfo.swizzle->permutation());
+    SmallVector<int64_t> finalShape(cast<ShapedType>(packedValue->getType())
+                                        .getShape()
+                                        .take_front(origRank));
+    finalShape.append(permutedInnerShape);
+    RankedTensorType finalType = encodingOp.getSourceType().clone(finalShape);
+
+    // Fast path: when the permutation is a layout no-op and the fold is
+    // expressible as a single reshape, replace expand_shape + transpose with
+    // one expand_shape straight to the permuted shape. This drops the
+    // intermediate buffer that, under dynamic shapes, gets hoisted to a stack
+    // alloca with a bogus index-umax-derived static size.
+    if (isSwizzlePermutationLayoutNoOp(*encodingInfo.swizzle)) {
+      if (auto reassoc = getSwizzleFoldedReassociation(
+              origRank, encodingInfo.innerTileSizes, *encodingInfo.swizzle);
+          succeeded(reassoc)) {
+        auto expandShapeOp = tensor::ExpandShapeOp::create(
+            rewriter, loc, finalType, packedValue.value(), *reassoc);
+        rewriter.replaceOp(encodingOp, expandShapeOp.getResult());
+        return success();
+      }
+    }
+
+    // General case: expand_shape to the unpermuted inner tile, then
+    // linalg.transpose to apply the swizzle permutation.
     SmallVector<int64_t> expandShapeShape(
         cast<ShapedType>(packedValue->getType())
             .getShape()
@@ -596,37 +713,53 @@ struct UnsetEncodingOpLoweringConversion
       int targetRank = unsetEncodingOp.getResultType().getRank();
       auto srcConvertedType =
           cast<RankedTensorType>(adaptor.getSource().getType());
-      SmallVector<OpFoldResult> emptyShape =
-          tensor::getMixedSizes(rewriter, loc, adaptor.getSource());
-      emptyShape.resize(targetRank);
-      for (auto i : getExpandedTileShape(encodingInfo.swizzle->expandShape())) {
-        emptyShape.push_back(rewriter.getIndexAttr(i));
-      }
-      auto emptyTensor = tensor::EmptyOp::create(
-          rewriter, loc, emptyShape,
-          unsetEncodingOp.getSourceType().getElementType());
-
-      SmallVector<int64_t> transposePerm =
-          llvm::to_vector(llvm::seq<int64_t>(0, targetRank));
-      for (auto perm : encodingInfo.swizzle->permutation()) {
-        transposePerm.push_back(targetRank + perm);
-      }
-      auto invertedTransposePerm = invertPermutationVector(transposePerm);
-      auto transposeOp =
-          linalg::TransposeOp::create(rewriter, loc, adaptor.getSource(),
-                                      emptyTensor, invertedTransposePerm);
-
-      SmallVector<ReassociationIndices> reassociation = getReassociationIndices(
-          targetRank, encodingInfo.swizzle->expandShape());
       SmallVector<int64_t> unpackSrcShape(
           srcConvertedType.getShape().take_front(targetRank));
       unpackSrcShape.append(encodingInfo.innerTileSizes.begin(),
                             encodingInfo.innerTileSizes.end());
       RankedTensorType unpackSrcType =
           unsetEncodingOp.getResultType().clone(unpackSrcShape);
-      unpackSrc = tensor::CollapseShapeOp::create(rewriter, loc, unpackSrcType,
-                                                  transposeOp->getResult(0),
-                                                  reassociation);
+
+      // Fast path mirroring the SetEncoding side: fold the inverse transpose +
+      // collapse_shape into a single collapse_shape when the permutation is a
+      // layout no-op and the fold is a single reshape.
+      FailureOr<SmallVector<ReassociationIndices>> foldedReassoc = failure();
+      if (isSwizzlePermutationLayoutNoOp(*encodingInfo.swizzle)) {
+        foldedReassoc = getSwizzleFoldedReassociation(
+            targetRank, encodingInfo.innerTileSizes, *encodingInfo.swizzle);
+      }
+      if (succeeded(foldedReassoc)) {
+        unpackSrc = tensor::CollapseShapeOp::create(
+            rewriter, loc, unpackSrcType, adaptor.getSource(), *foldedReassoc);
+      } else {
+        SmallVector<OpFoldResult> emptyShape =
+            tensor::getMixedSizes(rewriter, loc, adaptor.getSource());
+        emptyShape.resize(targetRank);
+        for (auto i :
+             getExpandedTileShape(encodingInfo.swizzle->expandShape())) {
+          emptyShape.push_back(rewriter.getIndexAttr(i));
+        }
+        auto emptyTensor = tensor::EmptyOp::create(
+            rewriter, loc, emptyShape,
+            unsetEncodingOp.getSourceType().getElementType());
+
+        SmallVector<int64_t> transposePerm =
+            llvm::to_vector(llvm::seq<int64_t>(0, targetRank));
+        for (auto perm : encodingInfo.swizzle->permutation()) {
+          transposePerm.push_back(targetRank + perm);
+        }
+        auto invertedTransposePerm = invertPermutationVector(transposePerm);
+        auto transposeOp =
+            linalg::TransposeOp::create(rewriter, loc, adaptor.getSource(),
+                                        emptyTensor, invertedTransposePerm);
+
+        SmallVector<ReassociationIndices> reassociation =
+            getReassociationIndices(targetRank,
+                                    encodingInfo.swizzle->expandShape());
+        unpackSrc = tensor::CollapseShapeOp::create(
+            rewriter, loc, unpackSrcType, transposeOp->getResult(0),
+            reassociation);
+      }
     }
 
     auto unpackedValue = lowerUnsetEncodingToUnpackOp(rewriter, unsetEncodingOp,

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
@@ -302,6 +302,61 @@ func.func @matmul_bf16_f32_avx2_generic(
 
 // -----
 
+// The ACC swizzle for the same generic-scalar config above
+// (intrinsics_m=2, intrinsics_n=4) has `expandShape = [[Cross(2),
+// Int(1)], [Cross(4), Int(1)]]` with `permutation = [0, 2, 1, 3]` —
+// non-identity, but a no-op modulo unit dims (the permutation only
+// reorders the `Internal(1)` placeholders relative to the non-unit
+// `CrossIntrinsic` dims). The set_encoding lowering recognizes this
+// and emits a single `tensor.expand_shape` from the rank-4 pack output
+// directly into the rank-6 permuted layout, with no `linalg.transpose`.
+// The unset_encoding side is symmetric: a single `tensor.collapse_shape`
+// from the rank-6 permuted source directly into the rank-4 unpack input.
+// Iteration_sizes are pinned to (M=2, N=4, K=?) so the cost model lands
+// on intrinsics_m=2, intrinsics_n=4 regardless of whether the
+// power-of-two cap on `chooseUnrolling` is active.
+
+#map_g_no = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map_g_no1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map_g_no2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding_g_no_res = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map_g_no, #map_g_no1, #map_g_no2], iteration_sizes = [2, 4, ?]>
+func.func @set_encoding_RESULT_avx2_generic_no_op_transpose(
+    %arg0: tensor<2x4xf32>, %k: index) -> tensor<2x4xf32, #encoding_g_no_res> attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx2,+fma", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%k}
+      : tensor<2x4xf32> -> tensor<2x4xf32, #encoding_g_no_res>
+  return %0 : tensor<2x4xf32, #encoding_g_no_res>
+}
+// CHECK-LABEL: func @set_encoding_RESULT_avx2_generic_no_op_transpose
+//       CHECK:   %[[PACK:.+]] = linalg.pack
+//  CHECK-SAME:     inner_dims_pos = [0, 1] inner_tiles = [2, 4]
+//  CHECK-SAME:     -> tensor<1x1x2x4xf32>
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[PACK]]
+//  CHECK-SAME{LITERAL}: [[0], [1], [2], [3, 4, 5]]
+//  CHECK-SAME:     : tensor<1x1x2x4xf32> into tensor<1x1x2x4x1x1xf32>
+//   CHECK-NOT:   linalg.transpose
+//       CHECK:   return %[[EXPAND]] : tensor<1x1x2x4x1x1xf32>
+
+func.func @unset_encoding_RESULT_avx2_generic_no_op_transpose(
+    %arg0: tensor<2x4xf32, #encoding_g_no_res>, %k: index) -> tensor<2x4xf32> attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx2,+fma", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %0 = iree_encoding.unset_encoding %arg0 encoding_dims{%k}
+      : tensor<2x4xf32, #encoding_g_no_res> -> tensor<2x4xf32>
+  return %0 : tensor<2x4xf32>
+}
+// CHECK-LABEL: func @unset_encoding_RESULT_avx2_generic_no_op_transpose
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape
+//  CHECK-SAME{LITERAL}: [[0], [1], [2], [3, 4, 5]]
+//  CHECK-SAME:     : tensor<1x1x2x4x1x1xf32> into tensor<1x1x2x4xf32>
+//   CHECK-NOT:   linalg.transpose
+//       CHECK:   %[[UNPACK:.+]] = linalg.unpack %[[COLLAPSE]]
+//  CHECK-SAME:     inner_dims_pos = [0, 1] inner_tiles = [2, 4]
+//       CHECK:   return %[[UNPACK]]
+
+// -----
+
 // Sub-byte LHS/RHS forces `chooseUnrolling` to also pick `intrinsics_k > 1`
 // for the generic intrinsic, so each contiguous K-group covers a whole
 // number of bytes (otherwise sub-byte elements aren't byte-addressable in

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -793,46 +793,37 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   }
 }
 
-/// Returns `v` with trailing unit dims stripped, down to but not below
-/// rank `minRank`. Emits a `vector.shape_cast` if any dim is stripped;
-/// returns `v` unchanged otherwise.
-static Value dropTrailingUnitDims(OpBuilder &builder, Location loc, Value v,
-                                  int64_t minRank) {
-  auto vt = cast<VectorType>(v.getType());
-  ArrayRef<int64_t> shape = vt.getShape();
-  int64_t newRank = shape.size();
-  while (newRank > minRank && shape[newRank - 1] == 1) {
-    --newRank;
-  }
-  if (newRank == static_cast<int64_t>(shape.size())) {
-    return v;
-  }
-  auto flatTy = VectorType::get(shape.take_front(newRank), vt.getElementType());
-  return vector::ShapeCastOp::create(builder, loc, flatTy, v);
-}
-
 /// Lowers a `DataTiledMMAAttr` whose intrinsic is one of the
 /// `MMA_GENERIC_SCALAR_1x1x1_REG*` cases directly to a single
-/// `vector.contract`. Since the intrinsic's tile shape is 1×1×1, the
-/// operand tiles after applying `intrinsics_m` / `intrinsics_n` /
-/// `intrinsics_k` are simple row-major (M, K)/(N, K)/(M, N) matmul
-/// tiles — no swizzle-based distribution is needed.
+/// `vector.contract`. Since the intrinsic's tile shape is 1×1×1, the only
+/// non-unit dims in each operand tile come from `intrinsics_{m,n,k}`, and
+/// the `Codegen::expand`/`fixupSwizzle` machinery places them in row-major
+/// (M, K) / (N, K) / (M, N) order. Collapse to that rank-2 form with
+/// `vector.shape_cast` regardless of where the non-unit dim(s) sit in the
+/// operand tile, then `shape_cast` the contract result back to the ACC
+/// tile's original shape so callers downstream see the expected type.
 static LogicalResult lowerGenericScalarToVectorContract(
     OpBuilder &builder, Location loc, IREE::CPU::DataTiledMMAAttr attr,
     ValueRange inputs, ValueRange outputs, SmallVectorImpl<Value> &results) {
   assert(isGenericScalar(attr.getIntrinsic()) &&
          "lowerGenericScalarToVectorContract only handles "
          "MMA_GENERIC_SCALAR_1x1x1_REG* intrinsics");
-  // The 1×1×1 base intrinsic means every non-unit dim in the operand tile
-  // came from `intrinsics_{m,n,k}` and is a `Codegen::TileSwizzle`
-  // `CrossIntrinsic` dim, which `Codegen::expand` placed at the start of
-  // its `expandShape` group and at memory slot 0. So all the unit dims end
-  // up at trailing positions of the per-operand tile; drop them to get the
-  // rank-2 (M, K)/(N, K)/(M, N) shape `vector.contract` expects below.
-  Value lhs = dropTrailingUnitDims(builder, loc, inputs[0], /*minRank=*/2);
-  Value rhs = dropTrailingUnitDims(builder, loc, inputs[1], /*minRank=*/2);
-  Value acc = dropTrailingUnitDims(builder, loc, outputs[0], /*minRank=*/2);
-  Type accElem = cast<VectorType>(acc.getType()).getElementType();
+  int64_t M = attr.getIntrinsicsM();
+  int64_t N = attr.getIntrinsicsN();
+  int64_t K = attr.getIntrinsicsK();
+  auto reshape = [&](Value v, ArrayRef<int64_t> targetShape) -> Value {
+    auto vt = cast<VectorType>(v.getType());
+    auto targetTy = VectorType::get(targetShape, vt.getElementType());
+    if (vt == targetTy) {
+      return v;
+    }
+    return vector::ShapeCastOp::create(builder, loc, targetTy, v);
+  };
+  Value lhs = reshape(inputs[0], {M, K});
+  Value rhs = reshape(inputs[1], {N, K});
+  auto accTy = cast<VectorType>(outputs[0].getType());
+  Value acc = reshape(outputs[0], {M, N});
+  Type accElem = accTy.getElementType();
   // For the generic intrinsic, ACC is always at least as wide as LHS/RHS,
   // and they're either all float or all integer (the cost model only picks
   // this intrinsic when element types are mutually consistent that way).
@@ -865,9 +856,10 @@ static LogicalResult lowerGenericScalarToVectorContract(
   // `iree_codegen.inner_tiled` op's own indexing maps for CPU.
   vector::IteratorType par = vector::IteratorType::parallel;
   vector::IteratorType red = vector::IteratorType::reduction;
-  results.push_back(vector::ContractionOp::create(
+  Value contractResult = vector::ContractionOp::create(
       builder, loc, lhs, rhs, acc, MapList{{m, k}, {n, k}, {m, n}},
-      ArrayRef<vector::IteratorType>{par, par, red}));
+      ArrayRef<vector::IteratorType>{par, par, red});
+  results.push_back(reshape(contractResult, accTy.getShape()));
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -214,6 +214,51 @@ module attributes { transform.with_named_sequence } {
 
 // -----
 
+// Generic-scalar with `intrinsics_n = 1` (narrow N): the ACC operand
+// arrives as rank-3 `vector<4x1x1xf32>` rather than the rank-2 `(M, N)`
+// form `vector.contract` consumes. The non-unit M dim is at position 0,
+// and the trailing two unit dims come from the swizzle's `Internal(1)`
+// placeholders for the K-side and N-side of the 1×1×1 base intrinsic.
+// The lowering must `shape_cast` the rank-3 operand into the rank-2
+// `(M, N)` shape for the contract, then `shape_cast` the contract result
+// back to the original rank-3 ACC type so the inner_tiled op's result
+// type is preserved downstream.
+
+#contraction_accesses_n = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_generic_narrow_n_f32(
+    %lhs: vector<4x1xf32>, %rhs: vector<1x1xf32>, %acc: vector<4x1x1xf32>)
+    -> vector<4x1x1xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_n,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 4, lhs_type = f32, rhs_type = f32, acc_type = f32>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<4x1xf32>, vector<1x1xf32> into vector<4x1x1xf32>
+  return %0 : vector<4x1x1xf32>
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_generic_narrow_n_f32
+//       CHECK:   %[[ACC_2D:.+]] = vector.shape_cast %{{.+}} : vector<4x1x1xf32> to vector<4x1xf32>
+//       CHECK:   %[[RES_2D:.+]] = vector.contract
+//  CHECK-SAME:     %{{.+}}, %{{.+}}, %[[ACC_2D]] : vector<4x1xf32>, vector<1x1xf32> into vector<4x1xf32>
+//       CHECK:   vector.shape_cast %[[RES_2D]] : vector<4x1xf32> to vector<4x1x1xf32>
+
+// -----
+
 // AVX-512 16×1×1 f32 (M↔N-swapped orientation of 1×16×1) with intrinsics_m=2,
 // intrinsics_n=4. The narrow side is RHS, so broadcast widens RHS 1→16; FMA
 // is LHS/RHS-symmetric so the call args don't swap.


### PR DESCRIPTION
The set_encoding pack lowering (and symmetrically the unset_encoding unpack) currently always emits

  linalg.pack → tensor.expand_shape → linalg.transpose

to apply the swizzle's `permutation` to the packed inner tile. For many swizzles the permutation only reorders unit dims relative to non-unit dims (e.g. the generic-scalar 1×1×1 MMA ACC swizzle has `expandShape = [[CrossIntrinsic(M), Internal(1)], [CrossIntrinsic(N), Internal(1)]]` with `permutation = [0, 2, 1, 3]` — swapping the `Internal(1)` placeholders past the `CrossIntrinsic` non-unit dims). The linearized memory layout of the unpermuted and permuted shapes is identical there, so the `linalg.transpose` is a no-op in terms of data movement.

Add `isSwizzlePermutationLayoutNoOp`, a predicate that detects this case (the permutation, restricted to non-unit source dims, is order-preserving), and `getSwizzleFoldedReassociation`, which — given that predicate holds — builds the reassociation that drops the `linalg.transpose`: the `tensor.expand_shape` (pack side) / `tensor.collapse_shape` (unpack side) is instead given a reassociation that lands directly on the permuted shape, partitioning the permuted inner dims into contiguous slices matching the pack's `innerTileSizes` one-to-one. Fall through to the existing expand + transpose lowering when the permutation actually reorders non-unit dims — the gfx950 scaled-matmul case for instance, where the permutation moves a size-16 dim past two size-4 dims, must keep the transpose.

The folded reshape still carries the swizzle's unit dims: the permuted inner shape is the materialized encoding type fixed by `getEncodingInfo`, which dialect conversion requires the replacement value to match exactly — dropping unit dims is not a local choice here. Hence `getSwizzleFoldedReassociation` only picks a reassociation reaching that already-fixed shape; whether the materialized type should carry unit dims at all is a separate, cross-cutting question.

This was motivated by a separate bug in
`hoistOneStaticallyBoundAllocation` (#24483): under dynamic shapes the intermediate `tensor.empty` between the pack and the transpose bufferizes to a stack alloca whose size comes from `ValueBoundsConstraintSet::computeConstantBound` on the dynamic dim, which for a workload-ordinal dim with only the default `index` umax constraint (2^53 - 1) produces a ~2^52-element static alloca, overflows i64 stride math, and lowers to `llvm.alloca poison`. Eliminating the intermediate via this fast path sidesteps the bug for the cases that hit this path; the hoist bug is real and the fix here is in addition to fixing it at the source.

Progress towards #24323.