### PR TITLE
[Codegen] Add v0 TileAndFuse constraints for mamtul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
@@ -156,6 +156,10 @@ struct ConstraintEvaluator {
                     smt::IntDivOp, smt::IntModOp, smt::IntMulOp, smt::IntSubOp,
                     smt::IteOp, smt::NotOp, smt::OrOp>(
                   [&](auto op) { return eval(op); })
+              .Case<smt::DeclareFunOp>([&](smt::DeclareFunOp declOp) {
+                intValues[declOp.getResult()] = std::nullopt;
+                return success();
+              })
               .Default([](Operation *unhandled) {
                 return unhandled->emitError(
                     "unsupported op in constraint evaluator");

--- a/compiler/src/iree/compiler/Codegen/Common/test/insert_smt_constraints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/insert_smt_constraints.mlir
@@ -48,6 +48,8 @@ hal.executable @matmul_f32_ex {
 // CHECK:           linalg.fill
 // CHECK-NOT:       iree_codegen.smt.constraints
 // CHECK:           linalg.matmul
+// CHECK:           iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<TileAndFuse>
+// CHECK-NEXT{LITERAL}: knobs = {mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>, reduction = [0, 0, #iree_codegen.smt.int_knob<"red_2">], subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, 0], subgroup_size = #iree_codegen.smt.int_knob<"sg_size">, workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0], workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]}
 //
 // CHECK:           iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK-NEXT{LITERAL}: knobs = {mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>, reduction = [0, 0, #iree_codegen.smt.int_knob<"red_2">], subgroup_basis = [[#iree_codegen.smt.int_knob<"sg_m_cnt">, #iree_codegen.smt.int_knob<"sg_n_cnt">, 1], [0, 1, 2]], subgroup_size = #iree_codegen.smt.int_knob<"sg_size">, workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0], workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]}

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
@@ -171,7 +171,7 @@ func.func @conv_e2e_generated_violation_tf(
           workgroup = [1, 1, 48, 64, 0, 0, 0],
           reduction = [0, 0, 0, 0, 1, 1, 16],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-          subgroup = [0, 1, 1, 1, 0, 0, 0]}>,
+          subgroup = [1, 1, 1, 1, 0, 0, 0]}>,
       root_op = #iree_codegen.root_op<set = 1>,
       strides = dense<1> : tensor<2xi64>}
       ins(%input, %filter : tensor<1x18x130x64xf32>,

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
@@ -75,8 +75,6 @@ func.func @matmul_e2e_generated_violation_tf(
       -> tensor<128x256xf32>
   // expected-error @below {{pipeline constraints violated}}
   // expected-note @below {{dim_0 must be divisible by wg_0 (128 % 48 == 0)}}
-  // expected-note @below {{sg_num <= 10}}
-  // expected-note @below {{wg_size_x == total_threads}}
   %result = linalg.matmul {
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [48, 64, 0],
@@ -163,8 +161,6 @@ func.func @conv_e2e_generated_violation_tf(
       -> tensor<1x16x128x128xf32>
   // expected-error @below {{pipeline constraints violated}}
   // expected-note @below {{dim_2 must be divisible by wg_2 (128 % 48 == 0)}}
-  // expected-note @below {{sg_num <= 10}}
-  // expected-note @below {{wg_size_x == total_threads}}
   %result = linalg.conv_2d_nhwc_hwcf {
       dilations = dense<1> : tensor<2xi64>,
       lowering_config = #iree_gpu.lowering_config<{

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
@@ -22,7 +22,7 @@
     pipeline = #iree_gpu.pipeline<VectorDistribute>
     workgroup_size = [64, 1, 1] subgroup_size = 64>
 
-func.func @matmul_e2e_generated_violation(
+func.func @matmul_e2e_generated_violation_vd(
     %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
     -> tensor<128x256xf32>
     attributes {hal.executable.target = #exec_target,
@@ -60,10 +60,53 @@ func.func @matmul_e2e_generated_violation(
 #exec_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
     {iree_codegen.target_info = #gpu_target}>
 #translation = #iree_codegen.translation_info<
+    pipeline = #iree_gpu.pipeline<TileAndFuse>
+    workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+func.func @matmul_e2e_generated_violation_tf(
+    %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
+    -> tensor<128x256xf32>
+    attributes {hal.executable.target = #exec_target,
+                translation_info = #translation} {
+  %cst = arith.constant 0.0 : f32
+  %init = tensor.empty() : tensor<128x256xf32>
+  %fill = linalg.fill {root_op = #iree_codegen.root_op<set = 0>}
+      ins(%cst : f32) outs(%init : tensor<128x256xf32>)
+      -> tensor<128x256xf32>
+  // expected-error @below {{pipeline constraints violated}}
+  // expected-note @below {{dim_0 must be divisible by wg_0 (128 % 48 == 0)}}
+  // expected-note @below {{sg_num <= 10}}
+  // expected-note @below {{wg_size_x == total_threads}}
+  %result = linalg.matmul {
+      lowering_config = #iree_gpu.lowering_config<{
+          workgroup = [48, 64, 0],
+          reduction = [0, 0, 16],
+          mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+          subgroup = [1, 1, 0]}>,
+      root_op = #iree_codegen.root_op<set = 0>}
+      ins(%lhs, %rhs : tensor<128x64xf32>, tensor<64x256xf32>)
+      outs(%fill : tensor<128x256xf32>) -> tensor<128x256xf32>
+  return %result : tensor<128x256xf32>
+}
+
+// -----
+
+#gpu_target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  mma = [<MFMA_F32_16x16x4_F32>],
+  subgroup_size_choices = [64],
+  max_load_instruction_bits = 128,
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536,
+  max_workgroup_counts = [2147483647, 2147483647, 2147483647]
+>>
+#exec_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+    {iree_codegen.target_info = #gpu_target}>
+#translation = #iree_codegen.translation_info<
     pipeline = #iree_gpu.pipeline<VectorDistribute>
     workgroup_size = [64, 1, 1] subgroup_size = 64>
 
-func.func @conv_e2e_generated_violation(
+func.func @conv_e2e_generated_violation_vd(
     %input: tensor<1x18x130x64xf32>, %filter: tensor<3x3x64x128xf32>)
     -> tensor<1x16x128x128xf32>
     attributes {hal.executable.target = #exec_target,
@@ -93,6 +136,52 @@ func.func @conv_e2e_generated_violation(
 
 // -----
 
+#gpu_target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  mma = [<MFMA_F32_16x16x4_F32>],
+  subgroup_size_choices = [64],
+  max_load_instruction_bits = 128,
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536,
+  max_workgroup_counts = [2147483647, 2147483647, 2147483647]
+>>
+#exec_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+    {iree_codegen.target_info = #gpu_target}>
+#translation = #iree_codegen.translation_info<
+    pipeline = #iree_gpu.pipeline<TileAndFuse>
+    workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+func.func @conv_e2e_generated_violation_tf(
+    %input: tensor<1x18x130x64xf32>, %filter: tensor<3x3x64x128xf32>)
+    -> tensor<1x16x128x128xf32>
+    attributes {hal.executable.target = #exec_target,
+                translation_info = #translation} {
+  %cst = arith.constant 0.0 : f32
+  %init = tensor.empty() : tensor<1x16x128x128xf32>
+  %fill = linalg.fill {root_op = #iree_codegen.root_op<set = 1>}
+      ins(%cst : f32) outs(%init : tensor<1x16x128x128xf32>)
+      -> tensor<1x16x128x128xf32>
+  // expected-error @below {{pipeline constraints violated}}
+  // expected-note @below {{dim_2 must be divisible by wg_2 (128 % 48 == 0)}}
+  // expected-note @below {{sg_num <= 10}}
+  // expected-note @below {{wg_size_x == total_threads}}
+  %result = linalg.conv_2d_nhwc_hwcf {
+      dilations = dense<1> : tensor<2xi64>,
+      lowering_config = #iree_gpu.lowering_config<{
+          workgroup = [1, 1, 48, 64, 0, 0, 0],
+          reduction = [0, 0, 0, 0, 1, 1, 16],
+          mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+          subgroup = [0, 1, 1, 1, 0, 0, 0]}>,
+      root_op = #iree_codegen.root_op<set = 1>,
+      strides = dense<1> : tensor<2xi64>}
+      ins(%input, %filter : tensor<1x18x130x64xf32>,
+                               tensor<3x3x64x128xf32>)
+      outs(%fill : tensor<1x16x128x128xf32>) -> tensor<1x16x128x128xf32>
+  return %result : tensor<1x16x128x128xf32>
+}
+
+// -----
+
 // Test: End-to-end constraint insertion and verification.
 // Use the same shapes as above but with divisible workgroup sizes.
 // It should pass verification and have constraints erased.
@@ -111,7 +200,7 @@ func.func @conv_e2e_generated_violation(
     pipeline = #iree_gpu.pipeline<VectorDistribute>
     workgroup_size = [64, 1, 1] subgroup_size = 64>
 
-func.func @matmul_e2e_constraints_erased(
+func.func @matmul_e2e_constraints_erased_vd(
     %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
     -> tensor<128x256xf32>
     attributes {hal.executable.target = #exec_target,
@@ -133,11 +222,11 @@ func.func @matmul_e2e_constraints_erased(
   return %result : tensor<128x256xf32>
 }
 
-// CHECK-LABEL: func.func @matmul_e2e_constraints_erased
+// CHECK-LABEL: func.func @matmul_e2e_constraints_erased_vd
 // CHECK:       linalg.matmul
 // CHECK-NOT:   iree_codegen.smt.constraints
 
-func.func @conv_e2e_constraints_erased(
+func.func @conv_e2e_constraints_erased_vd(
     %input: tensor<1x18x130x64xf32>, %filter: tensor<3x3x64x128xf32>)
     -> tensor<1x16x128x128xf32>
     attributes {hal.executable.target = #exec_target,
@@ -163,6 +252,78 @@ func.func @conv_e2e_constraints_erased(
   return %result : tensor<1x16x128x128xf32>
 }
 
-// CHECK-LABEL: func.func @conv_e2e_constraints_erased
+// CHECK-LABEL: func.func @conv_e2e_constraints_erased_vd
+// CHECK:       linalg.conv_2d_nhwc_hwcf
+// CHECK-NOT:   iree_codegen.smt.constraints
+
+// -----
+
+#gpu_target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  mma = [<MFMA_F32_16x16x4_F32>],
+  subgroup_size_choices = [64],
+  max_load_instruction_bits = 128,
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536,
+  max_workgroup_counts = [2147483647, 2147483647, 2147483647]
+>>
+#exec_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+    {iree_codegen.target_info = #gpu_target}>
+#translation = #iree_codegen.translation_info<
+    pipeline = #iree_gpu.pipeline<TileAndFuse>
+    workgroup_size = [64, 1, 1] subgroup_size = 64>
+
+func.func @matmul_e2e_constraints_erased_tf(
+    %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
+    -> tensor<128x256xf32>
+    attributes {hal.executable.target = #exec_target,
+                translation_info = #translation} {
+  %cst = arith.constant 0.0 : f32
+  %init = tensor.empty() : tensor<128x256xf32>
+  %fill = linalg.fill {root_op = #iree_codegen.root_op<set = 0>}
+      ins(%cst : f32) outs(%init : tensor<128x256xf32>)
+      -> tensor<128x256xf32>
+  %result = linalg.matmul {
+      lowering_config = #iree_gpu.lowering_config<{
+          workgroup = [16, 16, 0],
+          reduction = [0, 0, 16],
+          mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+          subgroup = [1, 1, 0]}>,
+      root_op = #iree_codegen.root_op<set = 0>}
+      ins(%lhs, %rhs : tensor<128x64xf32>, tensor<64x256xf32>)
+      outs(%fill : tensor<128x256xf32>) -> tensor<128x256xf32>
+  return %result : tensor<128x256xf32>
+}
+
+// CHECK-LABEL: func.func @matmul_e2e_constraints_erased_tf
+// CHECK:       linalg.matmul
+// CHECK-NOT:   iree_codegen.smt.constraints
+
+func.func @conv_e2e_constraints_erased_tf(
+    %input: tensor<1x18x130x64xf32>, %filter: tensor<3x3x64x128xf32>)
+    -> tensor<1x16x128x128xf32>
+    attributes {hal.executable.target = #exec_target,
+                translation_info = #translation} {
+  %cst = arith.constant 0.0 : f32
+  %init = tensor.empty() : tensor<1x16x128x128xf32>
+  %fill = linalg.fill {root_op = #iree_codegen.root_op<set = 1>}
+      ins(%cst : f32) outs(%init : tensor<1x16x128x128xf32>)
+      -> tensor<1x16x128x128xf32>
+  %result = linalg.conv_2d_nhwc_hwcf {
+      dilations = dense<1> : tensor<2xi64>,
+      lowering_config = #iree_gpu.lowering_config<{
+          workgroup = [1, 1, 16, 64, 0, 0, 0],
+          reduction = [0, 0, 0, 0, 1, 1, 16],
+          mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+          subgroup = [0, 1, 0, 1, 1, 0, 0]}>,
+      root_op = #iree_codegen.root_op<set = 1>,
+      strides = dense<1> : tensor<2xi64>}
+      ins(%input, %filter : tensor<1x18x130x64xf32>,
+                               tensor<3x3x64x128xf32>)
+      outs(%fill : tensor<1x16x128x128xf32>) -> tensor<1x16x128x128xf32>
+  return %result : tensor<1x16x128x128xf32>
+}
+
+// CHECK-LABEL: func.func @conv_e2e_constraints_erased_tf
 // CHECK:       linalg.conv_2d_nhwc_hwcf
 // CHECK-NOT:   iree_codegen.smt.constraints

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -47,10 +47,28 @@ struct RootOpLoopInfo {
 
 // Keys for entries in the SMT constraints `knobs` dictionary.
 // These names are aligned with lowering config and translation info fields.
+
+// Lowering config knob list for VectorDistribute (VD):
+//   workgroup = [wg_#, wg_#, ...]
+//   reduction = [..., ..., red_#]
+//   mma_kind = mma_idx
+//   subgroup_basis = [[..., sg_m_cnt, sg_n_cnt, ...], [0, 1, 2, ...]]
+
+// Lowering config knob list for TileAndFuse (TF):
+//   workgroup = [wg_#, wg_#, ...]
+//   reduction = [..., ..., red_#]
+//   mma_kind = mma_idx
+//   subgroup = [sg_#, sg_#, ...]
+
+// Translation info knob list (shared by both pipelines):
+//   workgroup_size = [wg_size_x, wg_size_y, wg_size_z]
+//   subgroup_size = sg_size
+
 constexpr StringLiteral kKnobWorkgroupKey = "workgroup";
 constexpr StringLiteral kKnobReductionKey = "reduction";
 constexpr StringLiteral kKnobMmaKindKey = "mma_kind";
 constexpr StringLiteral kKnobSubgroupBasisKey = "subgroup_basis";
+constexpr StringLiteral kKnobSubgroupKey = "subgroup";
 constexpr StringLiteral kKnobWorkgroupSizeKey = "workgroup_size";
 constexpr StringLiteral kKnobSubgroupSizeKey = "subgroup_size";
 
@@ -63,10 +81,12 @@ constexpr StringLiteral kKnobWgSizeXName = "wg_size_x";
 constexpr StringLiteral kKnobWgSizeYName = "wg_size_y";
 constexpr StringLiteral kKnobWgSizeZName = "wg_size_z";
 
-// SMT variable name prefixes. The loop dim count varies
-// per problem, so names are built at runtime as prefix + dim idx.
+// SMT variable name prefixes.
+// The loop dim count varies per problem, so names are built at runtime
+// as prefix + dim idx, for example: wg_0, red_1, sg_0, etc.
 constexpr StringLiteral kKnobWgPrefix = "wg_";
 constexpr StringLiteral kKnobRedPrefix = "red_";
+constexpr StringLiteral kKnobSgPrefix = "sg_";
 
 // Default value for dims that are not knobbed.
 constexpr int64_t kNoTileDimVal = 0;
@@ -114,6 +134,26 @@ static std::string makeVarName(StringRef prefix, unsigned idx) {
 /// Helper to create an i64 IntegerAttr with a fixed value.
 static IntegerAttr makeIntAttr(MLIRContext *ctx, int64_t value = 0) {
   return IntegerAttr::get(IntegerType::get(ctx, 64), value);
+}
+
+/// Emit product(values), returning 1 for an empty range.
+static Value emitProduct(OpBuilder &builder, Location loc,
+                         ArrayRef<Value> values) {
+  if (values.empty()) {
+    return mkIntConst(builder, loc, 1);
+  }
+  return smt::IntMulOp::create(builder, loc, values);
+}
+
+/// Emit ceil(lhs / rhs) * rhs.
+static Value emitAlignUpToMultiple(OpBuilder &builder, Location loc, Value lhs,
+                                   Value rhs) {
+  Value one = mkIntConst(builder, loc, 1);
+  Value rhsMinusOne = smt::IntSubOp::create(builder, loc, rhs, one);
+  Value lhsPlus =
+      smt::IntAddOp::create(builder, loc, ValueRange{lhs, rhsMinusOne});
+  Value div = smt::IntDivOp::create(builder, loc, lhsPlus, rhs);
+  return smt::IntMulOp::create(builder, loc, ValueRange{div, rhs});
 }
 
 /// Get unique compatible MMA attrs for matmul and conv ops.
@@ -177,7 +217,8 @@ getCompatibleMMAAttrs(linalg::LinalgOp op, IREE::GPU::TargetAttr gpuTarget,
 /// Get contraction-like (m,n,k) dims for a linalg op.
 /// Only supports contraction and convolution today.
 static FailureOr<ContractionLikeDims>
-inferContractionLikeDims(linalg::LinalgOp linalgOp) {
+inferContractionLikeDims(linalg::LinalgOp linalgOp,
+                         IREE::GPU::LoweringPipeline pipeline) {
   if (linalg::isaContractionOpInterface(linalgOp)) {
     FailureOr<mlir::linalg::ContractionDimensions> contractionDims =
         mlir::linalg::inferContractionDims(linalgOp);
@@ -192,19 +233,44 @@ inferContractionLikeDims(linalg::LinalgOp linalgOp) {
   if (linalg::isaConvolutionOpInterface(linalgOp)) {
     FailureOr<mlir::linalg::ConvolutionDimensions> convolutionDims =
         mlir::linalg::inferConvolutionDims(linalgOp);
-    if (failed(convolutionDims) || convolutionDims->outputImage.empty() ||
-        convolutionDims->outputChannel.empty() ||
-        convolutionDims->inputChannel.empty()) {
+    if (failed(convolutionDims)) {
       return failure();
     }
-    // TODO(Amily): This mapping aligns with how VectorDistribute
-    // sets the dims for convs. It may be too coarse for conv
-    // semantics; revisit when plumbing through conv constraint
-    // generation.
-    return ContractionLikeDims{llvm::to_vector(convolutionDims->batch),
-                               llvm::to_vector(convolutionDims->outputImage),
-                               llvm::to_vector(convolutionDims->outputChannel),
-                               llvm::to_vector(convolutionDims->inputChannel)};
+    if (pipeline == IREE::GPU::LoweringPipeline::VectorDistribute) {
+      if (convolutionDims->outputImage.empty() ||
+          convolutionDims->outputChannel.empty() ||
+          convolutionDims->inputChannel.empty()) {
+        return failure();
+      }
+      // TODO(Amily): This mapping aligns with how VectorDistribute sets conv
+      // dims. It may be too coarse for conv semantics and should be revisited
+      // when conv constraint generation is fully plumbed.
+      return ContractionLikeDims{
+          llvm::to_vector(convolutionDims->batch),
+          llvm::to_vector(convolutionDims->outputImage),
+          llvm::to_vector(convolutionDims->outputChannel),
+          llvm::to_vector(convolutionDims->inputChannel)};
+    }
+    if (pipeline == IREE::GPU::LoweringPipeline::TileAndFuse) {
+      if (convolutionDims->outputChannel.empty() ||
+          convolutionDims->inputChannel.empty() ||
+          convolutionDims->filterLoop.empty() ||
+          convolutionDims->outputImage.empty()) {
+        return failure();
+      }
+      // Match TileAndFuse conv mapping.
+      SmallVector<unsigned> mDims;
+      llvm::append_range(mDims, convolutionDims->batch);
+      llvm::append_range(mDims, convolutionDims->outputImage);
+      llvm::sort(mDims);
+      SmallVector<unsigned> kDims;
+      llvm::append_range(kDims, convolutionDims->filterLoop);
+      llvm::append_range(kDims, convolutionDims->inputChannel);
+      return ContractionLikeDims{
+          llvm::to_vector(convolutionDims->depth), mDims,
+          llvm::to_vector(convolutionDims->outputChannel), kDims};
+    }
+    return failure();
   }
   return failure();
 }
@@ -282,6 +348,74 @@ buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
       ArrayAttr::get(ctx, {ArrayAttr::get(ctx, subgroupCounts),
                            ArrayAttr::get(ctx, subgroupMapping)});
   knobsEntries.emplace_back(kKnobSubgroupBasisKey, subgroupBasis);
+
+  // Add workgroup size and subgroup size at the top level.
+  SmallVector<Attribute> wgSizeKnobs = {
+      IntKnobAttr::get(ctx, kKnobWgSizeXName),
+      IntKnobAttr::get(ctx, kKnobWgSizeYName),
+      IntKnobAttr::get(ctx, kKnobWgSizeZName)};
+  knobsEntries.emplace_back(kKnobWorkgroupSizeKey,
+                            ArrayAttr::get(ctx, wgSizeKnobs));
+  knobsEntries.emplace_back(kKnobSubgroupSizeKey,
+                            IntKnobAttr::get(ctx, kKnobSgSizeName));
+
+  return DictionaryAttr::get(ctx, knobsEntries);
+}
+
+/// Build the TileAndFuse knobs dict for contraction-like dims.
+static DictionaryAttr
+buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
+                          const ContractionLikeDims &dims,
+                          ArrayRef<Attribute> compatibleMMAs) {
+  SmallVector<NamedAttribute> knobsEntries;
+
+  // Build workgroup entries.
+  // Batch, M, N dims are knobbed, K dims are not tiled and get 0.
+  SmallVector<Attribute> workgroupEntries(loopInfo.numLoops,
+                                          makeIntAttr(ctx, kNoTileDimVal));
+  SmallVector<unsigned> knobbedWorkgroupDims;
+  llvm::append_range(knobbedWorkgroupDims, dims.b);
+  llvm::append_range(knobbedWorkgroupDims, dims.m);
+  llvm::append_range(knobbedWorkgroupDims, dims.n);
+  for (unsigned i : knobbedWorkgroupDims) {
+    workgroupEntries[i] = IntKnobAttr::get(ctx, makeVarName(kKnobWgPrefix, i));
+  }
+  knobsEntries.emplace_back(kKnobWorkgroupKey,
+                            ArrayAttr::get(ctx, workgroupEntries));
+
+  // Build reduction entries.
+  // Only innermost K dim is knobbed, other K dims are unit tiled as 1.
+  // Other untiled dims get 0.
+  SmallVector<Attribute> reductionEntries(loopInfo.numLoops,
+                                          makeIntAttr(ctx, kNoTileDimVal));
+  for (unsigned i = 0; i < loopInfo.numLoops; ++i) {
+    reductionEntries[i] = makeIntAttr(ctx, kNoTileDimVal);
+  }
+  for (unsigned i : dims.k) {
+    reductionEntries[i] = makeIntAttr(ctx, kUnitTileDimVal);
+  }
+  reductionEntries[dims.k.back()] =
+      IntKnobAttr::get(ctx, makeVarName(kKnobRedPrefix, dims.k.back()));
+  knobsEntries.emplace_back(kKnobReductionKey,
+                            ArrayAttr::get(ctx, reductionEntries));
+
+  // Build subgroup entries.
+  // M and N dims are knobbed, other untiled dims get 0.
+  SmallVector<Attribute> subgroupEntries(loopInfo.numLoops,
+                                         makeIntAttr(ctx, kNoTileDimVal));
+  SmallVector<unsigned> knobbedSubgroupDims;
+  llvm::append_range(knobbedSubgroupDims, dims.m);
+  llvm::append_range(knobbedSubgroupDims, dims.n);
+  for (unsigned i : knobbedSubgroupDims) {
+    subgroupEntries[i] = IntKnobAttr::get(ctx, makeVarName(kKnobSgPrefix, i));
+  }
+  knobsEntries.emplace_back(kKnobSubgroupKey,
+                            ArrayAttr::get(ctx, subgroupEntries));
+
+  // Add mma_kind knob.
+  knobsEntries.emplace_back(
+      kKnobMmaKindKey,
+      OneOfKnobAttr::get(ctx, kKnobMmaIdxName, compatibleMMAs));
 
   // Add workgroup size and subgroup size at the top level.
   SmallVector<Attribute> wgSizeKnobs = {
@@ -554,10 +688,198 @@ static LogicalResult emitVectorDistributeConstraints(
   return success();
 }
 
-/// Emit constraints for a single root op under the VectorDistribute pipeline.
+/// Emit TileAndFuse constraints for contraction-like dims (matmul/conv).
+static LogicalResult emitTileAndFuseConstraints(
+    OpBuilder &builder, linalg::LinalgOp linalgOp,
+    const ContractionLikeDims &dims, IREE::GPU::TargetAttr gpuTarget,
+    ArrayRef<Value> smtDimArgs, ArrayRef<Attribute> compatibleMMAs) {
+  Location loc = linalgOp.getLoc();
+
+  // Hardware constants.
+  Value subgroupSizeVal =
+      mkIntConst(builder, loc, gpuTarget.getPreferredSubgroupSize());
+  Value maxThreadsVal = mkIntConst(
+      builder, loc, gpuTarget.getWgp().getMaxThreadCountPerWorkgroup());
+  Value maxSharedMemVal =
+      mkIntConst(builder, loc, gpuTarget.getWgp().getMaxWorkgroupMemoryBytes());
+  Value maxVGPRsVal = mkIntConst(builder, loc, 512);
+  Value one = mkIntConst(builder, loc, 1);
+  Value thirtyTwo = mkIntConst(builder, loc, 32);
+  Value ten = mkIntConst(builder, loc, 10);
+
+  // Only innermost M and N dims are constrained, same as VectorDistribute.
+  unsigned mDim = dims.m.back();
+  unsigned nDim = dims.n.back();
+  unsigned kDim = dims.k.back();
+  std::string wgMName = makeVarName(kKnobWgPrefix, mDim);
+  std::string wgNName = makeVarName(kKnobWgPrefix, nDim);
+  std::string mDimName = makeVarName(kLoopRangePrefix, mDim);
+  std::string nDimName = makeVarName(kLoopRangePrefix, nDim);
+
+  // Create top-level knobs from lowering and translation configs.
+  Value wgM = mkKnob(builder, loc, wgMName);
+  Value wgN = mkKnob(builder, loc, wgNName);
+  Value sgMInner = mkKnob(builder, loc, makeVarName(kKnobSgPrefix, mDim));
+  Value sgNInner = mkKnob(builder, loc, makeVarName(kKnobSgPrefix, nDim));
+  Value sgSize = mkKnob(builder, loc, kKnobSgSizeName);
+  Value wgSizeX = mkKnob(builder, loc, kKnobWgSizeXName);
+  Value wgSizeY = mkKnob(builder, loc, kKnobWgSizeYName);
+  Value wgSizeZ = mkKnob(builder, loc, kKnobWgSizeZName);
+
+  // Create MMA shape lookup values from `mma_idx`.
+  auto [mmaMLookup, mmaNLookup, mmaKLookup] =
+      emitMMALookup(builder, loc, compatibleMMAs);
+
+  // Create reduction tile knob for innermost K only.
+  Value redK = mkKnob(builder, loc, makeVarName(kKnobRedPrefix, kDim));
+
+  // Create intermediate variables.
+  // Do not create these as knobs because they are not in the knob dict
+  // and would fail constraint verification.
+  Value prodKTiles = redK;
+  Value sgMDenom =
+      smt::IntMulOp::create(builder, loc, ValueRange{sgMInner, mmaMLookup});
+  Value sgNDenom =
+      smt::IntMulOp::create(builder, loc, ValueRange{sgNInner, mmaNLookup});
+  Value sgMCnt = smt::IntDivOp::create(builder, loc, wgM, sgMDenom);
+  Value sgNCnt = smt::IntDivOp::create(builder, loc, wgN, sgNDenom);
+  Value subgroups =
+      smt::IntMulOp::create(builder, loc, ValueRange{sgMCnt, sgNCnt});
+  Value totalThreads =
+      smt::IntMulOp::create(builder, loc, ValueRange{subgroups, sgSize});
+
+  // Constraint 0: Set concrete values for knobs.
+  // sg_size == preferred_subgroup_size.
+  Value sgSizeEq = smt::EqOp::create(builder, loc, sgSize, subgroupSizeVal);
+  AssertOp::create(builder, loc, sgSizeEq,
+                   "sg_size == preferred_subgroup_size");
+  // Constraint 1: Tile size must divide problem size.
+  // dim % wg_tile == 0 for innermost M/N loops and packed inner K alignment.
+  assertDivisible(
+      builder, loc, smtDimArgs[mDim], wgM,
+      llvm::join_items("", mDimName, " must be divisible by ", wgMName));
+  assertDivisible(
+      builder, loc, smtDimArgs[nDim], wgN,
+      llvm::join_items("", nDimName, " must be divisible by ", wgNName));
+
+  // Align the innermost K problem size to the chosen intrinsic K.
+  Value kInnerAligned =
+      emitAlignUpToMultiple(builder, loc, smtDimArgs[kDim], mmaKLookup);
+
+  // Constraint 4: Reduction tile structure.
+  // Only innermost K is a knob. Outer K dims are fixed to unit tile in knobs.
+  Value packedK =
+      smt::IntMulOp::create(builder, loc, ValueRange{redK, mmaKLookup});
+  assertCmp(builder, loc, smt::IntPredicate::le, packedK, kInnerAligned,
+            "inner packed k tile <= aligned k dim");
+  assertDivisible(builder, loc, kInnerAligned, packedK,
+                  "aligned inner k dim must be divisible by packed k tile");
+
+  // Constraint 2: Tile size bounds.
+  // 1 <= tile <= dim and inner M/N are intrinsic-aligned.
+  assertBounds(builder, loc, wgM, wgMName, one, "1", smtDimArgs[mDim],
+               mDimName);
+  assertBounds(builder, loc, wgN, wgNName, one, "1", smtDimArgs[nDim],
+               nDimName);
+  assertCmp(builder, loc, smt::IntPredicate::ge, wgM, mmaMLookup,
+            "inner m tile >= mma_m");
+  assertCmp(builder, loc, smt::IntPredicate::ge, wgN, mmaNLookup,
+            "inner n tile >= mma_n");
+  assertDivisible(builder, loc, wgM, mmaMLookup,
+                  llvm::join_items("", wgMName, " must be divisible by mma_m"));
+  assertDivisible(builder, loc, wgN, mmaNLookup,
+                  llvm::join_items("", wgNName, " must be divisible by mma_n"));
+
+  // Constraint 3: Tile size decomposition.
+  // Inner subgroup tiles and full M/N tile products must decompose into
+  // subgroup tiles, subgroup counts, and intrinsic shape.
+  assertCmp(builder, loc, smt::IntPredicate::ge, sgMInner, one,
+            "sg_m_inner >= 1");
+  assertCmp(builder, loc, smt::IntPredicate::ge, sgNInner, one,
+            "sg_n_inner >= 1");
+  Value mInnerDiv =
+      smt::IntMulOp::create(builder, loc, ValueRange{sgMInner, mmaMLookup});
+  Value nInnerDiv =
+      smt::IntMulOp::create(builder, loc, ValueRange{sgNInner, mmaNLookup});
+  assertDivisible(builder, loc, wgM, mInnerDiv,
+                  "inner m tile must be divisible by subgroup_m_inner * mma_m");
+  assertDivisible(builder, loc, wgN, nInnerDiv,
+                  "inner n tile must be divisible by subgroup_n_inner * mma_n");
+  Value mDecompRhs = smt::IntMulOp::create(
+      builder, loc, ValueRange{sgMInner, sgMCnt, mmaMLookup});
+  Value nDecompRhs = smt::IntMulOp::create(
+      builder, loc, ValueRange{sgNInner, sgNCnt, mmaNLookup});
+  Value mDecompEq = smt::EqOp::create(builder, loc, wgM, mDecompRhs);
+  Value nDecompEq = smt::EqOp::create(builder, loc, wgN, nDecompRhs);
+  AssertOp::create(builder, loc, mDecompEq,
+                   "prod_m_tiles == prod_subgroup_m_tiles * sg_m_cnt * mma_m");
+  AssertOp::create(builder, loc, nDecompEq,
+                   "prod_n_tiles == prod_subgroup_n_tiles * sg_n_cnt * mma_n");
+
+  // Constraint 4: Subgroup count bounds.
+  assertBounds(builder, loc, sgMCnt, "sg_m_cnt", one, "1", thirtyTwo, "32");
+  assertBounds(builder, loc, sgNCnt, "sg_n_cnt", one, "1", thirtyTwo, "32");
+  // Keep current tuner-compatible subgroup range.
+  assertBounds(builder, loc, subgroups, "sg_num", one, "1", ten, "10");
+
+  // Constraint 5: Thread count limit.
+  // sg_m_cnt * sg_n_cnt * sg_size <= max_threads.
+  assertCmp(builder, loc, smt::IntPredicate::le, totalThreads, maxThreadsVal,
+            "total_threads <= max_threads");
+
+  // Constraint 6: Shared memory limit.
+  // Use promoted operand memory (LHS + RHS) with packed-K scaling.
+  auto lhsType =
+      cast<ShapedType>(linalgOp.getDpsInputOperand(0)->get().getType());
+  auto rhsType =
+      cast<ShapedType>(linalgOp.getDpsInputOperand(1)->get().getType());
+  Value lhsBytes =
+      mkIntConst(builder, loc, lhsType.getElementTypeBitWidth() / 8);
+  Value rhsBytes =
+      mkIntConst(builder, loc, rhsType.getElementTypeBitWidth() / 8);
+  Value lhsElems =
+      smt::IntMulOp::create(builder, loc, ValueRange{wgM, prodKTiles});
+  Value rhsElems =
+      smt::IntMulOp::create(builder, loc, ValueRange{wgN, prodKTiles});
+  Value lhsMem =
+      smt::IntMulOp::create(builder, loc, ValueRange{lhsBytes, lhsElems});
+  Value rhsMem =
+      smt::IntMulOp::create(builder, loc, ValueRange{rhsBytes, rhsElems});
+  Value totalSharedMem =
+      smt::IntAddOp::create(builder, loc, ValueRange{lhsMem, rhsMem});
+  Value packedSharedMem = smt::IntMulOp::create(
+      builder, loc, ValueRange{totalSharedMem, mmaKLookup});
+  assertCmp(builder, loc, smt::IntPredicate::le, packedSharedMem,
+            maxSharedMemVal, "shared memory must fit in workgroup memory");
+
+  // Constraint 7: TranslationInfo workgroup structure.
+  // For TileAndFuse, workgroup_size = [total_threads, 1, 1].
+  Value wgXEq = smt::EqOp::create(builder, loc, wgSizeX, totalThreads);
+  AssertOp::create(builder, loc, wgXEq, "wg_size_x == total_threads");
+  Value wgYEq = smt::EqOp::create(builder, loc, wgSizeY, one);
+  AssertOp::create(builder, loc, wgYEq, "wg_size_y == 1");
+  Value wgZEq = smt::EqOp::create(builder, loc, wgSizeZ, one);
+  AssertOp::create(builder, loc, wgZEq, "wg_size_z == 1");
+
+  // Constraint 8: Additional heuristic filters to narrow the search space.
+  // Keep product bounds from the tuner reference.
+  assertCmp(builder, loc, smt::IntPredicate::le, wgM, maxVGPRsVal,
+            "prod_m_tiles <= 512");
+  assertCmp(builder, loc, smt::IntPredicate::le, wgN, maxVGPRsVal,
+            "prod_n_tiles <= 512");
+  Value kProdLimit =
+      smt::IntMulOp::create(builder, loc, ValueRange{prodKTiles, mmaKLookup});
+  assertCmp(builder, loc, smt::IntPredicate::le, kProdLimit, maxVGPRsVal,
+            "prod_k_tiles * mma_k <= 512");
+
+  return success();
+}
+
+/// Emit constraints for a single root op under a supported LLVMGPU pipeline.
 /// Only supports linalg contraction and convolution today.
 static LogicalResult
-emitVectorDistributeConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr) {
+emitConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr,
+                     IREE::GPU::LoweringPipeline pipeline) {
   // Gate on contraction-like linalg ops.
   auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp);
   if (!linalgOp || (!linalg::isaContractionOpInterface(linalgOp) &&
@@ -575,7 +897,8 @@ emitVectorDistributeConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr) {
     return success();
   }
 
-  FailureOr<ContractionLikeDims> dims = inferContractionLikeDims(linalgOp);
+  FailureOr<ContractionLikeDims> dims =
+      inferContractionLikeDims(linalgOp, pipeline);
   if (failed(dims)) {
     return success();
   }
@@ -588,16 +911,29 @@ emitVectorDistributeConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr) {
 
   MLIRContext *ctx = rootOp->getContext();
   OpBuilder builder(ctx);
-  DictionaryAttr knobs =
-      buildVectorDistributeKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs);
-  auto pipelineAttr = IREE::GPU::PipelineAttr::get(
-      ctx, IREE::GPU::LoweringPipeline::VectorDistribute);
+  DictionaryAttr knobs;
+  if (pipeline == IREE::GPU::LoweringPipeline::VectorDistribute) {
+    knobs =
+        buildVectorDistributeKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs);
+  } else if (pipeline == IREE::GPU::LoweringPipeline::TileAndFuse) {
+    knobs = buildTileAndFuseKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs);
+  } else {
+    return success();
+  }
+  auto pipelineAttr = IREE::GPU::PipelineAttr::get(ctx, pipeline);
   ConstraintsOpShell shell =
       createConstraintsOpShell(builder, rootOp, rootOpAttr, pipelineAttr, knobs,
                                loopInfo->numLoops, loopInfo->indexingMaps);
 
-  return emitVectorDistributeConstraints(builder, linalgOp, *dims, gpuTarget,
-                                         shell.smtDimArgs, compatibleMMAs);
+  if (pipeline == IREE::GPU::LoweringPipeline::VectorDistribute) {
+    return emitVectorDistributeConstraints(builder, linalgOp, *dims, gpuTarget,
+                                           shell.smtDimArgs, compatibleMMAs);
+  }
+  if (pipeline == IREE::GPU::LoweringPipeline::TileAndFuse) {
+    return emitTileAndFuseConstraints(builder, linalgOp, *dims, gpuTarget,
+                                      shell.smtDimArgs, compatibleMMAs);
+  }
+  return success();
 }
 
 /// Multiple root ops may be present in a set, e.g. <set = 0>:
@@ -633,13 +969,12 @@ LogicalResult emitLLVMGPUConstraints(Attribute attr,
 
   auto gpuPipelineAttr = cast<IREE::GPU::PipelineAttr>(attr);
 
-  // Only VectorDistribute has constraint generation today.
-  if (gpuPipelineAttr.getValue() !=
-      IREE::GPU::LoweringPipeline::VectorDistribute) {
+  IREE::GPU::LoweringPipeline pipeline = gpuPipelineAttr.getValue();
+  if (pipeline != IREE::GPU::LoweringPipeline::VectorDistribute &&
+      pipeline != IREE::GPU::LoweringPipeline::TileAndFuse) {
     return success();
   }
-
-  return emitVectorDistributeConstraintsForOp(tunableOp, opAttr);
+  return emitConstraintsForOp(tunableOp, opAttr, pipeline);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -780,6 +780,9 @@ static LogicalResult emitTileAndFuseConstraints(
   // total_threads = sg_m_cnt * sg_n_cnt * sg_size
   Value totalThreads =
       smt::IntMulOp::create(builder, loc, ValueRange{subgroups, sgSize});
+  // packed_k = red_k * mma_k
+  Value packedK =
+      smt::IntMulOp::create(builder, loc, ValueRange{redK, mmaKLookup});
 
   // Constraint 0: Set concrete values for knobs.
   // sg_size == preferred_subgroup_size.
@@ -881,24 +884,24 @@ static LogicalResult emitTileAndFuseConstraints(
   }
 
   // Constraint 2: Reduction Tile.
-  // aligned_dim_k % red_k == 0, aligned_dim_k = ceil(dim_k / mma_k) * mma_k
-  // problemInnerKAligned = ceil(dim_k / mma_k) * mma_k.
+  // red_k >= 1
+  assertCmp(builder, loc, smt::IntPredicate::ge, redK,
+            mkIntConst(builder, loc, 1),
+            llvm::join_items("", redKInnerName, " >= 1"));
+  // aligned_dim_k % (red_k * mma_k) == 0, aligned_dim_k = ceil(dim_k / mma_k) *
+  // mma_k problemInnerKAligned = ceil(dim_k / mma_k) * mma_k.
   Value problemInnerKAligned =
       emitAlignUpToMultiple(builder, loc, smtDimArgs[kInnerDim], mmaKLookup);
-  assertDivisible(builder, loc, problemInnerKAligned, redK,
+  assertDivisible(builder, loc, problemInnerKAligned, packedK,
                   llvm::join_items("", "aligned inner k dim ", kInnerDimName,
-                                   " must be divisible by ", redKInnerName));
-  // red_k <= max_vgprs
-  assertCmp(builder, loc, smt::IntPredicate::le, redK, maxVGPRsVal,
-            llvm::join_items("", redKInnerName, " <= 512 (max_vgprs)"));
-  // red_k <= aligned_dim_k
-  assertCmp(builder, loc, smt::IntPredicate::le, redK, problemInnerKAligned,
-            llvm::join_items("", redKInnerName, " <= aligned k dim"));
-  // unpacked_k >= 1, unpacked_k = red_k / mma_k
-  Value unpackedK = smt::IntDivOp::create(builder, loc, redK, mmaKLookup);
-  assertCmp(builder, loc, smt::IntPredicate::ge, unpackedK,
-            mkIntConst(builder, loc, 1),
-            llvm::join_items("", "1 <= ", redKInnerName, " / mma_k"));
+                                   " must be divisible by ", redKInnerName,
+                                   " * mma_k"));
+  // red_k * mma_k <= max_vgprs
+  assertCmp(builder, loc, smt::IntPredicate::le, packedK, maxVGPRsVal,
+            llvm::join_items("", redKInnerName, " * mma_k <= 512 (max_vgprs)"));
+  // red_k * mma_k <= aligned_dim_k
+  assertCmp(builder, loc, smt::IntPredicate::le, packedK, problemInnerKAligned,
+            llvm::join_items("", redKInnerName, " * mma_k <= aligned k dim"));
 
   // Constraint 3: Subgroup tile size.
   // sg >= 1 for M and N tiles.
@@ -924,13 +927,13 @@ static LogicalResult emitTileAndFuseConstraints(
             "total_threads <= max_threads");
 
   // Constraint 5: Shared memory limit.
-  // (lhs_bytes * wg_m * red_k) + (rhs_bytes * wg_n * red_k)
+  // (lhs_bytes * wg_m * red_k * mma_k) + (rhs_bytes * wg_n * red_k * mma_k)
   auto [lhsBytesVal, rhsBytesVal] =
       getLhsRhsOperandBytes(builder, loc, linalgOp);
-  Value lhsMem = smt::IntMulOp::create(builder, loc,
-                                       ValueRange{lhsBytesVal, wgMInner, redK});
-  Value rhsMem = smt::IntMulOp::create(builder, loc,
-                                       ValueRange{rhsBytesVal, wgNInner, redK});
+  Value lhsMem = smt::IntMulOp::create(
+      builder, loc, ValueRange{lhsBytesVal, wgMInner, packedK});
+  Value rhsMem = smt::IntMulOp::create(
+      builder, loc, ValueRange{rhsBytesVal, wgNInner, packedK});
   Value totalSharedMem =
       smt::IntAddOp::create(builder, loc, ValueRange{lhsMem, rhsMem});
   assertCmp(builder, loc, smt::IntPredicate::le, totalSharedMem,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -49,16 +49,16 @@ struct RootOpLoopInfo {
 // These names are aligned with lowering config and translation info fields.
 
 // Lowering config knob list for VectorDistribute (VD):
-//   workgroup = [wg_#, wg_#, ...]
-//   reduction = [..., ..., red_#]
+//   workgroup = [wg_#, wg_#, ...], only innermost M and N dims are knobbed.
+//   reduction = [..., ..., red_#], only innermost K dim is knobbed.
 //   mma_kind = mma_idx
 //   subgroup_basis = [[..., sg_m_cnt, sg_n_cnt, ...], [0, 1, 2, ...]]
 
 // Lowering config knob list for TileAndFuse (TF):
-//   workgroup = [wg_#, wg_#, ...]
-//   reduction = [..., ..., red_#]
+//   workgroup = [wg_#, wg_#, ...], B, M, N dims are knobbed.
+//   reduction = [..., ..., red_#], only innermost K dim is knobbed.
 //   mma_kind = mma_idx
-//   subgroup = [sg_#, sg_#, ...]
+//   subgroup = [sg_#, sg_#, ...], M and N dims are knobbed.
 
 // Translation info knob list (shared by both pipelines):
 //   workgroup_size = [wg_size_x, wg_size_y, wg_size_z]
@@ -125,26 +125,6 @@ static void assertBounds(OpBuilder &builder, Location loc, Value val,
             llvm::join_items("", name, " <= ", hiName));
 }
 
-/// Helper to build a knob variable name from a prefix.
-/// e.g. ("wg_", 2) -> "wg_2".
-static std::string makeVarName(StringRef prefix, unsigned idx) {
-  return (prefix + Twine(idx)).str();
-}
-
-/// Helper to create an i64 IntegerAttr with a fixed value.
-static IntegerAttr makeIntAttr(MLIRContext *ctx, int64_t value = 0) {
-  return IntegerAttr::get(IntegerType::get(ctx, 64), value);
-}
-
-/// Emit product(values), returning 1 for an empty range.
-static Value emitProduct(OpBuilder &builder, Location loc,
-                         ArrayRef<Value> values) {
-  if (values.empty()) {
-    return mkIntConst(builder, loc, 1);
-  }
-  return smt::IntMulOp::create(builder, loc, values);
-}
-
 /// Emit ceil(lhs / rhs) * rhs.
 static Value emitAlignUpToMultiple(OpBuilder &builder, Location loc, Value lhs,
                                    Value rhs) {
@@ -154,6 +134,43 @@ static Value emitAlignUpToMultiple(OpBuilder &builder, Location loc, Value lhs,
       smt::IntAddOp::create(builder, loc, ValueRange{lhs, rhsMinusOne});
   Value div = smt::IntDivOp::create(builder, loc, lhsPlus, rhs);
   return smt::IntMulOp::create(builder, loc, ValueRange{div, rhs});
+}
+
+/// Emit product(values[0], values[1], ..., values[n-1]).
+static Value emitProduct(OpBuilder &builder, Location loc,
+                         ArrayRef<Value> values) {
+  Value prod = mkIntConst(builder, loc, 1);
+  for (Value value : values) {
+    prod = smt::IntMulOp::create(builder, loc, ValueRange{prod, value});
+  }
+  return prod;
+}
+
+/// Get the LHS and RHS operand element-type byte sizes of a linalg op as SMT
+/// int constants.
+static std::pair<Value, Value>
+getLhsRhsOperandBytes(OpBuilder &builder, Location loc,
+                      linalg::LinalgOp linalgOp) {
+  auto lhsType =
+      cast<ShapedType>(linalgOp.getDpsInputOperand(0)->get().getType());
+  auto rhsType =
+      cast<ShapedType>(linalgOp.getDpsInputOperand(1)->get().getType());
+  Value lhsBytes =
+      mkIntConst(builder, loc, lhsType.getElementTypeBitWidth() / 8);
+  Value rhsBytes =
+      mkIntConst(builder, loc, rhsType.getElementTypeBitWidth() / 8);
+  return {lhsBytes, rhsBytes};
+}
+
+/// Helper to build a knob variable name from a prefix.
+/// e.g. ("wg_", 2) -> "wg_2".
+static std::string makeVarName(StringRef prefix, unsigned idx) {
+  return (prefix + Twine(idx)).str();
+}
+
+/// Helper to create an i64 IntegerAttr with a fixed value.
+static IntegerAttr makeIntAttr(MLIRContext *ctx, int64_t value = 0) {
+  return IntegerAttr::get(IntegerType::get(ctx, 64), value);
 }
 
 /// Get unique compatible MMA attrs for matmul and conv ops.
@@ -703,48 +720,64 @@ static LogicalResult emitTileAndFuseConstraints(
   Value maxSharedMemVal =
       mkIntConst(builder, loc, gpuTarget.getWgp().getMaxWorkgroupMemoryBytes());
   Value maxVGPRsVal = mkIntConst(builder, loc, 512);
-  Value one = mkIntConst(builder, loc, 1);
-  Value thirtyTwo = mkIntConst(builder, loc, 32);
-  Value ten = mkIntConst(builder, loc, 10);
 
-  // Only innermost M and N dims are constrained, same as VectorDistribute.
-  unsigned mDim = dims.m.back();
-  unsigned nDim = dims.n.back();
-  unsigned kDim = dims.k.back();
-  std::string wgMName = makeVarName(kKnobWgPrefix, mDim);
-  std::string wgNName = makeVarName(kKnobWgPrefix, nDim);
-  std::string mDimName = makeVarName(kLoopRangePrefix, mDim);
-  std::string nDimName = makeVarName(kLoopRangePrefix, nDim);
+  // Innermost M, N, K dims.
+  unsigned mInnerDim = dims.m.back();
+  unsigned nInnerDim = dims.n.back();
+  unsigned kInnerDim = dims.k.back();
+  std::string wgMInnerName = makeVarName(kKnobWgPrefix, mInnerDim);
+  std::string wgNInnerName = makeVarName(kKnobWgPrefix, nInnerDim);
+  std::string redKInnerName = makeVarName(kKnobRedPrefix, kInnerDim);
+  std::string kInnerDimName = makeVarName(kLoopRangePrefix, kInnerDim);
+  std::string sgMInnerName = makeVarName(kKnobSgPrefix, mInnerDim);
+  std::string sgNInnerName = makeVarName(kKnobSgPrefix, nInnerDim);
 
   // Create top-level knobs from lowering and translation configs.
-  Value wgM = mkKnob(builder, loc, wgMName);
-  Value wgN = mkKnob(builder, loc, wgNName);
-  Value sgMInner = mkKnob(builder, loc, makeVarName(kKnobSgPrefix, mDim));
-  Value sgNInner = mkKnob(builder, loc, makeVarName(kKnobSgPrefix, nDim));
+  SmallVector<unsigned> wgMNBDims;
+  llvm::append_range(wgMNBDims, dims.m);
+  llvm::append_range(wgMNBDims, dims.n);
+  llvm::append_range(wgMNBDims, dims.b);
+  SmallVector<unsigned> sgMNDims;
+  llvm::append_range(sgMNDims, dims.m);
+  llvm::append_range(sgMNDims, dims.n);
+  auto createKnobsByDim = [&](ArrayRef<unsigned> dimList,
+                              StringRef knobPrefix) -> SmallVector<Value> {
+    SmallVector<Value> knobsByDim(smtDimArgs.size());
+    for (unsigned dim : dimList) {
+      knobsByDim[dim] = mkKnob(builder, loc, makeVarName(knobPrefix, dim));
+    }
+    return knobsByDim;
+  };
+  SmallVector<Value> wgKnobsByDim = createKnobsByDim(wgMNBDims, kKnobWgPrefix);
+  SmallVector<Value> sgKnobsByDim = createKnobsByDim(sgMNDims, kKnobSgPrefix);
+  Value wgMInner = wgKnobsByDim[mInnerDim];
+  Value wgNInner = wgKnobsByDim[nInnerDim];
+  Value sgM = sgKnobsByDim[mInnerDim];
+  Value sgN = sgKnobsByDim[nInnerDim];
+  Value redK = mkKnob(builder, loc, redKInnerName);
   Value sgSize = mkKnob(builder, loc, kKnobSgSizeName);
   Value wgSizeX = mkKnob(builder, loc, kKnobWgSizeXName);
   Value wgSizeY = mkKnob(builder, loc, kKnobWgSizeYName);
   Value wgSizeZ = mkKnob(builder, loc, kKnobWgSizeZName);
 
-  // Create MMA shape lookup values from `mma_idx`.
-  auto [mmaMLookup, mmaNLookup, mmaKLookup] =
-      emitMMALookup(builder, loc, compatibleMMAs);
-
-  // Create reduction tile knob for innermost K only.
-  Value redK = mkKnob(builder, loc, makeVarName(kKnobRedPrefix, kDim));
-
   // Create intermediate variables.
   // Do not create these as knobs because they are not in the knob dict
   // and would fail constraint verification.
-  Value prodKTiles = redK;
+  // mma_m, mma_n, mma_k
+  auto [mmaMLookup, mmaNLookup, mmaKLookup] =
+      emitMMALookup(builder, loc, compatibleMMAs);
   Value sgMDenom =
-      smt::IntMulOp::create(builder, loc, ValueRange{sgMInner, mmaMLookup});
+      smt::IntMulOp::create(builder, loc, ValueRange{sgM, mmaMLookup});
   Value sgNDenom =
-      smt::IntMulOp::create(builder, loc, ValueRange{sgNInner, mmaNLookup});
-  Value sgMCnt = smt::IntDivOp::create(builder, loc, wgM, sgMDenom);
-  Value sgNCnt = smt::IntDivOp::create(builder, loc, wgN, sgNDenom);
+      smt::IntMulOp::create(builder, loc, ValueRange{sgN, mmaNLookup});
+  // sg_m_cnt = wg_m / (sg_m * mma_m)
+  Value sgMCnt = smt::IntDivOp::create(builder, loc, wgMInner, sgMDenom);
+  // sg_n_cnt = wg_n / (sg_n * mma_n)
+  Value sgNCnt = smt::IntDivOp::create(builder, loc, wgNInner, sgNDenom);
+  // sg_num = sg_m_cnt * sg_n_cnt
   Value subgroups =
       smt::IntMulOp::create(builder, loc, ValueRange{sgMCnt, sgNCnt});
+  // total_threads = sg_m_cnt * sg_n_cnt * sg_size
   Value totalThreads =
       smt::IntMulOp::create(builder, loc, ValueRange{subgroups, sgSize});
 
@@ -753,124 +786,165 @@ static LogicalResult emitTileAndFuseConstraints(
   Value sgSizeEq = smt::EqOp::create(builder, loc, sgSize, subgroupSizeVal);
   AssertOp::create(builder, loc, sgSizeEq,
                    "sg_size == preferred_subgroup_size");
-  // Constraint 1: Tile size must divide problem size.
-  // dim % wg_tile == 0 for innermost M/N loops and packed inner K alignment.
+
+  // Constraint 1: Workgroup Tiles.
+  // Basic constraints for both outer and innermost M and N tiles.
+  for (unsigned dim : wgMNBDims) {
+    std::string wgName = makeVarName(kKnobWgPrefix, dim);
+    std::string problemName = makeVarName(kLoopRangePrefix, dim);
+    std::string sgName = makeVarName(kKnobSgPrefix, dim);
+    Value wg = wgKnobsByDim[dim];
+    Value sg = sgKnobsByDim[dim];
+    // dim % wg == 0.
+    assertDivisible(
+        builder, loc, smtDimArgs[dim], wg,
+        llvm::join_items("", problemName, " must be divisible by ", wgName));
+    // 1 <= wg <= dim
+    assertBounds(builder, loc, wg, wgName, mkIntConst(builder, loc, 1), "1",
+                 smtDimArgs[dim], problemName);
+    // wg % sg == 0.
+    assertDivisible(
+        builder, loc, wg, sg,
+        llvm::join_items("", wgName, " must be divisible by ", sgName));
+  }
+  // Extra constraints for innermost M and N tiles.
+  // wg >= mma
+  assertCmp(builder, loc, smt::IntPredicate::ge, wgMInner, mmaMLookup,
+            llvm::join_items("", wgMInnerName, " >= mma_m"));
+  assertCmp(builder, loc, smt::IntPredicate::ge, wgNInner, mmaNLookup,
+            llvm::join_items("", wgNInnerName, " >= mma_n"));
+  // wg % mma == 0.
   assertDivisible(
-      builder, loc, smtDimArgs[mDim], wgM,
-      llvm::join_items("", mDimName, " must be divisible by ", wgMName));
+      builder, loc, wgMInner, mmaMLookup,
+      llvm::join_items("", wgMInnerName, " must be divisible by mma_m"));
   assertDivisible(
-      builder, loc, smtDimArgs[nDim], wgN,
-      llvm::join_items("", nDimName, " must be divisible by ", wgNName));
-
-  // Align the innermost K problem size to the chosen intrinsic K.
-  Value kInnerAligned =
-      emitAlignUpToMultiple(builder, loc, smtDimArgs[kDim], mmaKLookup);
-
-  // Constraint 4: Reduction tile structure.
-  // Only innermost K is a knob. Outer K dims are fixed to unit tile in knobs.
-  Value packedK =
-      smt::IntMulOp::create(builder, loc, ValueRange{redK, mmaKLookup});
-  assertCmp(builder, loc, smt::IntPredicate::le, packedK, kInnerAligned,
-            "inner packed k tile <= aligned k dim");
-  assertDivisible(builder, loc, kInnerAligned, packedK,
-                  "aligned inner k dim must be divisible by packed k tile");
-
-  // Constraint 2: Tile size bounds.
-  // 1 <= tile <= dim and inner M/N are intrinsic-aligned.
-  assertBounds(builder, loc, wgM, wgMName, one, "1", smtDimArgs[mDim],
-               mDimName);
-  assertBounds(builder, loc, wgN, wgNName, one, "1", smtDimArgs[nDim],
-               nDimName);
-  assertCmp(builder, loc, smt::IntPredicate::ge, wgM, mmaMLookup,
-            "inner m tile >= mma_m");
-  assertCmp(builder, loc, smt::IntPredicate::ge, wgN, mmaNLookup,
-            "inner n tile >= mma_n");
-  assertDivisible(builder, loc, wgM, mmaMLookup,
-                  llvm::join_items("", wgMName, " must be divisible by mma_m"));
-  assertDivisible(builder, loc, wgN, mmaNLookup,
-                  llvm::join_items("", wgNName, " must be divisible by mma_n"));
-
-  // Constraint 3: Tile size decomposition.
-  // Inner subgroup tiles and full M/N tile products must decompose into
-  // subgroup tiles, subgroup counts, and intrinsic shape.
-  assertCmp(builder, loc, smt::IntPredicate::ge, sgMInner, one,
-            "sg_m_inner >= 1");
-  assertCmp(builder, loc, smt::IntPredicate::ge, sgNInner, one,
-            "sg_n_inner >= 1");
+      builder, loc, wgNInner, mmaNLookup,
+      llvm::join_items("", wgNInnerName, " must be divisible by mma_n"));
+  // wg % (sg * mma) == 0
   Value mInnerDiv =
-      smt::IntMulOp::create(builder, loc, ValueRange{sgMInner, mmaMLookup});
+      smt::IntMulOp::create(builder, loc, ValueRange{sgM, mmaMLookup});
   Value nInnerDiv =
-      smt::IntMulOp::create(builder, loc, ValueRange{sgNInner, mmaNLookup});
-  assertDivisible(builder, loc, wgM, mInnerDiv,
-                  "inner m tile must be divisible by subgroup_m_inner * mma_m");
-  assertDivisible(builder, loc, wgN, nInnerDiv,
-                  "inner n tile must be divisible by subgroup_n_inner * mma_n");
-  Value mDecompRhs = smt::IntMulOp::create(
-      builder, loc, ValueRange{sgMInner, sgMCnt, mmaMLookup});
-  Value nDecompRhs = smt::IntMulOp::create(
-      builder, loc, ValueRange{sgNInner, sgNCnt, mmaNLookup});
-  Value mDecompEq = smt::EqOp::create(builder, loc, wgM, mDecompRhs);
-  Value nDecompEq = smt::EqOp::create(builder, loc, wgN, nDecompRhs);
-  AssertOp::create(builder, loc, mDecompEq,
-                   "prod_m_tiles == prod_subgroup_m_tiles * sg_m_cnt * mma_m");
-  AssertOp::create(builder, loc, nDecompEq,
-                   "prod_n_tiles == prod_subgroup_n_tiles * sg_n_cnt * mma_n");
+      smt::IntMulOp::create(builder, loc, ValueRange{sgN, mmaNLookup});
+  assertDivisible(builder, loc, wgMInner, mInnerDiv,
+                  llvm::join_items("", wgMInnerName, " must be divisible by ",
+                                   sgMInnerName, " * mma_m"));
+  assertDivisible(builder, loc, wgNInner, nInnerDiv,
+                  llvm::join_items("", wgNInnerName, " must be divisible by ",
+                                   sgNInnerName, " * mma_n"));
+  // Product constraints for all M and N tiles.
+  // prod(wg) <= max_vgprs
+  auto buildWgProd = [&](ArrayRef<unsigned> axisDims) -> Value {
+    SmallVector<Value> values;
+    for (unsigned dim : axisDims) {
+      values.push_back(wgKnobsByDim[dim]);
+    }
+    return emitProduct(builder, loc, values);
+  };
+  Value wgMProd = buildWgProd(dims.m);
+  Value wgNProd = buildWgProd(dims.n);
+  assertCmp(builder, loc, smt::IntPredicate::le, wgMProd, maxVGPRsVal,
+            "prod(wg_m) <= 512 (max_vgprs)");
+  assertCmp(builder, loc, smt::IntPredicate::le, wgNProd, maxVGPRsVal,
+            "prod(wg_n) <= 512 (max_vgprs)");
 
-  // Constraint 4: Subgroup count bounds.
-  assertBounds(builder, loc, sgMCnt, "sg_m_cnt", one, "1", thirtyTwo, "32");
-  assertBounds(builder, loc, sgNCnt, "sg_n_cnt", one, "1", thirtyTwo, "32");
-  // Keep current tuner-compatible subgroup range.
-  assertBounds(builder, loc, subgroups, "sg_num", one, "1", ten, "10");
+  // prod(wg) == prod(sg * sg_cnt * mma)
+  auto buildSgProd = [&](ArrayRef<unsigned> axisDims) -> Value {
+    SmallVector<Value> values;
+    for (unsigned dim : axisDims) {
+      values.push_back(sgKnobsByDim[dim]);
+    }
+    return emitProduct(builder, loc, values);
+  };
+  Value allSgMProd = buildSgProd(dims.m);
+  Value allSgNProd = buildSgProd(dims.n);
+  Value mRhsProd = smt::IntMulOp::create(
+      builder, loc, ValueRange{allSgMProd, sgMCnt, mmaMLookup});
+  Value nRhsProd = smt::IntMulOp::create(
+      builder, loc, ValueRange{allSgNProd, sgNCnt, mmaNLookup});
+  Value mProdEq = smt::EqOp::create(builder, loc, wgMProd, mRhsProd);
+  Value nProdEq = smt::EqOp::create(builder, loc, wgNProd, nRhsProd);
+  AssertOp::create(builder, loc, mProdEq,
+                   "prod(wg_m) == prod(sg_m) * sg_m_cnt * mma_m");
+  AssertOp::create(builder, loc, nProdEq,
+                   "prod(wg_n) == prod(sg_n) * sg_n_cnt * mma_n");
+  // Batch dim tile constraints.
+  // TODO: This constraint can be expanded to allow wg_b values other than 1.
+  // wg_b == 1
+  for (auto dim : dims.b) {
+    std::string wgBatchName = makeVarName(kKnobWgPrefix, dim);
+    Value wgBatch = wgKnobsByDim[dim];
+    Value batchEqOne =
+        smt::EqOp::create(builder, loc, wgBatch, mkIntConst(builder, loc, 1));
+    AssertOp::create(builder, loc, batchEqOne,
+                     llvm::join_items("", wgBatchName, " == 1"));
+  }
 
-  // Constraint 5: Thread count limit.
+  // Constraint 2: Reduction Tile.
+  // aligned_dim_k % red_k == 0, aligned_dim_k = ceil(dim_k / mma_k) * mma_k
+  // problemInnerKAligned = ceil(dim_k / mma_k) * mma_k.
+  Value problemInnerKAligned =
+      emitAlignUpToMultiple(builder, loc, smtDimArgs[kInnerDim], mmaKLookup);
+  assertDivisible(builder, loc, problemInnerKAligned, redK,
+                  llvm::join_items("", "aligned inner k dim ", kInnerDimName,
+                                   " must be divisible by ", redKInnerName));
+  // red_k <= max_vgprs
+  assertCmp(builder, loc, smt::IntPredicate::le, redK, maxVGPRsVal,
+            llvm::join_items("", redKInnerName, " <= 512 (max_vgprs)"));
+  // red_k <= aligned_dim_k
+  assertCmp(builder, loc, smt::IntPredicate::le, redK, problemInnerKAligned,
+            llvm::join_items("", redKInnerName, " <= aligned k dim"));
+  // unpacked_k >= 1, unpacked_k = red_k / mma_k
+  Value unpackedK = smt::IntDivOp::create(builder, loc, redK, mmaKLookup);
+  assertCmp(builder, loc, smt::IntPredicate::ge, unpackedK,
+            mkIntConst(builder, loc, 1),
+            llvm::join_items("", "1 <= ", redKInnerName, " / mma_k"));
+
+  // Constraint 3: Subgroup tile size.
+  // sg >= 1 for M and N tiles.
+  for (unsigned dim : sgMNDims) {
+    std::string sgName = makeVarName(kKnobSgPrefix, dim);
+    Value sg = sgKnobsByDim[dim];
+    assertCmp(builder, loc, smt::IntPredicate::ge, sg,
+              mkIntConst(builder, loc, 1),
+              llvm::join_items("", sgName, " >= 1"));
+  }
+  // 1 <= sg_cnt <= 32
+  assertBounds(builder, loc, sgMCnt, "sg_m_cnt", mkIntConst(builder, loc, 1),
+               "1", mkIntConst(builder, loc, 32), "32");
+  assertBounds(builder, loc, sgNCnt, "sg_n_cnt", mkIntConst(builder, loc, 1),
+               "1", mkIntConst(builder, loc, 32), "32");
+  // 1 <= sg_num <= 10
+  assertBounds(builder, loc, subgroups, "sg_num", mkIntConst(builder, loc, 1),
+               "1", mkIntConst(builder, loc, 10), "10");
+
+  // Constraint 4: Thread count limit.
   // sg_m_cnt * sg_n_cnt * sg_size <= max_threads.
   assertCmp(builder, loc, smt::IntPredicate::le, totalThreads, maxThreadsVal,
             "total_threads <= max_threads");
 
-  // Constraint 6: Shared memory limit.
-  // Use promoted operand memory (LHS + RHS) with packed-K scaling.
-  auto lhsType =
-      cast<ShapedType>(linalgOp.getDpsInputOperand(0)->get().getType());
-  auto rhsType =
-      cast<ShapedType>(linalgOp.getDpsInputOperand(1)->get().getType());
-  Value lhsBytes =
-      mkIntConst(builder, loc, lhsType.getElementTypeBitWidth() / 8);
-  Value rhsBytes =
-      mkIntConst(builder, loc, rhsType.getElementTypeBitWidth() / 8);
-  Value lhsElems =
-      smt::IntMulOp::create(builder, loc, ValueRange{wgM, prodKTiles});
-  Value rhsElems =
-      smt::IntMulOp::create(builder, loc, ValueRange{wgN, prodKTiles});
-  Value lhsMem =
-      smt::IntMulOp::create(builder, loc, ValueRange{lhsBytes, lhsElems});
-  Value rhsMem =
-      smt::IntMulOp::create(builder, loc, ValueRange{rhsBytes, rhsElems});
+  // Constraint 5: Shared memory limit.
+  // (lhs_bytes * wg_m * red_k) + (rhs_bytes * wg_n * red_k)
+  auto [lhsBytesVal, rhsBytesVal] =
+      getLhsRhsOperandBytes(builder, loc, linalgOp);
+  Value lhsMem = smt::IntMulOp::create(builder, loc,
+                                       ValueRange{lhsBytesVal, wgMInner, redK});
+  Value rhsMem = smt::IntMulOp::create(builder, loc,
+                                       ValueRange{rhsBytesVal, wgNInner, redK});
   Value totalSharedMem =
       smt::IntAddOp::create(builder, loc, ValueRange{lhsMem, rhsMem});
-  Value packedSharedMem = smt::IntMulOp::create(
-      builder, loc, ValueRange{totalSharedMem, mmaKLookup});
-  assertCmp(builder, loc, smt::IntPredicate::le, packedSharedMem,
+  assertCmp(builder, loc, smt::IntPredicate::le, totalSharedMem,
             maxSharedMemVal, "shared memory must fit in workgroup memory");
 
-  // Constraint 7: TranslationInfo workgroup structure.
+  // Constraint 6: TranslationInfo workgroup structure.
   // For TileAndFuse, workgroup_size = [total_threads, 1, 1].
   Value wgXEq = smt::EqOp::create(builder, loc, wgSizeX, totalThreads);
   AssertOp::create(builder, loc, wgXEq, "wg_size_x == total_threads");
-  Value wgYEq = smt::EqOp::create(builder, loc, wgSizeY, one);
+  Value wgYEq =
+      smt::EqOp::create(builder, loc, wgSizeY, mkIntConst(builder, loc, 1));
   AssertOp::create(builder, loc, wgYEq, "wg_size_y == 1");
-  Value wgZEq = smt::EqOp::create(builder, loc, wgSizeZ, one);
+  Value wgZEq =
+      smt::EqOp::create(builder, loc, wgSizeZ, mkIntConst(builder, loc, 1));
   AssertOp::create(builder, loc, wgZEq, "wg_size_z == 1");
-
-  // Constraint 8: Additional heuristic filters to narrow the search space.
-  // Keep product bounds from the tuner reference.
-  assertCmp(builder, loc, smt::IntPredicate::le, wgM, maxVGPRsVal,
-            "prod_m_tiles <= 512");
-  assertCmp(builder, loc, smt::IntPredicate::le, wgN, maxVGPRsVal,
-            "prod_n_tiles <= 512");
-  Value kProdLimit =
-      smt::IntMulOp::create(builder, loc, ValueRange{prodKTiles, mmaKLookup});
-  assertCmp(builder, loc, smt::IntPredicate::le, kProdLimit, maxVGPRsVal,
-            "prod_k_tiles * mma_k <= 512");
 
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -766,14 +766,35 @@ static LogicalResult emitTileAndFuseConstraints(
   // mma_m, mma_n, mma_k
   auto [mmaMLookup, mmaNLookup, mmaKLookup] =
       emitMMALookup(builder, loc, compatibleMMAs);
+  auto buildWgProd = [&](ArrayRef<unsigned> axisDims) -> Value {
+    SmallVector<Value> values;
+    for (unsigned dim : axisDims) {
+      values.push_back(wgKnobsByDim[dim]);
+    }
+    return emitProduct(builder, loc, values);
+  };
+  auto buildSgProd = [&](ArrayRef<unsigned> axisDims) -> Value {
+    SmallVector<Value> values;
+    for (unsigned dim : axisDims) {
+      values.push_back(sgKnobsByDim[dim]);
+    }
+    return emitProduct(builder, loc, values);
+  };
+  Value wgMProd = buildWgProd(dims.m);
+  Value wgNProd = buildWgProd(dims.n);
+  Value allSgMProd = buildSgProd(dims.m);
+  Value allSgNProd = buildSgProd(dims.n);
   Value sgMDenom =
-      smt::IntMulOp::create(builder, loc, ValueRange{sgM, mmaMLookup});
+      smt::IntMulOp::create(builder, loc, ValueRange{allSgMProd, mmaMLookup});
   Value sgNDenom =
-      smt::IntMulOp::create(builder, loc, ValueRange{sgN, mmaNLookup});
-  // sg_m_cnt = wg_m / (sg_m * mma_m)
-  Value sgMCnt = smt::IntDivOp::create(builder, loc, wgMInner, sgMDenom);
-  // sg_n_cnt = wg_n / (sg_n * mma_n)
-  Value sgNCnt = smt::IntDivOp::create(builder, loc, wgNInner, sgNDenom);
+      smt::IntMulOp::create(builder, loc, ValueRange{allSgNProd, mmaNLookup});
+  smt::IntType smtIntTy = smt::IntType::get(builder.getContext());
+  auto sgMCntDecl = smt::DeclareFunOp::create(
+      builder, loc, smtIntTy, builder.getStringAttr(kKnobSgMCntName));
+  auto sgNCntDecl = smt::DeclareFunOp::create(
+      builder, loc, smtIntTy, builder.getStringAttr(kKnobSgNCntName));
+  Value sgMCnt = sgMCntDecl.getResult();
+  Value sgNCnt = sgNCntDecl.getResult();
   // sg_num = sg_m_cnt * sg_n_cnt
   Value subgroups =
       smt::IntMulOp::create(builder, loc, ValueRange{sgMCnt, sgNCnt});
@@ -783,6 +804,14 @@ static LogicalResult emitTileAndFuseConstraints(
   // packed_k = red_k * mma_k
   Value packedK =
       smt::IntMulOp::create(builder, loc, ValueRange{redK, mmaKLookup});
+  // problemInnerAligned = ceil(dim / mma) * mma.
+  Value problemInnerMAligned =
+      emitAlignUpToMultiple(builder, loc, smtDimArgs[mInnerDim], mmaMLookup);
+  Value problemInnerNAligned =
+      emitAlignUpToMultiple(builder, loc, smtDimArgs[nInnerDim], mmaNLookup);
+  // problemInnerKAligned = ceil(dim_k / mma_k) * mma_k.
+  Value problemInnerKAligned =
+      emitAlignUpToMultiple(builder, loc, smtDimArgs[kInnerDim], mmaKLookup);
 
   // Constraint 0: Set concrete values for knobs.
   // sg_size == preferred_subgroup_size.
@@ -792,20 +821,25 @@ static LogicalResult emitTileAndFuseConstraints(
 
   // Constraint 1: Workgroup Tiles.
   // Basic constraints for both outer and innermost M and N tiles.
-  // TODO: Add overpadding to problem M and N dims to get better tile sizes.
   for (unsigned dim : wgMNBDims) {
     std::string wgName = makeVarName(kKnobWgPrefix, dim);
     std::string problemName = makeVarName(kLoopRangePrefix, dim);
     std::string sgName = makeVarName(kKnobSgPrefix, dim);
     Value wg = wgKnobsByDim[dim];
     Value sg = sgKnobsByDim[dim];
+    Value problemDim = smtDimArgs[dim];
+    if (dim == mInnerDim) {
+      problemDim = problemInnerMAligned;
+    } else if (dim == nInnerDim) {
+      problemDim = problemInnerNAligned;
+    }
     // dim % wg == 0.
     assertDivisible(
-        builder, loc, smtDimArgs[dim], wg,
+        builder, loc, problemDim, wg,
         llvm::join_items("", problemName, " must be divisible by ", wgName));
     // 1 <= wg <= dim
     assertBounds(builder, loc, wg, wgName, mkIntConst(builder, loc, 1), "1",
-                 smtDimArgs[dim], problemName);
+                 problemDim, problemName);
     // wg % sg == 0.
     assertDivisible(
         builder, loc, wg, sg,
@@ -837,30 +871,16 @@ static LogicalResult emitTileAndFuseConstraints(
                                    sgNInnerName, " * mma_n"));
   // Product constraints for all M and N tiles.
   // prod(wg) <= max_vgprs
-  auto buildWgProd = [&](ArrayRef<unsigned> axisDims) -> Value {
-    SmallVector<Value> values;
-    for (unsigned dim : axisDims) {
-      values.push_back(wgKnobsByDim[dim]);
-    }
-    return emitProduct(builder, loc, values);
-  };
-  Value wgMProd = buildWgProd(dims.m);
-  Value wgNProd = buildWgProd(dims.n);
   assertCmp(builder, loc, smt::IntPredicate::le, wgMProd, maxVGPRsVal,
             "prod(wg_m) <= 512 (max_vgprs)");
   assertCmp(builder, loc, smt::IntPredicate::le, wgNProd, maxVGPRsVal,
             "prod(wg_n) <= 512 (max_vgprs)");
 
-  // prod(wg) == prod(sg * sg_cnt * mma)
-  auto buildSgProd = [&](ArrayRef<unsigned> axisDims) -> Value {
-    SmallVector<Value> values;
-    for (unsigned dim : axisDims) {
-      values.push_back(sgKnobsByDim[dim]);
-    }
-    return emitProduct(builder, loc, values);
-  };
-  Value allSgMProd = buildSgProd(dims.m);
-  Value allSgNProd = buildSgProd(dims.n);
+  // prod(wg) == prod(sg) * sg_cnt * mma
+  assertDivisible(builder, loc, wgMProd, sgMDenom,
+                  "prod(wg_m) must be divisible by prod(sg_m) * mma_m");
+  assertDivisible(builder, loc, wgNProd, sgNDenom,
+                  "prod(wg_n) must be divisible by prod(sg_n) * mma_n");
   Value mRhsProd = smt::IntMulOp::create(
       builder, loc, ValueRange{allSgMProd, sgMCnt, mmaMLookup});
   Value nRhsProd = smt::IntMulOp::create(
@@ -888,18 +908,15 @@ static LogicalResult emitTileAndFuseConstraints(
   assertCmp(builder, loc, smt::IntPredicate::ge, redK,
             mkIntConst(builder, loc, 1),
             llvm::join_items("", redKInnerName, " >= 1"));
-  // aligned_dim_k % (red_k * mma_k) == 0, aligned_dim_k = ceil(dim_k / mma_k) *
-  // mma_k problemInnerKAligned = ceil(dim_k / mma_k) * mma_k.
-  Value problemInnerKAligned =
-      emitAlignUpToMultiple(builder, loc, smtDimArgs[kInnerDim], mmaKLookup);
+  // problemInnerKAligned % (packed_k) == 0
   assertDivisible(builder, loc, problemInnerKAligned, packedK,
                   llvm::join_items("", "aligned inner k dim ", kInnerDimName,
                                    " must be divisible by ", redKInnerName,
                                    " * mma_k"));
-  // red_k * mma_k <= max_vgprs
+  // packed_k <= max_vgprs
   assertCmp(builder, loc, smt::IntPredicate::le, packedK, maxVGPRsVal,
             llvm::join_items("", redKInnerName, " * mma_k <= 512 (max_vgprs)"));
-  // red_k * mma_k <= aligned_dim_k
+  // packed_k <= aligned_dim_k
   assertCmp(builder, loc, smt::IntPredicate::le, packedK, problemInnerKAligned,
             llvm::join_items("", redKInnerName, " * mma_k <= aligned k dim"));
 
@@ -927,13 +944,13 @@ static LogicalResult emitTileAndFuseConstraints(
             "total_threads <= max_threads");
 
   // Constraint 5: Shared memory limit.
-  // (lhs_bytes * wg_m * red_k * mma_k) + (rhs_bytes * wg_n * red_k * mma_k)
+  // (lhs_bytes * wg_m * packed_k) + (rhs_bytes * wg_n * packed_k)
   auto [lhsBytesVal, rhsBytesVal] =
       getLhsRhsOperandBytes(builder, loc, linalgOp);
   Value lhsMem = smt::IntMulOp::create(
-      builder, loc, ValueRange{lhsBytesVal, wgMInner, packedK});
+      builder, loc, ValueRange{lhsBytesVal, wgMProd, packedK});
   Value rhsMem = smt::IntMulOp::create(
-      builder, loc, ValueRange{rhsBytesVal, wgNInner, packedK});
+      builder, loc, ValueRange{rhsBytesVal, wgNProd, packedK});
   Value totalSharedMem =
       smt::IntAddOp::create(builder, loc, ValueRange{lhsMem, rhsMem});
   assertCmp(builder, loc, smt::IntPredicate::le, totalSharedMem,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -789,6 +789,7 @@ static LogicalResult emitTileAndFuseConstraints(
 
   // Constraint 1: Workgroup Tiles.
   // Basic constraints for both outer and innermost M and N tiles.
+  // TODO: Add overpadding to problem M and N dims to get better tile sizes.
   for (unsigned dim : wgMNBDims) {
     std::string wgName = makeVarName(kKnobWgPrefix, dim);
     std::string problemName = makeVarName(kLoopRangePrefix, dim);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_llvm_gpu_constraints.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_llvm_gpu_constraints.mlir
@@ -50,6 +50,15 @@ func.func @matmul_and_fill() attributes {hal.executable.target = #exec_target} {
 // CHECK-NOT:   iree_codegen.smt.constraints
 // CHECK-NOT:   knobs
 // CHECK:       linalg.matmul {{.+}} #iree_codegen.root_op<set = [[SET:[0-9]+]]>
+// CHECK:       iree_codegen.smt.constraints target = <set = [[SET]]>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
+// CHECK-NEXT:  knobs = {
+// CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
+// CHECK-DAG:   reduction = [0, 0, #iree_codegen.smt.int_knob<"red_2">]
+// CHECK-DAG:   subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, 0]
+// CHECK-DAG:   subgroup_size = #iree_codegen.smt.int_knob<"sg_size">
+// CHECK-DAG:   workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0]
+// CHECK-DAG:   workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]
+// CHECK-SAME:  }
 // CHECK:       iree_codegen.smt.constraints target = <set = [[SET]]>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK-NEXT:  knobs = {
 // CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
@@ -108,6 +117,15 @@ func.func @conv_2d_nhwc_hwcf()
 // CHECK-LABEL: func.func @conv_2d_nhwc_hwcf
 // CHECK:       linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:  #iree_codegen.root_op<set = 1>
+// CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
+// CHECK-NEXT:  knobs = {
+// CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
+// CHECK-DAG:   reduction = [0, 0, 0, 0, 1, 1, #iree_codegen.smt.int_knob<"red_6">]
+// CHECK-DAG:   subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, #iree_codegen.smt.int_knob<"sg_2">, #iree_codegen.smt.int_knob<"sg_3">, 0, 0, 0]
+// CHECK-DAG:   subgroup_size = #iree_codegen.smt.int_knob<"sg_size">
+// CHECK-DAG:   workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, #iree_codegen.smt.int_knob<"wg_2">, #iree_codegen.smt.int_knob<"wg_3">, 0, 0, 0]
+// CHECK-DAG:   workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]
+// CHECK-SAME:  }
 // CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK-NEXT:  knobs = {
 // CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
@@ -152,6 +170,8 @@ func.func @expanded_matmul()
 
 // CHECK-LABEL: func.func @expanded_matmul
 // CHECK:       linalg.generic
+// CHECK:       iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
+// CHECK:       subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, #iree_codegen.smt.int_knob<"sg_2">, #iree_codegen.smt.int_knob<"sg_3">, 0]
 // CHECK:       iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK-NEXT:  knobs = {
 // CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
@@ -288,6 +308,7 @@ func.func @matmul_with_multiple_compatible_mmas()
 
 // CHECK-LABEL: func.func @matmul_with_multiple_compatible_mmas
 // CHECK:       linalg.matmul {{.+}} #iree_codegen.root_op<set = 0>
+// CHECK:       iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
 // CHECK:       iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK:       mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>]>
 
@@ -304,6 +325,7 @@ func.func @matmul_with_duplicate_mmas_deduped()
 
 // CHECK-LABEL: func.func @matmul_with_duplicate_mmas_deduped
 // CHECK:       linalg.matmul {{.+}} #iree_codegen.root_op<set = 1>
+// CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
 // CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK:       mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
 
@@ -338,6 +360,7 @@ func.func @matmul_with_block_intrinsic_filtered()
 
 // CHECK-LABEL: func.func @matmul_with_block_intrinsic_filtered
 // CHECK:       linalg.matmul {{.+}} #iree_codegen.root_op<set = 0>
+// CHECK:       iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
 // CHECK:       iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK:       mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>]>
 // CHECK-NOT:   MFMA_F32_4x4x4x16B_F16


### PR DESCRIPTION
After testing, this constraint set generates the same number of SMT solutions for matmul as the old tuner. See the SMT-LIB string [comparison](https://github.com/nod-ai/amd-shark-ai/commit/5d517500239f564f0bfa782c689b704a44d9f8b9).

Issue: #23535 