### PR TITLE
[Codegen][CPU] Drop the power-of-two cap on `chooseUnrolling`.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_aarch64.mlir
@@ -609,11 +609,11 @@ func.func @matmul_lowering_i8i4i32_aarch64_i8mm(
 //
 // FP4 register pressure: K=2 is the smallest power-of-two K that makes
 // K*4 a multiple of 8 (for byte-addressable packed groups). Inside the
-// 16-register budget the cost model lands on a square (im=2, in=2, ik=2)
-// tile (2*2 + 2*2 + 2*2 = 12 registers), which wins on arithmetic
-// intensity. Whether the lowering can actually densely pack f4E2M1FN
-// values into bytes today is orthogonal — the framework only insists
-// that the packed K-group be byte-aligned.
+// 16-register budget the cost model lands on (im=2, in=3, ik=2)
+// (2*3 + 2*2 + 3*2 = 16 registers, saturating the budget). Whether the
+// lowering can actually densely pack f4E2M1FN values into bytes today is
+// orthogonal — the framework only insists that the packed K-group be
+// byte-aligned.
 
 #map_g_fp4 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map_g_fp4_1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -634,7 +634,7 @@ func.func @matmul_fp4_f32_aarch64_generic(
 }
 // CHECK-LABEL: func @matmul_fp4_f32_aarch64_generic(
 //       CHECK:   %[[INNER_FP4:.+]] = iree_codegen.inner_tiled
-//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 2, intrinsics_k = 2, lhs_type = f4E2M1FN, rhs_type = f4E2M1FN, acc_type = f32>
+//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 3, intrinsics_k = 2, lhs_type = f4E2M1FN, rhs_type = f4E2M1FN, acc_type = f32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_x86_64.mlir
@@ -175,7 +175,8 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
   %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #encoding_result_it> -> tensor<?x?xf32>{%d0, %d1}
   return %5 : tensor<?x?xf32>
 }
-//   CHECK-DAG: #[[$MAP_INNER:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
+//   CHECK-DAG: #[[$MAP_INNER_M:.+]] = affine_map<()[s0] -> (s0 ceildiv 29)>
+//   CHECK-DAG: #[[$MAP_INNER_N:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
 //   CHECK-DAG: #[[$MAP_LHS:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 //   CHECK-DAG: #[[$MAP_RHS:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 //   CHECK-DAG: #[[$MAP_ACC:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -186,8 +187,8 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
-//   CHECK-DAG:   %[[OUT_D0:.+]] = affine.apply #[[$MAP_INNER]]()[%[[D0]]]
-//   CHECK-DAG:   %[[OUT_D1:.+]] = affine.apply #[[$MAP_INNER]]()[%[[D1]]]
+//   CHECK-DAG:   %[[OUT_D0:.+]] = affine.apply #[[$MAP_INNER_M]]()[%[[D0]]]
+//   CHECK-DAG:   %[[OUT_D1:.+]] = affine.apply #[[$MAP_INNER_N]]()[%[[D1]]]
 //   CHECK-DAG:   %[[PACK_LHS:.+]] = linalg.pack {{.*}}%[[ARG0]]
 // LHS swizzle splits the inner M tile into (intrinsics_m, M_intrinsic),
 // materialized as an `expand_shape` after the pack. ACC swizzle does
@@ -195,7 +196,7 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
 //   CHECK-DAG:   %[[EXPAND_LHS:.+]] = tensor.expand_shape %[[PACK_LHS]]
 //       CHECK:   %[[PACK_RHS:.+]] = linalg.pack
 //  CHECK-SAME:     %[[ARG1]]
-//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[OUT_D0]], %[[OUT_D1]]) : tensor<?x?x16x1x16xf32>
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[OUT_D0]], %[[OUT_D1]]) : tensor<?x?x29x1x16xf32>
 //       CHECK:   %[[FILL:.+]] = linalg.fill
 //  CHECK-SAME:       outs(%[[EMPTY]] :
 //       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled ins(%[[EXPAND_LHS]], %[[PACK_RHS]]) outs(%[[FILL]])
@@ -204,7 +205,7 @@ func.func @pack_gemm_fill_dynamic_inner_tiled_avx512(%arg0 : tensor<?x?xf32>, %a
 // must label its RHS operand with the matching `(d1, d2)` map, otherwise the
 // verifier rejects the op with "shape does not match iteration bounds".
 //  CHECK-SAME:       indexing_maps = [#[[$MAP_LHS]], #[[$MAP_RHS]], #[[$MAP_ACC]]]
-//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 16>, semantics = #iree_cpu.mma_semantics<>
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, intrinsics_m = 29>, semantics = #iree_cpu.mma_semantics<>
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[INNER]]
 //       CHECK:   %[[UNPACK:.+]] = linalg.unpack %[[COLLAPSE]]
 //       CHECK:   return %[[UNPACK]]
@@ -238,13 +239,13 @@ func.func @unset_encoding_matmul_RESULT_inner_tiled_avx512(%arg0: tensor<127x255
 // CHECK-LABEL: func @set_encoding_matmul_LHS_inner_tiled_avx512(
 //  CHECK-SAME:   %[[INPUT:[a-zA-Z0-9]+]]: tensor<127x255xf32>
 //   CHECK-DAG:   %[[CST:.+]] = arith.constant 0.0
-//       CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<8x255x16x1xf32>
-//       CHECK:   %[[PACK:.+]] = linalg.pack %[[INPUT]] padding_value(%[[CST]] : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %[[EMPTY]] : tensor<127x255xf32> -> tensor<8x255x16x1xf32>
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<5x255x29x1xf32>
+//       CHECK:   %[[PACK:.+]] = linalg.pack %[[INPUT]] padding_value(%[[CST]] : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [29, 1] into %[[EMPTY]] : tensor<127x255xf32> -> tensor<5x255x29x1xf32>
 // LHS swizzle splits the inner M tile into (intrinsics_m, M_intrinsic),
 // adding a trailing unit dim from M_intrinsic=1.
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[PACK]]
-//  CHECK-SAME:     : tensor<8x255x16x1xf32> into tensor<8x255x16x1x1xf32>
-//       CHECK:   return %[[EXPAND]] : tensor<8x255x16x1x1xf32>
+//  CHECK-SAME:     : tensor<5x255x29x1xf32> into tensor<5x255x29x1x1xf32>
+//       CHECK:   return %[[EXPAND]] : tensor<5x255x29x1x1xf32>
 // CHECK-LABEL: func @set_encoding_matmul_RHS_inner_tiled_avx512(
 //  CHECK-SAME:   %[[INPUT_R:[a-zA-Z0-9]+]]: tensor<127x255xf32>
 //   CHECK-DAG:   %[[CST_R:.+]] = arith.constant 0.0
@@ -255,11 +256,11 @@ func.func @unset_encoding_matmul_RESULT_inner_tiled_avx512(%arg0: tensor<127x255
 // CHECK-LABEL: func @unset_encoding_matmul_RESULT_inner_tiled_avx512(
 // ACC arrives in the swizzle-expanded rank-5 layout and is collapsed
 // back to rank-2 (M, N) inner before `unpack`.
-//  CHECK-SAME:   %[[PACKED:[a-zA-Z0-9]+]]: tensor<8x16x16x1x16xf32>
+//  CHECK-SAME:   %[[PACKED:[a-zA-Z0-9]+]]: tensor<5x16x29x1x16xf32>
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[PACKED]]
-//  CHECK-SAME:     : tensor<8x16x16x1x16xf32> into tensor<8x16x16x16xf32>
+//  CHECK-SAME:     : tensor<5x16x29x1x16xf32> into tensor<5x16x29x16xf32>
 //       CHECK:   %[[EMPTY_U:.+]] = tensor.empty() : tensor<127x255xf32>
-//       CHECK:   %[[UNPACK:.+]] = linalg.unpack %[[COLLAPSE]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 16] into %[[EMPTY_U]] : tensor<8x16x16x16xf32> -> tensor<127x255xf32>
+//       CHECK:   %[[UNPACK:.+]] = linalg.unpack %[[COLLAPSE]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [29, 16] into %[[EMPTY_U]] : tensor<5x16x29x16xf32> -> tensor<127x255xf32>
 //       CHECK:   return %[[UNPACK]]
 
 // -----
@@ -292,13 +293,12 @@ func.func @matmul_bf16_f32_avx2_generic(
 // the chosen `_REG*` enum case (16 here). One element per register, so the
 // register pressure is `intrinsics_m * intrinsics_n` (ACC) +
 // `intrinsics_m` (LHS) + `intrinsics_n` (RHS). Matmul dims are dynamic
-// here, so all three dims are free; arithmetic-intensity tie-breaking
-// favors approximately-square tiles. (im=2, in=4) and (im=4, in=2) tie at
-// intensity 8/6 — the search picks (im=2, in=4) (lower im first), packing
-// 8 + 2 + 4 = 14 registers within 16.
+// here, so all three dims are free; the arithmetic-intensity formula
+// `effM*effN/(effM+effN)` lands on (im=3, in=3): 3*3 + 3 + 3 = 15
+// registers within 16, intensity 9/6 = 1.5.
 // CHECK-LABEL: func @matmul_bf16_f32_avx2_generic(
 //       CHECK:   %[[INNER_G:.+]] = iree_codegen.inner_tiled
-//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 4, lhs_type = bf16, rhs_type = bf16, acc_type = f32>
+//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 3, intrinsics_n = 3, lhs_type = bf16, rhs_type = bf16, acc_type = f32>
 
 // -----
 
@@ -363,8 +363,8 @@ func.func @unset_encoding_RESULT_avx2_generic_no_op_transpose(
 // the packed layout). Smallest power-of-two K with K*4 % 8 == 0 is K = 2.
 // LHS pressure becomes `intrinsics_m * intrinsics_k`, RHS pressure
 // `intrinsics_n * intrinsics_k`, ACC `intrinsics_m * intrinsics_n`. Inside
-// `_REG16`'s budget, (m=2, n=2, k=2) packs 2·2 + 2·2 + 2·2 = 12 registers
-// and wins on arithmetic intensity (4/4 = 1.0).
+// `_REG16`'s budget, (m=2, n=3, k=2) packs 2·3 + 2·2 + 3·2 = 16 registers
+// (saturating the budget), intensity 6/5 = 1.2.
 
 #map_g4 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map_g4_1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -385,7 +385,7 @@ func.func @matmul_i4_i32_avx2_generic(
 }
 // CHECK-LABEL: func @matmul_i4_i32_avx2_generic(
 //       CHECK:   %[[INNER_G4:.+]] = iree_codegen.inner_tiled
-//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 2, intrinsics_k = 2, lhs_type = i4, rhs_type = i4, acc_type = i32>
+//  CHECK-SAME:     kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16, intrinsics_m = 2, intrinsics_n = 3, intrinsics_k = 2, lhs_type = i4, rhs_type = i4, acc_type = i32>
 
 // -----
 
@@ -393,11 +393,11 @@ func.func @matmul_i4_i32_avx2_generic(
 // M↔N-swapped orientation MMA_X86_AVX512_16x1x1_F32_F32 (rather than the
 // natural 1x16x1) — the static N=8 caps natural usefulOps to 8, while the
 // transposed orientation fully uses 16 lanes on the M side. Unrolling lands
-// on intrinsics_m=2, intrinsics_n=8 (M_inner=32, N_inner=8). Each operand's
+// on intrinsics_m=3, intrinsics_n=8 (M_inner=48, N_inner=8). Each operand's
 // pack inherits the intrinsic's natural (outer, inner) ordering — for the
 // 16x1x1 intrinsic, the LHS inner is (M=16, K=1), the RHS inner is (N=1, K=1),
 // and the ACC inner is (M=16, N=1). After cross-intrinsic unrolling, the ACC
-// is stored in physical (M=32, N=8) order, the way row-major matmul tiles are.
+// is stored in physical (M=48, N=8) order, the way row-major matmul tiles are.
 
 #map_t = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map_t1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -410,18 +410,18 @@ func.func @unset_encoding_RESULT_inner_tiled_avx512_narrow_n(%arg0: tensor<127x2
   return %0 : tensor<127x255xf32>
 }
 // CHECK-LABEL: func @unset_encoding_RESULT_inner_tiled_avx512_narrow_n(
-// The pre-transposed ACC swizzle here is non-identity: with intrinsics_m=2
+// The pre-transposed ACC swizzle here is non-identity: with intrinsics_m=3
 // and intrinsics_n=8, the swizzle's permutation places the cross-intrinsic
 // N dim (size 8) before the M dims. The ACC operand arrives in this
-// layout (`tensor<4x32x2x8x16x1>`: outer M_iter=4, N_iter=32 + inner
-// intrinsics_m=2, intrinsics_n=8, M_intrinsic=16, N_intrinsic=1), and is
-// transposed + collapsed back to rank-2 (M=32, N=8) inner before `unpack`.
-//  CHECK-SAME:   %[[PACKED_T:[a-zA-Z0-9]+]]: tensor<4x32x2x8x16x1xf32>
+// layout (`tensor<3x32x3x8x16x1>`: outer M_iter=3, N_iter=32 + inner
+// intrinsics_m=3, intrinsics_n=8, M_intrinsic=16, N_intrinsic=1), and is
+// transposed + collapsed back to rank-2 (M=48, N=8) inner before `unpack`.
+//  CHECK-SAME:   %[[PACKED_T:[a-zA-Z0-9]+]]: tensor<3x32x3x8x16x1xf32>
 //       CHECK:   %[[TRANSPOSED:.+]] = linalg.transpose ins(%[[PACKED_T]]
 //       CHECK:   %[[COLLAPSE_T:.+]] = tensor.collapse_shape %[[TRANSPOSED]]
-//  CHECK-SAME:     into tensor<4x32x32x8xf32>
+//  CHECK-SAME:     into tensor<3x32x48x8xf32>
 //       CHECK:   %[[UNPACK_T:.+]] = linalg.unpack %[[COLLAPSE_T]]
-//  CHECK-SAME:     outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 8]
+//  CHECK-SAME:     outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [48, 8]
 //       CHECK:   return %[[UNPACK_T]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -330,7 +330,7 @@ SmallVector<bool> LoweringConfigAttr::getVectorScalableFlags() const {
 // If you're trying to add support for a new intrinsic that doesn't have a
 // row-major tile layout, don't look at this function, go directly to
 // getIntrinsicSwizzle.
-static std::optional<std::tuple<int64_t, int64_t, int64_t>>
+std::optional<std::tuple<int64_t, int64_t, int64_t>>
 getRowMajorTilesMNKShape(MMAIntrinsic intrinsic) {
   using Tuple = std::tuple<int64_t, int64_t, int64_t>;
   switch (intrinsic) {
@@ -366,6 +366,10 @@ getRowMajorTilesMNKShape(MMAIntrinsic intrinsic) {
   case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return Tuple{16, 1, 2};
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
+    return Tuple{1, 16, 4};
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
+    return Tuple{16, 1, 4};
   default:
     if (isGenericScalar(intrinsic)) {
       return Tuple{1, 1, 1};
@@ -539,8 +543,8 @@ Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
   return swizzle;
 }
 
-static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
-                                                       MMAIntrinsic intrinsic) {
+std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
+                                                MMAIntrinsic intrinsic) {
   Type f64 = Float64Type::get(ctx);
   Type f32 = Float32Type::get(ctx);
   Type f16 = Float16Type::get(ctx);
@@ -579,6 +583,13 @@ static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
   case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return {i8, i8, i32};
+  // vpdpbusd: returned types preserve signedness for the cost model to
+  // match against the encoding's `element_types`; tile types in IR are
+  // signless and get stripped in `getUndistributedTileTypes` below.
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
+    return {IntegerType::get(ctx, 8, IntegerType::Unsigned), i8, i32};
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
+    return {i8, IntegerType::get(ctx, 8, IntegerType::Unsigned), i32};
   case MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32:
   case MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32:
     return {f32, f32, f32};
@@ -601,15 +612,7 @@ static std::tuple<Type, Type, Type>
 getABCElementTypes(MLIRContext *context, IREE::CPU::DataTiledMMAAttr attr) {
   MMAIntrinsic intrinsic = attr.getIntrinsic();
   if (isGenericScalar(intrinsic)) {
-    auto signless = [&](Type t) -> Type {
-      if (auto intTy = dyn_cast_if_present<IntegerType>(t);
-          intTy && !intTy.isSignless()) {
-        return IntegerType::get(context, intTy.getWidth());
-      }
-      return t;
-    };
-    return {signless(attr.getLhsType()), signless(attr.getRhsType()),
-            signless(attr.getAccType())};
+    return {attr.getLhsType(), attr.getRhsType(), attr.getAccType()};
   }
   return getABCElementTypes(context, intrinsic);
 }
@@ -636,6 +639,18 @@ void DataTiledMMAAttr::getUndistributedTileTypes(
     return;
   }
   auto [aType, bType, cType] = getABCElementTypes(ctx, *this);
+  // Tile types in IR are signless (IREE convention); strip the signedness
+  // that `getABCElementTypes` carries for cost-model matching.
+  auto signless = [&](Type t) -> Type {
+    if (auto intTy = dyn_cast_if_present<IntegerType>(t);
+        intTy && !intTy.isSignless()) {
+      return IntegerType::get(ctx, intTy.getWidth());
+    }
+    return t;
+  };
+  aType = signless(aType);
+  bType = signless(bType);
+  cType = signless(cType);
   result.assign({Codegen::getTileVectorType(getSwizzle(*this, 0), aType),
                  Codegen::getTileVectorType(getSwizzle(*this, 1), bType),
                  Codegen::getTileVectorType(getSwizzle(*this, 2), cType)});
@@ -741,11 +756,12 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   Type f32 = builder.getF32Type();
   Type i16 = builder.getI16Type();
   Type accType = acc.getType();
-  // The x86 MMAs supported here are LHS/RHS-symmetric (FMA, dpbf16ps,
-  // vpdpwssd, pmaddw), so natural and swapped orientations share the same
-  // LLVM intrinsic and arg order — after the broadcast above both operands
-  // have the same lane count. Asymmetric intrinsics (e.g. vpdpbusd) would
-  // need per-orientation arg-routing and aren't supported.
+  // The x86 MMAs supported here are mostly LHS/RHS-symmetric (FMA, dpbf16ps,
+  // vpdpwssd, pmaddw): natural and swapped orientations share the same LLVM
+  // intrinsic and arg order, since after the broadcast above both operands
+  // have the same lane count. The exception is vpdpbusd, which is asymmetric
+  // (first byte source is unsigned, second is signed); for its swapped
+  // sibling we route `rhs` (the unsigned operand) into the first slot.
   switch (intrinsic) {
   case MMAIntrinsic::MMA_X86_AVX2_FMA_1x8x1_F32_F32:
   case MMAIntrinsic::MMA_X86_AVX2_FMA_8x1x1_F32_F32:
@@ -788,6 +804,14 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
         call("llvm.x86.avx512.pmaddw.d.512", accType,
              ValueRange{widen(lhs, i16), widen(rhs, i16)}));
   }
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
+    // LHS unsigned, RHS signed — vpdpbusd takes (acc, unsigned, signed).
+    return call("llvm.x86.avx512.vpdpbusd.512", accType,
+                ValueRange{acc, lhs, rhs});
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
+    // LHS signed, RHS unsigned — swap to put the unsigned operand first.
+    return call("llvm.x86.avx512.vpdpbusd.512", accType,
+                ValueRange{acc, rhs, lhs});
   default:
     return {};
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -146,6 +146,14 @@ def MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16
     : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16", 0x13C2>;
 def MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16
     : I32EnumAttrCase<"MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16", 0x13C3>;
+// vpdpbusd: 4-byte K dot-product, asymmetric (LHS unsigned, RHS signed in
+// the natural orientation; swapped in the sibling, with arg-routing
+// reversed at lowering). IR storage is signless `i8`; the signedness
+// distinction lives on the encoding's `element_types`.
+def MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8", 0x13C4>;
+def MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8", 0x13C5>;
 
 // AArch64 SVE `fmla` (f32, f32): N×1×1 or 1×N×1 matmul tile; N is a scalable
 // vector of 4 f32 lanes per 128-bit chunk (see `ArmSveVLIn128bitUnits`).
@@ -195,6 +203,8 @@ def IREECPU_MMAIntrinsic
            MMA_X86_AVX512_16x1x2_I32_I8_CASTI16,
            MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16,
            MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16,
+           MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8,
+           MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8,
 
            // Arm SVE
            MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32, MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32,

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
@@ -85,6 +85,19 @@ bool isGenericScalar(MMAIntrinsic intr);
 // budget encoded in the enum case (8 or 16). Asserts otherwise.
 int64_t getGenericScalarRegisterBudget(MMAIntrinsic intr);
 
+// Returns the (LHS, RHS, ACC) element types for `intrinsic`, with
+// signedness preserved (e.g. `ui8` for vpdpbusd) — used by the cost model
+// to match against an encoding's `element_types`. Tile types in IR are
+// signless; `DataTiledMMAAttr::getUndistributedTileTypes` strips the
+// signedness annotations.
+std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
+                                                MMAIntrinsic intrinsic);
+
+// Returns the (M, N, K) tile shape for a row-major-tile intrinsic, or
+// nullopt otherwise (e.g. SVE).
+std::optional<std::tuple<int64_t, int64_t, int64_t>>
+getRowMajorTilesMNKShape(MMAIntrinsic intrinsic);
+
 } // namespace mlir::iree_compiler::IREE::CPU
 
 // clang-format on

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -307,3 +307,69 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"
 //       CHECK:   util.hoistable_conversion "shape_cast_from_intrinsic"
 //       CHECK:     vector.shape_cast {{.*}} : vector<2x4x16x1xf32> to vector<2x4x16xf32>
+
+// -----
+
+// vpdpbusd is asymmetric (first byte source unsigned, second signed). The
+// natural variant lowers as `(acc, lhs, rhs)`; the swapped variant flips
+// the args at the call so the unsigned operand still lands first.
+
+#contraction_accesses_b = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_avx512vnni_1x16x4_vpdpbusd(
+    %lhs: vector<1x4xi8>, %rhs: vector<16x4xi8>, %acc: vector<1x16xi32>)
+    -> vector<1x16xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_b,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x4xi8>, vector<16x4xi8> into vector<1x16xi32>
+  return %0 : vector<1x16xi32>
+}
+
+func.func @lower_avx512vnni_16x1x4_vpdpbusd(
+    %lhs: vector<16x4xi8>, %rhs: vector<1x4xi8>, %acc: vector<16x1xi32>)
+    -> vector<16x1xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_b,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<16x4xi8>, vector<1x4xi8> into vector<16x1xi32>
+  return %0 : vector<16x1xi32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// Natural: LHS (ui8, narrow) is broadcast and routed into vpdpbusd's
+// first (unsigned) byte-source slot.
+// CHECK-LABEL: func @lower_avx512vnni_1x16x4_vpdpbusd(
+//  CHECK-SAME:   %[[N_LHS:[a-zA-Z0-9]+]]: vector<1x4xi8>
+//  CHECK-SAME:   %[[N_RHS:[a-zA-Z0-9]+]]: vector<16x4xi8>
+//       CHECK:   %[[N_RHS_FLAT:.+]] = vector.shape_cast %[[N_RHS]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   %[[N_BCAST:.+]] = vector.broadcast %[[N_LHS]] : vector<1x4xi8> to vector<16x4xi8>
+//       CHECK:   %[[N_LHS_FLAT:.+]] = vector.shape_cast %[[N_BCAST]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   llvm.call_intrinsic "llvm.x86.avx512.vpdpbusd.512"(%{{.+}}, %[[N_LHS_FLAT]], %[[N_RHS_FLAT]])
+
+// Swapped: RHS (ui8, narrow) is broadcast; the lowering swaps arg order at
+// the call so the broadcast result still lands in vpdpbusd's first slot.
+// CHECK-LABEL: func @lower_avx512vnni_16x1x4_vpdpbusd(
+//  CHECK-SAME:   %[[S_LHS:[a-zA-Z0-9]+]]: vector<16x4xi8>
+//  CHECK-SAME:   %[[S_RHS:[a-zA-Z0-9]+]]: vector<1x4xi8>
+//       CHECK:   %[[S_LHS_FLAT:.+]] = vector.shape_cast %[[S_LHS]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   %[[S_BCAST:.+]] = vector.broadcast %[[S_RHS]] : vector<1x4xi8> to vector<16x4xi8>
+//       CHECK:   %[[S_RHS_FLAT:.+]] = vector.shape_cast %[[S_BCAST]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   llvm.call_intrinsic "llvm.x86.avx512.vpdpbusd.512"(%{{.+}}, %[[S_RHS_FLAT]], %[[S_LHS_FLAT]])

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -356,6 +356,8 @@ getMmaIntrinsicRequiredFeatures(IREE::CPU::MMAIntrinsic intr) {
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
     return {"+avx512vnni"};
   default:
     return {};
@@ -422,22 +424,15 @@ static bool isMmaIntrinsicArrayValid(MLIRContext *ctx,
     }
   }
 
-  // For (3) and (4) we need shape + element types from `DataTiledMMAAttr`.
+  // (3) and (4) need types *with* signedness so e.g. vpdpbusd's natural
+  // `ui8` LHS visibly swaps with its sibling's `ui8` RHS. Read directly
+  // from `getABCElementTypes`; `getUndistributedTileTypes` would strip it.
   auto getShapeAndTypes = [&](MMAIntrinsic intr) {
-    auto attr = DataTiledMMAAttr::get(ctx, intr, /*intrinsics_m=*/1,
-                                      /*intrinsics_n=*/1, /*intrinsics_k=*/1,
-                                      /*lhs_type=*/Type(),
-                                      /*rhs_type=*/Type(),
-                                      /*acc_type=*/Type());
-    SmallVector<VectorType> tiles;
-    attr.getUndistributedTileTypes(tiles);
-    assert(tiles.size() == 3);
-    return std::make_tuple(tiles[0].getShape()[0],     // M (LHS dim 0)
-                           tiles[1].getShape()[0],     // N (RHS dim 0)
-                           tiles[0].getShape()[1],     // K (LHS dim 1)
-                           tiles[0].getElementType(),  // LHS elem
-                           tiles[1].getElementType(),  // RHS elem
-                           tiles[2].getElementType()); // ACC elem
+    auto mnk = IREE::CPU::getRowMajorTilesMNKShape(intr);
+    assert(mnk && "validator only handles row-major-tile intrinsics");
+    auto [m, n, k] = *mnk;
+    auto [lhs, rhs, acc] = IREE::CPU::getABCElementTypes(ctx, intr);
+    return std::make_tuple(m, n, k, lhs, rhs, acc);
   };
 
   for (size_t i = 0; i < arr.size(); ++i) {
@@ -517,6 +512,8 @@ getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
         MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16,
         MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16,
         MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16,
+        MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8,
+        MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8,
     };
     for (MMAIntrinsic intr : kAllX86) {
       SmallVector<StringRef> required = getMmaIntrinsicRequiredFeatures(intr);
@@ -564,27 +561,29 @@ getIntrinsicInfo(MLIRContext *ctx, ArrayRef<Type> elementTypes,
     info.intrinsicM = info.intrinsicN = info.intrinsicK = 1;
     return info;
   }
-  auto base = IREE::CPU::DataTiledMMAAttr::get(
-      ctx, intr, /*intrinsics_m=*/1, /*intrinsics_n=*/1,
-      /*intrinsics_k=*/1, /*lhs_type=*/Type(),
-      /*rhs_type=*/Type(), /*acc_type=*/Type());
-  SmallVector<VectorType> baseTiles;
-  base.getUndistributedTileTypes(baseTiles);
-  if (baseTiles.size() != 3) {
+  // Same as the validator above: match against the encoding's
+  // `element_types` *with* signedness — vpdpbusd's `ui8` is what
+  // distinguishes it from CASTI16 paths.
+  auto [lhsTy, rhsTy, accTy] = IREE::CPU::getABCElementTypes(ctx, intr);
+  if (!lhsTy || !rhsTy || !accTy) {
     return std::nullopt;
   }
-  if (baseTiles[0].getElementType() != elementTypes[0] ||
-      baseTiles[1].getElementType() != elementTypes[1] ||
-      baseTiles[2].getElementType() != elementTypes[2]) {
+  if (lhsTy != elementTypes[0] || rhsTy != elementTypes[1] ||
+      accTy != elementTypes[2]) {
     return std::nullopt;
   }
+  auto mnk = IREE::CPU::getRowMajorTilesMNKShape(intr);
+  if (!mnk) {
+    return std::nullopt;
+  }
+  auto [m, n, k] = *mnk;
   IntrinsicInfo info;
-  info.intrinsicM = baseTiles[0].getShape()[0];
-  info.intrinsicK = baseTiles[0].getShape()[1];
-  info.intrinsicN = baseTiles[1].getShape()[0];
-  info.lhsBits = baseTiles[0].getElementType().getIntOrFloatBitWidth();
-  info.rhsBits = baseTiles[1].getElementType().getIntOrFloatBitWidth();
-  info.accBits = baseTiles[2].getElementType().getIntOrFloatBitWidth();
+  info.intrinsicM = m;
+  info.intrinsicN = n;
+  info.intrinsicK = k;
+  info.lhsBits = lhsTy.getIntOrFloatBitWidth();
+  info.rhsBits = rhsTy.getIntOrFloatBitWidth();
+  info.accBits = accTy.getIntOrFloatBitWidth();
   return info;
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -52,7 +52,6 @@
 #include "iree/compiler/Dialect/Encoding/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/ADT/bit.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/InterleavedRange.h"
 #include "mlir/IR/AffineMap.h"
@@ -633,27 +632,23 @@ chooseIntrinsic(MLIRContext *ctx, ArrayRef<Type> elementTypes,
   return best;
 }
 
-/// Power-of-two cap on one unroll dim. For a static matmul extent
-/// `matmulSize` divided by `intrinsicSize`, we floor the cover count to a
-/// power of two. For dynamic dims we fall back to `fallback`, which callers
-/// set to something at least as large as the register budget — that budget
-/// itself terminates the enumeration below, so no tighter static cap is
-/// needed.
-static int64_t po2UnrollCap(int64_t matmulSize, int64_t intrinsicSize,
-                            int64_t fallback) {
+/// Per-dim cap on the unroll factor: how many intrinsic-sized tiles fit in
+/// the matmul dim. For dynamic matmul dims we return `fallback` (the
+/// register budget), which the budget check in the enumeration loop bounds
+/// anyway.
+static int64_t unrollCap(int64_t matmulSize, int64_t intrinsicSize,
+                         int64_t fallback) {
   if (ShapedType::isDynamic(matmulSize)) {
     return fallback;
   }
-  uint64_t cover =
-      std::max<int64_t>(1, llvm::divideCeil(matmulSize, intrinsicSize));
-  return llvm::bit_floor(cover);
+  return std::max<int64_t>(1, llvm::divideCeil(matmulSize, intrinsicSize));
 }
 
 // Phase 2 of `chooseCpuInnerTiledMmaForEncoding`: for an already-chosen
-// intrinsic, pick the largest power-of-two unroll factors (intrinsicsM,
-// intrinsicsN) such that the three tiles (ACC + LHS + RHS) still fit in
-// the target's register budget, breaking ties with arithmetic intensity
-// (effM*effN)/(effM+effN) so approximately-square tiles win.
+// intrinsic, pick unroll factors (intrinsicsM, intrinsicsN) such that the
+// three tiles (ACC + LHS + RHS) still fit in the target's register budget,
+// breaking ties with arithmetic intensity (effM*effN)/(effM+effN) so
+// approximately-square tiles win.
 //
 // "Register budget" depends on what the lowering will use:
 //   * Architecture-specific SIMD intrinsics use the vector register file,
@@ -710,28 +705,26 @@ chooseUnrolling(MLIRContext *ctx, ArrayRef<Type> elementTypes,
     lhsUnit = info->lhsBits;
     rhsUnit = info->rhsBits;
   }
-  int64_t capMPo2 = po2UnrollCap(matmulSizes.M, info->intrinsicM, budget);
-  int64_t capNPo2 = po2UnrollCap(matmulSizes.N, info->intrinsicN, budget);
+  int64_t capM = unrollCap(matmulSizes.M, info->intrinsicM, budget);
+  int64_t capN = unrollCap(matmulSizes.N, info->intrinsicN, budget);
   int64_t accTerm = info->intrinsicM * info->intrinsicN * accUnit;
   int64_t lhsTerm = info->intrinsicM * info->intrinsicK * intrinsicsK * lhsUnit;
   int64_t rhsTerm = info->intrinsicN * info->intrinsicK * intrinsicsK * rhsUnit;
   std::optional<std::pair<int64_t, int64_t>> bestMN;
   double bestIntensity = -1.0;
-  // Enumerate power-of-two intrinsicsM; for each, pick the largest feasible
-  // power-of-two intrinsicsN under the budget and the static N cap. The
-  // budget bounds im on its own (im*lhsTerm alone must be < budget), which
-  // terminates the loop without any numRegs-style cap.
-  for (int64_t im = 1; im <= capMPo2; im *= 2) {
+  // Enumerate intrinsicsM; for each, pick the largest feasible intrinsicsN
+  // under the budget and the static N cap. The budget bounds im on its own
+  // (im*lhsTerm alone must be < budget), which terminates the loop.
+  for (int64_t im = 1; im <= capM; ++im) {
     int64_t remaining = budget - im * lhsTerm;
     if (remaining <= 0) {
       break;
     }
     int64_t inMaxBudget = remaining / (im * accTerm + rhsTerm);
-    uint64_t inCap = std::min<int64_t>(capNPo2, inMaxBudget);
-    if (inCap < 1) {
+    int64_t in = std::min<int64_t>(capN, inMaxBudget);
+    if (in < 1) {
       continue;
     }
-    int64_t in = llvm::bit_floor(inCap);
     double effM = static_cast<double>(im) * info->intrinsicM;
     double effN = static_cast<double>(in) * info->intrinsicN;
     double intensity = effM * effN / (effM + effN);

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -259,6 +259,38 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ("bf16", "f32"),
 ]]
 
+# Mixed unsigned-LHS / signed-RHS i8 matmul. The test framework otherwise
+# only generates symmetric-type matmuls. No matching MMA intrinsic exists
+# yet on any of the `target_cpu_features_variants` here — the test
+# exercises the standard codegen fallback through the data-tiling +
+# inner-tiled pipeline.
+iree_generated_e2e_runner_test(
+    name = "e2e_matmul_cpu_dt_inner_tiled_ui8_i8_i32",
+    compiler_flags = [
+        "--iree-opt-data-tiling",
+        "--iree-llvmcpu-enable-inner-tiled",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs=ui8",
+        "--rhs=i8",
+        "--acc_type=i32",
+        # easy_large_static (M=N=512): mixed LHS/RHS types lower to a
+        # `linalg.generic`, and unit-dim folding rewrites narrow-M/N
+        # forms of that into rank-reduced contractions that the
+        # inner_tiled lowering doesn't handle.
+        "--shapes=easy_large_static",
+    ],
+    target_backends_and_drivers = [
+        ("llvm-cpu", "local-task"),
+    ],
+    target_cpu_features_variants = [
+        "generic",
+    ],
+    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
+    test_type = "matmul",
+)
+
 # LLVMCPU, data-tiling, data-tiling + ukernels + late materialization.
 [iree_generated_e2e_runner_test(
     name = "e2e_matmul_cpu_experimental_dt%s_%s_%s" % (

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -259,11 +259,9 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ("bf16", "f32"),
 ]]
 
-# Mixed unsigned-LHS / signed-RHS i8 matmul. The test framework otherwise
-# only generates symmetric-type matmuls. No matching MMA intrinsic exists
-# yet on any of the `target_cpu_features_variants` here — the test
-# exercises the standard codegen fallback through the data-tiling +
-# inner-tiled pipeline.
+# Mixed unsigned-LHS / signed-RHS i8 matmul: exercises x86 AVX-512 VNNI
+# `vpdpbusd`, our first asymmetric MMA. The `generic` variant exercises
+# the standard codegen fallback (no matching MMA intrinsic).
 iree_generated_e2e_runner_test(
     name = "e2e_matmul_cpu_dt_inner_tiled_ui8_i8_i32",
     compiler_flags = [
@@ -286,6 +284,7 @@ iree_generated_e2e_runner_test(
     ],
     target_cpu_features_variants = [
         "generic",
+        "x86_64:avx512vnni:" + ",".join(X86_64_AVX512_VNNI),
     ],
     test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
     test_type = "matmul",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -735,6 +735,7 @@ iree_generated_e2e_runner_test(
     "--iree-llvmcpu-enable-inner-tiled"
   TARGET_CPU_FEATURES_VARIANTS
     "generic"
+    "x86_64:avx512vnni:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq,+avx512vnni"
 )
 
 iree_generated_e2e_runner_test(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -714,6 +714,31 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_cpu_dt_inner_tiled_ui8_i8_i32
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs=ui8"
+    "--rhs=i8"
+    "--acc_type=i32"
+    "--shapes=easy_large_static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-inner-tiled"
+  TARGET_CPU_FEATURES_VARIANTS
+    "generic"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_cpu_experimental_dt_i8_i32
   TEST_TYPE
     matmul

--- a/tests/e2e/matmul/generate_code.py
+++ b/tests/e2e/matmul/generate_code.py
@@ -16,16 +16,40 @@ from tests.e2e.matmul.compilation_info import *
 from tests.e2e.matmul.generate_code_mx import *
 
 
+# IR storage type for `t`: `ui8` → signless `i8` (the unsigned semantics
+# live on `arith.extui` in the linalg body and surface via encoding
+# inference).
+def _storage_type(t: MatrixElemTypeId) -> str:
+    if t == MatrixElemTypeId.UI8:
+        return "i8"
+    return t.value
+
+
+# True when the matmul must be expressed as `linalg.generic` (explicit
+# body) rather than named `linalg.matmul`: distinct LHS/RHS types, or an
+# unsigned operand.
+def _needs_linalg_generic(
+    lhs_type: MatrixElemTypeId, rhs_type: MatrixElemTypeId
+) -> bool:
+    if lhs_type != rhs_type:
+        return True
+    if lhs_type == MatrixElemTypeId.UI8:
+        return True
+    return False
+
+
 # Helper for generate_function.
 # Generates a name for a test function in the generated MLIR code.
 def generate_function_name(
-    lhs_rhs_type: MatrixElemTypeId,
+    lhs_type: MatrixElemTypeId,
+    rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     shapes: TestInputMatricesShapes,
     accumulate: bool,
     compilation_info: typing.Optional[CompilationInfo] = None,
 ):
-    input_t = lhs_rhs_type.value
+    lhs_t = lhs_type.value
+    rhs_t = rhs_type.value
     acc_t = acc_type.value
     lhs_r = int_or_DYN(shapes.lhs_rows)
     lhs_c = int_or_DYN(shapes.lhs_cols)
@@ -45,8 +69,8 @@ def generate_function_name(
     matmul_kind = "matmul_accumulate" if accumulate else "matmul"
 
     return (
-        f"{matmul_kind}_{lhs_r}x{lhs_c}x{input_t}_times_"
-        + f"{rhs_r}x{rhs_c}x{input_t}_into_{acc_r}x{acc_c}x{acc_t}{info}"
+        f"{matmul_kind}_{lhs_r}x{lhs_c}x{lhs_t}_times_"
+        + f"{rhs_r}x{rhs_c}x{rhs_t}_into_{acc_r}x{acc_c}x{acc_t}{info}"
     )
 
 
@@ -54,7 +78,8 @@ def generate_function_name(
 # The generated function will take the same arguments as linalg.matmul variants
 # and will just call linalg.matmul variants with them, returning its result.
 def generate_function(
-    lhs_rhs_type: MatrixElemTypeId,
+    lhs_type: MatrixElemTypeId,
+    rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     mx_scale_type: MatrixElemTypeId,
     mx_block_size: int,
@@ -64,8 +89,10 @@ def generate_function(
     compilation_info: Optional[CompilationInfo] = None,
 ):
     if mx_scale_type:
+        # MX matmul currently only supports same-type inputs.
+        assert lhs_type == rhs_type, "MX matmul requires lhs_type == rhs_type"
         return generate_function_mx(
-            lhs_rhs_type=lhs_rhs_type,
+            lhs_rhs_type=lhs_type,
             acc_type=acc_type,
             mx_scale_type=mx_scale_type,
             mx_block_size=mx_block_size,
@@ -77,7 +104,8 @@ def generate_function(
 
     shapes = generate_shapes(shape, transpose_rhs, dynamicities)
     func_name = generate_function_name(
-        lhs_rhs_type=lhs_rhs_type,
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
         acc_type=acc_type,
         shapes=shapes,
         accumulate=shape.accumulate,
@@ -90,8 +118,11 @@ def generate_function(
     acc_r = int_or_question_mark(shapes.acc_rows)
     acc_c = int_or_question_mark(shapes.acc_cols)
 
-    lhs_tensor_type = f"tensor<{lhs_r}x{lhs_c}x{lhs_rhs_type.value}>"
-    rhs_tensor_type = f"tensor<{rhs_r}x{rhs_c}x{lhs_rhs_type.value}>"
+    # Use signless storage in IR (`ui8` becomes `i8` here) — the unsigned
+    # semantics are expressed by `arith.extui` in the linalg body, which the
+    # encoding system's signedness inference picks up.
+    lhs_tensor_type = f"tensor<{lhs_r}x{lhs_c}x{_storage_type(lhs_type)}>"
+    rhs_tensor_type = f"tensor<{rhs_r}x{rhs_c}x{_storage_type(rhs_type)}>"
     acc_tensor_type = f"tensor<{acc_r}x{acc_c}x{acc_type.value}>"
 
     (
@@ -141,11 +172,52 @@ def generate_function(
     indexing_maps_attr = ""
     if transpose_rhs:
         indexing_maps_attr = "indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>]"
-    func_definition += (
-        f"  %result = linalg.matmul {indexing_maps_attr} {compilation_info_attr} ins(%lhs, %rhs: {lhs_tensor_type}, {rhs_tensor_type}) outs(%acc: {acc_tensor_type}) -> {acc_tensor_type}\n"
-        f"  util.return %result: {acc_tensor_type}\n"
-        f"}}\n"
-    )
+
+    if _needs_linalg_generic(lhs_type, rhs_type):
+        # `linalg.generic` body widens each operand to the accumulator
+        # type. `arith.extui` for unsigned, `arith.extsi` for signed —
+        # the encoding system's signedness inference reads this to route
+        # `ui8` operands to the right MMA intrinsic (e.g. vpdpbusd).
+        lhs_storage = _storage_type(lhs_type)
+        rhs_storage = _storage_type(rhs_type)
+        acc_t = acc_type.value
+        lhs_ext = "arith.extui" if lhs_type == MatrixElemTypeId.UI8 else "arith.extsi"
+        rhs_ext = "arith.extui" if rhs_type == MatrixElemTypeId.UI8 else "arith.extsi"
+        # Iterators: M, N parallel; K reduction. Maps: (m,k), (k,n)/(n,k),
+        # (m,n) — RHS uses (n,k) when transpose_rhs is set.
+        if transpose_rhs:
+            maps = (
+                "affine_map<(d0, d1, d2) -> (d0, d2)>, "
+                "affine_map<(d0, d1, d2) -> (d1, d2)>, "
+                "affine_map<(d0, d1, d2) -> (d0, d1)>"
+            )
+        else:
+            maps = (
+                "affine_map<(d0, d1, d2) -> (d0, d2)>, "
+                "affine_map<(d0, d1, d2) -> (d2, d1)>, "
+                "affine_map<(d0, d1, d2) -> (d0, d1)>"
+            )
+        func_definition += (
+            f"  %result = linalg.generic {{indexing_maps = [{maps}], "
+            f'iterator_types = ["parallel", "parallel", "reduction"]}} '
+            f"{compilation_info_attr} ins(%lhs, %rhs: {lhs_tensor_type}, "
+            f"{rhs_tensor_type}) outs(%acc: {acc_tensor_type}) {{\n"
+            f"  ^bb0(%a: {lhs_storage}, %b: {rhs_storage}, %c: {acc_t}):\n"
+            f"    %a_ext = {lhs_ext} %a : {lhs_storage} to {acc_t}\n"
+            f"    %b_ext = {rhs_ext} %b : {rhs_storage} to {acc_t}\n"
+            f"    %prod = arith.muli %a_ext, %b_ext : {acc_t}\n"
+            f"    %sum = arith.addi %c, %prod : {acc_t}\n"
+            f"    linalg.yield %sum : {acc_t}\n"
+            f"  }} -> {acc_tensor_type}\n"
+            f"  util.return %result: {acc_tensor_type}\n"
+            f"}}\n"
+        )
+    else:
+        func_definition += (
+            f"  %result = linalg.matmul {indexing_maps_attr} {compilation_info_attr} ins(%lhs, %rhs: {lhs_tensor_type}, {rhs_tensor_type}) outs(%acc: {acc_tensor_type}) -> {acc_tensor_type}\n"
+            f"  util.return %result: {acc_tensor_type}\n"
+            f"}}\n"
+        )
 
     signature = ", ".join([ty for name, ty in args]) + " -> {acc_tensor_type}"
     import_declaration = (
@@ -168,7 +240,8 @@ call_id = 0
 # as a dictionary to be passed to yaml.dump.
 def generate_call(
     function: MLIRFunction,
-    lhs_rhs_type: MatrixElemTypeId,
+    lhs_type: MatrixElemTypeId,
+    rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     mx_scale_type: MatrixElemTypeId,
     mx_block_size: int,
@@ -178,7 +251,7 @@ def generate_call(
     if mx_scale_type:
         return generate_call_mx(
             function=function,
-            lhs_rhs_type=lhs_rhs_type,
+            lhs_rhs_type=lhs_type,
             acc_type=acc_type,
             mx_scale_type=mx_scale_type,
             mx_block_size=mx_block_size,
@@ -210,8 +283,8 @@ def generate_call(
         rhs_shape = [shape.k, shape.n]
         transpose_rhs = 0
     matmul_args = [
-        ("lhs", lhs_shape, lhs_rhs_type),
-        ("rhs", rhs_shape, lhs_rhs_type),
+        ("lhs", lhs_shape, lhs_type),
+        ("rhs", rhs_shape, rhs_type),
     ]
     check_args = matmul_args.copy()
 

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -105,7 +105,8 @@ def get_test_shapes(shapes_id: ShapesId, accumulate=True):
 
 # Generates all output files' contents as strings.
 def generate(
-    lhs_rhs_type: MatrixElemTypeId,
+    lhs_type: MatrixElemTypeId,
+    rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     mx_scale_type: MatrixElemTypeId,
     mx_block_size: int,
@@ -118,12 +119,13 @@ def generate(
     calls = []
 
     for compilation_info in get_test_compilation_infos(
-        compilation_info_id, lhs_rhs_type, acc_type
+        compilation_info_id, lhs_type, acc_type
     ):
         for shape in get_test_shapes(shapes_id, accumulate):
             for dynamicities in get_dynamicities(shapes_id):
                 function = generate_function(
-                    lhs_rhs_type=lhs_rhs_type,
+                    lhs_type=lhs_type,
+                    rhs_type=rhs_type,
                     acc_type=acc_type,
                     mx_scale_type=mx_scale_type,
                     mx_block_size=mx_block_size,
@@ -142,7 +144,8 @@ def generate(
                 calls.append(
                     generate_call(
                         function=function,
-                        lhs_rhs_type=lhs_rhs_type,
+                        lhs_type=lhs_type,
+                        rhs_type=rhs_type,
                         acc_type=acc_type,
                         mx_scale_type=mx_scale_type,
                         mx_block_size=mx_block_size,
@@ -168,26 +171,45 @@ def parse_arguments():
         help="Path of output .mlir file containing the calls",
         required=True,
     )
+    elem_type_choices = [
+        "i32",
+        "i8",
+        "ui8",
+        "f64",
+        "f32",
+        "f16",
+        "bf16",
+        "f8E5M2",
+        "f8E4M3FN",
+        "f8E5M2FNUZ",
+        "f8E4M3FNUZ",
+        "f6E3M2FN",
+        "f6E2M3FN",
+        "f4E2M1FN",
+    ]
+    # Legacy single-flag form: same type for LHS and RHS. Mutually exclusive
+    # with the per-operand --lhs / --rhs pair below; exactly one set of flags
+    # must be provided.
     parser.add_argument(
         "--lhs_rhs_type",
         type=str,
-        choices=[
-            "i32",
-            "i8",
-            "f64",
-            "f32",
-            "f16",
-            "bf16",
-            "f8E5M2",
-            "f8E4M3FN",
-            "f8E5M2FNUZ",
-            "f8E4M3FNUZ",
-            "f6E3M2FN",
-            "f6E2M3FN",
-            "f4E2M1FN",
-        ],
-        help="Numeric type of input LHS and RHS matrices",
-        required=True,
+        choices=elem_type_choices,
+        help="Numeric type of input LHS and RHS matrices (when both are equal)",
+        required=False,
+    )
+    parser.add_argument(
+        "--lhs",
+        type=str,
+        choices=elem_type_choices,
+        help="Numeric type of the LHS matrix. Use with --rhs.",
+        required=False,
+    )
+    parser.add_argument(
+        "--rhs",
+        type=str,
+        choices=elem_type_choices,
+        help="Numeric type of the RHS matrix. Use with --lhs.",
+        required=False,
     )
     parser.add_argument(
         "--acc_type",
@@ -313,8 +335,25 @@ def main(args):
     ShapesId.set_custom_mnk(shapes_id, args.mnk)
     ShapesId.set_dynamicity(shapes_id, args.mnk_dynamicities)
 
+    # Resolve LHS/RHS types: exactly one of {--lhs_rhs_type} or {--lhs and --rhs}.
+    lhs_rhs_set = args.lhs_rhs_type is not None
+    per_op_set = args.lhs is not None or args.rhs is not None
+    if lhs_rhs_set == per_op_set:
+        raise ValueError(
+            "specify exactly one of --lhs_rhs_type or the (--lhs, --rhs) pair"
+        )
+    if per_op_set:
+        if args.lhs is None or args.rhs is None:
+            raise ValueError("--lhs and --rhs must be specified together")
+        lhs_type = MatrixElemTypeId(args.lhs)
+        rhs_type = MatrixElemTypeId(args.rhs)
+    else:
+        lhs_type = MatrixElemTypeId(args.lhs_rhs_type)
+        rhs_type = lhs_type
+
     (functions, calls) = generate(
-        lhs_rhs_type=MatrixElemTypeId(args.lhs_rhs_type),
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
         acc_type=MatrixElemTypeId(args.acc_type),
         mx_scale_type=args.mx_scale_type,
         mx_block_size=args.mx_block_size,

--- a/tools/testing/e2e/iree-e2e-matmul-test.cc
+++ b/tools/testing/e2e/iree-e2e-matmul-test.cc
@@ -47,6 +47,7 @@
 REFERENCE_MATMUL(float, float, float, float)
 REFERENCE_MATMUL(double, double, double, double)
 REFERENCE_MATMUL(int8_t, int8_t, int32_t, int32_t)
+REFERENCE_MATMUL(uint8_t, int8_t, int32_t, int32_t)
 REFERENCE_MATMUL(int32_t, int32_t, int32_t, int32_t)
 
 // Reference mamtul for the f16 input, f16 accumulation, and f16 result.
@@ -164,6 +165,16 @@ static iree_status_t reference_matmul_element(
         m_size, k_size, n_size, lhs_type, rhs_type, acc_type, transpose_rhs,
         (const double*)lhs_data, (const double*)rhs_data,
         (const double*)acc_data, (double*)result_data, m, n);
+  } else if (lhs_type == IREE_HAL_ELEMENT_TYPE_UINT_8 &&
+             iree_hal_element_type_is_integer(rhs_type, 8) &&
+             iree_hal_element_type_is_integer(acc_type, 32)) {
+    // Mixed unsigned-LHS / signed-RHS i8 matmul (e.g. x86 vpdpbusd). IR
+    // storage is signless i8; the buffer-view's UINT_8 LHS carries the
+    // signedness.
+    reference_matmul_uint8_t_int8_t_int32_t_int32_t(
+        m_size, k_size, n_size, lhs_type, rhs_type, acc_type, transpose_rhs,
+        (const uint8_t*)lhs_data, (const int8_t*)rhs_data,
+        (const int32_t*)acc_data, (int32_t*)result_data, m, n);
   } else if (iree_hal_element_type_is_integer(lhs_type, 8) &&
              iree_hal_element_type_is_integer(rhs_type, 8) &&
              iree_hal_element_type_is_integer(acc_type, 32)) {


### PR DESCRIPTION
`chooseUnrolling` previously enumerated `intrinsics_m` / `intrinsics_n` through powers of two. There's no real reason for that — within the register budget, the cost model can pick any factor.

Looking ahead: some intrinsics may eventually want the unroll factor on a particular dim to be a multiple of some target-specific number — Arm scalar-by-element FMA forms are an example, where the scalar is a lane of a vector register, so covering whole vector registers is more efficient. But even there it's not a strict preference: narrow matmuls (e.g. matrix-vector) are better off avoiding the padding that imposing that multiple would force. So a simple per-intrinsic "preferred multiple" doesn't capture it. We'll come back to this when we have a concrete need.

Lit-test fallout: relaxing pow2 lets the cost model land on better non-pow2 unrolls in some cases the existing tests pin (e.g. `materialize_encoding_x86_64.mlir`'s dynamic-N AVX-512 case now picks `intrinsics_m = 29` instead of 16 — saturating the zmm register file much more tightly, and at higher arithmetic intensity per the existing scoring formula). CHECK lines updated to the new values.

Progress towards #24323.