### PR TITLE
[LLVMCPU] fix: return valid vscale range only for targets supporting SVE

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/FoldTensorSubsetIntoVectorTransferOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldTensorSubsetIntoVectorTransferOps.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 
 #include "mlir/Dialect/Arith/Utils/Utils.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Interfaces/VectorizableOpInterface.h"
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/Im2colUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/LLVMCPU/DispatchABI.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
@@ -89,11 +89,6 @@ bool hasAnyVFeature(DictionaryAttr targetConfig) {
          hasFeature(targetConfig, "+zve64d");
 }
 
-bool hasAnySVEFeature(DictionaryAttr targetConfig) {
-  return hasFeature(targetConfig, "+sve") ||
-         hasFeature(targetConfig, "+sve2") || hasFeature(targetConfig, "+v9a");
-}
-
 bool hasSMEFeature(DictionaryAttr targetConfig) {
   return hasFeature(targetConfig, "+sme");
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
@@ -49,10 +49,6 @@ bool hasZve64xFeature(DictionaryAttr targetConfig);
 /// cpu features.
 bool hasAnyVFeature(DictionaryAttr targetConfig);
 
-/// Returns true if the 'targetAttr' contains '+sve' or '+sve2' in its cpu
-/// features or any other feature flag that includes them.
-bool hasAnySVEFeature(DictionaryAttr targetConfig);
-
 /// Returns true if the 'targetAttr' contains '+sme' in its cpu features.
 bool hasSMEFeature(DictionaryAttr targetConfig);
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -125,4 +125,24 @@ bool isProducerOfRootOp(Operation *op, Operation *rootOp) {
   return false;
 }
 
+bool hasAnySVEFeature(DictionaryAttr targetConfig) {
+  return hasFeature(targetConfig, "+sve") ||
+         hasFeature(targetConfig, "+sve2") || hasFeature(targetConfig, "+v9a");
+}
+
+std::optional<vector::VscaleRange>
+getDefaultVscaleRange(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  if (targetAttr) {
+    DictionaryAttr targetConfig = targetAttr.getConfiguration();
+    if (isAArch64(targetConfig) && hasAnySVEFeature(targetConfig)) {
+      // For Arm SVE/SVE2 the scalable vector length is between 128-bit and
+      // 2048-bit, corresponding to a vscale range of 1 to 16. See:
+      // https://developer.arm.com/Architectures/Scalable%20Vector%20Extensions
+      return vector::VscaleRange{1, 16};
+    }
+  }
+  // TODO: Implement for other architectures.
+  return std::nullopt;
+}
+
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
@@ -49,6 +49,15 @@ unsigned getUserVscaleValue();
 /// of `op`'s results is used as an operand of `rootOp`.
 bool isProducerOfRootOp(Operation *op, Operation *rootOp);
 
+/// Returns true if the 'targetAttr' contains '+sve' or '+sve2' in its cpu
+/// features or any other feature flag that includes them.
+bool hasAnySVEFeature(DictionaryAttr targetConfig);
+
+/// Returns the default vscale range for the given target. Currently only
+/// returns a range for AArch64 targets with SVE/SVE2 enabled.
+std::optional<vector::VscaleRange>
+getDefaultVscaleRange(IREE::HAL::ExecutableTargetAttr targetAttr);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_UTILS_CPUUTILS_H_

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Interfaces/ProcessorOpInterfaces.h"
 #include "iree/compiler/Codegen/Interfaces/UKernelOpInterface.h"
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
@@ -298,11 +299,6 @@ bool isRISCV32(DictionaryAttr targetConfig) {
 bool isRISCV64(DictionaryAttr targetConfig) {
   std::optional<llvm::Triple> triple = getTargetTriple(targetConfig);
   return triple && triple.value().isRISCV64();
-}
-
-static bool hasAnySVEFeature(DictionaryAttr targetConfig) {
-  return hasFeature(targetConfig, "+sve") ||
-         hasFeature(targetConfig, "+sve2");
 }
 
 std::array<int64_t, 3> getMaxWorkgroupCount(DictionaryAttr targetConfig) {
@@ -1749,21 +1745,6 @@ bool hasFusedLeadingOp(linalg::LinalgOp rootOp) {
   }
 
   return llvm::any_of(backwardSlice, llvm::IsaPred<linalg::LinalgOp>);
-}
-
-std::optional<vector::VscaleRange>
-getDefaultVscaleRange(IREE::HAL::ExecutableTargetAttr targetAttr) {
-  if (targetAttr) {
-    DictionaryAttr targetConfig = targetAttr.getConfiguration();
-    if (isAArch64(targetConfig) && hasAnySVEFeature(targetConfig)) {
-      // For Arm SVE/SVE2 the scalable vector length is between 128-bit and
-      // 2048-bit, corresponding to a vscale range of 1 to 16. See:
-      // https://developer.arm.com/Architectures/Scalable%20Vector%20Extensions
-      return vector::VscaleRange{1, 16};
-    }
-  }
-  // TODO: Implement for other architectures.
-  return std::nullopt;
 }
 
 std::optional<SizesAndScalableFlags>

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -300,6 +300,11 @@ bool isRISCV64(DictionaryAttr targetConfig) {
   return triple && triple.value().isRISCV64();
 }
 
+static bool hasAnySVEFeature(DictionaryAttr targetConfig) {
+  return hasFeature(targetConfig, "+sve") ||
+         hasFeature(targetConfig, "+sve2");
+}
+
 std::array<int64_t, 3> getMaxWorkgroupCount(DictionaryAttr targetConfig) {
   // TODO(MaheshRavishankar): For now the target info is only available for
   // GPUs, and is recorded in the configuration with the name `iree.gpu.target`.
@@ -1748,11 +1753,14 @@ bool hasFusedLeadingOp(linalg::LinalgOp rootOp) {
 
 std::optional<vector::VscaleRange>
 getDefaultVscaleRange(IREE::HAL::ExecutableTargetAttr targetAttr) {
-  if (targetAttr && isAArch64(targetAttr.getConfiguration())) {
-    // On AArch64 the scalable vector length will always be between 128-bit and
-    // 2048-bit. This works out as a vscale range of 1 to 16. See:
-    // https://developer.arm.com/Architectures/Scalable%20Vector%20Extensions
-    return vector::VscaleRange{1, 16};
+  if (targetAttr) {
+    DictionaryAttr targetConfig = targetAttr.getConfiguration();
+    if (isAArch64(targetConfig) && hasAnySVEFeature(targetConfig)) {
+      // For Arm SVE/SVE2 the scalable vector length is between 128-bit and
+      // 2048-bit, corresponding to a vscale range of 1 to 16. See:
+      // https://developer.arm.com/Architectures/Scalable%20Vector%20Extensions
+      return vector::VscaleRange{1, 16};
+    }
   }
   // TODO: Implement for other architectures.
   return std::nullopt;

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -340,9 +340,6 @@ bool isFullSlice(OffsetSizeAndStrideOpInterface sliceLoadStoreOp,
 // Scalable size utility functions
 //===---------------------------------------------------------------------===//
 
-std::optional<vector::VscaleRange>
-getDefaultVscaleRange(IREE::HAL::ExecutableTargetAttr targetAttr);
-
 using SizesAndScalableFlags =
     std::pair<SmallVector<int64_t>, SmallVector<bool>>;
 


### PR DESCRIPTION
fixes the `getDefaultVscaleRange` to only return a vscale range if the target supports it. 