### PR TITLE
[Codegen][CPU] Run HoistInnerTiledAccReshapes before vector lowering.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -106,6 +106,13 @@ void buildLLVMCPUVectorLoweringPipeline(
     OpPassManager &funcPassManager,
     const LLVMCPUVectorLoweringPassOptions &options) {
   funcPassManager.addPass(createDropVectorUnitDimsPass());
+  // Wrap reshape ops around `inner_tiled` in `HoistableConversionOp` pairs
+  // so they can hoist/cancel out of K-reduction loops; otherwise they
+  // remain bridges between the loop's iter args and the inner_tiled's
+  // accumulator, and the per-intrinsic conversion pairs that
+  // `LLVMCPUVirtualVectorLoweringPass` emits below fail to hoist (no
+  // direct iter_arg match) and fall back to inlining-in-place.
+  funcPassManager.addPass(createHoistInnerTiledAccReshapesPass());
   funcPassManager.addPass(createLLVMCPUVirtualVectorLoweringPass(
       LLVMCPUVirtualVectorLoweringPassOptions{options.splitVectorTransfersTo,
                                               options.enableArmI8mm}));


### PR DESCRIPTION
Mirrors the GPU pipeline (`buildLLVMGPUCodegenPassPipeline` adds this pass right before `UnrollToIntrinsicsPass`). Before this change, on CPU the reshape ops left around `iree_codegen.inner_tiled` sat between the K-reduction loop's `scf.for` iter args and the op's accumulator operand, so the per-tile `HoistableConversionOp` pairs that the inner_tiled lowering wraps around its ACC distribute/reassemble couldn't satisfy
`HoistConversionFromLoopPattern`'s strict iter-arg match. They failed to hoist, got inlined in place, and
`EliminateHoistableConversions` fired a `hoistable_conversion was not hoisted or cancelled; inlining in place` remark on every CPU matmul build using the inner_tiled path.

Running `HoistInnerTiledAccReshapes` before
`LLVMCPUVirtualVectorLoweringPass` wraps the prefix/suffix reshape ops (transpose, shape_cast, broadcast) around the inner_tiled as `acc_reshape_to_intrinsic` / `acc_reshape_from_intrinsic` hoistable conversions and runs the elimination over them. The reshapes hoist out of the K loop, the inner_tiled's accumulator is fed directly by the iter arg, and the per-tile conversion pairs emitted later in the vector lowering see direct iter-arg inputs and hoist cleanly.

Progress towards #24323.