### PR TITLE
[CUDA] Update SM89 target feature test

### DIFF
--- a/compiler/plugins/target/CUDA/test/target_device_features.mlir
+++ b/compiler/plugins/target/CUDA/test/target_device_features.mlir
@@ -10,7 +10,7 @@
 // SM89: target_info = #iree_gpu.target<arch = "sm_89", features = "+ptx78",
 // SM89-SAME: wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b64|b32|b16|b8,
 // SM89-SAME:         subgroup = shuffle|arithmetic, dot = dp4xi8toi32,
-// SM89-SAME:         mma = [<NV_MMA_SYNC_F32_16x8x16_F16>, <NV_MMA_SYNC_F16_16x8x16_F16>, <NV_WMMA_F32_16x16x16_F16>, <NV_WMMA_F16_16x16x16_F16>],
+// SM89-SAME:         mma = [<NV_MMA_SYNC_F32_16x8x16_F16>, <NV_MMA_SYNC_F16_16x8x16_F16>, <NV_MMA_SYNC_F32_16x8x16_BF16>, <NV_WMMA_F32_16x16x16_F16>, <NV_WMMA_F16_16x16x16_F16>],
 // SM89-SAME:         subgroup_size_choices = [32], max_workgroup_sizes = [1024, 1024, 1024],
 // SM89-SAME:         max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 166912,
 // SM89-SAME:         max_workgroup_counts = [2147483647, 65535, 65535]>>


### PR DESCRIPTION
Include the BF16 mma.sync intrinsic now advertised by Ampere-class target details in the CUDA target device feature expectation.

Fix for breakage from #24423.