### PR TITLE
[HAL][AMDGPU] Support raw HSACO custom kernargs

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/abi/kernel_args.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/abi/kernel_args.h
@@ -54,8 +54,11 @@ typedef struct iree_hal_amdgpu_device_kernel_args_t {
   uint16_t constant_count;
   // Total number of bindings used by the dispatch (if a HAL dispatch).
   uint16_t binding_count;
+  // Offset of HIP/OpenCL implicit args within custom-direct kernargs, or
+  // UINT16_MAX if the kernel does not use an implicit suffix.
+  uint16_t implicit_args_offset;
   // Reserved for future hot kernel metadata. Must be zero.
-  uint32_t reserved;
+  uint16_t reserved;
 } iree_hal_amdgpu_device_kernel_args_t;
 IREE_AMDGPU_STATIC_ASSERT(
     sizeof(iree_hal_amdgpu_device_kernel_args_t) <= 64,

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1690,11 +1690,32 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
       }
       return iree_ok_status();
     }
-    case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT:
-      if (constants.data_length > 0) {
-        memcpy(tail_payload, constants.data, constants.data_length);
+    case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT: {
+      // Custom-direct callers hand us a pre-packed HIP ABI blob. Some raw
+      // HSACO kernels also need an implicit suffix synthesized after that blob,
+      // so zero the full reservation before copying only caller-owned bytes.
+      const iree_host_size_t total_kernarg_size =
+          layout->total_kernarg_size ? layout->total_kernarg_size
+                                     : constants.data_length;
+      memset(tail_payload, 0, total_kernarg_size);
+      const iree_host_size_t explicit_bytes =
+          layout->has_implicit_args ? layout->implicit_args_offset
+                                    : total_kernarg_size;
+      const iree_host_size_t copy_bytes =
+          constants.data_length < explicit_bytes ? constants.data_length
+                                                 : explicit_bytes;
+      if (copy_bytes > 0) {
+        memcpy(tail_payload, constants.data, copy_bytes);
+      }
+      if (layout->has_implicit_args) {
+        iree_amdgpu_kernel_implicit_args_t* implicit_args =
+            (iree_amdgpu_kernel_implicit_args_t*)(tail_payload +
+                                                  layout->implicit_args_offset);
+        iree_hal_amdgpu_aql_command_buffer_write_implicit_args(
+            kernel_args, config, implicit_args);
       }
       return iree_ok_status();
+    }
     case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_INDIRECT:
       return iree_make_status(
           IREE_STATUS_UNIMPLEMENTED,
@@ -2017,18 +2038,40 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
 
   if (iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(
           out_plan)) {
-    if (IREE_UNLIKELY(inputs->constants.data_length !=
-                      out_plan->descriptor->kernel_args.kernarg_size)) {
+    // Callers (e.g. rocBLAS/Tensile) sometimes omit trailing ABI padding or pad
+    // beyond the declared kernarg_segment_size with extra trailing scalars. The
+    // kernel only reads its declared size, so trailing bytes are ignored and the
+    // memcpy in write_dispatch_tail clamps to the declared size.
+    //
+    // Validate after 8-byte ABI padding so we accept missing tail padding while
+    // still rejecting truly short pre-packed HIP argument buffers.
+    const uint32_t required_explicit_bytes =
+        (uint32_t)out_plan->descriptor->custom_kernarg_layout
+            .explicit_kernarg_size;
+    const iree_host_size_t padded_constant_length =
+        iree_host_align(inputs->constants.data_length, /*alignment=*/8);
+    if (IREE_UNLIKELY(padded_constant_length < required_explicit_bytes)) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
-          "custom dispatch argument length mismatch; expected %u but got "
-          "%" PRIhsz,
-          out_plan->descriptor->kernel_args.kernarg_size,
-          inputs->constants.data_length);
+          "custom dispatch argument length too short; expected at least %u "
+          "but got %" PRIhsz " (padded to %" PRIhsz ")",
+          required_explicit_bytes, inputs->constants.data_length,
+          padded_constant_length);
     }
     out_plan->layout = &out_plan->descriptor->custom_kernarg_layout;
     out_plan->kernarg_block_count =
         iree_max(1u, out_plan->descriptor->custom_kernarg_block_count);
+    if (out_plan->layout->total_kernarg_size == 0 &&
+        inputs->constants.data_length > 0) {
+      // Some raw kernels have no reflected kernarg size. In that case the
+      // caller-provided blob is the only reservation size we can trust.
+      const uint32_t provided_kernarg_block_count =
+          (uint32_t)iree_host_size_ceil_div(
+              inputs->constants.data_length,
+              sizeof(iree_hal_amdgpu_kernarg_block_t));
+      out_plan->kernarg_block_count =
+          iree_max(out_plan->kernarg_block_count, provided_kernarg_block_count);
+    }
     out_plan->kernarg_strategy =
         IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT;
     return iree_ok_status();
@@ -2102,14 +2145,18 @@ iree_hal_amdgpu_aql_command_buffer_calculate_dispatch_layout(
           ? 0
           : (iree_host_size_t)plan->kernel_args->binding_count *
                 sizeof(uint64_t);
-  const iree_host_size_t tail_byte_length =
-      plan->layout->total_kernarg_size - binding_bytes;
+  const iree_host_size_t total_kernarg_size =
+      iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(plan) &&
+              plan->layout->total_kernarg_size == 0
+          ? inputs->constants.data_length
+          : plan->layout->total_kernarg_size;
+  const iree_host_size_t tail_byte_length = total_kernarg_size - binding_bytes;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_aql_command_buffer_qword_length(
       tail_byte_length, "dispatch tail payload",
       &out_layout->kernarg.tail_length_qwords,
       &out_layout->kernarg.tail_padded_length));
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_aql_command_buffer_qword_length(
-      plan->layout->total_kernarg_size, "dispatch kernarg",
+      total_kernarg_size, "dispatch kernarg",
       &out_layout->kernarg.total_length_qwords,
       &out_layout->kernarg.total_padded_length));
   out_layout->kernarg.implicit_args_offset_qwords =

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
@@ -96,14 +96,34 @@ void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
 }
 
 void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
+    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
+        kernel_args,
+    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const void* IREE_AMDGPU_RESTRICT custom_kernarg_ptr,
+    size_t custom_kernarg_length,
     void* IREE_AMDGPU_RESTRICT kernarg_ptr) {
-  if (layout->total_kernarg_size > 0) {
-    iree_amdgpu_memcpy(kernarg_ptr, custom_kernarg_ptr,
-                       layout->total_kernarg_size);
+  const size_t total_kernarg_size =
+      layout->total_kernarg_size ? layout->total_kernarg_size
+                                 : custom_kernarg_length;
+  if (total_kernarg_size > 0) {
+    iree_amdgpu_memset(kernarg_ptr, 0, total_kernarg_size);
+    const size_t explicit_bytes =
+        layout->has_implicit_args
+            ? layout->implicit_args_offset
+            : total_kernarg_size;
+    const size_t copy_bytes =
+        custom_kernarg_length < explicit_bytes ? custom_kernarg_length
+                                               : explicit_bytes;
+    if (copy_bytes > 0) {
+      iree_amdgpu_memcpy(kernarg_ptr, custom_kernarg_ptr, copy_bytes);
+    }
   }
+
+  iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
+      kernel_args, workgroup_count, dynamic_workgroup_local_memory, layout,
+      kernarg_ptr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -178,18 +178,24 @@ void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
 
 // Populates custom direct kernargs in already-reserved storage.
 //
-// |custom_kernarg_ptr| must provide |layout->total_kernarg_size| bytes in the
-// final kernel ABI shape expected by the target kernel.
+// |custom_kernarg_ptr| provides up to |layout->total_kernarg_size| bytes in the
+// final kernel ABI shape expected by the target kernel. Missing trailing padding
+// bytes remain zeroed.
 //
 // Preconditions:
-//   - |layout| and |kernarg_ptr| are non-NULL.
+//   - |kernel_args|, |workgroup_count|, |layout|, and |kernarg_ptr| are
+//     non-NULL.
 //   - |layout| was derived with
 //     iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout.
-//   - |custom_kernarg_ptr| is non-NULL when |layout->total_kernarg_size| > 0.
+//   - |custom_kernarg_ptr| is non-NULL when |custom_kernarg_length| > 0.
 void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
+    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
+        kernel_args,
+    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const void* IREE_AMDGPU_RESTRICT custom_kernarg_ptr,
+    size_t custom_kernarg_length,
     void* IREE_AMDGPU_RESTRICT kernarg_ptr);
 
 // Populates the builtin patch dispatch that updates an indirect-parameter

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -965,6 +965,7 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_kernel_args_from_symbol(
 
   out_kernel_args->binding_count = binding_count;
   out_kernel_args->constant_count = constant_count;
+  out_kernel_args->implicit_args_offset = UINT16_MAX;
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -1141,6 +1142,21 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
   out_descriptor->custom_kernarg_layout =
       iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout(
           kernel_args->kernarg_size);
+  const uint16_t custom_implicit_args_offset =
+      kernel_args->implicit_args_offset != UINT16_MAX
+          ? kernel_args->implicit_args_offset
+          : kernel_args->kernarg_size;
+  if (custom_implicit_args_offset != UINT16_MAX) {
+    out_descriptor->custom_kernarg_layout.explicit_kernarg_size =
+        custom_implicit_args_offset;
+    out_descriptor->custom_kernarg_layout.implicit_args_offset =
+        custom_implicit_args_offset;
+    out_descriptor->custom_kernarg_layout.total_kernarg_size = iree_max(
+        (size_t)kernel_args->kernarg_size,
+        (size_t)custom_implicit_args_offset +
+            IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
+    out_descriptor->custom_kernarg_layout.has_implicit_args = true;
+  }
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_calculate_kernarg_block_count(
       &out_descriptor->custom_kernarg_layout,
       &out_descriptor->custom_kernarg_block_count));
@@ -1656,13 +1672,6 @@ iree_hal_amdgpu_executable_calculate_raw_hsaco_reflection_storage(
     iree_host_size_t* out_export_name_storage_size,
     iree_host_size_t* out_export_parameter_count,
     iree_host_size_t* out_export_parameter_name_storage_size) {
-  if (iree_string_view_is_empty(hsaco_metadata->target)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "raw HSACO metadata is missing `amdhsa.target`; direct loading "
-        "requires the code object to declare its target ISA");
-  }
-
   iree_host_size_t export_name_storage_size = 0;
   iree_host_size_t export_parameter_count = 0;
   iree_host_size_t export_parameter_name_storage_size = 0;
@@ -1922,6 +1931,60 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
             requirements.binding_count, &host_kernel_args[kernel_ordinal]),
         "resolving kernel args for raw kernel `%.*s`", (int)symbol_name.size,
         symbol_name.data);
+    // Raw HSACO metadata is the source of truth for caller-visible kernargs:
+    // some code objects report a smaller HSA symbol size than the metadata
+    // segment needed by pre-packed HIP launch buffers.
+    if (host_kernel_args[kernel_ordinal].kernarg_size <
+        kernel->kernarg_segment_size) {
+      host_kernel_args[kernel_ordinal].kernarg_size =
+          kernel->kernarg_segment_size;
+    }
+    if (host_kernel_args[kernel_ordinal].kernarg_alignment <
+        kernel->kernarg_segment_alignment) {
+      host_kernel_args[kernel_ordinal].kernarg_alignment =
+          kernel->kernarg_segment_alignment;
+    }
+
+    uint16_t implicit_args_offset = UINT16_MAX;
+    uint32_t explicit_args_end = 0;
+    for (iree_host_size_t arg_i = 0; arg_i < kernel->arg_count; ++arg_i) {
+      const iree_hal_amdgpu_hsaco_metadata_arg_t* arg =
+          &kernel->args[arg_i];
+      if (arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN ||
+          arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN_NONE) {
+        if (arg->offset <= UINT16_MAX &&
+            (implicit_args_offset == UINT16_MAX ||
+             arg->offset < implicit_args_offset)) {
+          implicit_args_offset = (uint16_t)arg->offset;
+        }
+      } else {
+        iree_host_size_t arg_end = 0;
+        if (!iree_host_size_checked_add(arg->offset, arg->size, &arg_end) ||
+            arg_end > UINT32_MAX) {
+          return iree_make_status(
+              IREE_STATUS_OUT_OF_RANGE,
+              "AMDGPU kernel `%.*s` argument offset overflows",
+              (int)symbol_name.size, symbol_name.data);
+        }
+        explicit_args_end = iree_max(explicit_args_end, (uint32_t)arg_end);
+      }
+    }
+    if (implicit_args_offset != UINT16_MAX && implicit_args_offset > 0) {
+      host_kernel_args[kernel_ordinal].implicit_args_offset =
+          implicit_args_offset;
+    } else if (explicit_args_end <= UINT16_MAX &&
+               host_kernel_args[kernel_ordinal].kernarg_size >=
+                   explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
+      host_kernel_args[kernel_ordinal].implicit_args_offset =
+          (uint16_t)explicit_args_end;
+    } else if (kernel->uses_borrowed_arg_layout &&
+               host_kernel_args[kernel_ordinal].kernarg_size > 0) {
+      // ELF-synthesized exports borrow a template arg layout, so its hidden arg
+      // offsets may not apply. Preserve the full caller-provided raw kernarg
+      // blob and append the implicit suffix after the HSA-reported segment.
+      host_kernel_args[kernel_ordinal].implicit_args_offset =
+          host_kernel_args[kernel_ordinal].kernarg_size;
+    }
   }
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -221,13 +221,17 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_kernargs(
 
   iree_host_size_t operation_resource_count = 1;
   if (iree_any_bit_set(flags, IREE_HAL_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS)) {
-    if (IREE_UNLIKELY(constants.data_length !=
-                      descriptor->kernel_args.kernarg_size)) {
+    const uint32_t required_explicit_bytes =
+        (uint32_t)descriptor->custom_kernarg_layout.explicit_kernarg_size;
+    const iree_host_size_t padded_constant_length =
+        iree_host_align(constants.data_length, /*alignment=*/8);
+    if (IREE_UNLIKELY(padded_constant_length < required_explicit_bytes)) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
-          "custom dispatch argument length mismatch; expected %u but got "
-          "%" PRIhsz,
-          descriptor->kernel_args.kernarg_size, constants.data_length);
+          "custom dispatch argument length too short; expected at least %u "
+          "but got %" PRIhsz " (padded to %" PRIhsz ")",
+          required_explicit_bytes, constants.data_length,
+          padded_constant_length);
     }
     if (IREE_UNLIKELY(constants.data_length > 0 && !constants.data)) {
       return iree_make_status(
@@ -238,6 +242,13 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_kernargs(
     *out_layout = &descriptor->custom_kernarg_layout;
     *out_kernarg_block_count =
         iree_max(1u, descriptor->custom_kernarg_block_count);
+    if ((*out_layout)->total_kernarg_size == 0 && constants.data_length > 0) {
+      const uint32_t provided_kernarg_block_count =
+          (uint32_t)iree_host_size_ceil_div(
+              constants.data_length, sizeof(iree_hal_amdgpu_kernarg_block_t));
+      *out_kernarg_block_count =
+          iree_max(*out_kernarg_block_count, provided_kernarg_block_count);
+    }
   } else {
     if (IREE_UNLIKELY(constants.data_length > 0 && !constants.data)) {
       return iree_make_status(
@@ -531,7 +542,9 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_direct_dispatch(
 
   if (uses_custom_direct_arguments) {
     iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-        plan->layout, constants.data, submission.kernel.kernargs.blocks->data);
+        plan->kernel_args, config.workgroup_count,
+        config.dynamic_workgroup_local_memory, plan->layout, constants.data,
+        constants.data_length, submission.kernel.kernargs.blocks->data);
   } else {
     iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
         plan->kernel_args, config.workgroup_count,
@@ -725,7 +738,9 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_indirect_dispatch(
   const uint32_t placeholder_workgroup_count[3] = {0, 0, 0};
   if (uses_custom_direct_arguments) {
     iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-        plan->layout, constants.data, dispatch_kernarg_data);
+        plan->kernel_args, placeholder_workgroup_count,
+        config.dynamic_workgroup_local_memory, plan->layout, constants.data,
+        constants.data_length, dispatch_kernarg_data);
   } else {
     iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
         plan->kernel_args, placeholder_workgroup_count,

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -22,9 +22,16 @@
 #define IREE_HAL_AMDGPU_ELF_MACHINE_AMDGPU 224
 #define IREE_HAL_AMDGPU_ELF_PT_NOTE 4
 #define IREE_HAL_AMDGPU_ELF_NOTE_AMDGPU_METADATA 32
+#define IREE_HAL_AMDGPU_ELF_SHT_SYMTAB 2
+#define IREE_HAL_AMDGPU_ELF_SHT_DYNSYM 11
+#define IREE_HAL_AMDGPU_ELF_STT_FUNC 2
+#define IREE_HAL_AMDGPU_ELF_STB_GLOBAL 1
+#define IREE_HAL_AMDGPU_ELF_STB_WEAK 2
 
 #define IREE_HAL_AMDGPU_ELF64_HEADER_SIZE 64
 #define IREE_HAL_AMDGPU_ELF64_PROGRAM_HEADER_SIZE 56
+#define IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE 64
+#define IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE 24
 
 static uint16_t iree_hal_amdgpu_hsaco_metadata_load_le_u16(const uint8_t* ptr) {
   return iree_unaligned_load_le((const uint16_t*)ptr);
@@ -1143,6 +1150,418 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_allocate_storage(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_amdgpu_hsaco_metadata_elf_section(
+    iree_const_byte_span_t elf_data, uint16_t section_index,
+    const uint8_t** out_section) {
+  *out_section = NULL;
+  if (elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU ELF data too small");
+  }
+  const uint8_t* header = elf_data.data;
+  uint64_t section_offset =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(header + 40);
+  uint16_t section_entry_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 58);
+  uint16_t section_count =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
+  if (section_index >= section_count ||
+      section_entry_size < IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU ELF section index out of range");
+  }
+  uint64_t selected_offset =
+      section_offset + (uint64_t)section_index * section_entry_size;
+  if (selected_offset > elf_data.data_length ||
+      IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE >
+          elf_data.data_length - selected_offset) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU ELF section header out of bounds");
+  }
+  *out_section = elf_data.data + selected_offset;
+  return iree_ok_status();
+}
+
+static iree_string_view_t iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(
+    iree_const_byte_span_t elf_data, const uint8_t* symbol_section,
+    iree_host_size_t symbol_index) {
+  uint64_t symbol_section_offset =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 24);
+  uint64_t symbol_section_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 32);
+  uint64_t symbol_entry_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 56);
+  if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE) {
+    return iree_string_view_empty();
+  }
+  uint64_t symbol_offset =
+      symbol_section_offset + (uint64_t)symbol_index * symbol_entry_size;
+  if (symbol_offset > elf_data.data_length ||
+      IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE >
+          elf_data.data_length - symbol_offset ||
+      symbol_offset >= symbol_section_offset + symbol_section_size) {
+    return iree_string_view_empty();
+  }
+  const uint8_t* symbol = elf_data.data + symbol_offset;
+  uint32_t name_offset = iree_hal_amdgpu_hsaco_metadata_load_le_u32(symbol);
+  uint32_t string_section_index =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u32(symbol_section + 40);
+  const uint8_t* string_section = NULL;
+  if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
+          elf_data, (uint16_t)string_section_index, &string_section))) {
+    return iree_string_view_empty();
+  }
+  uint64_t string_offset =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(string_section + 24);
+  uint64_t string_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(string_section + 32);
+  if (name_offset >= string_size ||
+      string_offset + name_offset >= elf_data.data_length) {
+    return iree_string_view_empty();
+  }
+  const char* name = (const char*)elf_data.data + string_offset + name_offset;
+  const char* end = (const char*)elf_data.data + string_offset + string_size;
+  const char* p = name;
+  while (p < end && *p) ++p;
+  return iree_make_string_view(name, (iree_host_size_t)(p - name));
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
+    const iree_hal_amdgpu_hsaco_metadata_t* metadata,
+    iree_host_size_t kernel_count, iree_string_view_t name) {
+  for (iree_host_size_t i = 0; i < kernel_count; ++i) {
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
+        &metadata->kernels[i];
+    if (iree_string_view_equal(kernel->symbol_name, name) ||
+        iree_string_view_equal(kernel->reflection_name, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
+    iree_string_view_t descriptor_name, iree_string_view_t kernel_name) {
+  return descriptor_name.size == kernel_name.size + 3 &&
+         iree_string_view_starts_with(descriptor_name, kernel_name) &&
+         iree_string_view_ends_with(descriptor_name, IREE_SV(".kd"));
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(
+    iree_const_byte_span_t elf_data, iree_string_view_t kernel_name) {
+  if (iree_string_view_is_empty(kernel_name) ||
+      elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return false;
+  }
+  const uint8_t* header = elf_data.data;
+  uint16_t section_count =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
+  for (uint16_t section_index = 0; section_index < section_count;
+       ++section_index) {
+    const uint8_t* section = NULL;
+    if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
+            elf_data, section_index, &section))) {
+      return false;
+    }
+    uint32_t section_type =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
+        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
+      continue;
+    }
+    uint64_t symbol_section_offset =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+    uint64_t symbol_section_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+    uint64_t symbol_entry_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+        symbol_section_offset > elf_data.data_length ||
+        symbol_section_size > elf_data.data_length - symbol_section_offset) {
+      continue;
+    }
+    iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const uint8_t* symbol =
+          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+      uint8_t binding = symbol[4] >> 4;
+      if (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
+          binding != IREE_HAL_AMDGPU_ELF_STB_WEAK) {
+        continue;
+      }
+      iree_string_view_t name =
+          iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(elf_data, section, i);
+      if (iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
+              name, kernel_name)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
+    iree_const_byte_span_t elf_data, const uint8_t* symbol_section,
+    const uint8_t* symbol, iree_host_size_t symbol_index,
+    iree_string_view_t* out_name) {
+  *out_name = iree_string_view_empty();
+  uint8_t binding = symbol[4] >> 4;
+  uint8_t type = symbol[4] & 0x0F;
+  if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||
+      (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
+       binding != IREE_HAL_AMDGPU_ELF_STB_WEAK)) {
+    return false;
+  }
+  iree_string_view_t name = iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(
+      elf_data, symbol_section, symbol_index);
+  if (iree_string_view_is_empty(name) ||
+      !iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(elf_data,
+                                                                   name)) {
+    return false;
+  }
+  *out_name = name;
+  return true;
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
+    iree_const_byte_span_t elf_data, iree_string_view_t kernel_name) {
+  if (iree_string_view_is_empty(kernel_name) ||
+      elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return false;
+  }
+  const uint8_t* header = elf_data.data;
+  uint16_t section_count =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
+  for (uint16_t section_index = 0; section_index < section_count;
+       ++section_index) {
+    const uint8_t* section = NULL;
+    if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
+            elf_data, section_index, &section))) {
+      return false;
+    }
+    uint32_t section_type =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
+        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
+      continue;
+    }
+    uint64_t symbol_section_offset =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+    uint64_t symbol_section_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+    uint64_t symbol_entry_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+        symbol_section_offset > elf_data.data_length ||
+        symbol_section_size > elf_data.data_length - symbol_section_offset) {
+      continue;
+    }
+    iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const uint8_t* symbol =
+          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+      iree_string_view_t name = iree_string_view_empty();
+      if (iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
+              elf_data, section, symbol, i, &name) &&
+          iree_string_view_equal(name, kernel_name)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static iree_status_t
+iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
+    iree_hal_amdgpu_hsaco_metadata_t* metadata) {
+  iree_const_byte_span_t elf_data = metadata->elf_data;
+  if (elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return iree_ok_status();
+  }
+  const uint8_t* header = elf_data.data;
+  uint64_t section_offset =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(header + 40);
+  uint16_t section_entry_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 58);
+  uint16_t section_count =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
+  if (section_entry_size < IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE ||
+      section_offset > elf_data.data_length) {
+    return iree_ok_status();
+  }
+
+  iree_host_size_t extra_count = 0;
+  iree_host_size_t extra_symbol_name_storage_size = 0;
+  for (uint16_t section_index = 0; section_index < section_count;
+       ++section_index) {
+    const uint8_t* section = NULL;
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_elf_section(
+        elf_data, section_index, &section));
+    uint32_t section_type = iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
+        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
+      continue;
+    }
+    uint64_t symbol_section_offset =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+    uint64_t symbol_section_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+    uint64_t symbol_entry_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+        symbol_section_offset > elf_data.data_length) {
+      continue;
+    }
+    iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const uint8_t* symbol =
+          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+      iree_string_view_t name = iree_string_view_empty();
+      if (!iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
+              elf_data, section, symbol, i, &name) ||
+          iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
+              metadata, metadata->kernel_count, name)) {
+        continue;
+      }
+      ++extra_count;
+      IREE_RETURN_IF_ERROR(iree_host_size_checked_add(
+          extra_symbol_name_storage_size, name.size + 3,
+          &extra_symbol_name_storage_size)
+                            ? iree_ok_status()
+                            : iree_make_status(
+                                  IREE_STATUS_OUT_OF_RANGE,
+                                  "AMDGPU metadata symbol name storage "
+                                  "size overflow"));
+    }
+  }
+  if (extra_count == 0) return iree_ok_status();
+
+  iree_host_size_t template_kernel_index = IREE_HOST_SIZE_MAX;
+  for (iree_host_size_t i = 0; i < metadata->kernel_count; ++i) {
+    iree_string_view_t template_name = iree_string_view_strip_suffix(
+        metadata->kernels[i].symbol_name, IREE_SV(".kd"));
+    if (metadata->kernels[i].arg_count > 0 &&
+        iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
+            elf_data, template_name)) {
+      template_kernel_index = i;
+      break;
+    }
+  }
+  if (template_kernel_index == IREE_HOST_SIZE_MAX) {
+    return iree_ok_status();
+  }
+
+  iree_hal_amdgpu_hsaco_metadata_t expanded = *metadata;
+  iree_hal_amdgpu_hsaco_metadata_count_t expanded_count = {
+      .kernel_count = metadata->kernel_count + extra_count,
+      .arg_count = metadata->arg_count,
+  };
+  expanded.kernels = NULL;
+  expanded.args = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_allocate_storage(
+      expanded_count, metadata->host_allocator, &expanded));
+  char* extra_symbol_name_storage = NULL;
+  if (extra_symbol_name_storage_size) {
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+        metadata->host_allocator, extra_symbol_name_storage_size,
+        (void**)&extra_symbol_name_storage));
+    expanded.owned_string_storage = extra_symbol_name_storage;
+  }
+  if (metadata->arg_count) {
+    memcpy(expanded.args, metadata->args,
+           metadata->arg_count * sizeof(metadata->args[0]));
+  }
+  for (iree_host_size_t i = 0; i < metadata->kernel_count; ++i) {
+    expanded.kernels[i] = metadata->kernels[i];
+    if (metadata->kernels[i].args) {
+      iree_host_size_t arg_offset =
+          (iree_host_size_t)(metadata->kernels[i].args - metadata->args);
+      expanded.kernels[i].args = &expanded.args[arg_offset];
+    }
+  }
+
+  iree_host_size_t write_index = metadata->kernel_count;
+  iree_host_size_t extra_symbol_name_storage_offset = 0;
+  for (uint16_t section_index = 0; section_index < section_count;
+       ++section_index) {
+    const uint8_t* section = NULL;
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_elf_section(
+        elf_data, section_index, &section));
+    uint32_t section_type = iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
+        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
+      continue;
+    }
+    uint64_t symbol_section_offset =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+    uint64_t symbol_section_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+    uint64_t symbol_entry_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+        symbol_section_offset > elf_data.data_length) {
+      continue;
+    }
+    iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const uint8_t* symbol =
+          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+      iree_string_view_t name = iree_string_view_empty();
+      if (!iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
+              elf_data, section, symbol, i, &name) ||
+          iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
+              &expanded, write_index, name)) {
+        continue;
+      }
+      iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
+          &expanded.kernels[write_index++];
+      memset(kernel, 0, sizeof(*kernel));
+      char* symbol_name_storage =
+          extra_symbol_name_storage + extra_symbol_name_storage_offset;
+      memcpy(symbol_name_storage, name.data, name.size);
+      memcpy(symbol_name_storage + name.size, ".kd", 3);
+      extra_symbol_name_storage_offset += name.size + 3;
+      kernel->name = name;
+      kernel->symbol_name =
+          iree_make_string_view(symbol_name_storage, name.size + 3);
+      kernel->reflection_name = name;
+      const iree_hal_amdgpu_hsaco_metadata_kernel_t* template_kernel =
+          &expanded.kernels[template_kernel_index];
+      kernel->arg_name_storage_size = template_kernel->arg_name_storage_size;
+      kernel->kernarg_segment_size = template_kernel->kernarg_segment_size;
+      kernel->kernarg_segment_alignment =
+          template_kernel->kernarg_segment_alignment;
+      kernel->group_segment_fixed_size =
+          template_kernel->group_segment_fixed_size;
+      kernel->private_segment_fixed_size =
+          template_kernel->private_segment_fixed_size;
+      memcpy(kernel->required_workgroup_size,
+             template_kernel->required_workgroup_size,
+             sizeof(kernel->required_workgroup_size));
+      kernel->has_required_workgroup_size =
+          template_kernel->has_required_workgroup_size;
+      kernel->arg_count = template_kernel->arg_count;
+      kernel->args = template_kernel->args;
+      kernel->uses_borrowed_arg_layout = true;
+    }
+  }
+  expanded.kernel_count = write_index;
+
+  if (metadata->owned_string_storage) {
+    iree_allocator_free(metadata->host_allocator, metadata->owned_string_storage);
+  }
+  iree_allocator_free(metadata->host_allocator, metadata->kernels);
+  metadata->kernels = expanded.kernels;
+  metadata->args = expanded.args;
+  metadata->owned_string_storage = expanded.owned_string_storage;
+  metadata->kernel_count = expanded.kernel_count;
+  return iree_ok_status();
+}
+
 iree_status_t iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
     iree_const_byte_span_t elf_data, iree_allocator_t host_allocator,
     iree_hal_amdgpu_hsaco_metadata_t* out_metadata) {
@@ -1169,6 +1588,10 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
     status = iree_hal_amdgpu_hsaco_metadata_parse_message_pack(
         out_metadata->message_pack_data, out_metadata);
   }
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(out_metadata);
+  }
   if (!iree_status_is_ok(status)) {
     iree_hal_amdgpu_hsaco_metadata_deinitialize(out_metadata);
   }
@@ -1182,6 +1605,9 @@ void iree_hal_amdgpu_hsaco_metadata_deinitialize(
     return;
   }
   IREE_TRACE_ZONE_BEGIN(z0);
+  if (metadata->owned_string_storage) {
+    iree_allocator_free(metadata->host_allocator, metadata->owned_string_storage);
+  }
   if (metadata->kernels) {
     iree_allocator_free(metadata->host_allocator, metadata->kernels);
   }
@@ -1242,7 +1668,7 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
                 arg, &name_storage_size));
         break;
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE: {
-        if (arg->size > UINT8_MAX) {
+        if (arg->size > UINT16_MAX) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
               "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
@@ -1250,19 +1676,11 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
               (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
               arg->size);
         }
-        if (!iree_host_size_has_alignment(arg->size, sizeof(uint32_t))) {
-          return iree_make_status(
-              IREE_STATUS_INVALID_ARGUMENT,
-              "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
-              " size %u is not a whole number of 32-bit HAL constants",
-              (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
-              arg->size);
-        }
-        if (constant_byte_count > UINT16_MAX) {
+        if (arg->offset > UINT16_MAX) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
               "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
-              " constant offset exceeds HAL parameter offset range",
+              " kernarg offset exceeds HAL parameter offset range",
               (int)kernel->symbol_name.size, kernel->symbol_name.data, i);
         }
         ++parameter_count;
@@ -1288,11 +1706,12 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
   }
 
   iree_host_size_t aligned_constant_byte_count = 0;
-  if (!iree_host_size_checked_align(constant_byte_count, sizeof(uint32_t),
+  if (!iree_host_size_checked_align(kernel->kernarg_segment_size,
+                                    sizeof(uint32_t),
                                     &aligned_constant_byte_count)) {
     return iree_make_status(
         IREE_STATUS_OUT_OF_RANGE,
-        "AMDGPU metadata reflected constant byte count alignment overflow");
+        "AMDGPU metadata kernarg segment size alignment overflow");
   }
   const iree_host_size_t constant_count =
       aligned_constant_byte_count / sizeof(uint32_t);
@@ -1338,8 +1757,6 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
 
   iree_host_size_t parameter_index = 0;
   iree_host_size_t name_storage_offset = 0;
-  uint16_t binding_ordinal = 0;
-  iree_host_size_t constant_offset = 0;
   for (iree_host_size_t i = 0; i < kernel->arg_count; ++i) {
     const iree_hal_amdgpu_hsaco_metadata_arg_t* arg = &kernel->args[i];
     if (iree_hal_amdgpu_hsaco_metadata_arg_kind_is_hidden(arg->kind)) {
@@ -1350,7 +1767,7 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
         &out_parameters[parameter_index++];
     memset(parameter, 0, sizeof(*parameter));
     parameter->flags = IREE_HAL_EXECUTABLE_EXPORT_PARAMETER_FLAG_NONE;
-    parameter->size = (uint8_t)arg->size;
+    parameter->size = (uint16_t)arg->size;
     if (!iree_string_view_is_empty(arg->name)) {
       memcpy(name_storage + name_storage_offset, arg->name.data,
              arg->name.size);
@@ -1361,15 +1778,14 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
       parameter->name = iree_string_view_empty();
     }
 
+    parameter->offset = (uint16_t)arg->offset;
+    parameter->kernarg_offset = (uint16_t)arg->offset;
     switch (arg->kind) {
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER:
         parameter->type = IREE_HAL_EXECUTABLE_EXPORT_PARAMETER_TYPE_BINDING;
-        parameter->offset = binding_ordinal++;
         break;
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE:
         parameter->type = IREE_HAL_EXECUTABLE_EXPORT_PARAMETER_TYPE_CONSTANT;
-        parameter->offset = (uint16_t)constant_offset;
-        constant_offset += arg->size;
         break;
       default:
         return iree_make_status(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -90,6 +90,9 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_t {
   iree_host_size_t arg_count;
   // Argument records borrowed from the owning metadata object.
   const iree_hal_amdgpu_hsaco_metadata_arg_t* args;
+  // True when this kernel was synthesized from an ELF symbol and borrowed
+  // argument layout metadata from another kernel in the same code object.
+  bool uses_borrowed_arg_layout;
 } iree_hal_amdgpu_hsaco_metadata_kernel_t;
 
 // Decoded AMDGPU code object metadata.
@@ -109,6 +112,8 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_t {
   iree_host_size_t reflection_name_storage_size;
   // Bytes required to clone all decoded argument names.
   iree_host_size_t arg_name_storage_size;
+  // Extra string storage owned by HRX metadata augmentation.
+  char* owned_string_storage;
   // Number of decoded kernels.
   iree_host_size_t kernel_count;
   // Decoded kernel records.

--- a/runtime/src/iree/hal/executable.h
+++ b/runtime/src/iree/hal/executable.h
@@ -99,14 +99,21 @@ typedef uint16_t iree_hal_executable_export_parameter_flags_t;
 typedef struct iree_hal_executable_export_parameter_t {
   // Type of the parameter.
   iree_hal_executable_export_parameter_type_t type;
-  // Size of the parameter in bytes. Does not contain padding.
-  uint8_t size;
   // Flags indicating parameter behavior.
   iree_hal_executable_export_parameter_flags_t flags;
-  // Parameter name if available, otherwise empty.
-  iree_string_view_t name;
+  // Size of the parameter in bytes. Does not contain padding.
+  // Widened from uint8_t so we can represent kernarg structs emitted by
+  // user toolchains.
+  uint16_t size;
   // Offset of the parameter in bytes or binding ordinal, depending on type.
   uint16_t offset;
+  // Backend-reported byte offset of this parameter within the raw kernarg
+  // segment. Consumers that synthesize raw kernarg blobs must use this field
+  // for BINDING parameters because |offset| may be a binding ordinal for
+  // backends that follow the generic HAL contract.
+  uint16_t kernarg_offset;
+  // Parameter name if available, otherwise empty.
+  iree_string_view_t name;
 } iree_hal_executable_export_parameter_t;
 
 // Handle to a loaded executable.


### PR DESCRIPTION
Allow AMDGPU raw HSACO modules to expose HIP-visible kernel symbols that have companion kernel descriptors, even when the code object metadata only describes a subset of exports.

Preserve native kernarg layouts for those raw kernels by widening reflected parameter sizes and offsets, accepting pre-packed HIP argument blobs that omit trailing ABI padding, zero-filling missing bytes, and synthesizing HIP implicit args at the metadata-derived or HSA-reported suffix offset.

Use ELF symbol metadata and kernel descriptors to identify additional raw code object exports and keep their dispatch ABI consistent with the loaded HSA executable.