### PR TITLE
[Runtime][Python] Convert numpy.uint8 to ABI type i8

### DIFF
--- a/runtime/bindings/python/iree/runtime/benchmark.py
+++ b/runtime/bindings/python/iree/runtime/benchmark.py
@@ -35,13 +35,17 @@ BenchmarkResult = namedtuple(
 )
 
 DTYPE_TO_ABI_TYPE = {
-    numpy.dtype(numpy.float32): "f32",
-    numpy.dtype(numpy.int32): "i32",
-    numpy.dtype(numpy.int64): "i64",
-    numpy.dtype(numpy.float64): "f64",
-    numpy.dtype(numpy.int16): "i16",
     numpy.dtype(numpy.float16): "f16",
+    numpy.dtype(numpy.float32): "f32",
+    numpy.dtype(numpy.float64): "f64",
     numpy.dtype(numpy.int8): "i8",
+    numpy.dtype(numpy.uint8): "i8",
+    numpy.dtype(numpy.int16): "i16",
+    numpy.dtype(numpy.uint16): "i16",
+    numpy.dtype(numpy.int32): "i32",
+    numpy.dtype(numpy.uint32): "i32",
+    numpy.dtype(numpy.int64): "i64",
+    numpy.dtype(numpy.uint64): "i64",
     numpy.dtype(numpy.bool_): "i1",
 }
 
@@ -66,14 +70,13 @@ def benchmark_exe():
     )
 
 
-def benchmark_module(
+def _build_benchmark_args(
     module: Union[VmModule, PathLike],
-    entry_function=None,
-    inputs=[],
-    timeout=None,
+    entry_function: str | None = None,
+    inputs: list[Union[str, numpy.ndarray]] | None = None,
     **kwargs,
-):
-    args = [iree.runtime.benchmark_exe()]
+) -> tuple[list[str], bytes | None]:
+    args = [benchmark_exe()]
 
     if isinstance(module, VmModule):
         funcs = [a for a in module.function_names if a != "__init"]
@@ -115,6 +118,20 @@ def benchmark_module(
             values = ",".join([str(v) for v in values])
 
         args.append(f"--input={shape}x{abitype}={values}")
+
+    return args, flatbuffer
+
+
+def benchmark_module(
+    module: Union[VmModule, PathLike],
+    entry_function: str | None = None,
+    inputs: list[Union[str, numpy.ndarray]] | None = None,
+    timeout: float | None = None,
+    **kwargs,
+):
+    args, flatbuffer = _build_benchmark_args(
+        module=module, entry_function=entry_function, inputs=inputs, **kwargs
+    )
 
     try:
         benchmark_process = subprocess.run(

--- a/runtime/bindings/python/tests/benchmark_test.py
+++ b/runtime/bindings/python/tests/benchmark_test.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import iree.compiler
 import iree.runtime
 from iree.runtime.benchmark import (
+    _build_benchmark_args as build_benchmark_args,
     benchmark_module,
     BenchmarkTimeoutError,
 )
@@ -73,6 +74,55 @@ def create_large_matmul_module(instance):
 class BenchmarkTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
+
+    def testBuildBenchmarkArgs(self):
+        args, flatbuffer = build_benchmark_args(
+            module="test_module.vmfb",
+            entry_function="test_func",
+            inputs=[np.array([1.0, 2.0], dtype=np.float32)],
+            # kwargs should be passed through as --{k}={v}
+            device="test_device",
+            extra_arg="extra_value",
+        )
+        ref_args = [
+            iree.runtime.benchmark_exe(),
+            "--module=test_module.vmfb",
+            "--function=test_func",
+            "--device=test_device",
+            "--extra_arg=extra_value",
+            "--input=2xf32=1.0,2.0",
+        ]
+        self.assertEqual(args, ref_args)
+        self.assertIsNone(flatbuffer)
+
+    def testBuildBenchmarkArgsInputs(self):
+        all_inputs = [
+            # empty
+            [],
+            # single input
+            [np.ones([2], dtype=np.float16)],
+            # multiple inputs
+            [np.ones([2], dtype=np.float64), np.ones([3], dtype=np.int8)],
+            # string input
+            ["input_string"],
+            # explicit values
+            [np.array([0, 1, 2, 3], dtype=np.uint8)],
+        ]
+        ref_args = [
+            [],
+            ["--input=2xf16=1.0"],
+            ["--input=2xf64=1.0", "--input=3xi8=1"],
+            ["--input=input_string"],
+            ["--input=4xi8=0,1,2,3"],
+        ]
+        for inp, ref in zip(all_inputs, ref_args):
+            args, flatbuffer = build_benchmark_args(
+                module="test_module.vmfb",
+                entry_function="test_func",
+                inputs=inp,
+            )
+            self.assertEqual(args[3:], ref)
+            self.assertIsNone(flatbuffer)
 
     def testBenchmarkModule(self):
         ctx = iree.runtime.SystemContext()


### PR DESCRIPTION
Benchmarks are currently failing because of "KeyError: dtype(uint8)" these are fixed by simply converting numpy.uint8 to i8.

Also added other missing data types for numpy, i.e. `uint16` and `uint32` and added a test case to ensure the benchmark argument creation works for all cases