### PR TITLE
[VectorDistribute] LDS promotion with async DMA

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPULowerAsyncDMA.cpp
@@ -36,134 +36,6 @@ using namespace IREE::VectorExt;
 
 namespace {
 
-/// Distribute |total| across |shape| from the innermost dimension.
-/// |shape| is updated in place to reflect the remaining shape after
-/// distribution. Returns failure if any dimension doesn't divide evenly.
-static FailureOr<SmallVector<int64_t>>
-distributeFromInnermost(int64_t total, MutableArrayRef<int64_t> shape) {
-  int64_t rank = shape.size();
-  SmallVector<int64_t> result(rank, 1);
-  int64_t remaining = total;
-  for (int64_t i = rank - 1; i >= 0 && remaining > 1; --i) {
-    int64_t take = std::min(remaining, shape[i]);
-    if (shape[i] % take != 0) {
-      return failure();
-    }
-    result[i] = take;
-    shape[i] /= take;
-    remaining /= take;
-  }
-  if (remaining != 1) {
-    return failure();
-  }
-  return result;
-}
-
-/// Distribute |total| across |shape| from the outermost dimension.
-/// |shape| is updated in place to reflect the remaining shape after
-/// distribution. Returns failure if any dimension doesn't divide evenly.
-static FailureOr<SmallVector<int64_t>>
-distributeFromOutermost(int64_t total, MutableArrayRef<int64_t> shape) {
-  int64_t rank = shape.size();
-  SmallVector<int64_t> result(rank, 1);
-  int64_t remaining = total;
-  for (int64_t i = 0; i < rank && remaining > 1; ++i) {
-    int64_t take = std::min(remaining, shape[i]);
-    if (shape[i] % take != 0) {
-      return failure();
-    }
-    result[i] = take;
-    shape[i] /= take;
-    remaining /= take;
-  }
-  if (remaining != 1) {
-    return failure();
-  }
-  return result;
-}
-
-/// Try to compute a DMA-optimized NestedLayoutAttr for a single DMA size.
-/// Returns failure if the layout is not compatible.
-static FailureOr<NestedLayoutAttr>
-getGlobalLoadDMALayoutForSize(MLIRContext *context, ArrayRef<int64_t> shape,
-                              int64_t numThreads, int64_t subgroupSize,
-                              int64_t elementBitWidth, int64_t dmaSize) {
-  int64_t rank = shape.size();
-  int64_t elementsPerDMA = dmaSize / elementBitWidth;
-  if (elementsPerDMA == 0 || dmaSize % elementBitWidth != 0) {
-    return failure();
-  }
-
-  // Check that the total number of elements is divisible by the number of
-  // elements transferred per subgroup (subgroupSize * elementsPerDMA).
-  int64_t totalElements = ShapedType::getNumElements(shape);
-  int64_t elementsPerSubgroup = subgroupSize * elementsPerDMA;
-  if (totalElements % elementsPerSubgroup != 0) {
-    return failure();
-  }
-
-  // Track the remaining shape as we distribute each tile level.
-  SmallVector<int64_t> remainingShape(shape);
-
-  // Element tile: distribute elementsPerDMA from innermost.
-  auto elementResult = distributeFromInnermost(elementsPerDMA, remainingShape);
-  if (failed(elementResult)) {
-    return failure();
-  }
-  SmallVector<int64_t> elementTile = *elementResult;
-
-  // Thread tile: distribute subgroupSize from innermost over remaining shape.
-  auto threadResult = distributeFromInnermost(subgroupSize, remainingShape);
-  if (failed(threadResult)) {
-    return failure();
-  }
-  SmallVector<int64_t> threadTile = *threadResult;
-
-  // Subgroup tile: distribute numSubgroups from outermost. All subgroups must
-  // participate - partial subgroup participation would cause non-participating
-  // subgroups to compute out-of-bounds indices.
-  int64_t numSubgroups = numThreads / subgroupSize;
-  auto subgroupResult = distributeFromOutermost(numSubgroups, remainingShape);
-  if (failed(subgroupResult)) {
-    return failure();
-  }
-  SmallVector<int64_t> subgroupTile = *subgroupResult;
-
-  // Batch tile: whatever remains.
-  SmallVector<int64_t> batchTile(remainingShape);
-
-  // Outer tile: always 1 for DMA layouts.
-  SmallVector<int64_t> outerTile(rank, 1);
-
-  // Strides: computed from innermost (suffix products), so the innermost
-  // non-trivial dimension always has stride 1.
-  SmallVector<int64_t> subgroupStrides = computeStrides(subgroupTile);
-  SmallVector<int64_t> threadStrides = computeStrides(threadTile);
-
-  return NestedLayoutAttr::get(context, subgroupTile, batchTile, outerTile,
-                               threadTile, elementTile, subgroupStrides,
-                               threadStrides);
-}
-
-/// Try DMA sizes in descending order, take first success.
-static FailureOr<NestedLayoutAttr>
-getGlobalLoadDMALayout(MLIRContext *context, ArrayRef<int64_t> shape,
-                       int64_t numThreads, int64_t subgroupSize,
-                       int64_t elementBitWidth, ArrayRef<int64_t> dmaSizes) {
-  SmallVector<int64_t> sorted(dmaSizes);
-  llvm::sort(sorted, std::greater<>());
-  for (int64_t dmaSize : sorted) {
-    FailureOr<NestedLayoutAttr> layout = getGlobalLoadDMALayoutForSize(
-        context, shape, numThreads, subgroupSize, elementBitWidth, dmaSize);
-    if (succeeded(layout)) {
-      LDBG() << "  Selected DMA size: " << dmaSize << " bits";
-      LDBG() << "  DMA layout: " << *layout;
-      return layout;
-    }
-  }
-  return failure();
-}
-
 static IREE::Codegen::XORShuffleAttr getDestXorSwizzleAttr(Value dest) {
   while (auto viewOp = dest.getDefiningOp<ViewLikeOpInterface>()) {
     dest = viewOp.getViewSource();
@@ -258,28 +130,18 @@ struct LowerAsyncDMA final : OpRewritePattern<IREE::GPU::AsyncDMAOp> {
 
     IREE::Codegen::XORShuffleAttr destSwizzle =
         getDestXorSwizzleAttr(op.getDest());
-    // When dest has a swizzle_hint, filter DMA sizes to those where
-    // elementsPerDMA fits within one swizzle access block. This ensures
-    // gather_to_lds writes contiguous dest elements that all map to contiguous
-    // source elements under the XOR permutation.
-    SmallVector<int64_t> filteredDmaSizes(dmaSizes);
+    std::optional<int64_t> swizzleAccessElems;
     if (destSwizzle) {
-      int64_t accessElems = destSwizzle.getAccessElementCount();
-      llvm::erase_if(filteredDmaSizes, [&](int64_t dmaSize) {
-        if (dmaSize % elementBitWidth != 0) {
-          return true;
-        }
-        int64_t elemsPerDMA = dmaSize / elementBitWidth;
-        if (elemsPerDMA == 0) {
-          return true;
-        }
-        return accessElems % elemsPerDMA != 0;
-      });
+      // When dest has a swizzle_hint, only use DMA sizes where elementsPerDMA
+      // fits within one swizzle access block. This ensures gather_to_lds writes
+      // contiguous dest elements that all map to contiguous source elements
+      // under the XOR permutation.
+      swizzleAccessElems = destSwizzle.getAccessElementCount();
     }
 
     FailureOr<NestedLayoutAttr> dmaLayoutOrFailure =
         getGlobalLoadDMALayout(context, transferShape, numThreads, subgroupSize,
-                               elementBitWidth, filteredDmaSizes);
+                               elementBitWidth, dmaSizes, swizzleAccessElems);
     if (failed(dmaLayoutOrFailure)) {
       return rewriter.notifyMatchFailure(op, "failed to compute DMA layout");
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUConvertToCoalescedDMA.cpp
@@ -194,58 +194,6 @@ static bool sourceIsFromFatRawBuffer(Value source) {
   return hasAMDGPUFatRawBufferAddressSpace(memrefType);
 }
 
-/// Returns the minimum number of elements needed (after padding) for DMA
-/// alignment, or std::nullopt if DMA is not supported for this element type.
-static std::optional<int64_t>
-getMinDMAAlignedElements(FunctionOpInterface funcOp, Type elementType) {
-  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
-  if (!subgroupSize) {
-    return std::nullopt;
-  }
-
-  int64_t elementBits = elementType.getIntOrFloatBitWidth();
-
-  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
-  if (!target || !targetSupportsGlobalLoadDMA(target)) {
-    return std::nullopt;
-  }
-
-  ArrayRef<int64_t> dmaSizes;
-  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
-    dmaSizes = dmaSizesAttr.asArrayRef();
-  }
-
-  int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
-  for (int64_t dmaSize : dmaSizes) {
-    if (dmaSize % elementBits != 0) {
-      continue;
-    }
-    int64_t elementsPerLane = dmaSize / elementBits;
-    int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
-    minElementsPerTransfer =
-        std::min(minElementsPerTransfer, elementsPerTransfer);
-  }
-
-  if (minElementsPerTransfer == std::numeric_limits<int64_t>::max()) {
-    return std::nullopt;
-  }
-  return minElementsPerTransfer;
-}
-
-/// Returns the subgroup size if the available elements are aligned to DMA
-/// transfer sizes, std::nullopt otherwise.
-static std::optional<int64_t>
-getDMAAlignedSubgroupSize(FunctionOpInterface funcOp, Type elementType,
-                          int64_t availableElements) {
-  std::optional<int64_t> minAligned =
-      getMinDMAAlignedElements(funcOp, elementType);
-  if (!minAligned || availableElements % *minAligned != 0) {
-    return std::nullopt;
-  }
-  // getMinDMAAlignedElements already validated subgroupSize is present.
-  return getSubgroupSize(funcOp);
-}
-
 /// Largest numWarps in [1, totalWarps] (by repeated halving) such that
 /// `product(shape) / numWarps` satisfies the minimum DMA transfer alignment.
 /// Conservative for shapes that don't divide evenly (the real greedy in

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.cpp
@@ -6,8 +6,12 @@
 
 #include "iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h"
 
+#include <functional>
+
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 
 namespace mlir::iree_compiler {
@@ -96,6 +100,137 @@ SmallVector<int64_t> getElementVectorTileShape(NestedLayoutAttr vectorLayout) {
     tileShape[i] = 1;
   }
   return tileShape;
+}
+
+/// Distribute |total| across |shape| from the innermost dimension.
+/// |shape| is updated in place to reflect the remaining shape after
+/// distribution. Returns failure if any dimension doesn't divide evenly.
+static FailureOr<SmallVector<int64_t>>
+distributeFromInnermost(int64_t total, MutableArrayRef<int64_t> shape) {
+  int64_t rank = shape.size();
+  SmallVector<int64_t> result(rank, 1);
+  int64_t remaining = total;
+  for (int64_t i = rank - 1; i >= 0 && remaining > 1; --i) {
+    int64_t take = std::min(remaining, shape[i]);
+    if (shape[i] % take != 0) {
+      return failure();
+    }
+    result[i] = take;
+    shape[i] /= take;
+    remaining /= take;
+  }
+  if (remaining != 1) {
+    return failure();
+  }
+  return result;
+}
+
+/// Distribute |total| across |shape| from the outermost dimension.
+/// |shape| is updated in place to reflect the remaining shape after
+/// distribution. Returns failure if any dimension doesn't divide evenly.
+static FailureOr<SmallVector<int64_t>>
+distributeFromOutermost(int64_t total, MutableArrayRef<int64_t> shape) {
+  int64_t rank = shape.size();
+  SmallVector<int64_t> result(rank, 1);
+  int64_t remaining = total;
+  for (int64_t i = 0; i < rank && remaining > 1; ++i) {
+    int64_t take = std::min(remaining, shape[i]);
+    if (shape[i] % take != 0) {
+      return failure();
+    }
+    result[i] = take;
+    shape[i] /= take;
+    remaining /= take;
+  }
+  if (remaining != 1) {
+    return failure();
+  }
+  return result;
+}
+
+/// Try to compute a DMA-optimized NestedLayoutAttr for a single DMA size.
+/// Returns failure if the layout is not compatible.
+static FailureOr<NestedLayoutAttr>
+getGlobalLoadDMALayoutForSize(MLIRContext *context, ArrayRef<int64_t> shape,
+                              int64_t numThreads, int64_t subgroupSize,
+                              int64_t elementBitWidth, int64_t dmaSize) {
+  int64_t rank = shape.size();
+  if (elementBitWidth <= 0) {
+    return failure();
+  }
+  int64_t elementsPerDMA = dmaSize / elementBitWidth;
+  if (elementsPerDMA == 0 || dmaSize % elementBitWidth != 0) {
+    return failure();
+  }
+
+  int64_t totalElements = ShapedType::getNumElements(shape);
+  int64_t elementsPerSubgroup = subgroupSize * elementsPerDMA;
+  if (totalElements % elementsPerSubgroup != 0) {
+    return failure();
+  }
+
+  SmallVector<int64_t> remainingShape(shape);
+
+  auto elementResult = distributeFromInnermost(elementsPerDMA, remainingShape);
+  if (failed(elementResult)) {
+    return failure();
+  }
+  SmallVector<int64_t> elementTile = *elementResult;
+
+  auto threadResult = distributeFromInnermost(subgroupSize, remainingShape);
+  if (failed(threadResult)) {
+    return failure();
+  }
+  SmallVector<int64_t> threadTile = *threadResult;
+
+  int64_t numSubgroups = numThreads / subgroupSize;
+  auto subgroupResult = distributeFromOutermost(numSubgroups, remainingShape);
+  if (failed(subgroupResult)) {
+    return failure();
+  }
+  SmallVector<int64_t> subgroupTile = *subgroupResult;
+
+  SmallVector<int64_t> batchTile(remainingShape);
+  SmallVector<int64_t> outerTile(rank, 1);
+  SmallVector<int64_t> subgroupStrides = computeStrides(subgroupTile);
+  SmallVector<int64_t> threadStrides = computeStrides(threadTile);
+
+  return NestedLayoutAttr::get(context, subgroupTile, batchTile, outerTile,
+                               threadTile, elementTile, subgroupStrides,
+                               threadStrides);
+}
+
+FailureOr<NestedLayoutAttr>
+getGlobalLoadDMALayout(MLIRContext *context, ArrayRef<int64_t> shape,
+                       int64_t numThreads, int64_t subgroupSize,
+                       int64_t elementBitWidth, ArrayRef<int64_t> dmaSizes,
+                       std::optional<int64_t> swizzleAccessElems) {
+  if (subgroupSize <= 0 || numThreads % subgroupSize != 0) {
+    return failure();
+  }
+
+  SmallVector<int64_t> sorted(dmaSizes);
+  llvm::sort(sorted, std::greater<>());
+  if (swizzleAccessElems) {
+    llvm::erase_if(sorted, [&](int64_t dmaSize) {
+      if (dmaSize % elementBitWidth != 0) {
+        return true;
+      }
+      int64_t elemsPerDMA = dmaSize / elementBitWidth;
+      if (elemsPerDMA == 0) {
+        return true;
+      }
+      return *swizzleAccessElems % elemsPerDMA != 0;
+    });
+  }
+  for (int64_t dmaSize : sorted) {
+    FailureOr<NestedLayoutAttr> layout = getGlobalLoadDMALayoutForSize(
+        context, shape, numThreads, subgroupSize, elementBitWidth, dmaSize);
+    if (succeeded(layout)) {
+      return layout;
+    }
+  }
+  return failure();
 }
 
 FailureOr<NestedLayoutAttr>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h
@@ -7,6 +7,8 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_GPU_GPUNESTEDLAYOUTUTILS_H_
 #define IREE_COMPILER_CODEGEN_COMMON_GPU_GPUNESTEDLAYOUTUTILS_H_
 
+#include <optional>
+
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
@@ -40,6 +42,14 @@ FailureOr<IREE::VectorExt::NestedLayoutAttr>
 getDerivedThreadLayout(MLIRContext *context, ArrayRef<int64_t> workgroupSize,
                        ArrayRef<int64_t> logicalShape,
                        ArrayRef<int64_t> elementTile);
+
+/// Computes the nested layout used for global-load DMA lowering. Returns
+/// failure if no DMA size can evenly distribute the transfer across the
+/// subgroup/thread layout.
+FailureOr<IREE::VectorExt::NestedLayoutAttr> getGlobalLoadDMALayout(
+    MLIRContext *context, ArrayRef<int64_t> shape, int64_t numThreads,
+    int64_t subgroupSize, int64_t elementBitWidth, ArrayRef<int64_t> dmaSizes,
+    std::optional<int64_t> swizzleAccessElems = std::nullopt);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -4,8 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <limits>
-
 #include "iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h"
@@ -214,41 +212,37 @@ static bool hasAllInBounds(vector::TransferReadOp readOp) {
          });
 }
 
-static bool isDMAAlignedForWorkgroup(FunctionOpInterface funcOp,
-                                     IREE::GPU::TargetAttr target,
-                                     Type elementType,
-                                     int64_t availableElements) {
+static bool hasLowerableAsyncDMALayout(
+    FunctionOpInterface funcOp, IREE::GPU::TargetAttr target,
+    VectorType vectorType,
+    std::optional<int64_t> swizzleAccessElems = std::nullopt) {
   std::optional<SmallVector<int64_t>> maybeWorkgroupSize =
       getWorkgroupSize(funcOp);
   if (!maybeWorkgroupSize) {
     return false;
   }
+  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
+  if (!subgroupSize) {
+    return false;
+  }
 
   int64_t numThreads = ShapedType::getNumElements(*maybeWorkgroupSize);
-  int64_t elementBits = elementType.getIntOrFloatBitWidth();
+  int64_t elementBits = vectorType.getElementTypeBitWidth();
 
   ArrayRef<int64_t> dmaSizes;
   if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
     dmaSizes = dmaSizesAttr.asArrayRef();
   }
 
-  int64_t minElementsPerWorkgroup = std::numeric_limits<int64_t>::max();
-  for (int64_t dmaSize : dmaSizes) {
-    if (dmaSize % elementBits != 0) {
-      continue;
-    }
-    int64_t elementsPerLane = dmaSize / elementBits;
-    minElementsPerWorkgroup =
-        std::min(minElementsPerWorkgroup, numThreads * elementsPerLane);
-  }
-
-  return minElementsPerWorkgroup != std::numeric_limits<int64_t>::max() &&
-         availableElements % minElementsPerWorkgroup == 0;
+  return succeeded(getGlobalLoadDMALayout(
+      funcOp->getContext(), vectorType.getShape(), numThreads, *subgroupSize,
+      elementBits, dmaSizes, swizzleAccessElems));
 }
 
-static bool isAsyncDMAEligible(FunctionOpInterface funcOp,
-                               vector::TransferReadOp readOp,
-                               IREE::GPU::TargetAttr target) {
+static bool
+isAsyncDMAEligible(FunctionOpInterface funcOp, vector::TransferReadOp readOp,
+                   IREE::GPU::TargetAttr target,
+                   std::optional<int64_t> swizzleAccessElems = std::nullopt) {
   if (!target || !targetSupportsGlobalLoadDMA(target)) {
     return false;
   }
@@ -261,8 +255,8 @@ static bool isAsyncDMAEligible(FunctionOpInterface funcOp,
     return false;
   }
 
-  return isDMAAlignedForWorkgroup(funcOp, target, vectorType.getElementType(),
-                                  vectorType.getNumElements());
+  return hasLowerableAsyncDMALayout(funcOp, target, vectorType,
+                                    swizzleAccessElems);
 }
 
 static FailureOr<IREE::Codegen::XORShuffleAttr>
@@ -311,7 +305,18 @@ static FailureOr<Value> materializeAsyncDMARead(
     vector::TransferReadOp readOp,
     IREE::VectorExt::VectorLayoutInterface allocationLayout) {
   IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
-  if (!isAsyncDMAEligible(funcOp, readOp, target)) {
+  VectorType vectorType = readOp.getVectorType();
+  FailureOr<IREE::Codegen::XORShuffleAttr> swizzle = failure();
+  std::optional<int64_t> swizzleAccessElems;
+  if (target && targetSupportsGlobalLoadDMA(target) &&
+      !vectorType.isScalable()) {
+    swizzle = deriveDMASwizzle(builder.getContext(), target, vectorType,
+                               allocationLayout);
+    if (succeeded(swizzle)) {
+      swizzleAccessElems = swizzle->getAccessElementCount();
+    }
+  }
+  if (!isAsyncDMAEligible(funcOp, readOp, target, swizzleAccessElems)) {
     return failure();
   }
   // Synchronize before the write to shared memory to avoid stepping over
@@ -320,13 +325,10 @@ static FailureOr<Value> materializeAsyncDMARead(
   insertWorkgroupBarrierAtBlockStart(builder, readOp);
 
   Location loc = readOp.getLoc();
-  VectorType vectorType = readOp.getVectorType();
   builder.setInsertionPoint(readOp);
   Value dest = allocateWorkgroupTensor(builder, loc,
                                        allocationLayout.getUndistributedShape(),
                                        vectorType.getElementType());
-  FailureOr<IREE::Codegen::XORShuffleAttr> swizzle = deriveDMASwizzle(
-      builder.getContext(), target, vectorType, allocationLayout);
   if (succeeded(swizzle)) {
     dest = IREE::Codegen::SwizzleHintOp::create(builder, loc, dest, *swizzle);
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -4,12 +4,17 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <limits>
+
 #include "iree/compiler/Codegen/Common/GPU/GPUNestedLayoutUtils.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUPatterns.h"
 #include "iree/compiler/Codegen/Common/GPU/GPUPromotionAnalysis.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
@@ -40,40 +45,35 @@ namespace {
 using LayoutMap =
     llvm::MapVector<Value, IREE::VectorExt::VectorLayoutInterface>;
 
-// Allocates a tensor to copy the vector into a la bufferization.alloc_tensor
-// and then writes the vector into the allocated tensor. This allocation is
-// always static as vectors are currently always static where this is used.
-static FailureOr<Value> allocateTensorAndWriteVector(OpBuilder &b, Location loc,
-                                                     Value vector,
-                                                     ArrayRef<int64_t> shape) {
+/// Allocate a workgroup-addressed tensor with the given shape and element type.
+static bufferization::AllocTensorOp
+allocateWorkgroupTensor(OpBuilder &b, Location loc, ArrayRef<int64_t> shape,
+                        Type elementType) {
+  Attribute sharedMemoryAddrSpace = gpu::AddressSpaceAttr::get(
+      b.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
+
+  RankedTensorType tensorType =
+      RankedTensorType::get(shape, elementType, sharedMemoryAddrSpace);
+  auto allocTensorOp = bufferization::AllocTensorOp::create(
+      b, loc, tensorType, ValueRange{}, Value());
+  allocTensorOp.setMemorySpaceAttr(sharedMemoryAddrSpace);
+  return allocTensorOp;
+}
+
+static FailureOr<Value> writeVectorToTensor(OpBuilder &b, Location loc,
+                                            Value vector, Value dest) {
   VectorType vectorType = cast<VectorType>(vector.getType());
   if (vectorType.isScalable()) {
     return failure();
   }
 
-  Attribute sharedMemoryAddrSpace = gpu::AddressSpaceAttr::get(
-      b.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
-
-  RankedTensorType tensorType = RankedTensorType::get(
-      shape, vectorType.getElementType(), sharedMemoryAddrSpace);
-  // Vectors are always statically shaped.
-  auto allocTensorOp = bufferization::AllocTensorOp::create(
-      b, loc, tensorType, ValueRange{}, Value());
-  allocTensorOp.setMemorySpaceAttr(sharedMemoryAddrSpace);
-
   Value c0 = arith::ConstantIndexOp::create(b, loc, 0);
   llvm::Repeated<Value> indices(vectorType.getRank(), c0);
   SmallVector<bool> inBounds(vectorType.getRank(), true);
-  Value copied = vector::TransferWriteOp::create(b, loc, vector, allocTensorOp,
-                                                 indices, inBounds)
-                     .getResult();
+  Value copied =
+      vector::TransferWriteOp::create(b, loc, vector, dest, indices, inBounds)
+          .getResult();
   return copied;
-}
-
-static FailureOr<Value> allocateTensorAndWriteVector(OpBuilder &b, Location loc,
-                                                     Value vector) {
-  VectorType vectorType = cast<VectorType>(vector.getType());
-  return allocateTensorAndWriteVector(b, loc, vector, vectorType.getShape());
 }
 
 static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
@@ -143,8 +143,12 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
     OpOperand &operand = op.getInputMutable();
     // TODO: Since we know the read/write layout for this memory, we can get
     // optimal swizzling here. Figure out how to do that.
-    FailureOr<Value> ret =
-        allocateTensorAndWriteVector(builder, op->getLoc(), operand.get());
+    VectorType vectorType = cast<VectorType>(operand.get().getType());
+    auto allocTensorOp =
+        allocateWorkgroupTensor(builder, op->getLoc(), vectorType.getShape(),
+                                vectorType.getElementType());
+    FailureOr<Value> ret = writeVectorToTensor(builder, op->getLoc(),
+                                               operand.get(), allocTensorOp);
     if (failed(ret)) {
       return failure();
     }
@@ -167,35 +171,238 @@ materializeSharedMemoryConversions(FunctionOpInterface funcOp) {
 struct PromotionCandidate {
   Operation *op = nullptr;
   Value vector;
+  Attribute promotionType;
 };
+
+template <typename... PromotionTypes>
+static std::optional<PromotionCandidate>
+shouldPromoteCandidate(const PromotionTypeMap &promotionTypes, Operation *op,
+                       Value vector) {
+  auto promotionType = promotionTypes.find(vector);
+  if (promotionType == promotionTypes.end()) {
+    return std::nullopt;
+  }
+
+  if (!isa<PromotionTypes...>(promotionType->second)) {
+    return std::nullopt;
+  }
+  return PromotionCandidate{op, vector, promotionType->second};
+}
 
 /// Find promotion candidates, i.e., operations that load data from memory and
 /// were reached by a promotion type during analysis propagation.
 static std::optional<PromotionCandidate>
 getPromotionCandidate(Operation *op, const PromotionTypeMap &promotionTypes) {
-  auto shouldPromoteCandidate =
-      [&](Operation *op, Value vector) -> std::optional<PromotionCandidate> {
-    auto promotionType = promotionTypes.find(vector);
-    if (promotionType == promotionTypes.end()) {
-      return std::nullopt;
-    }
-
-    // TODO: Currently only handles derived_thread_config promotion types,
-    // extend to other promotion types.
-    if (!isa<IREE::GPU::DerivedThreadConfigAttr>(promotionType->second)) {
-      return std::nullopt;
-    }
-    return PromotionCandidate{op, vector};
-  };
   return TypeSwitch<Operation *, std::optional<PromotionCandidate>>(op)
       .Case([&](vector::TransferReadOp read) {
-        return shouldPromoteCandidate(read.getOperation(), read.getVector());
+        return shouldPromoteCandidate<IREE::GPU::DerivedThreadConfigAttr,
+                                      IREE::GPU::UseGlobalLoadDMAAttr>(
+            promotionTypes, read.getOperation(), read.getVector());
       })
       .Case([&](vector::GatherOp gather) {
-        return shouldPromoteCandidate(gather.getOperation(),
-                                      gather.getResult());
+        // TODO: Currently, we support use_global_load_dma only for read ops.
+        return shouldPromoteCandidate<IREE::GPU::DerivedThreadConfigAttr>(
+            promotionTypes, gather.getOperation(), gather.getResult());
       })
       .Default(std::nullopt);
+}
+
+static bool hasAllInBounds(vector::TransferReadOp readOp) {
+  std::optional<ArrayAttr> inBounds = readOp.getInBounds();
+  return inBounds && llvm::all_of(*inBounds, [](Attribute attr) {
+           return cast<BoolAttr>(attr).getValue();
+         });
+}
+
+static bool isDMAAlignedForWorkgroup(FunctionOpInterface funcOp,
+                                     IREE::GPU::TargetAttr target,
+                                     Type elementType,
+                                     int64_t availableElements) {
+  std::optional<SmallVector<int64_t>> maybeWorkgroupSize =
+      getWorkgroupSize(funcOp);
+  if (!maybeWorkgroupSize) {
+    return false;
+  }
+
+  int64_t numThreads = ShapedType::getNumElements(*maybeWorkgroupSize);
+  int64_t elementBits = elementType.getIntOrFloatBitWidth();
+
+  ArrayRef<int64_t> dmaSizes;
+  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
+    dmaSizes = dmaSizesAttr.asArrayRef();
+  }
+
+  int64_t minElementsPerWorkgroup = std::numeric_limits<int64_t>::max();
+  for (int64_t dmaSize : dmaSizes) {
+    if (dmaSize % elementBits != 0) {
+      continue;
+    }
+    int64_t elementsPerLane = dmaSize / elementBits;
+    minElementsPerWorkgroup =
+        std::min(minElementsPerWorkgroup, numThreads * elementsPerLane);
+  }
+
+  return minElementsPerWorkgroup != std::numeric_limits<int64_t>::max() &&
+         availableElements % minElementsPerWorkgroup == 0;
+}
+
+static bool isAsyncDMAEligible(FunctionOpInterface funcOp,
+                               vector::TransferReadOp readOp,
+                               IREE::GPU::TargetAttr target) {
+  if (!target || !targetSupportsGlobalLoadDMA(target)) {
+    return false;
+  }
+  if (!hasAllInBounds(readOp)) {
+    return false;
+  }
+
+  VectorType vectorType = readOp.getVectorType();
+  if (vectorType.isScalable()) {
+    return false;
+  }
+
+  return isDMAAlignedForWorkgroup(funcOp, target, vectorType.getElementType(),
+                                  vectorType.getNumElements());
+}
+
+static FailureOr<IREE::Codegen::XORShuffleAttr>
+deriveDMASwizzle(MLIRContext *context, IREE::GPU::TargetAttr target,
+                 VectorType vectorType,
+                 IREE::VectorExt::VectorLayoutInterface allocationLayout) {
+  auto nestedLayout =
+      dyn_cast<IREE::VectorExt::NestedLayoutAttr>(allocationLayout);
+  if (!nestedLayout) {
+    return failure();
+  }
+
+  int64_t elementBitWidth = vectorType.getElementTypeBitWidth();
+  // The innermost element tile dimension is the contiguous access width per
+  // thread during reads from the flat LDS allocation.
+  int64_t accessElems = nestedLayout.getElementTile().back();
+  FailureOr<XorShuffleParams> swizzleParams = getXorShuffleParamsForDMA(
+      target, elementBitWidth, vectorType.getNumElements(), accessElems);
+  if (failed(swizzleParams)) {
+    return failure();
+  }
+
+  return IREE::Codegen::XORShuffleAttr::get(context, swizzleParams->rowElems,
+                                            swizzleParams->accessElems,
+                                            /*row_stride=*/0,
+                                            /*per_phase=*/0);
+}
+
+/// Materialize async DMA promotion.
+///
+/// Assume this candidate operation:
+///
+/// %read = vector.transfer_read %global_memref ...
+///
+/// This gets promoted by transforming the IR as follows:
+///
+/// %alloc = bufferization.alloc_tensor <workgroup_memory>
+/// %dest = iree_codegen.swizzle_hint %alloc[...]  // If valid for the layout.
+/// %dma = iree_gpu.async_dma %global_memref[...] to %dest[...]
+/// %barrier = iree_gpu.value_barrier %dma
+/// %lds_read = vector.transfer_read %barrier
+///
+/// All uses of %read are replaced by %lds_read.
+static FailureOr<Value> materializeAsyncDMARead(
+    OpBuilder &builder, FunctionOpInterface funcOp,
+    vector::TransferReadOp readOp,
+    IREE::VectorExt::VectorLayoutInterface allocationLayout) {
+  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+  if (!isAsyncDMAEligible(funcOp, readOp, target)) {
+    return failure();
+  }
+  // Synchronize before the write to shared memory to avoid stepping over
+  // reads in the previous iteration of a loop. We set this barrier at the
+  // start of this block.
+  insertWorkgroupBarrierAtBlockStart(builder, readOp);
+
+  Location loc = readOp.getLoc();
+  VectorType vectorType = readOp.getVectorType();
+  builder.setInsertionPoint(readOp);
+  Value dest = allocateWorkgroupTensor(builder, loc,
+                                       allocationLayout.getUndistributedShape(),
+                                       vectorType.getElementType());
+  FailureOr<IREE::Codegen::XORShuffleAttr> swizzle = deriveDMASwizzle(
+      builder.getContext(), target, vectorType, allocationLayout);
+  if (succeeded(swizzle)) {
+    dest = IREE::Codegen::SwizzleHintOp::create(builder, loc, dest, *swizzle);
+  }
+
+  Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
+  SmallVector<Value> zeroIndices(cast<ShapedType>(dest.getType()).getRank(),
+                                 c0);
+
+  auto dmaOp = IREE::GPU::AsyncDMAOp::create(
+      builder, loc, dest.getType(), readOp.getBase(), readOp.getIndices(), dest,
+      zeroIndices, TypeAttr::get(vectorType), readOp.getPermutationMapAttr(),
+      readOp.getInBoundsAttr());
+  auto synced =
+      IREE::GPU::ValueBarrierOp::create(builder, loc, dmaOp.getResult());
+  return readVectorFromTensor(builder, vectorType, synced.getResult(0));
+}
+
+/// Materialize shared memory promotion through registers.
+///
+/// Assume this candidate operation:
+///
+/// %read = vector.transfer_read %global_memref ...
+///
+/// This gets promoted by transforming the IR as follows:
+///
+/// %read = vector.transfer_read %global_memref ...
+/// %global_layout = vector_ext.to_layout %read, #derived_thread_layout
+/// %alloc = bufferization.alloc_tensor <workgroup_memory>
+/// %lds_write = vector.transfer_write %global_layout, %alloc ...
+/// %barrier = iree_gpu.value_barrier %lds_write
+/// %lds_read = vector.transfer_read %barrier
+///
+/// All uses of %read except %global_layout are replaced by %lds_read.
+static LogicalResult materializeSharedMemoryPromotion(
+    OpBuilder &builder, PromotionCandidate candidate,
+    IREE::VectorExt::VectorLayoutInterface allocationLayout,
+    ArrayRef<int64_t> workgroupSize) {
+  Value vector = candidate.vector;
+  VectorType readType = cast<VectorType>(vector.getType());
+  SmallVector<int64_t> elementTile = IREE::GPU::deriveThreadTileSizes(
+      readType.getShape(), ShapedType::getNumElements(workgroupSize),
+      readType.getElementTypeBitWidth());
+  FailureOr<IREE::VectorExt::NestedLayoutAttr> readLayout =
+      getDerivedThreadLayout(candidate.op->getContext(), workgroupSize,
+                             readType.getShape(), elementTile);
+  if (failed(readLayout)) {
+    return candidate.op->emitOpError(
+        "failed to derive layout for promoted read-like op");
+  }
+  Operation *op = candidate.op;
+  // Synchronize before the write to shared memory to avoid stepping over
+  // reads in the previous iteration of a loop. We set this barrier at the
+  // start of this block.
+  insertWorkgroupBarrierAtBlockStart(builder, op);
+
+  builder.setInsertionPointAfter(op);
+
+  auto toLayout = IREE::VectorExt::ToLayoutOp::create(builder, op->getLoc(),
+                                                      vector, *readLayout);
+
+  Value dest = allocateWorkgroupTensor(builder, op->getLoc(),
+                                       allocationLayout.getUndistributedShape(),
+                                       readType.getElementType());
+  FailureOr<Value> copied =
+      writeVectorToTensor(builder, op->getLoc(), toLayout.getResult(), dest);
+  if (failed(copied)) {
+    return failure();
+  }
+
+  auto synced =
+      IREE::GPU::ValueBarrierOp::create(builder, op->getLoc(), *copied);
+  Value newRead = readVectorFromTensor(builder, readType, synced.getResult(0));
+
+  vector.replaceUsesWithIf(
+      newRead, [&](OpOperand &use) { return use.getOwner() != toLayout; });
+  return success();
 }
 
 /// Materialize promotion of operands to LDS.
@@ -221,20 +428,7 @@ materializeSharedMemoryPromotions(FunctionOpInterface funcOp,
   if (!workgroupSize) {
     return funcOp.emitOpError("unable to query workgroup_size information");
   }
-  // Assume this candidate operation:
-  //
-  // %read = vector.transfer_read %global_memref ...
-  //
-  // This gets promoted by transforming the IR as follows:
-  //
-  // %read = vector.transfer_read %global_memref ...
-  // %global_layout = vector_ext.to_layout %read, #derived_thread_layout
-  // %alloc = bufferization.alloc_tensor <workgroup_memory>
-  // %lds_write = vector.transfer_write %global_layout, %alloc ...
-  // %barrier = iree_gpu.value_barrier %lds_write
-  // %lds_read = transfer_read %barrier
-  //
-  // All uses of %read except %global_layout will be replaced by %lds_read.
+
   for (PromotionCandidate candidate : readsToPromote) {
     Value vector = candidate.vector;
     IREE::VectorExt::VectorLayoutInterface allocationLayout =
@@ -244,42 +438,29 @@ materializeSharedMemoryPromotions(FunctionOpInterface funcOp,
           "missing layout for promoted read-like op");
     }
 
-    VectorType readType = cast<VectorType>(vector.getType());
-    SmallVector<int64_t> elementTile = IREE::GPU::deriveThreadTileSizes(
-        readType.getShape(), ShapedType::getNumElements(*workgroupSize),
-        readType.getElementTypeBitWidth());
-    FailureOr<IREE::VectorExt::NestedLayoutAttr> readLayout =
-        getDerivedThreadLayout(candidate.op->getContext(), *workgroupSize,
-                               readType.getShape(), elementTile);
-    if (failed(readLayout)) {
-      return candidate.op->emitOpError(
-          "failed to derive layout for promoted read-like op");
+    Attribute promotionType = candidate.promotionType;
+    // If promotion via DMA was requested, first attempt to use DMA for
+    // promotion. If any of the prerequisites isn't met, fall back to regular
+    // global loads.
+    if (isa<IREE::GPU::UseGlobalLoadDMAAttr>(promotionType)) {
+      builder.setInsertionPointToStart(candidate.op->getBlock());
+      gpu::BarrierOp::create(builder, candidate.op->getLoc(),
+                             gpu::AddressSpace::Workgroup);
+
+      auto readOp = cast<vector::TransferReadOp>(candidate.op);
+      FailureOr<Value> dmaRead =
+          materializeAsyncDMARead(builder, funcOp, readOp, allocationLayout);
+      if (succeeded(dmaRead)) {
+        readOp.getResult().replaceAllUsesWith(*dmaRead);
+        readOp->erase();
+        continue;
+      }
     }
-    Operation *op = candidate.op;
-    builder.setInsertionPointAfter(op);
 
-    // Synchronize before the write to shared memory to avoid stepping over
-    // reads in the previous iteration of a loop. We set this barrier at the
-    // start of this block.
-    insertWorkgroupBarrierAtBlockStart(builder, op);
-
-    auto toLayout = IREE::VectorExt::ToLayoutOp::create(builder, op->getLoc(),
-                                                        vector, *readLayout);
-
-    FailureOr<Value> copied = allocateTensorAndWriteVector(
-        builder, op->getLoc(), toLayout.getResult(),
-        allocationLayout.getUndistributedShape());
-    if (failed(copied)) {
+    if (failed(materializeSharedMemoryPromotion(
+            builder, candidate, allocationLayout, *workgroupSize))) {
       return failure();
     }
-
-    auto synced =
-        IREE::GPU::ValueBarrierOp::create(builder, op->getLoc(), *copied);
-    Value newRead =
-        readVectorFromTensor(builder, readType, synced.getResult(0));
-
-    vector.replaceUsesWithIf(
-        newRead, [&](OpOperand &use) { return use.getOwner() != toLayout; });
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
@@ -50,37 +50,6 @@ func.func @promote_global_transfer_read(%src: memref<16x16xf16>) -> vector<16x16
   thread_strides   = [0, 0]
 >
 
-func.func @promote_global_transfer_read_dma(%src: memref<16x16xf16>) -> vector<16x16xf16>
-    attributes {translation_info = #translation} {
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 0.0 : f16
-  %read = vector.transfer_read %src[%c0, %c0], %cst : memref<16x16xf16>, vector<16x16xf16>
-  %out = iree_vector_ext.to_layout %read to layout(#consumer_layout)
-      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<16x16xf16>
-  return %out : vector<16x16xf16>
-}
-
-// CHECK-DAG: #[[$DMA_CONSUMER_LAYOUT:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [4, 16], element_tile = [4, 1], subgroup_strides = [0, 0], thread_strides = [0, 0]>
-// CHECK-LABEL: func.func @promote_global_transfer_read_dma
-// CHECK: %[[DMA_GLOBAL:.+]] = vector.transfer_read %{{.*}} : memref<16x16xf16>, vector<16x16xf16>
-// CHECK-NEXT: %[[DMA_OUT:.+]] = iree_vector_ext.to_layout %[[DMA_GLOBAL]] to layout(#[[$DMA_CONSUMER_LAYOUT]])
-// CHECK-NOT: shared_memory_conversion
-// CHECK: return %[[DMA_OUT]]
-
-// -----
-
-#translation = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64>
-
-#consumer_layout = #iree_vector_ext.nested_layout<
-  subgroup_tile = [1, 1],
-  batch_tile = [1, 1],
-  outer_tile = [1, 1],
-  thread_tile = [4, 16],
-  element_tile = [4, 1],
-  subgroup_strides = [0, 0],
-  thread_strides   = [0, 0]
->
-
 func.func @promote_global_gather(%src: memref<16x16xf16>,
                                  %indices: vector<16x16xindex>,
                                  %mask: vector<16x16xi1>,
@@ -205,3 +174,148 @@ func.func @invalid_shared_memory_conversion_attr(%vector: vector<16x16xf16>) -> 
   %out = iree_vector_ext.to_layout %vector to layout(#layout) {shared_memory_conversion = "invalid"} : vector<16x16xf16>
   return %out : vector<16x16xf16>
 }
+
+// -----
+
+#gpu_target_dma = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128],
+  workgroup_memory_bank_count = 32
+>>
+#exec_target_dma = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_dma}>
+#translation_dma = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+#consumer_layout_dma = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 64],
+  element_tile = [4, 1],
+  subgroup_strides = [0, 0],
+  thread_strides   = [0, 1]
+>
+
+func.func @promote_global_transfer_read_with_async_dma(
+    %src: memref<4x64xf16>, %other: vector<4x64xf16>)
+    -> vector<4x64xf16>
+    attributes {hal.executable.target = #exec_target_dma, translation_info = #translation_dma} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  %read = vector.transfer_read %src[%c0, %c0], %cst {in_bounds = [true, true]}
+      : memref<4x64xf16>, vector<4x64xf16>
+  %mul = arith.mulf %read, %other : vector<4x64xf16>
+  %out = iree_vector_ext.to_layout %mul to layout(#consumer_layout_dma)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<4x64xf16>
+  return %out : vector<4x64xf16>
+}
+
+// CHECK-LABEL: func.func @promote_global_transfer_read_with_async_dma
+// CHECK-SAME: %[[SRC:[a-zA-Z0-9]+]]: memref<4x64xf16>
+// CHECK: gpu.barrier
+// CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<4x64xf16, #gpu.address_space<workgroup>>
+// CHECK: %[[DMA:.+]] = iree_gpu.async_dma %[[SRC]]
+// CHECK-SAME: to %[[ALLOC]]
+// CHECK-SAME: vector<4x64xf16>
+// CHECK: %[[BARRIER:.+]] = iree_gpu.value_barrier %[[DMA]]
+// CHECK: %[[READ:.+]] = vector.transfer_read %[[BARRIER]]
+// CHECK: %[[MUL:.+]] = arith.mulf %[[READ]]
+// CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[MUL]]
+// CHECK-NOT: shared_memory_conversion
+// CHECK: return %[[OUT]]
+
+// -----
+
+#gpu_target_dma_fallback = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128],
+  workgroup_memory_bank_count = 32
+>>
+#exec_target_dma_fallback = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_dma_fallback}>
+#translation_dma_fallback = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [256, 1, 1] subgroup_size = 64>
+
+#consumer_layout_dma_fallback = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1, 1],
+  batch_tile = [1, 1, 1],
+  outer_tile = [1, 1, 1],
+  thread_tile = [1, 4, 16],
+  element_tile = [1, 4, 1],
+  subgroup_strides = [0, 0, 0],
+  thread_strides   = [0, 16, 1]
+>
+
+func.func @promote_global_transfer_read_with_async_dma_fallback(
+    %src: memref<1x16x16xf16>) -> vector<1x16x16xf16>
+    attributes {hal.executable.target = #exec_target_dma_fallback, translation_info = #translation_dma_fallback} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  %read = vector.transfer_read %src[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]}
+      : memref<1x16x16xf16>, vector<1x16x16xf16>
+  %out = iree_vector_ext.to_layout %read to layout(#consumer_layout_dma_fallback)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<1x16x16xf16>
+  return %out : vector<1x16x16xf16>
+}
+
+// CHECK-LABEL: func.func @promote_global_transfer_read_with_async_dma_fallback
+// CHECK: gpu.barrier
+// CHECK: %[[GLOBAL:.+]] = vector.transfer_read
+// CHECK-NOT: iree_gpu.async_dma
+// CHECK: %[[READ_LAYOUT_VALUE:.+]] = iree_vector_ext.to_layout %[[GLOBAL]]
+// CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>}
+// CHECK: %[[WRITE:.+]] = vector.transfer_write %[[READ_LAYOUT_VALUE]], %[[ALLOC]]
+// CHECK: %[[BARRIER:.+]] = iree_gpu.value_barrier %[[WRITE]]
+// CHECK: %[[LDS_READ:.+]] = vector.transfer_read %[[BARRIER]]
+// CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[LDS_READ]]
+// CHECK: return %[[OUT]]
+
+// -----
+
+#gpu_target_dma_swizzle = #iree_gpu.target<arch = "gfx950", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  max_load_instruction_bits = 128, subgroup_size_choices = [64],
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647],
+  dma_sizes = [32, 128],
+  workgroup_memory_bank_count = 32
+>>
+#exec_target_dma_swizzle = #hal.executable.target<"rocm", "rocm-hsaco-fb", {iree_codegen.target_info = #gpu_target_dma_swizzle}>
+#translation_dma_swizzle = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+#consumer_layout_dma_swizzle = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [1, 8],
+  subgroup_strides = [0, 0],
+  thread_strides   = [16, 1]
+>
+
+func.func @promote_global_transfer_read_with_swizzled_async_dma(
+    %src: memref<4x128xf16>) -> vector<4x128xf16>
+    attributes {hal.executable.target = #exec_target_dma_swizzle, translation_info = #translation_dma_swizzle} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  %read = vector.transfer_read %src[%c0, %c0], %cst {in_bounds = [true, true]}
+      : memref<4x128xf16>, vector<4x128xf16>
+  %out = iree_vector_ext.to_layout %read to layout(#consumer_layout_dma_swizzle)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<4x128xf16>
+  return %out : vector<4x128xf16>
+}
+
+// CHECK-LABEL: func.func @promote_global_transfer_read_with_swizzled_async_dma
+// CHECK-SAME: %[[SRC:[a-zA-Z0-9]+]]: memref<4x128xf16>
+// CHECK: gpu.barrier
+// CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>} : tensor<4x128xf16, #gpu.address_space<workgroup>>
+// CHECK: %[[HINT:.+]] = iree_codegen.swizzle_hint %[[ALLOC]][#iree_codegen.xor_shuffle<64, 8>]
+// CHECK: %[[DMA:.+]] = iree_gpu.async_dma %[[SRC]]
+// CHECK-SAME: to %[[HINT]]
+// CHECK: %[[BARRIER:.+]] = iree_gpu.value_barrier %[[DMA]]
+// CHECK: %[[READ:.+]] = vector.transfer_read %[[BARRIER]]
+// CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[READ]]
+// CHECK: return %[[OUT]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
@@ -226,6 +226,66 @@ func.func @promote_global_transfer_read_with_async_dma(
 // CHECK-NOT: shared_memory_conversion
 // CHECK: return %[[OUT]]
 
+#translation_dma_no_subgroup = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<VectorDistribute> workgroup_size = [64, 1, 1]>
+
+func.func @promote_global_transfer_read_with_async_dma_no_subgroup(
+    %src: memref<4x64xf16>) -> vector<4x64xf16>
+    attributes {hal.executable.target = #exec_target_dma, translation_info = #translation_dma_no_subgroup} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  %read = vector.transfer_read %src[%c0, %c0], %cst {in_bounds = [true, true]}
+      : memref<4x64xf16>, vector<4x64xf16>
+  %out = iree_vector_ext.to_layout %read to layout(#consumer_layout_dma)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<4x64xf16>
+  return %out : vector<4x64xf16>
+}
+
+// CHECK-LABEL: func.func @promote_global_transfer_read_with_async_dma_no_subgroup
+// CHECK: gpu.barrier
+// CHECK: %[[GLOBAL:.+]] = vector.transfer_read
+// CHECK-NOT: iree_gpu.async_dma
+// CHECK: %[[READ_LAYOUT_VALUE:.+]] = iree_vector_ext.to_layout %[[GLOBAL]]
+// CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>}
+// CHECK: %[[WRITE:.+]] = vector.transfer_write %[[READ_LAYOUT_VALUE]], %[[ALLOC]]
+// CHECK: %[[BARRIER:.+]] = iree_gpu.value_barrier %[[WRITE]]
+// CHECK: %[[LDS_READ:.+]] = vector.transfer_read %[[BARRIER]]
+// CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[LDS_READ]]
+// CHECK: return %[[OUT]]
+
+#consumer_layout_dma_shape_fallback = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [32, 2],
+  element_tile = [1, 6],
+  subgroup_strides = [0, 0],
+  thread_strides   = [2, 1]
+>
+
+func.func @promote_global_transfer_read_with_async_dma_shape_fallback(
+    %src: memref<32x12xf16>) -> vector<32x12xf16>
+    attributes {hal.executable.target = #exec_target_dma, translation_info = #translation_dma} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f16
+  %read = vector.transfer_read %src[%c0, %c0], %cst {in_bounds = [true, true]}
+      : memref<32x12xf16>, vector<32x12xf16>
+  %out = iree_vector_ext.to_layout %read to layout(#consumer_layout_dma_shape_fallback)
+      {shared_memory_conversion = #iree_gpu.use_global_load_dma} : vector<32x12xf16>
+  return %out : vector<32x12xf16>
+}
+
+// CHECK-LABEL: func.func @promote_global_transfer_read_with_async_dma_shape_fallback
+// CHECK: gpu.barrier
+// CHECK: %[[GLOBAL:.+]] = vector.transfer_read
+// CHECK-NOT: iree_gpu.async_dma
+// CHECK: %[[READ_LAYOUT_VALUE:.+]] = iree_vector_ext.to_layout %[[GLOBAL]]
+// CHECK: %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>}
+// CHECK: %[[WRITE:.+]] = vector.transfer_write %[[READ_LAYOUT_VALUE]], %[[ALLOC]]
+// CHECK: %[[BARRIER:.+]] = iree_gpu.value_barrier %[[WRITE]]
+// CHECK: %[[LDS_READ:.+]] = vector.transfer_read %[[BARRIER]]
+// CHECK: %[[OUT:.+]] = iree_vector_ext.to_layout %[[LDS_READ]]
+// CHECK: return %[[OUT]]
+
 // -----
 
 #gpu_target_dma_fallback = #iree_gpu.target<arch = "gfx950", features = "", wgp = <

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -845,6 +845,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   addGPUBufferizePasses(funcPassManager);
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createFlattenSwizzleHintAllocsPass());
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
 
   // Vector SIMD -> Vector SIMT

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -32,6 +32,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <optional>
 
 #define DEBUG_TYPE "iree-codegen-gpu-utils"
@@ -1329,6 +1330,84 @@ bool targetSupportsShuffleBitwidth(IREE::GPU::TargetAttr target,
     return true;
   }
   return target && target.isAMD();
+}
+
+std::optional<int64_t> getMinDMAAlignedElements(FunctionOpInterface funcOp,
+                                                Type elementType) {
+  std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
+  if (!subgroupSize) {
+    return std::nullopt;
+  }
+
+  int64_t elementBits = elementType.getIntOrFloatBitWidth();
+
+  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+  if (!target || !targetSupportsGlobalLoadDMA(target)) {
+    return std::nullopt;
+  }
+
+  ArrayRef<int64_t> dmaSizes;
+  if (auto dmaSizesAttr = target.getWgp().getDmaSizes()) {
+    dmaSizes = dmaSizesAttr.asArrayRef();
+  }
+
+  int64_t minElementsPerTransfer = std::numeric_limits<int64_t>::max();
+  for (int64_t dmaSize : dmaSizes) {
+    if (dmaSize % elementBits != 0) {
+      continue;
+    }
+    int64_t elementsPerLane = dmaSize / elementBits;
+    int64_t elementsPerTransfer = *subgroupSize * elementsPerLane;
+    minElementsPerTransfer =
+        std::min(minElementsPerTransfer, elementsPerTransfer);
+  }
+
+  if (minElementsPerTransfer == std::numeric_limits<int64_t>::max()) {
+    return std::nullopt;
+  }
+  return minElementsPerTransfer;
+}
+
+std::optional<int64_t> getDMAAlignedSubgroupSize(FunctionOpInterface funcOp,
+                                                 Type elementType,
+                                                 int64_t availableElements) {
+  std::optional<int64_t> minAligned =
+      getMinDMAAlignedElements(funcOp, elementType);
+  if (!minAligned || availableElements % *minAligned != 0) {
+    return std::nullopt;
+  }
+  // getMinDMAAlignedElements already validated subgroupSize is present.
+  return getSubgroupSize(funcOp);
+}
+
+FailureOr<XorShuffleParams>
+getXorShuffleParamsForDMA(IREE::GPU::TargetAttr target, int64_t elementBitWidth,
+                          int64_t totalElements, int64_t computeAccessWidth) {
+  IREE::GPU::TargetWgpAttr wgp = target.getWgp();
+  std::optional<int64_t> bankCount = wgp.getWorkgroupMemoryBankCount();
+  if (!bankCount) {
+    return failure();
+  }
+
+  constexpr int64_t bankWidthBits = 32;
+  int64_t rowElems = (*bankCount * bankWidthBits) / elementBitWidth;
+  if (!isXORShuffleValid(rowElems, computeAccessWidth, totalElements)) {
+    return failure();
+  }
+
+  ArrayRef<int64_t> dmaSizes;
+  if (auto dmaSizesAttr = wgp.getDmaSizes()) {
+    dmaSizes = dmaSizesAttr.asArrayRef();
+  }
+  bool hasCompatibleDMASize = llvm::any_of(dmaSizes, [&](int64_t dmaSize) {
+    return dmaSize % elementBitWidth == 0 &&
+           computeAccessWidth % (dmaSize / elementBitWidth) == 0;
+  });
+  if (!hasCompatibleDMASize) {
+    return failure();
+  }
+
+  return XorShuffleParams{rowElems, computeAccessWidth};
 }
 
 void addConfigGPUTarget(MLIRContext *context,

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -348,6 +348,22 @@ bool targetSupportsGlobalLoadDMA(IREE::GPU::TargetAttr target);
 bool targetSupportsShuffleBitwidth(IREE::GPU::TargetAttr target,
                                    unsigned bitwidth);
 
+/// Returns the minimum number of elements needed (after padding) for DMA
+/// alignment, or std::nullopt if DMA is not supported for this element type.
+std::optional<int64_t> getMinDMAAlignedElements(FunctionOpInterface funcOp,
+                                                Type elementType);
+
+/// Returns the subgroup size if the available elements are aligned to DMA
+/// transfer sizes for a single subgroup, std::nullopt otherwise.
+std::optional<int64_t> getDMAAlignedSubgroupSize(FunctionOpInterface funcOp,
+                                                 Type elementType,
+                                                 int64_t availableElements);
+
+/// Derives XOR swizzle parameters for DMA-promoted LDS allocations.
+FailureOr<XorShuffleParams>
+getXorShuffleParamsForDMA(IREE::GPU::TargetAttr target, int64_t elementBitWidth,
+                          int64_t totalElements, int64_t computeAccessWidth);
+
 // Methods to retrieve information association with `configuration` field
 // of `hal.executable.target` attribute used commonly in GPU codegen pipelines.
 std::optional<int64_t> getConfigWavesPerEu(DictionaryAttr targetAttr);


### PR DESCRIPTION
Extends the `GPUVectorAlloc` pass to promote operands to LDS using asynchronous DMA operations (e.g., AMD GPU direct-to-LDS).

Based on propagation of the `use_global_load_dma` propagation type during analysis, the pass inserts LDS allocation and `async_dma` operations, if the necessary requirements are met. Otherwise, promotion falls back to load/store via registers. 

The inserted `async_dma` operations are lowered and distributed by the pass landed in https://github.com/iree-org/iree/pull/24299 further down in the pipeline.

This is part of https://github.com/iree-org/iree/issues/23782.

Assisted-by: Claude Code and Codex