### PR TITLE
[Codegen][CPU] Support distinct LHS/RHS types in e2e matmul test framework.

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -259,6 +259,38 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ("bf16", "f32"),
 ]]
 
+# Mixed unsigned-LHS / signed-RHS i8 matmul. The test framework otherwise
+# only generates symmetric-type matmuls. No matching MMA intrinsic exists
+# yet on any of the `target_cpu_features_variants` here — the test
+# exercises the standard codegen fallback through the data-tiling +
+# inner-tiled pipeline.
+iree_generated_e2e_runner_test(
+    name = "e2e_matmul_cpu_dt_inner_tiled_ui8_i8_i32",
+    compiler_flags = [
+        "--iree-opt-data-tiling",
+        "--iree-llvmcpu-enable-inner-tiled",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs=ui8",
+        "--rhs=i8",
+        "--acc_type=i32",
+        # easy_large_static (M=N=512): mixed LHS/RHS types lower to a
+        # `linalg.generic`, and unit-dim folding rewrites narrow-M/N
+        # forms of that into rank-reduced contractions that the
+        # inner_tiled lowering doesn't handle.
+        "--shapes=easy_large_static",
+    ],
+    target_backends_and_drivers = [
+        ("llvm-cpu", "local-task"),
+    ],
+    target_cpu_features_variants = [
+        "generic",
+    ],
+    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
+    test_type = "matmul",
+)
+
 # LLVMCPU, data-tiling, data-tiling + ukernels + late materialization.
 [iree_generated_e2e_runner_test(
     name = "e2e_matmul_cpu_experimental_dt%s_%s_%s" % (

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -714,6 +714,31 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_cpu_dt_inner_tiled_ui8_i8_i32
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs=ui8"
+    "--rhs=i8"
+    "--acc_type=i32"
+    "--shapes=easy_large_static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-inner-tiled"
+  TARGET_CPU_FEATURES_VARIANTS
+    "generic"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_cpu_experimental_dt_i8_i32
   TEST_TYPE
     matmul

--- a/tests/e2e/matmul/generate_code.py
+++ b/tests/e2e/matmul/generate_code.py
@@ -16,16 +16,40 @@ from tests.e2e.matmul.compilation_info import *
 from tests.e2e.matmul.generate_code_mx import *
 
 
+# IR storage type for `t`: `ui8` → signless `i8` (the unsigned semantics
+# live on `arith.extui` in the linalg body and surface via encoding
+# inference).
+def _storage_type(t: MatrixElemTypeId) -> str:
+    if t == MatrixElemTypeId.UI8:
+        return "i8"
+    return t.value
+
+
+# True when the matmul must be expressed as `linalg.generic` (explicit
+# body) rather than named `linalg.matmul`: distinct LHS/RHS types, or an
+# unsigned operand.
+def _needs_linalg_generic(
+    lhs_type: MatrixElemTypeId, rhs_type: MatrixElemTypeId
+) -> bool:
+    if lhs_type != rhs_type:
+        return True
+    if lhs_type == MatrixElemTypeId.UI8:
+        return True
+    return False
+
+
 # Helper for generate_function.
 # Generates a name for a test function in the generated MLIR code.
 def generate_function_name(
-    lhs_rhs_type: MatrixElemTypeId,
+    lhs_type: MatrixElemTypeId,
+    rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     shapes: TestInputMatricesShapes,
     accumulate: bool,
     compilation_info: typing.Optional[CompilationInfo] = None,
 ):
-    input_t = lhs_rhs_type.value
+    lhs_t = lhs_type.value
+    rhs_t = rhs_type.value
     acc_t = acc_type.value
     lhs_r = int_or_DYN(shapes.lhs_rows)
     lhs_c = int_or_DYN(shapes.lhs_cols)
@@ -45,8 +69,8 @@ def generate_function_name(
     matmul_kind = "matmul_accumulate" if accumulate else "matmul"
 
     return (
-        f"{matmul_kind}_{lhs_r}x{lhs_c}x{input_t}_times_"
-        + f"{rhs_r}x{rhs_c}x{input_t}_into_{acc_r}x{acc_c}x{acc_t}{info}"
+        f"{matmul_kind}_{lhs_r}x{lhs_c}x{lhs_t}_times_"
+        + f"{rhs_r}x{rhs_c}x{rhs_t}_into_{acc_r}x{acc_c}x{acc_t}{info}"
     )
 
 
@@ -54,7 +78,8 @@ def generate_function_name(
 # The generated function will take the same arguments as linalg.matmul variants
 # and will just call linalg.matmul variants with them, returning its result.
 def generate_function(
-    lhs_rhs_type: MatrixElemTypeId,
+    lhs_type: MatrixElemTypeId,
+    rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     mx_scale_type: MatrixElemTypeId,
     mx_block_size: int,
@@ -64,8 +89,10 @@ def generate_function(
     compilation_info: Optional[CompilationInfo] = None,
 ):
     if mx_scale_type:
+        # MX matmul currently only supports same-type inputs.
+        assert lhs_type == rhs_type, "MX matmul requires lhs_type == rhs_type"
         return generate_function_mx(
-            lhs_rhs_type=lhs_rhs_type,
+            lhs_rhs_type=lhs_type,
             acc_type=acc_type,
             mx_scale_type=mx_scale_type,
             mx_block_size=mx_block_size,
@@ -77,7 +104,8 @@ def generate_function(
 
     shapes = generate_shapes(shape, transpose_rhs, dynamicities)
     func_name = generate_function_name(
-        lhs_rhs_type=lhs_rhs_type,
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
         acc_type=acc_type,
         shapes=shapes,
         accumulate=shape.accumulate,
@@ -90,8 +118,11 @@ def generate_function(
     acc_r = int_or_question_mark(shapes.acc_rows)
     acc_c = int_or_question_mark(shapes.acc_cols)
 
-    lhs_tensor_type = f"tensor<{lhs_r}x{lhs_c}x{lhs_rhs_type.value}>"
-    rhs_tensor_type = f"tensor<{rhs_r}x{rhs_c}x{lhs_rhs_type.value}>"
+    # Use signless storage in IR (`ui8` becomes `i8` here) — the unsigned
+    # semantics are expressed by `arith.extui` in the linalg body, which the
+    # encoding system's signedness inference picks up.
+    lhs_tensor_type = f"tensor<{lhs_r}x{lhs_c}x{_storage_type(lhs_type)}>"
+    rhs_tensor_type = f"tensor<{rhs_r}x{rhs_c}x{_storage_type(rhs_type)}>"
     acc_tensor_type = f"tensor<{acc_r}x{acc_c}x{acc_type.value}>"
 
     (
@@ -141,11 +172,52 @@ def generate_function(
     indexing_maps_attr = ""
     if transpose_rhs:
         indexing_maps_attr = "indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>]"
-    func_definition += (
-        f"  %result = linalg.matmul {indexing_maps_attr} {compilation_info_attr} ins(%lhs, %rhs: {lhs_tensor_type}, {rhs_tensor_type}) outs(%acc: {acc_tensor_type}) -> {acc_tensor_type}\n"
-        f"  util.return %result: {acc_tensor_type}\n"
-        f"}}\n"
-    )
+
+    if _needs_linalg_generic(lhs_type, rhs_type):
+        # `linalg.generic` body widens each operand to the accumulator
+        # type. `arith.extui` for unsigned, `arith.extsi` for signed —
+        # the encoding system's signedness inference reads this to route
+        # `ui8` operands to the right MMA intrinsic (e.g. vpdpbusd).
+        lhs_storage = _storage_type(lhs_type)
+        rhs_storage = _storage_type(rhs_type)
+        acc_t = acc_type.value
+        lhs_ext = "arith.extui" if lhs_type == MatrixElemTypeId.UI8 else "arith.extsi"
+        rhs_ext = "arith.extui" if rhs_type == MatrixElemTypeId.UI8 else "arith.extsi"
+        # Iterators: M, N parallel; K reduction. Maps: (m,k), (k,n)/(n,k),
+        # (m,n) — RHS uses (n,k) when transpose_rhs is set.
+        if transpose_rhs:
+            maps = (
+                "affine_map<(d0, d1, d2) -> (d0, d2)>, "
+                "affine_map<(d0, d1, d2) -> (d1, d2)>, "
+                "affine_map<(d0, d1, d2) -> (d0, d1)>"
+            )
+        else:
+            maps = (
+                "affine_map<(d0, d1, d2) -> (d0, d2)>, "
+                "affine_map<(d0, d1, d2) -> (d2, d1)>, "
+                "affine_map<(d0, d1, d2) -> (d0, d1)>"
+            )
+        func_definition += (
+            f"  %result = linalg.generic {{indexing_maps = [{maps}], "
+            f'iterator_types = ["parallel", "parallel", "reduction"]}} '
+            f"{compilation_info_attr} ins(%lhs, %rhs: {lhs_tensor_type}, "
+            f"{rhs_tensor_type}) outs(%acc: {acc_tensor_type}) {{\n"
+            f"  ^bb0(%a: {lhs_storage}, %b: {rhs_storage}, %c: {acc_t}):\n"
+            f"    %a_ext = {lhs_ext} %a : {lhs_storage} to {acc_t}\n"
+            f"    %b_ext = {rhs_ext} %b : {rhs_storage} to {acc_t}\n"
+            f"    %prod = arith.muli %a_ext, %b_ext : {acc_t}\n"
+            f"    %sum = arith.addi %c, %prod : {acc_t}\n"
+            f"    linalg.yield %sum : {acc_t}\n"
+            f"  }} -> {acc_tensor_type}\n"
+            f"  util.return %result: {acc_tensor_type}\n"
+            f"}}\n"
+        )
+    else:
+        func_definition += (
+            f"  %result = linalg.matmul {indexing_maps_attr} {compilation_info_attr} ins(%lhs, %rhs: {lhs_tensor_type}, {rhs_tensor_type}) outs(%acc: {acc_tensor_type}) -> {acc_tensor_type}\n"
+            f"  util.return %result: {acc_tensor_type}\n"
+            f"}}\n"
+        )
 
     signature = ", ".join([ty for name, ty in args]) + " -> {acc_tensor_type}"
     import_declaration = (
@@ -168,7 +240,8 @@ call_id = 0
 # as a dictionary to be passed to yaml.dump.
 def generate_call(
     function: MLIRFunction,
-    lhs_rhs_type: MatrixElemTypeId,
+    lhs_type: MatrixElemTypeId,
+    rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     mx_scale_type: MatrixElemTypeId,
     mx_block_size: int,
@@ -178,7 +251,7 @@ def generate_call(
     if mx_scale_type:
         return generate_call_mx(
             function=function,
-            lhs_rhs_type=lhs_rhs_type,
+            lhs_rhs_type=lhs_type,
             acc_type=acc_type,
             mx_scale_type=mx_scale_type,
             mx_block_size=mx_block_size,
@@ -210,8 +283,8 @@ def generate_call(
         rhs_shape = [shape.k, shape.n]
         transpose_rhs = 0
     matmul_args = [
-        ("lhs", lhs_shape, lhs_rhs_type),
-        ("rhs", rhs_shape, lhs_rhs_type),
+        ("lhs", lhs_shape, lhs_type),
+        ("rhs", rhs_shape, rhs_type),
     ]
     check_args = matmul_args.copy()
 

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -105,7 +105,8 @@ def get_test_shapes(shapes_id: ShapesId, accumulate=True):
 
 # Generates all output files' contents as strings.
 def generate(
-    lhs_rhs_type: MatrixElemTypeId,
+    lhs_type: MatrixElemTypeId,
+    rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     mx_scale_type: MatrixElemTypeId,
     mx_block_size: int,
@@ -118,12 +119,13 @@ def generate(
     calls = []
 
     for compilation_info in get_test_compilation_infos(
-        compilation_info_id, lhs_rhs_type, acc_type
+        compilation_info_id, lhs_type, acc_type
     ):
         for shape in get_test_shapes(shapes_id, accumulate):
             for dynamicities in get_dynamicities(shapes_id):
                 function = generate_function(
-                    lhs_rhs_type=lhs_rhs_type,
+                    lhs_type=lhs_type,
+                    rhs_type=rhs_type,
                     acc_type=acc_type,
                     mx_scale_type=mx_scale_type,
                     mx_block_size=mx_block_size,
@@ -142,7 +144,8 @@ def generate(
                 calls.append(
                     generate_call(
                         function=function,
-                        lhs_rhs_type=lhs_rhs_type,
+                        lhs_type=lhs_type,
+                        rhs_type=rhs_type,
                         acc_type=acc_type,
                         mx_scale_type=mx_scale_type,
                         mx_block_size=mx_block_size,
@@ -168,26 +171,45 @@ def parse_arguments():
         help="Path of output .mlir file containing the calls",
         required=True,
     )
+    elem_type_choices = [
+        "i32",
+        "i8",
+        "ui8",
+        "f64",
+        "f32",
+        "f16",
+        "bf16",
+        "f8E5M2",
+        "f8E4M3FN",
+        "f8E5M2FNUZ",
+        "f8E4M3FNUZ",
+        "f6E3M2FN",
+        "f6E2M3FN",
+        "f4E2M1FN",
+    ]
+    # Legacy single-flag form: same type for LHS and RHS. Mutually exclusive
+    # with the per-operand --lhs / --rhs pair below; exactly one set of flags
+    # must be provided.
     parser.add_argument(
         "--lhs_rhs_type",
         type=str,
-        choices=[
-            "i32",
-            "i8",
-            "f64",
-            "f32",
-            "f16",
-            "bf16",
-            "f8E5M2",
-            "f8E4M3FN",
-            "f8E5M2FNUZ",
-            "f8E4M3FNUZ",
-            "f6E3M2FN",
-            "f6E2M3FN",
-            "f4E2M1FN",
-        ],
-        help="Numeric type of input LHS and RHS matrices",
-        required=True,
+        choices=elem_type_choices,
+        help="Numeric type of input LHS and RHS matrices (when both are equal)",
+        required=False,
+    )
+    parser.add_argument(
+        "--lhs",
+        type=str,
+        choices=elem_type_choices,
+        help="Numeric type of the LHS matrix. Use with --rhs.",
+        required=False,
+    )
+    parser.add_argument(
+        "--rhs",
+        type=str,
+        choices=elem_type_choices,
+        help="Numeric type of the RHS matrix. Use with --lhs.",
+        required=False,
     )
     parser.add_argument(
         "--acc_type",
@@ -313,8 +335,25 @@ def main(args):
     ShapesId.set_custom_mnk(shapes_id, args.mnk)
     ShapesId.set_dynamicity(shapes_id, args.mnk_dynamicities)
 
+    # Resolve LHS/RHS types: exactly one of {--lhs_rhs_type} or {--lhs and --rhs}.
+    lhs_rhs_set = args.lhs_rhs_type is not None
+    per_op_set = args.lhs is not None or args.rhs is not None
+    if lhs_rhs_set == per_op_set:
+        raise ValueError(
+            "specify exactly one of --lhs_rhs_type or the (--lhs, --rhs) pair"
+        )
+    if per_op_set:
+        if args.lhs is None or args.rhs is None:
+            raise ValueError("--lhs and --rhs must be specified together")
+        lhs_type = MatrixElemTypeId(args.lhs)
+        rhs_type = MatrixElemTypeId(args.rhs)
+    else:
+        lhs_type = MatrixElemTypeId(args.lhs_rhs_type)
+        rhs_type = lhs_type
+
     (functions, calls) = generate(
-        lhs_rhs_type=MatrixElemTypeId(args.lhs_rhs_type),
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
         acc_type=MatrixElemTypeId(args.acc_type),
         mx_scale_type=args.mx_scale_type,
         mx_block_size=args.mx_block_size,

--- a/tools/testing/e2e/iree-e2e-matmul-test.cc
+++ b/tools/testing/e2e/iree-e2e-matmul-test.cc
@@ -47,6 +47,7 @@
 REFERENCE_MATMUL(float, float, float, float)
 REFERENCE_MATMUL(double, double, double, double)
 REFERENCE_MATMUL(int8_t, int8_t, int32_t, int32_t)
+REFERENCE_MATMUL(uint8_t, int8_t, int32_t, int32_t)
 REFERENCE_MATMUL(int32_t, int32_t, int32_t, int32_t)
 
 // Reference mamtul for the f16 input, f16 accumulation, and f16 result.
@@ -164,6 +165,16 @@ static iree_status_t reference_matmul_element(
         m_size, k_size, n_size, lhs_type, rhs_type, acc_type, transpose_rhs,
         (const double*)lhs_data, (const double*)rhs_data,
         (const double*)acc_data, (double*)result_data, m, n);
+  } else if (lhs_type == IREE_HAL_ELEMENT_TYPE_UINT_8 &&
+             iree_hal_element_type_is_integer(rhs_type, 8) &&
+             iree_hal_element_type_is_integer(acc_type, 32)) {
+    // Mixed unsigned-LHS / signed-RHS i8 matmul (e.g. x86 vpdpbusd). IR
+    // storage is signless i8; the buffer-view's UINT_8 LHS carries the
+    // signedness.
+    reference_matmul_uint8_t_int8_t_int32_t_int32_t(
+        m_size, k_size, n_size, lhs_type, rhs_type, acc_type, transpose_rhs,
+        (const uint8_t*)lhs_data, (const int8_t*)rhs_data,
+        (const int32_t*)acc_data, (int32_t*)result_data, m, n);
   } else if (iree_hal_element_type_is_integer(lhs_type, 8) &&
              iree_hal_element_type_is_integer(rhs_type, 8) &&
              iree_hal_element_type_is_integer(acc_type, 32)) {


### PR DESCRIPTION
The framework so far only generated symmetric-type matmuls (LHS and RHS of the same type via `--lhs_rhs_type`). This generalizes it to support `--lhs` and `--rhs` separately so we can test asymmetric-type intrinsics like the upcoming x86 AVX-512 VNNI vpdpbusd (LHS=ui8, RHS=i8 → ACC=i32).

- `generate_e2e_matmul_tests.py`: replace `--lhs_rhs_type` with the per-operand `--lhs` / `--rhs` pair (legacy form still accepted; the CLI requires exactly one form). Adds a `ui8` choice. Plumbing for separate `lhs_type`/`rhs_type` is threaded through `generate()` / `generate_function()` / `generate_call()`.
- `generate_code.py`: emit a `linalg.generic` (with `arith.extui` / `arith.extsi` widening) when LHS != RHS or an operand is unsigned; buffer-view printing uses the `ui8` HAL element type for unsigned operands.
- `iree-e2e-matmul-test.cc`: new `REFERENCE_MATMUL(uint8_t, int8_t, int32_t, int32_t)` reference and matching dispatch arm for `IREE_HAL_ELEMENT_TYPE_UINT_8` LHS / signed-i8 RHS.

New test `e2e_matmul_cpu_dt_inner_tiled_ui8_i8_i32` exercises the generated ui8/i8 matmul through the data-tiling + inner-tiled pipeline. No matching hardware MMA intrinsic exists yet (this commit is purely framework), so it only runs on the `generic` CPU variant and falls through to the type-polymorphic generic-scalar MMA. A follow-up PR adds the vpdpbusd MMA and an `avx512vnni` variant.

Progress towards #24323.