### PR TITLE
[Codegen][CPU] Widen *_CAST* lhs/rhs before broadcasting.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -692,6 +692,46 @@ DataTiledMMAAttr::getDistributionWorkerCount(OpBuilder &builder, Location loc,
 static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
                                        MMAIntrinsic intrinsic, Value lhs,
                                        Value rhs, Value acc) {
+  // Sign-/float-extend a vector to a wider element type. Used by the
+  // *_CASTF32 (f16 → f32) and *_CASTI16 (i8 → i16) variants where the
+  // intrinsic only exists at the wider type.
+  auto widen = [&builder, loc](Value v, Type wider) -> Value {
+    auto vt = cast<VectorType>(v.getType());
+    auto wideTy = VectorType::get(vt.getShape(), wider);
+    if (isa<FloatType>(vt.getElementType())) {
+      return arith::ExtFOp::create(builder, loc, wideTy, v);
+    }
+    return arith::ExtSIOp::create(builder, loc, wideTy, v);
+  };
+
+  // For *_CAST* intrinsics, widen lhs/rhs to the intrinsic's element type
+  // *before* the broadcast below. The alternative — widening after the
+  // broadcast, when the smaller operand has already been replicated to the
+  // full lane count — would re-do the i8 → i16 (or f16 → f32) extension on
+  // every M row of the unrolled tile and force LLVM to scalarize the widen
+  // into a per-row `vpbroadcastw` + `vpandq` + `vpsrlvw` sequence around
+  // each FMA. Widening the narrow source vector once before the broadcast
+  // keeps the per-row inner loop down to just the FMA (with `m_bcst`).
+  Type widenTo;
+  switch (intrinsic) {
+  case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
+    widenTo = builder.getF32Type();
+    break;
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
+    widenTo = builder.getI16Type();
+    break;
+  default:
+    break;
+  }
+  if (widenTo) {
+    lhs = widen(lhs, widenTo);
+    rhs = widen(rhs, widenTo);
+  }
+
   // Replicate whichever of LHS/RHS has fewer lanes up to the other's lane
   // count, so both reach the intrinsic's flat lane width. In the natural
   // 1×N×K orientation that's the LHS (M=1) broadcast across the N lanes of
@@ -769,18 +809,6 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
     *bcastSrc = vector::BitCastOp::create(builder, loc, bcastDstType, splatted);
   }
 
-  // Sign-/float-extend a vector to a wider element type. Used by the
-  // *_CASTF32 (f16 → f32) and *_CASTI16 (i8 → i16) variants where the
-  // intrinsic only exists at the wider type.
-  auto widen = [&builder, loc](Value v, Type wider) -> Value {
-    auto vt = cast<VectorType>(v.getType());
-    auto wideTy = VectorType::get(vt.getShape(), wider);
-    if (isa<FloatType>(vt.getElementType())) {
-      return arith::ExtFOp::create(builder, loc, wideTy, v);
-    }
-    return arith::ExtSIOp::create(builder, loc, wideTy, v);
-  };
-
   // Emit llvm.call_intrinsic.
   auto call = [&builder, loc](StringRef name, Type resultType,
                               ValueRange args) -> Value {
@@ -789,8 +817,6 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
         .getResult(0);
   };
 
-  Type f32 = builder.getF32Type();
-  Type i16 = builder.getI16Type();
   Type accType = acc.getType();
   // Most x86 MMAs supported here are LHS/RHS-symmetric (FMA, dpbf16ps,
   // vpdpwssd, pmaddw): natural and swapped orientations share the same LLVM
@@ -802,6 +828,10 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
   // broadcast happens to land in the signed slot, that maps to vpdpbusd's
   // m_bcst-foldable slot too; when it lands on the unsigned side, no fold is
   // available (the ISA's m_bcst is on the signed operand).
+  //
+  // For *_CAST* variants (f16 → f32, i8 → i16), the widening already ran at
+  // the top of this function, so lhs/rhs reach the intrinsic call at the
+  // wider type without any per-row widen in the unrolled tile.
   Value bcst = lhsIsBroadcast ? lhs : rhs;
   Value full = lhsIsBroadcast ? rhs : lhs;
   switch (intrinsic) {
@@ -813,11 +843,9 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
     return call("llvm.fma.v8f64", accType, ValueRange{full, bcst, acc});
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F32:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F32:
-    return call("llvm.fma.v16f32", accType, ValueRange{full, bcst, acc});
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
-    return call("llvm.fma.v16f32", accType,
-                ValueRange{widen(full, f32), widen(bcst, f32), acc});
+    return call("llvm.fma.v16f32", accType, ValueRange{full, bcst, acc});
   case MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16:
   case MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16:
     return call("llvm.fma.v32f16", accType, ValueRange{full, bcst, acc});
@@ -827,24 +855,17 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
                 ValueRange{acc, full, bcst});
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I16:
-    return call("llvm.x86.avx512.vpdpwssd.512", accType,
-                ValueRange{acc, full, bcst});
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
     return call("llvm.x86.avx512.vpdpwssd.512", accType,
-                ValueRange{acc, widen(full, i16), widen(bcst, i16)});
+                ValueRange{acc, full, bcst});
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16:
-  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16: {
-    return arith::AddIOp::create(
-        builder, loc, acc,
-        call("llvm.x86.avx512.pmaddw.d.512", accType, ValueRange{full, bcst}));
-  }
+  case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16: {
     return arith::AddIOp::create(
         builder, loc, acc,
-        call("llvm.x86.avx512.pmaddw.d.512", accType,
-             ValueRange{widen(full, i16), widen(bcst, i16)}));
+        call("llvm.x86.avx512.pmaddw.d.512", accType, ValueRange{full, bcst}));
   }
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
     // LHS unsigned, RHS signed — vpdpbusd takes (acc, unsigned, signed).

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -70,10 +70,10 @@ module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @lower_avx512_1x16x1_f16_castf32
-//       CHECK:   %[[SCALAR:.+]] = vector.extract {{.*}} : f16 from vector<{{1x1|1}}xf16>
-//       CHECK:   %[[BCST:.+]] = vector.broadcast %[[SCALAR]] : f16 to vector<16xf16>
+//       CHECK:   arith.extf {{.*}} : vector<1xf16> to vector<1xf32>
 //       CHECK:   arith.extf {{.*}} : vector<16xf16> to vector<16xf32>
-//       CHECK:   arith.extf {{.*}} : vector<16xf16> to vector<16xf32>
+//       CHECK:   %[[SCALAR:.+]] = vector.extract {{.*}} : f32 from vector<1xf32>
+//       CHECK:   %[[BCST:.+]] = vector.broadcast %[[SCALAR]] : f32 to vector<16xf32>
 //       CHECK:   llvm.call_intrinsic "llvm.fma.v16f32"({{.*}}) : (vector<16xf32>, vector<16xf32>, vector<16xf32>) -> vector<16xf32>
 
 // -----
@@ -112,11 +112,11 @@ module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @lower_avx512_1x16x2_i8_casti16
-//       CHECK:   %[[SCALAR:.+]] = vector.extract {{.*}} : i16 from vector<1xi16>
-//       CHECK:   %[[BCST_I16:.+]] = vector.broadcast %[[SCALAR]] : i16 to vector<16xi16>
-//       CHECK:   vector.bitcast %[[BCST_I16]] : vector<16xi16> to vector<32xi8>
+//       CHECK:   arith.extsi {{.*}} : vector<2xi8> to vector<2xi16>
 //       CHECK:   arith.extsi {{.*}} : vector<32xi8> to vector<32xi16>
-//       CHECK:   arith.extsi {{.*}} : vector<32xi8> to vector<32xi16>
+//       CHECK:   %[[SCALAR:.+]] = vector.extract {{.*}} : i32 from vector<1xi32>
+//       CHECK:   %[[BCST:.+]] = vector.broadcast %[[SCALAR]] : i32 to vector<16xi32>
+//       CHECK:   vector.bitcast %[[BCST]] : vector<16xi32> to vector<32xi16>
 //       CHECK:   %[[DOT:.+]] = llvm.call_intrinsic "llvm.x86.avx512.pmaddw.d.512"({{.*}}) : (vector<32xi16>, vector<32xi16>) -> vector<16xi32>
 //       CHECK:   arith.addi {{.*}}, %[[DOT]] : vector<16xi32>
 


### PR DESCRIPTION
For the `*_CASTF32` (f16 -> f32) and `*_CASTI16` (i8 -> i16) inner_tiled intrinsic variants, the lowering needs to extend the narrow operand to the intrinsic's element type before the FMA. The previous code widened *after* the broadcast: the smaller operand had already been replicated across the full lane width when `arith.extf` / `arith.extsi` ran, so LLVM had to materialize the widen on the full replicated vector (`<32 x bfloat>` -> `<32 x f32>`, `<32 x i8>` -> `<32 x i16>`) once per M row inside the unrolled tile.

Concretely for bf16x bf16 -> f32 the bf16 storage matches the intrinsic so this didn't matter, but for f16xf16 -> f32 with `+avx512f` (no +avx512fp16), the AVX-512 FMA wants f32 operands and the prior code emitted, per M-row, a vbroadcastw + vpmovzxwd-equivalent sequence around each `vfmaddps`. For i8xi8 -> i32 with `+avx512vnni`, the same shape produced a per-row `vpbroadcastw` + `vpandq` + `vpsrlvw` mask- and-shift sequence around each `vpdpwssd`, inflating the inner-loop op count by ~3x.

Hoist the widen above the broadcast: extend the small `<K x narrow>` input to `<K x wide>` once, then broadcast it. Because the broadcast emits the splat-of-a-single-packed-lane idiom at the wider element type, the broadcast unit grows to `K * wide_bits` (e.g. 32 bits for i8 K=2 after i16 widening), which is the natural m32bcst broadcast unit the m_bcst fold from the sibling commit recognizes.

Measured on Zen 4 (4096x4096, dynamic shapes), inner_tiled vs the mmt4d ukernel path:

  - f16xf16 -> f32: 138 ms -> 126 ms (now 4% *faster* than the ukernel at 131 ms).
  - bf16xbf16 -> f32: unchanged (no widen; 52.9 ms vs ukernel's 50.9).
  - i16xi16 -> i32: unchanged (no widen; 53 ms vs ukernel's 52).
  - f32xf32 -> f32: unchanged (no widen; 102 ms vs ukernel's 116, we were already faster).
  - i8xi8 -> i32 via i16 cast: improves slightly (74 -> 73 ms) but the per-row widen is still expensive because each row's i8 K-pair is a different source, so we still emit 30 small `vpmovsxbw` plus `vpbroadcastd` per K-step. The ukernel sidesteps this by loading the whole M=16 LHS panel as one `vpmovsxbw` and shuffling out per- row K-pairs inside the registers. Closing that gap would need a structurally different lowering (panel-wise widen + per-row shuffle) and is left for a follow-up.

Progress towards #24515.