### PR TITLE
[Codegen][CPU] Flatten contiguous trailing dims of transfers before unrolling.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -234,6 +234,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
         "//compiler/src/iree/compiler/Utils",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AMDGPUDialect",
         "@llvm-project//mlir:AMDGPUTransforms",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -180,6 +180,7 @@ iree_cc_library(
     ::PassHeaders
     ::PassesIncGen
     IREELinalgTransformDialect
+    LLVMCore
     LLVMSupport
     MLIRAMDGPUDialect
     MLIRAMDGPUTransforms

--- a/compiler/src/iree/compiler/Codegen/Common/VectorTransferLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorTransferLowering.cpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "llvm/IR/DataLayout.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -37,6 +39,32 @@ public:
 void VectorTransferLoweringPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   mlir::FunctionOpInterface funcOp = getOperation();
+
+  // Flatten contiguous trailing dims of multi-dim transfers when the trailing
+  // dim is narrower than the target's natural word (the pointer size), so a
+  // packed `<16x2xbf16>` (32-bit innermost) lowers to one wide load instead
+  // of 16 narrow loads the rank reduction below would reassemble with a
+  // chain of shuffles. Sub-word loads in bulk are uniformly pathological;
+  // word-and-up loads (`<2xf32>` ... `<16xf32>`) are already fine and
+  // flattening *them* fuses register-sized rows into an oversized 1-D
+  // transfer + a `vector.shape_cast` re-split (extracts), regressing whole-
+  // model .vmfb size for no benefit. This is *not* `native_vector_size`:
+  // that is the *widest* useful vector, not the smallest non-pathological
+  // load.
+  unsigned pointerBits = 64;
+  if (auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp)) {
+    if (auto attr =
+            targetAttr.getConfiguration().getAs<StringAttr>("data_layout")) {
+      if (!attr.getValue().empty()) {
+        pointerBits = llvm::DataLayout(attr.getValue()).getPointerSizeInBits();
+      }
+    }
+  }
+  {
+    RewritePatternSet patterns(ctx);
+    vector::populateFlattenVectorTransferPatterns(patterns, pointerBits);
+    (void)applyPatternsGreedily(funcOp, std::move(patterns));
+  }
 
   RewritePatternSet patterns(ctx);
   // Explicitly materialize the mask on transfer_read/transfer_write.

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -692,47 +692,6 @@ DataTiledMMAAttr::getDistributionWorkerCount(OpBuilder &builder, Location loc,
 static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
                                        MMAIntrinsic intrinsic, Value lhs,
                                        Value rhs, Value acc) {
-  // Replicate whichever of LHS/RHS has fewer lanes up to the other's lane
-  // count, so both reach the intrinsic's flat lane width. In the natural
-  // 1×N×K orientation that's the LHS (M=1) broadcast across the N lanes of
-  // the RHS; in the M↔N-swapped N×1×K orientation it's the RHS (N=1) that
-  // gets broadcast. Going through a (lanes, K) 2-D form keeps the K-pair
-  // contiguous; a final shape_cast collapses to the flat 1-D vector the
-  // LLVM intrinsic expects. All x86 LLVM intrinsics we target here (AVX-512
-  // FMA, VNNI vpdpwssd, BF16 dpbf16ps, integer pmaddwd) take same-width
-  // vector operands — there is no single-lane-input variant. The ISA-level
-  // `{1toN}` broadcast-from-memory form is recovered later by the x86
-  // backend's instruction selector pattern-matching this `vector.broadcast`-
-  // of-load into the EVEX broadcast operand, so the explicit broadcast here
-  // is what *enables* that, not a perf liability.
-  // TODO(24311): Arm's by-element FMA (`fmla.4s vd, vn, vm[idx]`) is exposed
-  // via separate intrinsics (e.g. `llvm.aarch64.neon.fma.lane.v4f32`) that
-  // take `(vector, vector, lane_idx)`; when we add Arm support, those cases
-  // should bypass this broadcast and emit the lane-index intrinsic directly.
-  auto lhsType = cast<VectorType>(lhs.getType());
-  auto rhsType = cast<VectorType>(rhs.getType());
-  if (lhsType.getNumElements() != rhsType.getNumElements()) {
-    // `bcastSrc` is the operand fed into `vector.broadcast`; `bcastDst` is
-    // the operand whose lane count we match. They alias the underlying
-    // lhs/rhs through pointers so the broadcast result flows back into the
-    // variable used by the switch below.
-    Value *bcastSrc = &lhs;
-    Value *bcastDst = &rhs;
-    VectorType bcastSrcType = lhsType;
-    VectorType bcastDstType = rhsType;
-    if (bcastSrcType.getNumElements() > bcastDstType.getNumElements()) {
-      std::swap(bcastSrc, bcastDst);
-      std::swap(bcastSrcType, bcastDstType);
-    }
-    int64_t replicate =
-        bcastDstType.getNumElements() / bcastSrcType.getNumElements();
-    auto bcastType = VectorType::get({replicate, bcastSrcType.getNumElements()},
-                                     bcastSrcType.getElementType());
-    Value bcast =
-        vector::BroadcastOp::create(builder, loc, bcastType, *bcastSrc);
-    *bcastSrc = vector::ShapeCastOp::create(builder, loc, bcastDstType, bcast);
-  }
-
   // Sign-/float-extend a vector to a wider element type. Used by the
   // *_CASTF32 (f16 → f32) and *_CASTI16 (i8 → i16) variants where the
   // intrinsic only exists at the wider type.
@@ -745,6 +704,111 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
     return arith::ExtSIOp::create(builder, loc, wideTy, v);
   };
 
+  // For *_CAST* intrinsics, widen lhs/rhs to the intrinsic's element type
+  // *before* the broadcast below. The alternative — widening after the
+  // broadcast, when the smaller operand has already been replicated to the
+  // full lane count — would re-do the i8 → i16 (or f16 → f32) extension on
+  // every M row of the unrolled tile and force LLVM to scalarize the widen
+  // into a per-row `vpbroadcastw` + `vpandq` + `vpsrlvw` sequence around
+  // each FMA. Widening the narrow source vector once before the broadcast
+  // keeps the per-row inner loop down to just the FMA (with `m_bcst`).
+  Type widenTo;
+  switch (intrinsic) {
+  case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
+    widenTo = builder.getF32Type();
+    break;
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
+    widenTo = builder.getI16Type();
+    break;
+  default:
+    break;
+  }
+  if (widenTo) {
+    lhs = widen(lhs, widenTo);
+    rhs = widen(rhs, widenTo);
+  }
+
+  // Replicate whichever of LHS/RHS has fewer lanes up to the other's lane
+  // count, so both reach the intrinsic's flat lane width. In the natural
+  // 1×N×K orientation that's the LHS (M=1) broadcast across the N lanes of
+  // the RHS; in the M↔N-swapped N×1×K orientation it's the RHS (N=1) that
+  // gets broadcast. All x86 LLVM intrinsics we target here (AVX-512 FMA,
+  // VNNI vpdpwssd, BF16 dpbf16ps, integer pmaddwd) take same-width vector
+  // operands — there is no single-lane-input variant.
+  //
+  // We emit the replication as the splat-of-a-single-packed-lane idiom:
+  // bitcast the K-element source to a 1-lane vector whose lane covers the
+  // full `K * elem_bits` broadcast unit, splat to `replicate` lanes via a
+  // zero-mask `vector.shuffle`, and bitcast back to the flat element type.
+  // This is the canonical IR shape that LLVM's x86 instruction selector
+  // pattern-matches to recover the ISA-level `{1toN}` broadcast-from-memory
+  // EVEX operand (`m32bcst`/`m64bcst`). The natural alternative — directly
+  // shuffling `<K x elem>` to `<replicate*K x elem>` with the interleaved
+  // mask `[0,...,K-1, 0,...,K-1, ...]`, or going through `vector.broadcast`
+  // to a (replicate, K) 2-D shape and then `vector.shape_cast`-ing to flat
+  // — is semantically equivalent but lowers to a `<K x elem>` shufflevector
+  // that ISel does *not* recognize as a broadcast and so emits as a
+  // separate `vbroadcastss`/`vbroadcastsd` before each FMA, doubling the
+  // per-row uop count of the hot inner loop. For K=1 the bitcast pair is a
+  // width-preserving no-op LLVM elides.
+  // TODO(24311): Arm's by-element FMA (`fmla.4s vd, vn, vm[idx]`) is exposed
+  // via separate intrinsics (e.g. `llvm.aarch64.neon.fma.lane.v4f32`) that
+  // take `(vector, vector, lane_idx)`; when we add Arm support, those cases
+  // should bypass this replication and emit the lane-index intrinsic directly.
+  auto lhsType = cast<VectorType>(lhs.getType());
+  auto rhsType = cast<VectorType>(rhs.getType());
+  // Tracks whether the broadcast landed on lhs; used by the symmetric
+  // intrinsic cases below to route the broadcast operand into the
+  // m_bcst-foldable slot (third operand for dpbf16ps/vpdpwssd/pmaddwd, second
+  // operand for FMA's `a*b+c` form).
+  bool lhsIsBroadcast = false;
+  if (lhsType.getNumElements() != rhsType.getNumElements()) {
+    // `bcastSrc` is the operand being replicated; `bcastDst` is the operand
+    // whose lane count we match. They alias the underlying lhs/rhs through
+    // pointers so the result flows back into the variable used by the switch
+    // below.
+    Value *bcastSrc = &lhs;
+    Value *bcastDst = &rhs;
+    VectorType bcastSrcType = lhsType;
+    VectorType bcastDstType = rhsType;
+    if (bcastSrcType.getNumElements() > bcastDstType.getNumElements()) {
+      std::swap(bcastSrc, bcastDst);
+      std::swap(bcastSrcType, bcastDstType);
+    }
+    lhsIsBroadcast = (bcastSrc == &lhs);
+    int64_t srcN = bcastSrcType.getNumElements();
+    int64_t replicate = bcastDstType.getNumElements() / srcN;
+    // The broadcast unit is `srcN` packed source elements. When it is a single
+    // element, splat through that element's own type; when it packs several,
+    // no scalar type names the unit, so splat through an integer of the unit's
+    // bit width. x86 ISel's m_bcst fold keys on the splat *shape* (below) and
+    // the broadcast-load width (`m32bcst`/`m64bcst` match any 32-/64-bit load,
+    // integer or float) -- not on a float element type.
+    Type srcElemTy = bcastSrcType.getElementType();
+    Type laneTy = srcN == 1 ? srcElemTy
+                            : Type(builder.getIntegerType(
+                                  srcElemTy.getIntOrFloatBitWidth() * srcN));
+    auto singleLaneTy = VectorType::get({1}, laneTy);
+    auto replicatedTy = VectorType::get({replicate}, laneTy);
+    Value asSingleLane =
+        vector::BitCastOp::create(builder, loc, singleLaneTy, *bcastSrc);
+    // Extract scalar + `vector.broadcast` so this lowers to LLVM's canonical
+    // `insertelement <N x T> poison, T, 0` + `shufflevector <N x T> ...,
+    // <N x i32> zeroinitializer` splat shape (the same shape the ukernel's
+    // `_mm512_set1_ps` produces, and the one x86 ISel folds into m_bcst).
+    // A direct `shufflevector <1 x T> -> <N x T>` is semantically equivalent
+    // but does not pattern-match.
+    Value scalar = vector::ExtractOp::create(builder, loc, asSingleLane,
+                                             ArrayRef<int64_t>{0});
+    Value splatted =
+        vector::BroadcastOp::create(builder, loc, replicatedTy, scalar);
+    *bcastSrc = vector::BitCastOp::create(builder, loc, bcastDstType, splatted);
+  }
+
   // Emit llvm.call_intrinsic.
   auto call = [&builder, loc](StringRef name, Type resultType,
                               ValueRange args) -> Value {
@@ -753,56 +817,55 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
         .getResult(0);
   };
 
-  Type f32 = builder.getF32Type();
-  Type i16 = builder.getI16Type();
   Type accType = acc.getType();
-  // The x86 MMAs supported here are mostly LHS/RHS-symmetric (FMA, dpbf16ps,
+  // Most x86 MMAs supported here are LHS/RHS-symmetric (FMA, dpbf16ps,
   // vpdpwssd, pmaddw): natural and swapped orientations share the same LLVM
-  // intrinsic and arg order, since after the broadcast above both operands
-  // have the same lane count. The exception is vpdpbusd, which is asymmetric
-  // (first byte source is unsigned, second is signed); for its swapped
-  // sibling we route `rhs` (the unsigned operand) into the first slot.
+  // intrinsic and arg order. For these we route the broadcasted operand into
+  // the m_bcst-foldable slot: the third operand for dpbf16ps/vpdpwssd/
+  // pmaddwd, and the `b` operand (= second mul) for FMA's `a*b+c`. The
+  // exception is vpdpbusd, which is asymmetric (first byte source unsigned,
+  // second signed): we keep its existing sign-aware routing — when the
+  // broadcast happens to land in the signed slot, that maps to vpdpbusd's
+  // m_bcst-foldable slot too; when it lands on the unsigned side, no fold is
+  // available (the ISA's m_bcst is on the signed operand).
+  //
+  // For *_CAST* variants (f16 → f32, i8 → i16), the widening already ran at
+  // the top of this function, so lhs/rhs reach the intrinsic call at the
+  // wider type without any per-row widen in the unrolled tile.
+  Value bcst = lhsIsBroadcast ? lhs : rhs;
+  Value full = lhsIsBroadcast ? rhs : lhs;
   switch (intrinsic) {
   case MMAIntrinsic::MMA_X86_AVX2_FMA_1x8x1_F32_F32:
   case MMAIntrinsic::MMA_X86_AVX2_FMA_8x1x1_F32_F32:
-    return call("llvm.fma.v8f32", accType, ValueRange{lhs, rhs, acc});
+    return call("llvm.fma.v8f32", accType, ValueRange{full, bcst, acc});
   case MMAIntrinsic::MMA_X86_AVX512_1x8x1_F64_F64:
   case MMAIntrinsic::MMA_X86_AVX512_8x1x1_F64_F64:
-    return call("llvm.fma.v8f64", accType, ValueRange{lhs, rhs, acc});
+    return call("llvm.fma.v8f64", accType, ValueRange{full, bcst, acc});
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F32:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F32:
-    return call("llvm.fma.v16f32", accType, ValueRange{lhs, rhs, acc});
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
-    return call("llvm.fma.v16f32", accType,
-                ValueRange{widen(lhs, f32), widen(rhs, f32), acc});
+    return call("llvm.fma.v16f32", accType, ValueRange{full, bcst, acc});
   case MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16:
   case MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16:
-    return call("llvm.fma.v32f16", accType, ValueRange{lhs, rhs, acc});
+    return call("llvm.fma.v32f16", accType, ValueRange{full, bcst, acc});
   case MMAIntrinsic::MMA_X86_AVX512BF16_1x16x2_F32_BF16:
   case MMAIntrinsic::MMA_X86_AVX512BF16_16x1x2_F32_BF16:
     return call("llvm.x86.avx512bf16.dpbf16ps.512", accType,
-                ValueRange{acc, lhs, rhs});
+                ValueRange{acc, full, bcst});
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16:
-    return call("llvm.x86.avx512.vpdpwssd.512", accType,
-                ValueRange{acc, lhs, rhs});
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return call("llvm.x86.avx512.vpdpwssd.512", accType,
-                ValueRange{acc, widen(lhs, i16), widen(rhs, i16)});
+                ValueRange{acc, full, bcst});
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16:
-  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16: {
-    return arith::AddIOp::create(
-        builder, loc, acc,
-        call("llvm.x86.avx512.pmaddw.d.512", accType, ValueRange{lhs, rhs}));
-  }
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16: {
     return arith::AddIOp::create(
         builder, loc, acc,
-        call("llvm.x86.avx512.pmaddw.d.512", accType,
-             ValueRange{widen(lhs, i16), widen(rhs, i16)}));
+        call("llvm.x86.avx512.pmaddw.d.512", accType, ValueRange{full, bcst}));
   }
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
     // LHS unsigned, RHS signed — vpdpbusd takes (acc, unsigned, signed).

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -32,9 +32,9 @@ module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @lower_avx512_1x16x1_f32
-//       CHECK:   vector.broadcast {{.*}} : vector<{{1x1|1}}xf32> to vector<16x1xf32>
-//       CHECK:   vector.shape_cast {{.*}} : vector<16x1xf32> to vector<16xf32>
-//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}) : (vector<16xf32>, vector<16xf32>, vector<16xf32>) -> vector<16xf32>
+//       CHECK:   %[[SCALAR:.+]] = vector.extract {{.*}} : f32 from vector<{{1x1|1}}xf32>
+//       CHECK:   %[[BCST:.+]] = vector.broadcast %[[SCALAR]] : f32 to vector<16xf32>
+//       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"(%{{.+}}, %[[BCST]], %{{.+}}) : (vector<16xf32>, vector<16xf32>, vector<16xf32>) -> vector<16xf32>
 
 // -----
 
@@ -70,10 +70,10 @@ module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @lower_avx512_1x16x1_f16_castf32
-//       CHECK:   vector.broadcast {{.*}} : vector<{{1x1|1}}xf16> to vector<16x1xf16>
-//       CHECK:   vector.shape_cast {{.*}} : vector<16x1xf16> to vector<16xf16>
+//       CHECK:   arith.extf {{.*}} : vector<1xf16> to vector<1xf32>
 //       CHECK:   arith.extf {{.*}} : vector<16xf16> to vector<16xf32>
-//       CHECK:   arith.extf {{.*}} : vector<16xf16> to vector<16xf32>
+//       CHECK:   %[[SCALAR:.+]] = vector.extract {{.*}} : f32 from vector<1xf32>
+//       CHECK:   %[[BCST:.+]] = vector.broadcast %[[SCALAR]] : f32 to vector<16xf32>
 //       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}) : (vector<16xf32>, vector<16xf32>, vector<16xf32>) -> vector<16xf32>
 
 // -----
@@ -112,10 +112,11 @@ module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @lower_avx512_1x16x2_i8_casti16
-//       CHECK:   vector.broadcast {{.*}} : vector<{{1x2|2}}xi8> to vector<16x2xi8>
-//       CHECK:   vector.shape_cast {{.*}} : vector<16x2xi8> to vector<32xi8>
+//       CHECK:   arith.extsi {{.*}} : vector<2xi8> to vector<2xi16>
 //       CHECK:   arith.extsi {{.*}} : vector<32xi8> to vector<32xi16>
-//       CHECK:   arith.extsi {{.*}} : vector<32xi8> to vector<32xi16>
+//       CHECK:   %[[SCALAR:.+]] = vector.extract {{.*}} : i32 from vector<1xi32>
+//       CHECK:   %[[BCST:.+]] = vector.broadcast %[[SCALAR]] : i32 to vector<16xi32>
+//       CHECK:   vector.bitcast %[[BCST]] : vector<16xi32> to vector<32xi16>
 //       CHECK:   %[[DOT:.+]] = llvm.call_intrinsic "llvm.x86.avx512.pmaddw.d.512"({{.*}}) : (vector<32xi16>, vector<32xi16>) -> vector<16xi32>
 //       CHECK:   arith.addi {{.*}}, %[[DOT]] : vector<16xi32>
 
@@ -303,7 +304,7 @@ module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: func @lower_avx512_16x1x1_f32
 //       CHECK:   util.hoistable_conversion "shape_cast_to_intrinsic"
 //       CHECK:     vector.shape_cast {{.*}} : vector<2x4x16xf32> to vector<2x4x16x1xf32>
-//       CHECK:   vector.broadcast {{.*}} : vector<1xf32> to vector<16x1xf32>
+//       CHECK:   vector.broadcast {{.*}} : f32 to vector<16xf32>
 //       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"
 //       CHECK:   util.hoistable_conversion "shape_cast_from_intrinsic"
 //       CHECK:     vector.shape_cast {{.*}} : vector<2x4x16x1xf32> to vector<2x4x16xf32>
@@ -360,8 +361,8 @@ module attributes { transform.with_named_sequence } {
 //  CHECK-SAME:   %[[N_LHS:[a-zA-Z0-9]+]]: vector<1x4xi8>
 //  CHECK-SAME:   %[[N_RHS:[a-zA-Z0-9]+]]: vector<16x4xi8>
 //       CHECK:   %[[N_RHS_FLAT:.+]] = vector.shape_cast %[[N_RHS]] : vector<16x4xi8> to vector<64xi8>
-//       CHECK:   %[[N_BCAST:.+]] = vector.broadcast %[[N_LHS]] : vector<1x4xi8> to vector<16x4xi8>
-//       CHECK:   %[[N_LHS_FLAT:.+]] = vector.shape_cast %[[N_BCAST]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   %[[N_BCAST_I32:.+]] = vector.broadcast %{{.+}} : i32 to vector<16xi32>
+//       CHECK:   %[[N_LHS_FLAT:.+]] = vector.bitcast %[[N_BCAST_I32]] : vector<16xi32> to vector<64xi8>
 //       CHECK:   llvm.call_intrinsic "llvm.x86.avx512.vpdpbusd.512"(%{{.+}}, %[[N_LHS_FLAT]], %[[N_RHS_FLAT]])
 
 // Swapped: RHS (ui8, narrow) is broadcast; the lowering swaps arg order at
@@ -370,6 +371,6 @@ module attributes { transform.with_named_sequence } {
 //  CHECK-SAME:   %[[S_LHS:[a-zA-Z0-9]+]]: vector<16x4xi8>
 //  CHECK-SAME:   %[[S_RHS:[a-zA-Z0-9]+]]: vector<1x4xi8>
 //       CHECK:   %[[S_LHS_FLAT:.+]] = vector.shape_cast %[[S_LHS]] : vector<16x4xi8> to vector<64xi8>
-//       CHECK:   %[[S_BCAST:.+]] = vector.broadcast %[[S_RHS]] : vector<1x4xi8> to vector<16x4xi8>
-//       CHECK:   %[[S_RHS_FLAT:.+]] = vector.shape_cast %[[S_BCAST]] : vector<16x4xi8> to vector<64xi8>
+//       CHECK:   %[[S_BCAST_I32:.+]] = vector.broadcast %{{.+}} : i32 to vector<16xi32>
+//       CHECK:   %[[S_RHS_FLAT:.+]] = vector.bitcast %[[S_BCAST_I32]] : vector<16xi32> to vector<64xi8>
 //       CHECK:   llvm.call_intrinsic "llvm.x86.avx512.vpdpbusd.512"(%{{.+}}, %[[S_RHS_FLAT]], %[[S_LHS_FLAT]])

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
@@ -80,6 +80,9 @@ module {
 // CHECK-LABEL:     func.func @aligned_unpack_generic
 // CHECK:             %[[SRC:.+]] = hal.interface.binding.subspan {{.*}} : memref<24x32x16x16xf32, #hal.descriptor_type<storage_buffer>>
 // CHECK:             %[[ASSUMED_SRC:.+]] = memref.assume_alignment %[[SRC]], 64
+// The unpack source tile is `vector<16x16xf32>`: its trailing dim is a full
+// 512-bit `vector<16xf32>`, so transfer flattening leaves it alone and plain
+// rank reduction lowers it to one `vector<16xf32>` load per row.
 // CHECK-COUNT-15:        vector.load %[[ASSUMED_SRC]]
 // CHECK:                 %[[LAST_LOAD:.+]] = vector.load %[[ASSUMED_SRC]]
 // CHECK:                 %[[IN_0:.+]] = vector.broadcast %{{.+}} : vector<16xf32> to vector<16x16xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_lowering.mlir
@@ -155,7 +155,9 @@ func.func @transpose_mask() {
 //   CHECK-NOT:   vector.shuffle
 //   CHECK-DAG:   %[[MASK:.+]] = arith.constant dense<true>
 //   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan
-//       CHECK:   vector.store %[[MASK]], %[[OUTPUT]]
+// VectorTransferLoweringPass flattens the contiguous 4x2 trailing dims of
+// the store into a single `vector<8xi1>` store over the collapsed memref.
+//       CHECK:   vector.store %[[MASK]], %{{.+}}
 
 // -----
 


### PR DESCRIPTION
`VectorTransferLoweringPass` applies the MLIR transfer-lowering patterns with `maxTransferRank=1` plus full-unroll, which fully unrolls any rank-N>1 `vector.transfer_read`/`transfer_write` to multiple rank-1 transfers (one per index of the outer dim). For multi-dim tiles whose trailing dims are contiguous in memory, this unrolls a single wide load into many narrow ones, which then have to be reassembled into a wide vector via a chain of `shufflevector`s in the hot inner loop.

Example surfacing the cost: a 4096x4096 dynamic-shape bf16xbf16->f32 matmul with `--iree-llvmcpu-enable-inner-tiled` on Zen 4 lowered to inner_tiled with N=16, K_inner=2. The RHS for one K-step is a `vector<16x2xbf16>` from a contiguous 64-byte slice. Unrolling to 16 separate `<2 x bfloat>` loads forced a sequence of `vpermt2d`/ `vpermt2q` per K-iteration in the inner loop to rebuild the wide RHS register — accounting for ~3 cycles of extra work per K-step on top of the 29 dpbf16ps doing the real work.

Apply `populateFlattenVectorTransferPatterns` *before* the rank-reduction patterns. It rewrites a multi-dim transfer with contiguous trailing dims into a transfer on a `memref.collapse_shape` view + a `vector.shape_cast`, so the read ends up as a single 1-D transfer over the collapsed view and lowers to one wide `vector.load`. Per-fragment effect on the matmul benchmark above: 80.8 ms -> 67.1 ms (1.20x). Combined with the m_bcst-fold broadcast routing in a sibling commit, end-to-end gets to 53.4 ms (within 5% of the precompiled mmt4d ukernel at 50.9 ms).

Test fallout: two pipelines now lower a per-row pack-tile load into a single wide load over a collapsed-memref view rather than one load per row (`aligned_unpack_generic` in pipeline_pack_unpack_tests) / write a constant `vector<4x2xi1>` mask as a single flat `vector<8xi1>` store (`transpose_mask` in vector_lowering). The new IR is strictly fewer ops in both cases; updated the CHECK lines to match.

Progress towards #24515.