### PR TITLE
[Codegen][Tuner] Materialize constraint assignments in compiler

### DIFF
--- a/compiler/bindings/python/test/api/tuner_api_test.py
+++ b/compiler/bindings/python/test/api/tuner_api_test.py
@@ -862,3 +862,78 @@ def test_materialize_compilation_info_partial_subgroup_overlay():
         "#iree_gpu.lowering_config<{subgroup = [8, 16, 0], "
         "workgroup = [64, 128, 0]}>"
     )
+    translation_info = iree_codegen.TranslationInfoAttr(
+        compilation_info.translation_info
+    )
+    assert list(translation_info.workgroup_size) == [64, 1, 1]
+    assert translation_info.subgroup_size == 32
+
+
+_MATERIALIZE_PARTIAL_WORKGROUP_BACKFILL_MODULE = """
+    module {
+      func.func @matmul_partial_workgroup_backfill(
+          %lhs: tensor<4x8xf32>, %rhs: tensor<8x4xf32>) -> tensor<4x4xf32>
+          attributes {translation_info = #iree_codegen.translation_info<
+            pipeline = #iree_gpu.pipeline<VectorDistribute>
+            workgroup_size = [64, 1, 1]
+            subgroup_size = 32>} {
+        %init = tensor.empty() : tensor<4x4xf32>
+        %result = linalg.matmul {
+          lowering_config = #iree_gpu.lowering_config<{
+            subgroup = [2, 4, 0],
+            workgroup = [64, 128, 0]
+          }>,
+          root_op = #iree_codegen.root_op<set = 0>
+        } ins(%lhs, %rhs : tensor<4x8xf32>, tensor<8x4xf32>)
+          outs(%init : tensor<4x4xf32>) -> tensor<4x4xf32>
+        return %result : tensor<4x4xf32>
+      }
+
+      iree_codegen.smt.constraints
+          target = <set = 0>,
+          pipeline = #iree_gpu.pipeline<VectorDistribute>,
+          knobs = {
+            workgroup = [
+              #iree_codegen.smt.int_knob<"wg_0">,
+              #iree_codegen.smt.int_knob<"wg_1">,
+              0
+            ],
+            subgroup = [
+              #iree_codegen.smt.int_knob<"sg_0">,
+              #iree_codegen.smt.int_knob<"sg_1">,
+              0
+            ]
+          }
+          dims() {
+          }
+    }
+"""
+
+
+@run
+def test_materialize_compilation_info_partial_workgroup_backfill():
+    # The constraints template tunes both workgroup and subgroup, but the
+    # caller assigns only the workgroup knobs. The subgroup knob values are
+    # backfilled from the existing dispatch lowering_config's `subgroup`
+    # array, so materialization must succeed.
+    input_module = ir.Module.parse(_MATERIALIZE_PARTIAL_WORKGROUP_BACKFILL_MODULE)
+    constraints_ops = ir.get_ops_of_type(input_module, iree_codegen.ConstraintsOp)
+    assert len(constraints_ops) == 1
+    constraints_op = constraints_ops[0]
+
+    compilation_info = iree_codegen.materialize_compilation_info(
+        constraints_op,
+        {
+            "wg_0": 16,
+            "wg_1": 32,
+        },
+    )
+    assert isinstance(compilation_info, iree_codegen.CompilationInfoAttr)
+    assert str(compilation_info.lowering_config) == (
+        "#iree_gpu.lowering_config<{subgroup = [2, 4, 0], " "workgroup = [16, 32, 0]}>"
+    )
+    translation_info = iree_codegen.TranslationInfoAttr(
+        compilation_info.translation_info
+    )
+    assert list(translation_info.workgroup_size) == [64, 1, 1]
+    assert translation_info.subgroup_size == 32

--- a/compiler/bindings/python/test/api/tuner_api_test.py
+++ b/compiler/bindings/python/test/api/tuner_api_test.py
@@ -804,3 +804,61 @@ def test_materialize_compilation_info_error_diagnostic():
         assert False, "expected missing wg_0 assignment to fail"
     except RuntimeError as e:
         assert "missing assignment for knob 'wg_0'" in str(e)
+
+
+_MATERIALIZE_PARTIAL_SUBGROUP_MODULE = """
+    module {
+      func.func @matmul_partial_subgroup(
+          %lhs: tensor<4x8xf32>, %rhs: tensor<8x4xf32>) -> tensor<4x4xf32>
+          attributes {translation_info = #iree_codegen.translation_info<
+            pipeline = #iree_gpu.pipeline<VectorDistribute>
+            workgroup_size = [64, 1, 1]
+            subgroup_size = 32>} {
+        %init = tensor.empty() : tensor<4x4xf32>
+        %result = linalg.matmul {
+          lowering_config = #iree_gpu.lowering_config<{
+            subgroup = [2, 4, 0],
+            workgroup = [64, 128, 0]
+          }>,
+          root_op = #iree_codegen.root_op<set = 0>
+        } ins(%lhs, %rhs : tensor<4x8xf32>, tensor<8x4xf32>)
+          outs(%init : tensor<4x4xf32>) -> tensor<4x4xf32>
+        return %result : tensor<4x4xf32>
+      }
+
+      iree_codegen.smt.constraints
+          target = <set = 0>,
+          pipeline = #iree_gpu.pipeline<VectorDistribute>,
+          knobs = {
+            subgroup = [
+              #iree_codegen.smt.int_knob<"sg_0">,
+              #iree_codegen.smt.int_knob<"sg_1">,
+              0
+            ]
+          }
+          dims() {
+          }
+    }
+"""
+
+
+@run
+def test_materialize_compilation_info_partial_subgroup_overlay():
+    # Config has workgroup and subgroup. Assign only subgroup knobs.
+    input_module = ir.Module.parse(_MATERIALIZE_PARTIAL_SUBGROUP_MODULE)
+    constraints_ops = ir.get_ops_of_type(input_module, iree_codegen.ConstraintsOp)
+    assert len(constraints_ops) == 1
+    constraints_op = constraints_ops[0]
+
+    compilation_info = iree_codegen.materialize_compilation_info(
+        constraints_op,
+        {
+            "sg_0": 8,
+            "sg_1": 16,
+        },
+    )
+    assert isinstance(compilation_info, iree_codegen.CompilationInfoAttr)
+    assert str(compilation_info.lowering_config) == (
+        "#iree_gpu.lowering_config<{subgroup = [8, 16, 0], "
+        "workgroup = [64, 128, 0]}>"
+    )

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeSMTConstraintAssignments.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeSMTConstraintAssignments.cpp
@@ -222,6 +222,9 @@ FailureOr<CompilationInfoAttr> materializeCompilationInfoFromConstraints(
 
   if (DictionaryAttr materializedKnobs =
           materializeKnobsDictionary(op, effectiveAssignments)) {
+    // The merge here only overlays at the flat top level; nested
+    // `lowering_config` / `translation_info` templates pass through as the
+    // sole source of truth.
     DictionaryAttr mergedKnobs =
         pipeline.mergeMaterializedKnobsForMaterialization(op.getOperation(),
                                                           materializedKnobs);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeSMTConstraintAssignments.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeSMTConstraintAssignments.cpp
@@ -5,12 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Materializes a concrete tuning assignment for an
-// `iree_codegen.smt.constraints` op. The common code only substitutes SMT knob
-// leaves with assigned values; each pipeline owns the mechanical repackaging of
-// that materialized knob dictionary into its concrete compilation_info attr.
+// `iree_codegen.smt.constraints` op. The pipeline merges existing dispatch
+// config with explicit knob assignments before substitution. Each pipeline
+// repackages the materialized knob dictionary into its concrete
+// compilation_info attr.
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -27,6 +29,33 @@ using IREE::Codegen::ConstraintsOp;
 using IREE::Codegen::IntKnobAttr;
 using IREE::Codegen::OneOfKnobAttr;
 using IREE::Codegen::PipelineAttrInterface;
+
+static DictionaryAttr
+knobAssignmentsToDict(MLIRContext *ctx,
+                      const DenseMap<StringRef, int64_t> &assignments) {
+  Builder b(ctx);
+  SmallVector<NamedAttribute> entries;
+  entries.reserve(assignments.size());
+  for (const auto &entry : assignments) {
+    entries.emplace_back(b.getStringAttr(entry.first),
+                         b.getI64IntegerAttr(entry.second));
+  }
+  return DictionaryAttr::get(ctx, entries);
+}
+
+static DenseMap<StringRef, int64_t>
+knobAssignmentsFromDict(DictionaryAttr assignments) {
+  DenseMap<StringRef, int64_t> result;
+  result.reserve(assignments.size());
+  for (NamedAttribute entry : assignments) {
+    auto value = dyn_cast<IntegerAttr>(entry.getValue());
+    if (!value) {
+      continue;
+    }
+    result[entry.getName().getValue()] = value.getInt();
+  }
+  return result;
+}
 
 static InFlightDiagnostic emitMaterializationError(ConstraintsOp op) {
   return op.emitError(
@@ -182,9 +211,21 @@ struct TestMaterializeSMTConstraintAssignmentsPass final
 
 FailureOr<CompilationInfoAttr> materializeCompilationInfoFromConstraints(
     ConstraintsOp op, const DenseMap<StringRef, int64_t> &assignments) {
+  PipelineAttrInterface pipeline = op.getPipeline();
+  DictionaryAttr assignmentsDict =
+      knobAssignmentsToDict(op.getContext(), assignments);
+  DictionaryAttr effectiveDict =
+      pipeline.mergeKnobAssignmentsForMaterialization(op.getOperation(),
+                                                      assignmentsDict);
+  DenseMap<StringRef, int64_t> effectiveAssignments =
+      knobAssignmentsFromDict(effectiveDict);
+
   if (DictionaryAttr materializedKnobs =
-          materializeKnobsDictionary(op, assignments)) {
-    return materializeCompilationInfo(op, materializedKnobs);
+          materializeKnobsDictionary(op, effectiveAssignments)) {
+    DictionaryAttr mergedKnobs =
+        pipeline.mergeMaterializedKnobsForMaterialization(op.getOperation(),
+                                                          materializedKnobs);
+    return materializeCompilationInfo(op, mergedKnobs);
   }
   return failure();
 }

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -195,7 +195,10 @@ mlir::OwningOpRef<mlir::ModuleOp>
 convertConstraintsToSMTModule(IREE::Codegen::ConstraintsOp op);
 
 /// Materializes a CompilationInfoAttr from a ConstraintsOp knobs dictionary and
-/// a flat mapping from knob name to concrete integer assignment.
+/// a flat mapping from knob name to concrete integer assignment. The
+/// constraints pipeline may overlay assignments on existing dispatch config via
+/// PipelineAttrInterface::mergeKnobAssignmentsForMaterialization and preserve
+/// non-template fields via mergeMaterializedKnobsForMaterialization.
 FailureOr<IREE::Codegen::CompilationInfoAttr>
 materializeCompilationInfoFromConstraints(
     IREE::Codegen::ConstraintsOp op,

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_smt_constraint_assignments.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_smt_constraint_assignments.mlir
@@ -144,9 +144,64 @@ iree_codegen.smt.constraints
     } {
     }
 
+// CHECK:       #translation = #iree_codegen.translation_info<
+// CHECK-SAME:  pipeline = #iree_gpu.pipeline<VectorDistribute>
+// CHECK-SAME:  workgroup_size = [64, 1, 1]
+// CHECK-SAME:  subgroup_size = 32>
 // CHECK:       #compilation = #iree_codegen.compilation_info<
 // CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{subgroup = [8, 16, 0], workgroup = [64, 128, 0]}>,
 // CHECK-SAME:      translation_info = #translation>
+// CHECK-LABEL: @matmul_partial_subgroup
+// CHECK:       iree_codegen.smt.constraints
+// CHECK:       dims() attributes {test.materialized_compilation_info = #compilation}
+
+// -----
+
+// Constraints tune both `workgroup` and `subgroup` knobs, but the caller
+// only assigns the `wg_*` values. The `sg_*` values must be backfilled
+// from the existing dispatch lowering_config's `subgroup = [...]` array.
+#translation_backfill = #iree_codegen.translation_info<
+    pipeline = #iree_gpu.pipeline<VectorDistribute>
+    workgroup_size = [64, 1, 1]
+    subgroup_size = 32>
+func.func @matmul_partial_workgroup_backfill(
+    %lhs: tensor<4x8xf32>, %rhs: tensor<8x4xf32>) -> tensor<4x4xf32>
+    attributes {translation_info = #translation_backfill} {
+  %init = tensor.empty() : tensor<4x4xf32>
+  %result = linalg.matmul {
+    lowering_config = #iree_gpu.lowering_config<{
+      subgroup = [2, 4, 0],
+      workgroup = [64, 128, 0]
+    }>,
+    root_op = #iree_codegen.root_op<set = 0>
+  } ins(%lhs, %rhs : tensor<4x8xf32>, tensor<8x4xf32>) outs(%init : tensor<4x4xf32>)
+    -> tensor<4x4xf32>
+  return %result : tensor<4x4xf32>
+}
+
+iree_codegen.smt.constraints
+    target = <set = 0>,
+    pipeline = #iree_gpu.pipeline<VectorDistribute>,
+    knobs = {
+      workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0],
+      subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, 0]
+    }
+    dims() attributes {
+      test.assignments = {
+        wg_0 = 16 : i64,
+        wg_1 = 32 : i64
+      }
+    } {
+    }
+
+// CHECK:       #translation = #iree_codegen.translation_info<
+// CHECK-SAME:  pipeline = #iree_gpu.pipeline<VectorDistribute>
+// CHECK-SAME:  workgroup_size = [64, 1, 1]
+// CHECK-SAME:  subgroup_size = 32>
+// CHECK:       #compilation = #iree_codegen.compilation_info<
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{subgroup = [2, 4, 0], workgroup = [16, 32, 0]}>,
+// CHECK-SAME:      translation_info = #translation>
+// CHECK-LABEL: @matmul_partial_workgroup_backfill
 // CHECK:       iree_codegen.smt.constraints
 // CHECK:       dims() attributes {test.materialized_compilation_info = #compilation}
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_smt_constraint_assignments.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_smt_constraint_assignments.mlir
@@ -109,7 +109,50 @@ iree_codegen.smt.constraints
 
 // -----
 
-// Reports a missing knob assignment.
+// Lowering config has workgroup and subgroup. Constraints only tune subgroup.
+// Materialized compilation_info keeps the original workgroup values.
+#translation_partial = #iree_codegen.translation_info<
+    pipeline = #iree_gpu.pipeline<VectorDistribute>
+    workgroup_size = [64, 1, 1]
+    subgroup_size = 32>
+func.func @matmul_partial_subgroup(
+    %lhs: tensor<4x8xf32>, %rhs: tensor<8x4xf32>) -> tensor<4x4xf32>
+    attributes {translation_info = #translation_partial} {
+  %init = tensor.empty() : tensor<4x4xf32>
+  %result = linalg.matmul {
+    lowering_config = #iree_gpu.lowering_config<{
+      subgroup = [2, 4, 0],
+      workgroup = [64, 128, 0]
+    }>,
+    root_op = #iree_codegen.root_op<set = 0>
+  } ins(%lhs, %rhs : tensor<4x8xf32>, tensor<8x4xf32>) outs(%init : tensor<4x4xf32>)
+    -> tensor<4x4xf32>
+  return %result : tensor<4x4xf32>
+}
+
+iree_codegen.smt.constraints
+    target = <set = 0>,
+    pipeline = #iree_gpu.pipeline<VectorDistribute>,
+    knobs = {
+      subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, 0]
+    }
+    dims() attributes {
+      test.assignments = {
+        sg_0 = 8 : i64,
+        sg_1 = 16 : i64
+      }
+    } {
+    }
+
+// CHECK:       #compilation = #iree_codegen.compilation_info<
+// CHECK-SAME:      lowering_config = #iree_gpu.lowering_config<{subgroup = [8, 16, 0], workgroup = [64, 128, 0]}>,
+// CHECK-SAME:      translation_info = #translation>
+// CHECK:       iree_codegen.smt.constraints
+// CHECK:       dims() attributes {test.materialized_compilation_info = #compilation}
+
+// -----
+
+// Reports a missing knob assignment when no dispatch config is present.
 // expected-error @below {{failed to materialize compilation_info from constraints: missing assignment for knob 'mma_idx'}}
 iree_codegen.smt.constraints
     target = <set = 0>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -794,6 +794,40 @@ def IREECodegen_PipelineAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Merge partial knob assignments with existing dispatch configuration.
+        Returns a dictionary of knob name to integer assignment. The default
+        returns the input assignments unchanged. Implementations may overlay
+        explicit assignments on values taken from the current lowering config.
+      }],
+      /*retTy=*/"::mlir::DictionaryAttr",
+      /*methodName=*/"mergeKnobAssignmentsForMaterialization",
+      /*args=*/(ins "::mlir::Operation *":$op,
+                    "::mlir::DictionaryAttr":$partialAssignments),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        (void)op;
+        return partialAssignments;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Merge a materialized knobs dictionary with existing dispatch
+        configuration. Returns a knobs dictionary that includes fields from the
+        current lowering config and translation info when they are absent from
+        the materialized template. Materialized entries override existing ones.
+      }],
+      /*retTy=*/"::mlir::DictionaryAttr",
+      /*methodName=*/"mergeMaterializedKnobsForMaterialization",
+      /*args=*/(ins "::mlir::Operation *":$op,
+                    "::mlir::DictionaryAttr":$materializedKnobs),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        (void)op;
+        return materializedKnobs;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Materialize the pipeline-specific compilation_info attribute from a
         knobs dictionary whose knob leaves have already been substituted with
         concrete values. Implementations should only mechanically repackage the

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -798,15 +798,17 @@ def IREECodegen_PipelineAttrInterface :
         Returns a dictionary of knob name to integer assignment. The default
         returns the input assignments unchanged. Implementations may overlay
         explicit assignments on values taken from the current lowering config.
+        Explicit `assignments` entries override values extracted from the
+        existing dispatch config.
       }],
       /*retTy=*/"::mlir::DictionaryAttr",
       /*methodName=*/"mergeKnobAssignmentsForMaterialization",
-      /*args=*/(ins "::mlir::Operation *":$op,
-                    "::mlir::DictionaryAttr":$partialAssignments),
+      /*args=*/(ins "::mlir::Operation *":$constraintsOperation,
+                    "::mlir::DictionaryAttr":$assignments),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        (void)op;
-        return partialAssignments;
+        (void)constraintsOperation;
+        return assignments;
       }]
     >,
     InterfaceMethod<
@@ -815,14 +817,17 @@ def IREECodegen_PipelineAttrInterface :
         configuration. Returns a knobs dictionary that includes fields from the
         current lowering config and translation info when they are absent from
         the materialized template. Materialized entries override existing ones.
+        Implementations may overlay only at the flat top level; nested
+        `lowering_config` / `translation_info` templates are treated as the
+        sole source of truth without overlay.
       }],
       /*retTy=*/"::mlir::DictionaryAttr",
       /*methodName=*/"mergeMaterializedKnobsForMaterialization",
-      /*args=*/(ins "::mlir::Operation *":$op,
+      /*args=*/(ins "::mlir::Operation *":$constraintsOperation,
                     "::mlir::DictionaryAttr":$materializedKnobs),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        (void)op;
+        (void)constraintsOperation;
         return materializedKnobs;
       }]
     >,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -56,6 +56,7 @@ iree_compiler_cc_library(
         "IREEGPUDialect.cpp",
         "IREEGPUInterfaces.cpp",
         "IREEGPUOps.cpp",
+        "IREEGPUSMTKnobResolution.cpp",
         "PromotionImpls.cpp",
     ],
     hdrs = [
@@ -67,6 +68,7 @@ iree_compiler_cc_library(
         "IREEGPUEnums.h",
         "IREEGPUInterfaces.h",
         "IREEGPUOps.h",
+        "IREEGPUSMTKnobResolution.h",
     ],
     textual_hdrs = [
         "IREEGPUAttrs.cpp.inc",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "IREEGPUEnums.h"
     "IREEGPUInterfaces.h"
     "IREEGPUOps.h"
+    "IREEGPUSMTKnobResolution.h"
   TEXTUAL_HDRS
     "IREEGPUAttrs.cpp.inc"
     "IREEGPUAttrs.h.inc"
@@ -41,6 +42,7 @@ iree_cc_library(
     "IREEGPUDialect.cpp"
     "IREEGPUInterfaces.cpp"
     "IREEGPUOps.cpp"
+    "IREEGPUSMTKnobResolution.cpp"
     "PromotionImpls.cpp"
   DEPS
     ::IREEGPUAttrs

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -17,6 +17,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Utils/EncodingUtils.h"
@@ -3425,6 +3426,41 @@ PipelineAttr::buildPipeline(OpPassManager &pm,
   assert(builder && "no GPU pipeline builder registered; ensure "
                     "registerCodegenLLVMGPUPasses() was called");
   return builder(*this, pm, options);
+}
+
+DictionaryAttr PipelineAttr::mergeKnobAssignmentsForMaterialization(
+    Operation *constraintsOperation, DictionaryAttr assignments) const {
+  auto constraintsOp = cast<IREE::Codegen::ConstraintsOp>(constraintsOperation);
+  KnobAssignmentMap assignmentMap;
+  assignmentMap.reserve(assignments.size());
+  for (NamedAttribute entry : assignments) {
+    auto value = dyn_cast<IntegerAttr>(entry.getValue());
+    if (!value) {
+      return assignments;
+    }
+    assignmentMap[entry.getName().getValue()] = value.getInt();
+  }
+  if (std::optional<KnobAssignmentMap> merged =
+          mergeKnobAssignmentsWithExistingGPUConfig(constraintsOp,
+                                                    assignmentMap)) {
+    MLIRContext *ctx = constraintsOp.getContext();
+    Builder b(ctx);
+    SmallVector<NamedAttribute> entries;
+    entries.reserve(merged->size());
+    for (const auto &entry : *merged) {
+      entries.emplace_back(StringAttr::get(ctx, entry.first),
+                           b.getI64IntegerAttr(entry.second));
+    }
+    return DictionaryAttr::get(ctx, entries);
+  }
+  return assignments;
+}
+
+DictionaryAttr PipelineAttr::mergeMaterializedKnobsForMaterialization(
+    Operation *constraintsOperation, DictionaryAttr materializedKnobs) const {
+  auto constraintsOp = cast<IREE::Codegen::ConstraintsOp>(constraintsOperation);
+  return mergeMaterializedKnobsWithExistingDispatchConfig(constraintsOp,
+                                                          materializedKnobs);
 }
 
 LogicalResult

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -823,7 +823,8 @@ def IREEGPU_TargetChipAttr : AttrDef<IREEGPU_Dialect, "TargetChip"> {
 
 def IREEGPU_PipelineAttr : AttrDef<IREEGPU_Dialect, "Pipeline", [
     DeclareAttrInterfaceMethods<IREECodegen_PipelineAttrInterface,
-      ["emitConstraints", "materializeCompilationInfo"]>
+      ["emitConstraints", "mergeKnobAssignmentsForMaterialization",
+       "mergeMaterializedKnobsForMaterialization", "materializeCompilationInfo"]>
   ]> {
   let mnemonic = "pipeline";
   let summary = "LLVMGPU lowering pipeline identifier.";

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.cpp
@@ -1,0 +1,221 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.h"
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+using Codegen::ConstraintsOp;
+using Codegen::IntKnobAttr;
+using Codegen::OneOfKnobAttr;
+
+static void collectTunerRootOps(Operation *scope,
+                                SmallVectorImpl<Operation *> &result) {
+  scope->walk([&](Operation *op) {
+    if (getRootOpInfo(op)) {
+      result.push_back(op);
+    }
+  });
+}
+
+static LogicalResult extractKnobValue(Attribute templateAttr,
+                                      Attribute configAttr,
+                                      DenseMap<StringAttr, int64_t> &result) {
+  return llvm::TypeSwitch<Attribute, LogicalResult>(templateAttr)
+      .Case([&](DictionaryAttr nestedTemplate) -> LogicalResult {
+        auto nestedConfig = dyn_cast_or_null<DictionaryAttr>(configAttr);
+        if (!nestedConfig) {
+          return failure();
+        }
+        for (NamedAttribute entry : nestedTemplate) {
+          if (failed(extractKnobValue(entry.getValue(),
+                                      nestedConfig.get(entry.getName()),
+                                      result))) {
+            return failure();
+          }
+        }
+        return success();
+      })
+      .Case([&](ArrayAttr templateArr) -> LogicalResult {
+        auto configArr = dyn_cast_or_null<ArrayAttr>(configAttr);
+        if (!configArr || configArr.size() != templateArr.size()) {
+          return failure();
+        }
+        for (auto [tmpl, actual] :
+             llvm::zip_equal(templateArr.getValue(), configArr.getValue())) {
+          if (failed(extractKnobValue(tmpl, actual, result))) {
+            return failure();
+          }
+        }
+        return success();
+      })
+      .Case([&](IntKnobAttr knob) -> LogicalResult {
+        auto intVal = dyn_cast_or_null<IntegerAttr>(configAttr);
+        if (!intVal) {
+          return failure();
+        }
+        result[knob.getName()] = intVal.getInt();
+        return success();
+      })
+      .Case([&](OneOfKnobAttr knob) -> LogicalResult {
+        if (!configAttr) {
+          return failure();
+        }
+        ArrayAttr options = knob.getOptions();
+        const auto *it = llvm::find(options, configAttr);
+        if (it == options.end()) {
+          return failure();
+        }
+        result[knob.getName()] = std::distance(options.begin(), it);
+        return success();
+      })
+      .Case([&](IntegerAttr templateInt) -> LogicalResult {
+        auto configInt = dyn_cast_or_null<IntegerAttr>(configAttr);
+        if (!configInt || configInt.getInt() != templateInt.getInt()) {
+          return failure();
+        }
+        return success();
+      })
+      .Default(failure());
+}
+
+LogicalResult extractKnobValues(DictionaryAttr knobsTemplate,
+                                DictionaryAttr configAttrs,
+                                DenseMap<StringAttr, int64_t> &result) {
+  for (NamedAttribute entry : knobsTemplate) {
+    if (failed(extractKnobValue(entry.getValue(),
+                                configAttrs.get(entry.getName()), result))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+DictionaryAttr
+buildKnobLookupDictFromGPUConfig(LoweringConfigAttr gpuConfig,
+                                 Codegen::TranslationInfoAttr translationInfo) {
+  MLIRContext *ctx = gpuConfig.getContext();
+  Builder b(ctx);
+  SmallVector<NamedAttribute> entries(gpuConfig.getAttributes().getValue());
+  ArrayRef<int64_t> wgSize = translationInfo.getWorkgroupSize();
+  if (!wgSize.empty()) {
+    auto wgSizeAttrs = llvm::map_to_vector(
+        wgSize, [&](int64_t v) -> Attribute { return b.getI64IntegerAttr(v); });
+    entries.emplace_back("workgroup_size", b.getArrayAttr(wgSizeAttrs));
+  }
+  entries.emplace_back("subgroup_size",
+                       b.getI64IntegerAttr(translationInfo.getSubgroupSize()));
+  return DictionaryAttr::get(ctx, entries);
+}
+
+static FunctionOpInterface
+findFunctionForConstraints(ConstraintsOp constraintsOp) {
+  if (auto funcOp = constraintsOp->getParentOfType<FunctionOpInterface>()) {
+    return funcOp;
+  }
+  auto moduleOp = constraintsOp->getParentOfType<ModuleOp>();
+  if (!moduleOp) {
+    return FunctionOpInterface();
+  }
+  Codegen::RootOpAttr target = constraintsOp.getTarget();
+  for (FunctionOpInterface funcOp : moduleOp.getOps<FunctionOpInterface>()) {
+    SmallVector<Operation *> rootOps;
+    collectTunerRootOps(funcOp.getOperation(), rootOps);
+    for (Operation *rootOp : rootOps) {
+      if (getRootOpInfo(rootOp) == target) {
+        return funcOp;
+      }
+    }
+  }
+  return FunctionOpInterface();
+}
+
+static std::optional<DictionaryAttr>
+getKnobLookupDictForConstraints(ConstraintsOp constraintsOp) {
+  FunctionOpInterface funcOp = findFunctionForConstraints(constraintsOp);
+  if (!funcOp) {
+    return std::nullopt;
+  }
+
+  Codegen::TranslationInfoAttr translationInfo = getTranslationInfo(funcOp);
+  if (!translationInfo) {
+    return std::nullopt;
+  }
+
+  Codegen::RootOpAttr target = constraintsOp.getTarget();
+  SmallVector<Operation *> rootOps;
+  collectTunerRootOps(funcOp.getOperation(), rootOps);
+  for (Operation *rootOp : rootOps) {
+    if (getRootOpInfo(rootOp) != target) {
+      continue;
+    }
+    auto gpuConfig = getLoweringConfig<LoweringConfigAttr>(rootOp);
+    if (!gpuConfig) {
+      continue;
+    }
+    return buildKnobLookupDictFromGPUConfig(gpuConfig, translationInfo);
+  }
+  return std::nullopt;
+}
+
+std::optional<KnobAssignmentMap> mergeKnobAssignmentsWithExistingGPUConfig(
+    ConstraintsOp constraintsOp, const KnobAssignmentMap &assignments) {
+  DictionaryAttr knobsTemplate = constraintsOp.getKnobs();
+  if (!knobsTemplate) {
+    return std::nullopt;
+  }
+
+  std::optional<DictionaryAttr> lookupDict =
+      getKnobLookupDictForConstraints(constraintsOp);
+  if (!lookupDict) {
+    return std::nullopt;
+  }
+
+  DenseMap<StringAttr, int64_t> knobValues;
+  if (failed(extractKnobValues(knobsTemplate, *lookupDict, knobValues))) {
+    return std::nullopt;
+  }
+  KnobAssignmentMap result;
+  result.reserve(knobValues.size() + assignments.size());
+  for (const auto &entry : knobValues) {
+    result[entry.first.getValue()] = entry.second;
+  }
+  for (const auto &entry : assignments) {
+    result[entry.first] = entry.second;
+  }
+  return result;
+}
+
+DictionaryAttr mergeMaterializedKnobsWithExistingDispatchConfig(
+    ConstraintsOp constraintsOp, DictionaryAttr materializedKnobs) {
+  std::optional<DictionaryAttr> lookupDict =
+      getKnobLookupDictForConstraints(constraintsOp);
+  if (!lookupDict) {
+    return materializedKnobs;
+  }
+
+  MLIRContext *ctx = constraintsOp.getContext();
+  llvm::StringMap<Attribute> merged;
+  for (NamedAttribute entry : *lookupDict) {
+    merged[entry.getName().getValue()] = entry.getValue();
+  }
+  for (NamedAttribute entry : materializedKnobs) {
+    merged[entry.getName().getValue()] = entry.getValue();
+  }
+  SmallVector<NamedAttribute> entries;
+  entries.reserve(merged.size());
+  for (const auto &entry : merged) {
+    entries.emplace_back(StringAttr::get(ctx, entry.getKey()),
+                         entry.getValue());
+  }
+  return DictionaryAttr::get(ctx, entries);
+}
+
+} // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.cpp
@@ -103,15 +103,28 @@ buildKnobLookupDictFromGPUConfig(LoweringConfigAttr gpuConfig,
                                  Codegen::TranslationInfoAttr translationInfo) {
   MLIRContext *ctx = gpuConfig.getContext();
   Builder b(ctx);
-  SmallVector<NamedAttribute> entries(gpuConfig.getAttributes().getValue());
+  // Deduplicate by name. A pathological GPU lowering config could already
+  // contain `workgroup_size` or `subgroup_size`; in that case keep the
+  // existing config entry rather than emitting a duplicate.
+  llvm::StringMap<Attribute> entryMap;
+  for (NamedAttribute entry : gpuConfig.getAttributes()) {
+    entryMap[entry.getName().getValue()] = entry.getValue();
+  }
   ArrayRef<int64_t> wgSize = translationInfo.getWorkgroupSize();
-  if (!wgSize.empty()) {
+  if (!wgSize.empty() && !entryMap.contains("workgroup_size")) {
     auto wgSizeAttrs = llvm::map_to_vector(
         wgSize, [&](int64_t v) -> Attribute { return b.getI64IntegerAttr(v); });
-    entries.emplace_back("workgroup_size", b.getArrayAttr(wgSizeAttrs));
+    entryMap["workgroup_size"] = b.getArrayAttr(wgSizeAttrs);
   }
-  entries.emplace_back("subgroup_size",
-                       b.getI64IntegerAttr(translationInfo.getSubgroupSize()));
+  if (!entryMap.contains("subgroup_size")) {
+    entryMap["subgroup_size"] =
+        b.getI64IntegerAttr(translationInfo.getSubgroupSize());
+  }
+  SmallVector<NamedAttribute> entries;
+  entries.reserve(entryMap.size());
+  for (const auto &kv : entryMap) {
+    entries.emplace_back(StringAttr::get(ctx, kv.getKey()), kv.getValue());
+  }
   return DictionaryAttr::get(ctx, entries);
 }
 
@@ -195,6 +208,15 @@ std::optional<KnobAssignmentMap> mergeKnobAssignmentsWithExistingGPUConfig(
 
 DictionaryAttr mergeMaterializedKnobsWithExistingDispatchConfig(
     ConstraintsOp constraintsOp, DictionaryAttr materializedKnobs) {
+  // This merge is flat-only by design. It overlays at the top level and is
+  // intended for the flat knobs template shape, e.g.
+  // `knobs = { workgroup = [...], subgroup = [...], workgroup_size = [...],
+  // subgroup_size = ... }`. If the template uses the nested form
+  // (`knobs = { lowering_config = { ... }, translation_info = { ... } }`),
+  // the dispatch-config overlay does not apply: the nested template is
+  // treated as self-sufficient and `PipelineAttr::materializeCompilationInfo`
+  // uses that nested source as the single source of truth. Callers wanting
+  // overlay behavior should use the flat template form.
   std::optional<DictionaryAttr> lookupDict =
       getKnobLookupDictForConstraints(constraintsOp);
   if (!lookupDict) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.h
@@ -39,6 +39,13 @@ mergeKnobAssignmentsWithExistingGPUConfig(Codegen::ConstraintsOp constraintsOp,
 
 /// Overlay materialized knobs on the existing dispatch config lookup dict.
 /// Returns `materializedKnobs` when no matching GPU config is available.
+///
+/// The merge is flat-only by design: it overlays at the top level and is
+/// intended for the flat knobs template shape, e.g.
+/// `knobs = { workgroup = [...], workgroup_size = [...], ... }`. Nested
+/// templates of the form
+/// `knobs = { lowering_config = { ... }, translation_info = { ... } }` are
+/// treated as self-sufficient and pass through unchanged at this step.
 DictionaryAttr mergeMaterializedKnobsWithExistingDispatchConfig(
     Codegen::ConstraintsOp constraintsOp, DictionaryAttr materializedKnobs);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUSMTKnobResolution.h
@@ -1,0 +1,47 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUSMTKNOBRESOLUTION_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUSMTKNOBRESOLUTION_H_
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "mlir/IR/Attributes.h"
+
+#include <optional>
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+using KnobAssignmentMap = llvm::DenseMap<llvm::StringRef, int64_t>;
+
+/// Walk a knobs template dictionary and extract concrete values from a
+/// config dictionary with matching structure.
+LogicalResult extractKnobValues(DictionaryAttr knobsTemplate,
+                                DictionaryAttr configAttrs,
+                                DenseMap<StringAttr, int64_t> &result);
+
+/// Build a flat knobs lookup dict from GPU lowering config and translation
+/// info for SMT knob extraction.
+DictionaryAttr
+buildKnobLookupDictFromGPUConfig(LoweringConfigAttr gpuConfig,
+                                 Codegen::TranslationInfoAttr translationInfo);
+
+/// Overlay explicit knob assignments on values from the existing dispatch
+/// config. Returns std::nullopt when no matching GPU config is available.
+std::optional<KnobAssignmentMap>
+mergeKnobAssignmentsWithExistingGPUConfig(Codegen::ConstraintsOp constraintsOp,
+                                          const KnobAssignmentMap &assignments);
+
+/// Overlay materialized knobs on the existing dispatch config lookup dict.
+/// Returns `materializedKnobs` when no matching GPU config is available.
+DictionaryAttr mergeMaterializedKnobsWithExistingDispatchConfig(
+    Codegen::ConstraintsOp constraintsOp, DictionaryAttr materializedKnobs);
+
+} // namespace mlir::iree_compiler::IREE::GPU
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUSMTKNOBRESOLUTION_H_


### PR DESCRIPTION
Previously IREE constructs `compilation_info` only with attributes solved from the constraint op. However, for the upstream constraint op, it only adds tunable knobs, such as `workgroup=[...]` to the constraint and the knob dict, but doesn't cover other IREE's kernel config attr, such as `promote_operands = [...]`.
As the downstream tuner directly invokes IREE API to get `compilation_info` for TD spec building, and because the `compilation_info` type `MlirAttribute` is immutable once created from `DictAttr`, this PR changes IREE to build `compilation_info` with existing default config values + knob assignment values solved from the constraint op.

For example:
- default_config = `#iree_gpu.lowering_config<{promote_operands = [0, 1], workgroup = [64, 64, 0]}>`
- constraints = `workgroup = [wg_m, wg_n, 0]`
- knob_assignments = `wg_m=32, wg_n=32`
- compilation_info = `#iree_gpu.lowering_config<{promote_operands = [0, 1], workgroup = [32, 32, 0]}>`

Assisted-by: [Claude Code](https://claude.ai/code)
Issue: #23535 