### PR TITLE
[Codegen] Use default read semantics for LinalgExt scatter

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -375,13 +375,6 @@ struct LinalgExtOpInterface
     : bufferization::DstBufferizableOpInterfaceExternalModel<
           LinalgExtOpInterface<OpTy>, OpTy> {
 
-  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
-                              const AnalysisState &state) const {
-    // TODO: Revisit this for ScatterOp. We can then get rid of
-    //       `bufferizesToMemoryRead` completely.
-    return !isa<IREE::LinalgExt::ScatterOp>(op);
-  }
-
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
                           const BufferizationOptions &options,
                           bufferization::BufferizationState &state) const {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/llvmgpu_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/llvmgpu_bufferize.mlir
@@ -36,3 +36,104 @@ func.func @bufferize_with_thread_private_memory(%arg0: index) {
 //  CHECK-SAME:       memref<1x1x4x4xf16, strided<[1310720, 4096, 64, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
 //  CHECK-SAME:       to memref<1x1x4x4xf16, #gpu.address_space<private>>
 //       CHECK:   } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+
+// -----
+
+#pipeline_layout_scatter = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @linalg_ext_scatter_preserves_original() {
+  %c0 = arith.constant 0 : index
+  %updates_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11x1x512xf32>>
+  %indices_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi32>>
+  %original_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1x512xf32>>
+  %result_dst = hal.interface.binding.subspan layout(#pipeline_layout_scatter) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1x512xf32>>
+  %updates = iree_tensor_ext.dispatch.tensor.load %updates_src, offsets = [0, 0, 0], sizes = [11, 1, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11x1x512xf32>> -> tensor<11x1x512xf32>
+  %indices = iree_tensor_ext.dispatch.tensor.load %indices_src, offsets = [0], sizes = [11], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi32>> -> tensor<11xi32>
+  %original = iree_tensor_ext.dispatch.tensor.load %original_src, offsets = [0, 0, 0], sizes = [32, 1, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1x512xf32>> -> tensor<32x1x512xf32>
+  %scatter = iree_linalg_ext.scatter dimension_map = [0] unique_indices(true) ins(%updates, %indices : tensor<11x1x512xf32>, tensor<11xi32>) outs(%original : tensor<32x1x512xf32>) {
+  ^bb0(%update: f32, %original_value: f32):
+    iree_linalg_ext.yield %update : f32
+  } -> tensor<32x1x512xf32>
+  iree_tensor_ext.dispatch.tensor.store %scatter, %result_dst, offsets = [0, 0, 0], sizes = [32, 1, 512], strides = [1, 1, 1] : tensor<32x1x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1x512xf32>>
+  return
+}
+// CHECK-LABEL: func.func @linalg_ext_scatter_preserves_original
+// CHECK:       %[[ORIGINAL_SUBSPAN:.+]] = hal.interface.binding.subspan {{.*}} binding(2)
+// CHECK:       %[[ORIGINAL:.+]] = memref.assume_alignment %[[ORIGINAL_SUBSPAN]]
+// CHECK:       %[[RESULT:.+]] = hal.interface.binding.subspan {{.*}} binding(3)
+// CHECK:       %[[ALLOC:.+]] = memref.alloc()
+// CHECK:       memref.copy %[[ORIGINAL]], %[[ALLOC]]
+// CHECK:       iree_linalg_ext.scatter
+// CHECK-SAME:    outs(%[[ALLOC]]
+
+// -----
+
+#pipeline_layout_scatter_combine = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @linalg_ext_scatter_combiner_reads_original() {
+  %c0 = arith.constant 0 : index
+  %updates_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter_combine) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11x1x512xf32>>
+  %indices_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter_combine) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi32>>
+  %original_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter_combine) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1x512xf32>>
+  %result_dst = hal.interface.binding.subspan layout(#pipeline_layout_scatter_combine) binding(3) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1x512xf32>>
+  %updates = iree_tensor_ext.dispatch.tensor.load %updates_src, offsets = [0, 0, 0], sizes = [11, 1, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11x1x512xf32>> -> tensor<11x1x512xf32>
+  %indices = iree_tensor_ext.dispatch.tensor.load %indices_src, offsets = [0], sizes = [11], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi32>> -> tensor<11xi32>
+  %original = iree_tensor_ext.dispatch.tensor.load %original_src, offsets = [0, 0, 0], sizes = [32, 1, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1x512xf32>> -> tensor<32x1x512xf32>
+  %scatter = iree_linalg_ext.scatter dimension_map = [0] unique_indices(false) ins(%updates, %indices : tensor<11x1x512xf32>, tensor<11xi32>) outs(%original : tensor<32x1x512xf32>) {
+  ^bb0(%update: f32, %original_value: f32):
+    %combined = arith.addf %update, %original_value : f32
+    iree_linalg_ext.yield %combined : f32
+  } -> tensor<32x1x512xf32>
+  iree_tensor_ext.dispatch.tensor.store %scatter, %result_dst, offsets = [0, 0, 0], sizes = [32, 1, 512], strides = [1, 1, 1] : tensor<32x1x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1x512xf32>>
+  return
+}
+// CHECK-LABEL: func.func @linalg_ext_scatter_combiner_reads_original
+// CHECK:       %[[ORIGINAL_SUBSPAN:.+]] = hal.interface.binding.subspan {{.*}} binding(2)
+// CHECK:       %[[ORIGINAL:.+]] = memref.assume_alignment %[[ORIGINAL_SUBSPAN]]
+// CHECK:       %[[ALLOC:.+]] = memref.alloc()
+// CHECK:       memref.copy %[[ORIGINAL]], %[[ALLOC]]
+// CHECK:       iree_linalg_ext.scatter
+// CHECK-SAME:    outs(%[[ALLOC]]
+
+// -----
+
+#pipeline_layout_scatter_mask = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @linalg_ext_scatter_masked_update_preserves_original() {
+  %c0 = arith.constant 0 : index
+  %updates_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter_mask) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11x1x512xf32>>
+  %indices_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter_mask) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi32>>
+  %mask_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter_mask) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi1>>
+  %original_src = hal.interface.binding.subspan layout(#pipeline_layout_scatter_mask) binding(3) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1x512xf32>>
+  %result_dst = hal.interface.binding.subspan layout(#pipeline_layout_scatter_mask) binding(4) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1x512xf32>>
+  %updates = iree_tensor_ext.dispatch.tensor.load %updates_src, offsets = [0, 0, 0], sizes = [11, 1, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11x1x512xf32>> -> tensor<11x1x512xf32>
+  %indices = iree_tensor_ext.dispatch.tensor.load %indices_src, offsets = [0], sizes = [11], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi32>> -> tensor<11xi32>
+  %mask = iree_tensor_ext.dispatch.tensor.load %mask_src, offsets = [0], sizes = [11], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<11xi1>> -> tensor<11xi1>
+  %original = iree_tensor_ext.dispatch.tensor.load %original_src, offsets = [0, 0, 0], sizes = [32, 1, 512], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<32x1x512xf32>> -> tensor<32x1x512xf32>
+  %scatter = iree_linalg_ext.scatter dimension_map = [0] unique_indices(true) ins(%updates, %indices, %mask : tensor<11x1x512xf32>, tensor<11xi32>, tensor<11xi1>) outs(%original : tensor<32x1x512xf32>) {
+  ^bb0(%update: f32, %original_value: f32):
+    iree_linalg_ext.yield %update : f32
+  } -> tensor<32x1x512xf32>
+  iree_tensor_ext.dispatch.tensor.store %scatter, %result_dst, offsets = [0, 0, 0], sizes = [32, 1, 512], strides = [1, 1, 1] : tensor<32x1x512xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<32x1x512xf32>>
+  return
+}
+// CHECK-LABEL: func.func @linalg_ext_scatter_masked_update_preserves_original
+// CHECK:       %[[ORIGINAL_SUBSPAN:.+]] = hal.interface.binding.subspan {{.*}} binding(3)
+// CHECK:       %[[ORIGINAL:.+]] = memref.assume_alignment %[[ORIGINAL_SUBSPAN]]
+// CHECK:       %[[ALLOC:.+]] = memref.alloc()
+// CHECK:       memref.copy %[[ORIGINAL]], %[[ALLOC]]
+// CHECK:       iree_linalg_ext.scatter
+// CHECK-SAME:    outs(%[[ALLOC]]


### PR DESCRIPTION
The original impl. will introduce critical but very subtle bugs. We identified the bug when running Qwen-3.5, with decode-prefill-decode pattern. Because of the problem detailed below, the 2nd decode are completely wrong.

## Problem

  `iree_linalg_ext.scatter` **was** special-cased in the LinalgExt bufferization
  external model as not reading its DPS init operand which is not correct.


  ## Fix

  Remove the ScatterOp-specific no-read override and use the default
  DestinationStyleOpInterface bufferization read semantics.

  After this change, out-of-place bufferization preserves the init value before
  scatter updates it:
```
  alloc tmp[32][1][512]
  copy original -> tmp // which was previously dropped.
  scatter writes 11 rows into tmp
```


  ### Minimal Repro

  A simple overwrite scatter still needs to preserve elements that are not updated:

  ```text
  result = original // this was incorrectly dropped if it's not fixed with the config shown in test cases attached
  for i in updated_indices:
    result[i] = update[i]
```

  Example shape:

  original: 32 x 1 x 512
  updates : 11 x 1 x 512
  indices : 11 rows
  result  : 32 x 1 x 512

  Scatter writes only 11 rows. The remaining 21 rows must come from original.

  **Before this change, bufferization thinks `outs(%original)` as a destination
  placeholder instead of a read. So it stores tmp[32][1][512] to output**

### Analysis

I propose that we remove the override because scatter op should be bufferized as reads except for some small corner cases. Overriding the scatter op does not preserve correctness.

Let's analyze the following cases for scatter:

  - `updates` is read: scatter must read the update value.
  - `indices` is read: scatter must read indices to know where to write.
  - `mask`, if present, is read: a false mask suppresses the update and preserves
    the original value.
  - DPS init / original is read:
    - elements not hit by `indices` must be inherited from original;
    - masked-off updates must preserve original;
    - the combiner region may use the old value, e.g. `yield update + old`;
    - `unique_indices(false)` combine/reduction-style scatter also needs the
      old/current value.

  The only case where init may not need to be read is a separately proven
  full-overwrite optimization: indices cover the entire result, mask cannot
  suppress updates, and the combiner does not use the old value. That should be
  handled by a dedicated copy-elision/full-overwrite analysis, not by the default
  bufferization semantics.

  ## Tests

  Added LLVMGPU bufferization tests for:

  - overwrite scatter preserving original;
  - combiner scatter reading original;
  - masked scatter preserving original.