### PR TITLE
[Runtime] Print allocator statistics for all devices

### DIFF
--- a/runtime/src/iree/tooling/context_util.c
+++ b/runtime/src/iree/tooling/context_util.c
@@ -349,19 +349,20 @@ static iree_status_t iree_tooling_close_hal_replay_recorder(
 static iree_status_t iree_tooling_load_hal_async_module(
     iree_vm_instance_t* instance, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_vm_module_t** out_module,
-    iree_hal_device_t** out_device, iree_hal_allocator_t** out_device_allocator,
+    iree_hal_device_list_t** out_device_list,
+    iree_hal_allocator_t** out_device_allocator,
     iree_hal_replay_recorder_t** out_replay_recorder) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(out_module);
-  IREE_ASSERT_ARGUMENT(out_device);
+  IREE_ASSERT_ARGUMENT(out_device_list);
   IREE_ASSERT_ARGUMENT(out_device_allocator);
-  if (*out_device || *out_device_allocator) {
+  if (*out_device_list || *out_device_allocator) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
         "async HAL module can not be used with other primary HAL module types");
   }
   *out_module = NULL;
-  *out_device = NULL;
+  *out_device_list = NULL;
   *out_device_allocator = NULL;
   if (out_replay_recorder) *out_replay_recorder = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -460,7 +461,6 @@ static iree_status_t iree_tooling_load_hal_async_module(
   }
   if (iree_status_is_ok(status)) {
     device = iree_hal_device_group_device_at(module_device_group, lead_index);
-    iree_hal_device_retain(device);
     device_allocator = iree_hal_device_allocator(device);
     iree_hal_allocator_retain(device_allocator);
   }
@@ -484,7 +484,6 @@ static iree_status_t iree_tooling_load_hal_async_module(
     if (!iree_status_is_ok(status)) {
       iree_hal_allocator_release(device_allocator);
       device_allocator = NULL;
-      iree_hal_device_release(device);
       device = NULL;
     } else {
       status = iree_hal_module_create(
@@ -499,11 +498,9 @@ static iree_status_t iree_tooling_load_hal_async_module(
   iree_hal_device_group_release(replay_device_group);
   iree_hal_device_group_release(device_group);
 
-  iree_hal_device_list_free(device_list);
-
   if (iree_status_is_ok(status)) {
     *out_module = module;
-    *out_device = device;
+    *out_device_list = device_list;
     *out_device_allocator = device_allocator;
     if (out_replay_recorder) {
       *out_replay_recorder = replay_recorder;
@@ -512,7 +509,7 @@ static iree_status_t iree_tooling_load_hal_async_module(
   } else {
     status = iree_tooling_close_hal_replay_recorder(status, replay_recorder);
     iree_hal_allocator_release(device_allocator);
-    iree_hal_device_release(device);
+    iree_hal_device_list_free(device_list);
     iree_vm_module_release(module);
   }
   IREE_TRACE_ZONE_END(z0);
@@ -692,8 +689,8 @@ typedef struct {
   iree_tooling_module_list_t* resolved_list;
   // Default device URI used when --device= was not specified.
   iree_string_view_t default_device_uri;
-  // Lead HAL device retained from the resolved HAL module, if any.
-  iree_hal_device_t* device;
+  // HAL device list retained from the resolved HAL module, if any.
+  iree_hal_device_list_t* device_list;
   // Lead HAL allocator retained from the resolved HAL module, if any.
   iree_hal_allocator_t* device_allocator;
   // Optional replay recorder retained when --device_replay_output= is
@@ -716,7 +713,7 @@ static iree_status_t iree_tooling_resolve_module_dependency_callback(
   if (iree_string_view_equal(dependency->name, IREE_SV("hal"))) {
     IREE_RETURN_IF_ERROR(iree_tooling_load_hal_async_module(
         state->instance, state->default_device_uri, state->host_allocator,
-        &module, &state->device, &state->device_allocator,
+        &module, &state->device_list, &state->device_allocator,
         &state->replay_recorder));
   } else if (iree_string_view_equal(dependency->name, IREE_SV("hal_inline"))) {
     IREE_RETURN_IF_ERROR(iree_tooling_load_hal_inline_module(
@@ -756,12 +753,13 @@ iree_status_t iree_tooling_resolve_modules(
     iree_vm_instance_t* instance, iree_host_size_t user_module_count,
     iree_vm_module_t** user_modules, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_tooling_module_list_t* resolved_list,
-    iree_hal_device_t** out_device, iree_hal_allocator_t** out_device_allocator,
+    iree_hal_device_list_t** out_device_list,
+    iree_hal_allocator_t** out_device_allocator,
     iree_hal_replay_recorder_t** out_replay_recorder) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(!user_module_count || user_modules);
   IREE_ASSERT_ARGUMENT(resolved_list);
-  if (out_device) *out_device = NULL;
+  if (out_device_list) *out_device_list = NULL;
   if (out_device_allocator) *out_device_allocator = NULL;
   if (out_replay_recorder) *out_replay_recorder = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -778,7 +776,7 @@ iree_status_t iree_tooling_resolve_modules(
       .host_allocator = host_allocator,
       .resolved_list = resolved_list,
       .default_device_uri = default_device_uri,
-      .device = NULL,
+      .device_list = NULL,
       .device_allocator = NULL,
       .replay_recorder = NULL,
   };
@@ -815,10 +813,10 @@ iree_status_t iree_tooling_resolve_modules(
     } else {
       iree_hal_allocator_release(resolve_state.device_allocator);
     }
-    if (out_device) {
-      *out_device = resolve_state.device;
+    if (out_device_list) {
+      *out_device_list = resolve_state.device_list;
     } else {
-      iree_hal_device_release(resolve_state.device);
+      iree_hal_device_list_free(resolve_state.device_list);
     }
     if (out_replay_recorder) {
       *out_replay_recorder = resolve_state.replay_recorder;
@@ -829,7 +827,7 @@ iree_status_t iree_tooling_resolve_modules(
     status = iree_tooling_close_hal_replay_recorder(
         status, resolve_state.replay_recorder);
     iree_hal_allocator_release(resolve_state.device_allocator);
-    iree_hal_device_release(resolve_state.device);
+    iree_hal_device_list_free(resolve_state.device_list);
   }
   IREE_TRACE_ZONE_END(z0);
   return status;
@@ -910,13 +908,14 @@ iree_status_t iree_tooling_create_context_from_flags(
     iree_vm_instance_t* instance, iree_host_size_t user_module_count,
     iree_vm_module_t** user_modules, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_vm_context_t** out_context,
-    iree_hal_device_t** out_device, iree_hal_allocator_t** out_device_allocator,
+    iree_hal_device_list_t** out_device_list,
+    iree_hal_allocator_t** out_device_allocator,
     iree_hal_replay_recorder_t** out_replay_recorder) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(!user_module_count || user_modules);
   IREE_ASSERT_ARGUMENT(out_context);
   *out_context = NULL;
-  if (out_device) *out_device = NULL;
+  if (out_device_list) *out_device_list = NULL;
   if (out_device_allocator) *out_device_allocator = NULL;
   if (out_replay_recorder) *out_replay_recorder = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -932,12 +931,12 @@ iree_status_t iree_tooling_create_context_from_flags(
   // All modules are retained in the list.
   iree_tooling_module_list_t resolved_list;
   iree_tooling_module_list_initialize(&resolved_list);
-  iree_hal_device_t* device = NULL;
+  iree_hal_device_list_t* device_list = NULL;
   iree_hal_allocator_t* device_allocator = NULL;
   iree_hal_replay_recorder_t* replay_recorder = NULL;
   iree_status_t status = iree_tooling_resolve_modules(
       instance, user_module_count, user_modules, default_device_uri,
-      host_allocator, &resolved_list, &device, &device_allocator,
+      host_allocator, &resolved_list, &device_list, &device_allocator,
       &replay_recorder);
   if (!iree_status_is_ok(status)) {
     iree_tooling_module_list_reset(&resolved_list);
@@ -976,10 +975,10 @@ iree_status_t iree_tooling_create_context_from_flags(
     } else {
       iree_hal_allocator_release(device_allocator);
     }
-    if (out_device) {
-      *out_device = device;
+    if (out_device_list) {
+      *out_device_list = device_list;
     } else {
-      iree_hal_device_release(device);
+      iree_hal_device_list_free(device_list);
     }
     if (out_replay_recorder) {
       *out_replay_recorder = replay_recorder;
@@ -989,7 +988,7 @@ iree_status_t iree_tooling_create_context_from_flags(
   } else {
     status = iree_tooling_close_hal_replay_recorder(status, replay_recorder);
     iree_hal_allocator_release(device_allocator);
-    iree_hal_device_release(device);
+    iree_hal_device_list_free(device_list);
     iree_vm_context_release(context);
   }
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/tooling/context_util.h
+++ b/runtime/src/iree/tooling/context_util.h
@@ -56,20 +56,21 @@ iree_vm_module_t* iree_tooling_module_list_back(
 //
 // |default_device_uri| can be specified to provide a default if a device flag
 // is not provided by the user.
-// |out_device| will contain the lead device if using the full HAL.
+// |out_device_list| will contain the created devices if using the full HAL.
 // |out_device_allocator| can be used to allocate buffers for use with the
 // context and is available in all execution models.
 // |out_replay_recorder| will contain a recorder that must be closed after all
 // HAL work is complete when --device_replay_output= is specified. Pass NULL
 // only when no replay capture flag is expected.
 //
-// If multiple devices are created the one returned (and its corresponding
+// If multiple devices are created the first one (and it's corresponding
 // allocator) are considered the 'lead' device for bookkeeping purposes.
 iree_status_t iree_tooling_resolve_modules(
     iree_vm_instance_t* instance, iree_host_size_t user_module_count,
     iree_vm_module_t** user_modules, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_tooling_module_list_t* resolved_list,
-    iree_hal_device_t** out_device, iree_hal_allocator_t** out_device_allocator,
+    iree_hal_device_list_t** out_device_list,
+    iree_hal_allocator_t** out_device_allocator,
     iree_hal_replay_recorder_t** out_replay_recorder);
 
 // Loads modules in the order specified by the --module= flag.
@@ -97,20 +98,21 @@ iree_status_t iree_tooling_create_instance(iree_allocator_t host_allocator,
 //
 // |default_device_uri| can be specified to provide a default if a device flag
 // is not provided by the user.
-// |out_device| will contain the lead device if using the full HAL.
+// |out_device_list| will contain the created devices if using the full HAL.
 // |out_device_allocator| can be used to allocate buffers for use with the
 // context and is available in all execution models.
 // |out_replay_recorder| will contain a recorder that must be closed after all
 // HAL work is complete when --device_replay_output= is specified. Pass NULL
 // only when no replay capture flag is expected.
 //
-// If multiple devices are created the one returned (and its corresponding
+// If multiple devices are created the first one (and it's corresponding
 // allocator) are considered the 'lead' device for bookkeeping purposes.
 iree_status_t iree_tooling_create_context_from_flags(
     iree_vm_instance_t* instance, iree_host_size_t user_module_count,
     iree_vm_module_t** user_modules, iree_string_view_t default_device_uri,
     iree_allocator_t host_allocator, iree_vm_context_t** out_context,
-    iree_hal_device_t** out_device, iree_hal_allocator_t** out_device_allocator,
+    iree_hal_device_list_t** out_device_list,
+    iree_hal_allocator_t** out_device_allocator,
     iree_hal_replay_recorder_t** out_replay_recorder);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/tooling/run_module.c
+++ b/runtime/src/iree/tooling/run_module.c
@@ -101,7 +101,8 @@ static iree_status_t iree_tooling_create_run_context(
     iree_vm_instance_t* instance, iree_string_view_t default_device_uri,
     iree_const_byte_span_t module_contents, iree_allocator_t host_allocator,
     iree_vm_context_t** out_context, iree_vm_function_t* out_function,
-    iree_hal_device_t** out_device, iree_hal_allocator_t** out_device_allocator,
+    iree_hal_device_list_t** out_device_list,
+    iree_hal_allocator_t** out_device_allocator,
     iree_hal_replay_recorder_t** out_replay_recorder) {
   // Load all modules specified by --module= flags.
   iree_tooling_module_list_t module_list;
@@ -145,14 +146,14 @@ static iree_status_t iree_tooling_create_run_context(
   // loaded (like the HAL) and special things like the HAL device and allocator
   // are returned for convenience. Note that not all programs need the HAL.
   iree_vm_context_t* context = NULL;
-  iree_hal_device_t* device = NULL;
+  iree_hal_device_list_t* device_list = NULL;
   iree_hal_allocator_t* device_allocator = NULL;
   iree_hal_replay_recorder_t* replay_recorder = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_status_annotate_f(
         iree_tooling_create_context_from_flags(
             instance, module_list.count, module_list.values, default_device_uri,
-            host_allocator, &context, &device, &device_allocator,
+            host_allocator, &context, &device_list, &device_allocator,
             &replay_recorder),
         "creating VM context");
   }
@@ -178,7 +179,7 @@ static iree_status_t iree_tooling_create_run_context(
   if (iree_status_is_ok(status)) {
     *out_context = context;
     *out_function = function;
-    *out_device = device;
+    *out_device_list = device_list;
     *out_device_allocator = device_allocator;
     *out_replay_recorder = replay_recorder;
   } else {
@@ -191,7 +192,7 @@ static iree_status_t iree_tooling_create_run_context(
       iree_hal_replay_recorder_release(replay_recorder);
     }
     iree_hal_allocator_release(device_allocator);
-    iree_hal_device_release(device);
+    iree_hal_device_list_free(device_list);
   }
   return status;
 }
@@ -427,15 +428,19 @@ iree_status_t iree_tooling_run_module_with_data(
   // This also returns the HAL device and allocator (if any) for I/O handling.
   iree_vm_context_t* context = NULL;
   iree_vm_function_t function = {0};
-  iree_hal_device_t* device = NULL;
+  iree_hal_device_list_t* device_list = NULL;
   iree_hal_allocator_t* device_allocator = NULL;
   iree_hal_replay_recorder_t* replay_recorder = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
-      iree_tooling_create_run_context(
-          instance, default_device_uri, module_contents, host_allocator,
-          &context, &function, &device, &device_allocator, &replay_recorder),
+      iree_tooling_create_run_context(instance, default_device_uri,
+                                      module_contents, host_allocator, &context,
+                                      &function, &device_list,
+                                      &device_allocator, &replay_recorder),
       "creating run context");
+
+  iree_hal_device_t* device =
+      device_list ? iree_hal_device_list_at(device_list, 0) : NULL;
 
   // Parse inputs, run the function, and process outputs.
   iree_status_t status =
@@ -473,13 +478,20 @@ iree_status_t iree_tooling_run_module_with_data(
 
   // Print statistics after we've released the inputs/outputs and the context
   // which may be holding on to resources like constants/variables.
-  if (device_allocator && FLAG_print_statistics) {
-    status = iree_status_join(
-        status, iree_hal_allocator_statistics_fprint(stderr, device_allocator));
+  if (FLAG_print_statistics && device_list) {
+    for (iree_host_size_t i = 0; i < device_list->count; ++i) {
+      iree_hal_device_t* dev = iree_hal_device_list_at(device_list, i);
+      iree_string_view_t device_id = iree_hal_device_id(dev);
+      fprintf(stderr, "Device: %.*s\n", (int)device_id.size, device_id.data);
+      iree_hal_allocator_t* allocator = iree_hal_device_allocator(dev);
+      status = iree_status_join(
+          status, iree_hal_allocator_statistics_fprint(stderr, allocator));
+      fprintf(stderr, "\n");
+    }
   }
 
   iree_hal_allocator_release(device_allocator);
-  iree_hal_device_release(device);
+  iree_hal_device_list_free(device_list);
 
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -531,16 +531,25 @@ class IREEBenchmark {
     instance_.reset();
 
     // Tear down device last in order to get accurate statistics.
-    if (device_allocator_ && FLAG_print_statistics) {
-      status = iree_status_join(status, iree_hal_allocator_statistics_fprint(
-                                            stderr, device_allocator_.get()));
+    if (FLAG_print_statistics && device_list_) {
+      for (iree_host_size_t i = 0; i < device_list_->count; ++i) {
+        iree_hal_device_t* dev = iree_hal_device_list_at(device_list_, i);
+        iree_string_view_t device_id = iree_hal_device_id(dev);
+        fprintf(stderr, "Device: %.*s\n", (int)device_id.size, device_id.data);
+        iree_hal_allocator_t* allocator = iree_hal_device_allocator(dev);
+        status = iree_status_join(
+            status, iree_hal_allocator_statistics_fprint(stderr, allocator));
+        fprintf(stderr, "\n");
+      }
     }
     device_allocator_.reset();
-    device_.reset();
+    device_ = nullptr;
+    iree_hal_device_list_free(device_list_);
+    device_list_ = nullptr;
     return status;
   }
 
-  iree_hal_device_t* device() const { return device_.get(); }
+  iree_hal_device_t* device() const { return device_; }
 
   iree_status_t CloseReplayCapture() {
     if (!replay_recorder_) return iree_ok_status();
@@ -581,7 +590,8 @@ class IREEBenchmark {
     IREE_RETURN_IF_ERROR(iree_tooling_create_context_from_flags(
         instance_.get(), module_list_.count, module_list_.values,
         /*default_device_uri=*/iree_string_view_empty(), host_allocator,
-        &context_, &device_, &device_allocator_, &replay_recorder_));
+        &context_, &device_list_, &device_allocator_, &replay_recorder_));
+    device_ = device_list_ ? iree_hal_device_list_at(device_list_, 0) : nullptr;
 
     IREE_TRACE_FRAME_MARK_END_NAMED("init");
     return iree_ok_status();
@@ -605,22 +615,19 @@ class IREEBenchmark {
         &signature, &arguments_cconv, &results_cconv));
 
     IREE_CHECK_OK(iree_tooling_parse_variants(
-        arguments_cconv, FLAG_input_list(), device_.get(),
-        device_allocator_.get(), iree_vm_instance_allocator(instance_.get()),
-        &inputs_));
+        arguments_cconv, FLAG_input_list(), device_, device_allocator_.get(),
+        iree_vm_instance_allocator(instance_.get()), &inputs_));
 
     iree_string_view_t invocation_model = iree_vm_function_lookup_attr_by_name(
         &function, IREE_SV("iree.abi.model"));
     if (iree_string_view_equal(invocation_model, IREE_SV("coarse-fences"))) {
       // Asynchronous invocation.
-      iree::RegisterAsyncBenchmark(function_name, replay_recorder_,
-                                   device_.get(), context_.get(), function,
-                                   inputs_.get());
+      iree::RegisterAsyncBenchmark(function_name, replay_recorder_, device_,
+                                   context_.get(), function, inputs_.get());
     } else {
       // Synchronous invocation.
-      iree::RegisterGenericBenchmark(function_name, replay_recorder_,
-                                     device_.get(), context_.get(), function,
-                                     inputs_.get());
+      iree::RegisterGenericBenchmark(function_name, replay_recorder_, device_,
+                                     context_.get(), function, inputs_.get());
     }
     return iree_ok_status();
   }
@@ -648,7 +655,7 @@ class IREEBenchmark {
       } else if (iree_string_view_equal(benchmark_type, IREE_SV("entry"))) {
         iree::RegisterGenericBenchmark(
             std::string(function_name.data, function_name.size),
-            replay_recorder_, device_.get(), context_.get(), function,
+            replay_recorder_, device_, context_.get(), function,
             /*inputs=*/nullptr);
       } else {
         // Pick up generic () -> () functions.
@@ -677,7 +684,7 @@ class IREEBenchmark {
             // Only functions taking a (wait, signal) fence pair are run.
             iree::RegisterAsyncBenchmark(
                 std::string(function_name.data, function_name.size),
-                replay_recorder_, device_.get(), context_.get(), function,
+                replay_recorder_, device_, context_.get(), function,
                 /*inputs=*/nullptr);
           }
         } else {
@@ -687,7 +694,7 @@ class IREEBenchmark {
             // anything).
             iree::RegisterGenericBenchmark(
                 std::string(function_name.data, function_name.size),
-                replay_recorder_, device_.get(), context_.get(), function,
+                replay_recorder_, device_, context_.get(), function,
                 /*inputs=*/nullptr);
           }
         }
@@ -698,7 +705,8 @@ class IREEBenchmark {
 
   iree::vm::ref<iree_vm_instance_t> instance_;
   iree::vm::ref<iree_vm_context_t> context_;
-  iree::vm::ref<iree_hal_device_t> device_;
+  iree_hal_device_list_t* device_list_ = NULL;
+  iree_hal_device_t* device_ = NULL;
   iree::vm::ref<iree_hal_allocator_t> device_allocator_;
   iree_hal_replay_recorder_t* replay_recorder_ = nullptr;
   iree_tooling_module_list_t module_list_;

--- a/tools/iree-check-module-main.cc
+++ b/tools/iree-check-module-main.cc
@@ -47,8 +47,9 @@ class CheckModuleTest : public ::testing::Test {
     IREE_CHECK_OK(iree_tooling_create_context_from_flags(
         instance_, module_list_.count, module_list_.values,
         /*default_device_uri=*/iree_string_view_empty(),
-        iree_vm_instance_allocator(instance_), &context_, &device_,
+        iree_vm_instance_allocator(instance_), &context_, &device_list_,
         /*out_device_allocator=*/NULL, &replay_recorder_));
+    device_ = device_list_ ? iree_hal_device_list_at(device_list_, 0) : nullptr;
   }
 
   void TearDown() override {
@@ -58,7 +59,7 @@ class CheckModuleTest : public ::testing::Test {
       iree_hal_replay_recorder_release(replay_recorder_);
       replay_recorder_ = nullptr;
     }
-    iree_hal_device_release(device_);
+    iree_hal_device_list_free(device_list_);
   }
 
   void TestBody() override {
@@ -83,6 +84,7 @@ class CheckModuleTest : public ::testing::Test {
   iree_vm_function_t function_;
 
   iree_vm_context_t* context_ = nullptr;
+  iree_hal_device_list_t* device_list_ = nullptr;
   iree_hal_device_t* device_ = nullptr;
   iree_hal_replay_recorder_t* replay_recorder_ = nullptr;
 };

--- a/tools/iree-encode-parameters-main.c
+++ b/tools/iree-encode-parameters-main.c
@@ -337,14 +337,14 @@ static iree_status_t iree_encode_call_indices(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_vm_context_t* context = NULL;
-  iree_hal_device_t* device = NULL;
+  iree_hal_device_list_t* device_list = NULL;
   iree_hal_replay_recorder_t* replay_recorder = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0,
-      iree_tooling_create_context_from_flags(
-          instance, module_list->count, module_list->values,
-          /*default_device_uri=*/iree_string_view_empty(), host_allocator,
-          &context, &device, /*out_device_allocator=*/NULL, &replay_recorder));
+      z0, iree_tooling_create_context_from_flags(
+              instance, module_list->count, module_list->values,
+              /*default_device_uri=*/iree_string_view_empty(), host_allocator,
+              &context, &device_list, /*out_device_allocator=*/NULL,
+              &replay_recorder));
 
   // Invoke indices function.
   iree_vm_list_t* outputs = NULL;
@@ -377,7 +377,7 @@ static iree_status_t iree_encode_call_indices(
                                "closing HAL replay capture"));
     iree_hal_replay_recorder_release(replay_recorder);
   }
-  iree_hal_device_release(device);
+  iree_hal_device_list_free(device_list);
 
   IREE_TRACE_ZONE_END(z0);
   return status;
@@ -744,13 +744,13 @@ static iree_status_t iree_encode_create_encoding_context(
     iree_vm_instance_t* instance, iree_tooling_module_list_t* module_list,
     iree_output_archive_t* archives, iree_host_size_t archive_count,
     iree_allocator_t host_allocator, iree_vm_context_t** out_context,
-    iree_hal_device_t** out_device,
+    iree_hal_device_list_t** out_device_list,
     iree_hal_replay_recorder_t** out_replay_recorder) {
   IREE_ASSERT_ARGUMENT(out_context);
-  IREE_ASSERT_ARGUMENT(out_device);
+  IREE_ASSERT_ARGUMENT(out_device_list);
   IREE_ASSERT_ARGUMENT(out_replay_recorder);
   *out_context = NULL;
-  *out_device = NULL;
+  *out_device_list = NULL;
   *out_replay_recorder = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -785,12 +785,12 @@ static iree_status_t iree_encode_create_encoding_context(
 
   // Resolve dependencies (adds HAL, etc.).
   if (iree_status_is_ok(status)) {
-    iree_hal_device_t* device = NULL;
+    iree_hal_device_list_t* device_list = NULL;
     iree_hal_replay_recorder_t* replay_recorder = NULL;
     status = iree_tooling_resolve_modules(
         instance, module_list->count, module_list->values,
         /*default_device_uri=*/iree_string_view_empty(), host_allocator,
-        &resolved_list, &device, /*out_device_allocator=*/NULL,
+        &resolved_list, &device_list, /*out_device_allocator=*/NULL,
         &replay_recorder);
 
     // Create context.
@@ -803,7 +803,7 @@ static iree_status_t iree_encode_create_encoding_context(
 
     if (iree_status_is_ok(status)) {
       *out_context = context;
-      *out_device = device;
+      *out_device_list = device_list;
       *out_replay_recorder = replay_recorder;
     } else {
       iree_vm_context_release(context);
@@ -814,7 +814,7 @@ static iree_status_t iree_encode_create_encoding_context(
                         "closing HAL replay capture"));
         iree_hal_replay_recorder_release(replay_recorder);
       }
-      iree_hal_device_release(device);
+      iree_hal_device_list_free(device_list);
     }
   }
 
@@ -1049,13 +1049,15 @@ static iree_status_t iree_tooling_encode_parameters(
 
   // Create encoding context with output providers.
   iree_vm_context_t* context = NULL;
-  iree_hal_device_t* device = NULL;
+  iree_hal_device_list_t* device_list = NULL;
   iree_hal_replay_recorder_t* replay_recorder = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_encode_create_encoding_context(
         instance, &module_list, archives, output_list.count, host_allocator,
-        &context, &device, &replay_recorder);
+        &context, &device_list, &replay_recorder);
   }
+  iree_hal_device_t* device =
+      device_list ? iree_hal_device_list_at(device_list, 0) : NULL;
 
   // Call steps function.
   iree_vm_list_t* steps_list = NULL;
@@ -1093,7 +1095,7 @@ static iree_status_t iree_tooling_encode_parameters(
                                "closing HAL replay capture"));
     iree_hal_replay_recorder_release(replay_recorder);
   }
-  iree_hal_device_release(device);
+  iree_hal_device_list_free(device_list);
   iree_output_scope_list_deinitialize(&output_list);
   iree_encode_target_set_deinitialize(&target_set);
   iree_tooling_module_list_reset(&module_list);

--- a/tools/testing/e2e/test_utils.c
+++ b/tools/testing/e2e/test_utils.c
@@ -565,14 +565,18 @@ iree_status_t iree_test_utils_load_and_run_e2e_tests(
 
   // Create the context with our support module and all --module= flags.
   iree_vm_context_t* context = NULL;
-  iree_hal_device_t* device = NULL;
+  iree_hal_device_list_t* device_list = NULL;
   iree_hal_replay_recorder_t* replay_recorder = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_tooling_create_context_from_flags(
         instance, module_list.count, module_list.values,
         /*default_device_uri=*/iree_string_view_empty(), host_allocator,
-        &context, &device, /*out_device_allocator=*/NULL, &replay_recorder);
+        &context, &device_list, /*out_device_allocator=*/NULL,
+        &replay_recorder);
   }
+
+  iree_hal_device_t* device =
+      device_list ? iree_hal_device_list_at(device_list, 0) : NULL;
 
   // Ensure the test module is possible to run.
   if (iree_status_is_ok(status)) {
@@ -607,7 +611,7 @@ iree_status_t iree_test_utils_load_and_run_e2e_tests(
                                "closing HAL replay capture"));
     iree_hal_replay_recorder_release(replay_recorder);
   }
-  iree_hal_device_release(device);
+  iree_hal_device_list_free(device_list);
   iree_vm_instance_release(instance);
 
   IREE_TRACE_ZONE_END(z0);


### PR DESCRIPTION
Extend run-module and benchmark with allocator statistics printing for all devices in the context.

This requires passing `iree_hal_device_list_t` through the runtime API for the devices to be available at the time of statistics printing.
