### PR TITLE
[Codegen][Tuner] Add TileAndFuse constraints for conv

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
@@ -182,6 +182,23 @@ buildCombinedConfigDict(IREE::GPU::LoweringConfigAttr gpuConfig,
   }
   entries.emplace_back("subgroup_size",
                        b.getI64IntegerAttr(translationInfo.getSubgroupSize()));
+
+  // TODO(#23535): This is a temporary hack to add the use_igemm_convolution
+  // knob from translation info config to support IGEMM convolution. It should
+  // be automatically handled by each backend in the future.
+  bool useIgemmConvolution = false;
+  if (DictionaryAttr config = translationInfo.getConfiguration()) {
+    if (auto pipelineOptions =
+            dyn_cast_or_null<IREE::GPU::GPUPipelineOptionsAttr>(config.get(
+                IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()))) {
+      if (BoolAttr useIgemmAttr = pipelineOptions.getUseIgemmConvolution()) {
+        useIgemmConvolution = useIgemmAttr.getValue();
+      }
+    }
+  }
+  entries.emplace_back(
+      "use_igemm_convolution",
+      StringAttr::get(ctx, useIgemmConvolution ? "true" : "false"));
   return DictionaryAttr::get(ctx, entries);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
@@ -196,9 +196,8 @@ buildCombinedConfigDict(IREE::GPU::LoweringConfigAttr gpuConfig,
       }
     }
   }
-  entries.emplace_back(
-      "use_igemm_convolution",
-      StringAttr::get(ctx, useIgemmConvolution ? "true" : "false"));
+  entries.emplace_back("use_igemm_convolution",
+                       BoolAttr::get(ctx, useIgemmConvolution));
   return DictionaryAttr::get(ctx, entries);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
@@ -534,6 +534,7 @@ func.func @attention_e2e_generated_violation(
        } -> tensor<4x1024x64xf16>, tensor<4x1024xf16>, tensor<4x1024xf16>
   return %res#0, %res#1, %res#2
       : tensor<4x1024x64xf16>, tensor<4x1024xf16>, tensor<4x1024xf16>
+}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
@@ -203,10 +203,10 @@ func.func @conv_e2e_generated_violation_tf(
   %result = linalg.conv_2d_nhwc_hwcf {
       dilations = dense<1> : tensor<2xi64>,
       lowering_config = #iree_gpu.lowering_config<{
-          workgroup = [1, 1, 48, 64, 0, 0, 0],
-          reduction = [0, 0, 0, 0, 1, 1, 16],
+          workgroup = [1, 1, 48, 64, 0],
+          reduction = [0, 0, 0, 0, 16],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-          subgroup = [1, 1, 1, 1, 0, 0, 0]}>,
+          subgroup = [1, 1, 1, 1, 0]}>,
       root_op = #iree_codegen.root_op<set = 1>,
       strides = dense<1> : tensor<2xi64>}
       ins(%input, %filter : tensor<1x18x130x64xf32>,
@@ -534,4 +534,53 @@ func.func @attention_e2e_generated_violation(
        } -> tensor<4x1024x64xf16>, tensor<4x1024xf16>, tensor<4x1024xf16>
   return %res#0, %res#1, %res#2
       : tensor<4x1024x64xf16>, tensor<4x1024xf16>, tensor<4x1024xf16>
+
+// -----
+
+// Test: TileAndFuse direct-convolution config explicitly sets
+// use_igemm_convolution = false and constraints are still verified.
+#gpu_target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <
+  compute = fp32, storage = b32, subgroup = shuffle,
+  mma = [<MFMA_F32_16x16x4_F32>],
+  subgroup_size_choices = [64],
+  max_load_instruction_bits = 128,
+  max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024,
+  max_workgroup_memory_bytes = 65536,
+  max_workgroup_counts = [2147483647, 2147483647, 2147483647]
+>>
+#exec_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+    {iree_codegen.target_info = #gpu_target}>
+#translation = #iree_codegen.translation_info<
+    pipeline = #iree_gpu.pipeline<TileAndFuse>
+    workgroup_size = [64, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<
+        prefetch_num_stages = 2,
+        no_reduce_shared_memory_bank_conflicts = false,
+        use_igemm_convolution = false>}>
+
+func.func @conv_e2e_generated_violation_tf_direct_conv(
+    %input: tensor<1x18x130x64xf32>, %filter: tensor<3x3x64x128xf32>)
+    -> tensor<1x16x128x128xf32>
+    attributes {hal.executable.target = #exec_target,
+                translation_info = #translation} {
+  %cst = arith.constant 0.0 : f32
+  %init = tensor.empty() : tensor<1x16x128x128xf32>
+  %fill = linalg.fill {root_op = #iree_codegen.root_op<set = 2>}
+      ins(%cst : f32) outs(%init : tensor<1x16x128x128xf32>)
+      -> tensor<1x16x128x128xf32>
+  // expected-error @below {{pipeline constraints violated}}
+  // expected-note @below {{dim_2 must be divisible by wg_2 (128 % 48 == 0)}}
+  %result = linalg.conv_2d_nhwc_hwcf {
+      dilations = dense<1> : tensor<2xi64>,
+      lowering_config = #iree_gpu.lowering_config<{
+          workgroup = [1, 1, 48, 64, 0],
+          reduction = [0, 0, 0, 0, 16],
+          mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+          subgroup = [1, 1, 1, 1, 0]}>,
+      root_op = #iree_codegen.root_op<set = 2>,
+      strides = dense<1> : tensor<2xi64>}
+      ins(%input, %filter : tensor<1x18x130x64xf32>,
+                               tensor<3x3x64x128xf32>)
+      outs(%fill : tensor<1x16x128x128xf32>) -> tensor<1x16x128x128xf32>
+  return %result : tensor<1x16x128x128xf32>
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
@@ -203,10 +203,10 @@ func.func @conv_e2e_generated_violation_tf(
   %result = linalg.conv_2d_nhwc_hwcf {
       dilations = dense<1> : tensor<2xi64>,
       lowering_config = #iree_gpu.lowering_config<{
-          workgroup = [1, 1, 48, 64, 0],
-          reduction = [0, 0, 0, 0, 16],
+          workgroup = [1, 1, 48, 64, 0, 0, 0],
+          reduction = [0, 0, 0, 0, 1, 1, 16],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-          subgroup = [1, 1, 1, 1, 0]}>,
+          subgroup = [1, 1, 1, 1, 0, 0, 0]}>,
       root_op = #iree_codegen.root_op<set = 1>,
       strides = dense<1> : tensor<2xi64>}
       ins(%input, %filter : tensor<1x18x130x64xf32>,
@@ -573,10 +573,10 @@ func.func @conv_e2e_generated_violation_tf_direct_conv(
   %result = linalg.conv_2d_nhwc_hwcf {
       dilations = dense<1> : tensor<2xi64>,
       lowering_config = #iree_gpu.lowering_config<{
-          workgroup = [1, 1, 48, 64, 0],
-          reduction = [0, 0, 0, 0, 16],
+          workgroup = [1, 1, 48, 64, 0, 0, 0],
+          reduction = [0, 0, 0, 0, 1, 1, 16],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-          subgroup = [1, 1, 1, 1, 0]}>,
+          subgroup = [1, 1, 1, 1, 0, 0, 0]}>,
       root_op = #iree_codegen.root_op<set = 2>,
       strides = dense<1> : tensor<2xi64>}
       ins(%input, %filter : tensor<1x18x130x64xf32>,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/DebugLog.h"
@@ -50,6 +51,12 @@ struct RootOpLoopInfo {
   SmallVector<AffineMap> indexingMaps;
 };
 
+/// Optional TileAndFuse constraint inputs for IGEMM convolution.
+struct TileAndFuseConstraintOptions {
+  bool useIgemm = false;
+  ArrayRef<unsigned> fusedIgemmKDims = {};
+};
+
 // Keys for entries in the SMT constraints `knobs` dictionary.
 // These names are aligned with lowering config and translation info fields.
 
@@ -69,6 +76,9 @@ struct RootOpLoopInfo {
 //   workgroup_size = [wg_size_x, wg_size_y, wg_size_z]
 //   subgroup_size = sg_size
 
+// Translation info knob list (TileAndFuse only):
+//   use_igemm_convolution = use_igemm_convolution ("true" or "false")
+
 constexpr StringLiteral kKnobWorkgroupKey = "workgroup";
 constexpr StringLiteral kKnobReductionKey = "reduction";
 constexpr StringLiteral kKnobMmaKindKey = "mma_kind";
@@ -76,6 +86,7 @@ constexpr StringLiteral kKnobSubgroupBasisKey = "subgroup_basis";
 constexpr StringLiteral kKnobSubgroupKey = "subgroup";
 constexpr StringLiteral kKnobWorkgroupSizeKey = "workgroup_size";
 constexpr StringLiteral kKnobSubgroupSizeKey = "subgroup_size";
+constexpr StringLiteral kKnobUseIgemmConvolutionKey = "use_igemm_convolution";
 
 // SMT variable names for knob values used in constraints.
 constexpr StringLiteral kKnobMmaIdxName = "mma_idx";
@@ -85,6 +96,7 @@ constexpr StringLiteral kKnobSgSizeName = "sg_size";
 constexpr StringLiteral kKnobWgSizeXName = "wg_size_x";
 constexpr StringLiteral kKnobWgSizeYName = "wg_size_y";
 constexpr StringLiteral kKnobWgSizeZName = "wg_size_z";
+constexpr StringLiteral kKnobUseIgemmConvolutionName = "use_igemm_convolution";
 
 // SMT variable name prefixes.
 // The loop dim count varies per problem, so names are built at runtime
@@ -168,6 +180,24 @@ static Value emitAlignUpToMultiple(OpBuilder &builder, Location loc, Value lhs,
       smt::IntAddOp::create(builder, loc, ValueRange{lhs, rhsMinusOne});
   Value div = smt::IntDivOp::create(builder, loc, lhsPlus, rhs);
   return smt::IntMulOp::create(builder, loc, ValueRange{div, rhs});
+}
+
+/// Emit tuner-style overpadded bound for a dimension.
+/// If dim > 128: align up to 128. Else if dim > 32: align up to 32.
+/// Otherwise keep dim unchanged.
+static Value emitOverpaddedBound(OpBuilder &builder, Location loc, Value dim) {
+  Value c32 = mkIntConst(builder, loc, 32);
+  Value c33 = mkIntConst(builder, loc, 33);
+  Value c128 = mkIntConst(builder, loc, 128);
+  Value c129 = mkIntConst(builder, loc, 129);
+  Value align32 = emitAlignUpToMultiple(builder, loc, dim, c32);
+  Value align128 = emitAlignUpToMultiple(builder, loc, dim, c128);
+  Value gt32 =
+      smt::IntCmpOp::create(builder, loc, smt::IntPredicate::ge, dim, c33);
+  Value gt128 =
+      smt::IntCmpOp::create(builder, loc, smt::IntPredicate::ge, dim, c129);
+  Value padded32 = smt::IteOp::create(builder, loc, gt32, align32, dim);
+  return smt::IteOp::create(builder, loc, gt128, align128, padded32);
 }
 
 /// Emit product(values[0], values[1], ..., values[n-1]).
@@ -343,6 +373,45 @@ static std::optional<RootOpLoopInfo> getRootOpLoopInfo(Operation *rootOp) {
   return std::nullopt;
 }
 
+/// Returns original conv K indices that fuse in IGEMM, excluding innermost.
+/// For conv K [3, 4, 5] mapping to [3, 3, 3], returns [3, 4]. For conv K
+/// [1, 4, 5] mapping to [1, 4, 4], returns [4].
+static SmallVector<unsigned>
+getFusedIgemmKDimIndices(linalg::LinalgOp linalgOp,
+                         ArrayRef<unsigned> convKDims) {
+  if (convKDims.empty()) {
+    return {};
+  }
+
+  FailureOr<IREE::LinalgExt::IGEMMGenericConvDetails> igemmDetails =
+      IREE::LinalgExt::getIGEMMGenericConvDetails(linalgOp);
+  if (failed(igemmDetails)) {
+    return {};
+  }
+
+  auto mapConvDimToIgemm = [&](unsigned convDim) -> unsigned {
+    return cast<AffineDimExpr>(igemmDetails->convToIgemmDimMap.lookup(convDim))
+        .getPosition();
+  };
+
+  DenseMap<unsigned, unsigned> igemmDimToConvKCount;
+  for (unsigned convKDim : convKDims) {
+    ++igemmDimToConvKCount[mapConvDimToIgemm(convKDim)];
+  }
+
+  unsigned innermostConvK = convKDims.back();
+  SmallVector<unsigned> fusedConvKDims;
+  for (unsigned convKDim : convKDims) {
+    if (convKDim == innermostConvK) {
+      continue;
+    }
+    if (igemmDimToConvKCount[mapConvDimToIgemm(convKDim)] > 1) {
+      fusedConvKDims.push_back(convKDim);
+    }
+  }
+  return fusedConvKDims;
+}
+
 /// Build the VectorDistribute knobs dict for contraction-like dims.
 static DictionaryAttr
 buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
@@ -421,15 +490,22 @@ buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
 }
 
 /// Build the TileAndFuse knobs dict for contraction-like dims.
-static DictionaryAttr
-buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
-                          const ContractionLikeDims &dims,
-                          ArrayRef<Attribute> compatibleMMAs) {
+/// When `useIgemm` is true, also adds the `use_igemm_convolution` one-of
+/// knob entry with string options "false"/"true".
+static DictionaryAttr buildTileAndFuseKnobsDict(
+    MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
+    const ContractionLikeDims &dims, ArrayRef<Attribute> compatibleMMAs,
+    bool isConv = false, ArrayRef<unsigned> fusedIgemmKDims = {}) {
   SmallVector<NamedAttribute> knobsEntries;
+
+  unsigned layoutNumLoops = loopInfo.numLoops;
+  if (!fusedIgemmKDims.empty()) {
+    layoutNumLoops = loopInfo.numLoops - fusedIgemmKDims.size();
+  }
 
   // Build workgroup entries.
   // Batch, M, N dims are knobbed, K dims are not tiled and get 0.
-  SmallVector<Attribute> workgroupEntries(loopInfo.numLoops,
+  SmallVector<Attribute> workgroupEntries(layoutNumLoops,
                                           makeIntAttr(ctx, kNoTileDimVal));
   SmallVector<unsigned> knobbedWorkgroupDims;
   llvm::append_range(knobbedWorkgroupDims, dims.b);
@@ -444,22 +520,25 @@ buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
   // Build reduction entries.
   // Only innermost K dim is knobbed, other K dims are unit tiled as 1.
   // Other untiled dims get 0.
-  SmallVector<Attribute> reductionEntries(loopInfo.numLoops,
+  SmallVector<Attribute> reductionEntries(layoutNumLoops,
                                           makeIntAttr(ctx, kNoTileDimVal));
-  for (unsigned i = 0; i < loopInfo.numLoops; ++i) {
+  for (auto i : knobbedWorkgroupDims) {
     reductionEntries[i] = makeIntAttr(ctx, kNoTileDimVal);
   }
   for (unsigned i : dims.k) {
+    if (llvm::is_contained(fusedIgemmKDims, i) || i >= layoutNumLoops) {
+      continue;
+    }
     reductionEntries[i] = makeIntAttr(ctx, kUnitTileDimVal);
   }
-  reductionEntries[dims.k.back()] =
+  reductionEntries[layoutNumLoops - 1] =
       IntKnobAttr::get(ctx, makeVarName(kKnobRedPrefix, dims.k.back()));
   knobsEntries.emplace_back(kKnobReductionKey,
                             ArrayAttr::get(ctx, reductionEntries));
 
   // Build subgroup entries.
   // M and N dims are knobbed, other untiled dims get 0.
-  SmallVector<Attribute> subgroupEntries(loopInfo.numLoops,
+  SmallVector<Attribute> subgroupEntries(layoutNumLoops,
                                          makeIntAttr(ctx, kNoTileDimVal));
   SmallVector<unsigned> knobbedSubgroupDims;
   llvm::append_range(knobbedSubgroupDims, dims.m);
@@ -484,6 +563,15 @@ buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
                             ArrayAttr::get(ctx, wgSizeKnobs));
   knobsEntries.emplace_back(kKnobSubgroupSizeKey,
                             IntKnobAttr::get(ctx, kKnobSgSizeName));
+
+  // Conv-only: use_igemm_convolution one-of knob with options "false"/"true".
+  if (isConv) {
+    knobsEntries.emplace_back(
+        kKnobUseIgemmConvolutionKey,
+        OneOfKnobAttr::get(
+            ctx, kKnobUseIgemmConvolutionName,
+            {StringAttr::get(ctx, "false"), StringAttr::get(ctx, "true")}));
+  }
 
   return DictionaryAttr::get(ctx, knobsEntries);
 }
@@ -756,10 +844,15 @@ static LogicalResult emitVectorDistributeConstraints(
 }
 
 /// Emit TileAndFuse constraints for contraction-like dims (matmul/conv).
+/// When `options.useIgemm` is true, also emits the `use_igemm_convolution`
+/// one-of knob and bounds constraints on its option index.
+/// `options.fusedIgemmKDims` lists original conv K indices that fuse in
+/// IGEMM, excluding innermost.
 static LogicalResult emitTileAndFuseConstraints(
     OpBuilder &builder, linalg::LinalgOp linalgOp,
     const ContractionLikeDims &dims, IREE::GPU::TargetAttr gpuTarget,
-    ArrayRef<Value> smtDimArgs, ArrayRef<Attribute> compatibleMMAs) {
+    ArrayRef<Value> smtDimArgs, ArrayRef<Attribute> compatibleMMAs,
+    TileAndFuseConstraintOptions options = {}) {
   Location loc = linalgOp.getLoc();
 
   // Hardware constants.
@@ -861,9 +954,33 @@ static LogicalResult emitTileAndFuseConstraints(
       emitAlignUpToMultiple(builder, loc, smtDimArgs[mInnerDim], mmaMLookup);
   Value problemInnerNAligned =
       emitAlignUpToMultiple(builder, loc, smtDimArgs[nInnerDim], mmaNLookup);
-  // problemInnerKAligned = ceil(dim_k / mma_k) * mma_k.
-  Value problemInnerKAligned =
+  // problemInnerKAligned = ceil(dim_k / mma_k) * mma_k, or dim_k * dim_fused
+  // with IGEMM.
+  Value alignedInnerK =
       emitAlignUpToMultiple(builder, loc, smtDimArgs[kInnerDim], mmaKLookup);
+  Value problemInnerKAligned = alignedInnerK;
+  Value useIgemmTrue;
+  if (options.useIgemm) {
+    // use_igemm_convolution knob, 0 -> direct conv, 1 -> IGEMM conv
+    Value useIgemmIdx = mkKnob(builder, loc, kKnobUseIgemmConvolutionName);
+    assertBounds(builder, loc, useIgemmIdx, kKnobUseIgemmConvolutionName,
+                 mkIntConst(builder, loc, 0), "0", mkIntConst(builder, loc, 1),
+                 "1");
+
+    SmallVector<Value> fusedDimValues;
+    fusedDimValues.reserve(options.fusedIgemmKDims.size());
+    for (unsigned dim : options.fusedIgemmKDims) {
+      fusedDimValues.push_back(smtDimArgs[dim]);
+    }
+    Value dimFused = emitProduct(builder, loc, fusedDimValues);
+    Value igemmInnerK = smt::IntMulOp::create(
+        builder, loc, ValueRange{smtDimArgs[kInnerDim], dimFused});
+
+    useIgemmTrue = smt::EqOp::create(builder, loc, useIgemmIdx,
+                                     mkIntConst(builder, loc, 1));
+    problemInnerKAligned = smt::IteOp::create(builder, loc, useIgemmTrue,
+                                              igemmInnerK, alignedInnerK);
+  }
 
   // Constraint 0: Set concrete values for knobs.
   // sg_size == preferred_subgroup_size.
@@ -884,6 +1001,11 @@ static LogicalResult emitTileAndFuseConstraints(
       problemDim = problemInnerMAligned;
     } else if (dim == nInnerDim) {
       problemDim = problemInnerNAligned;
+    } else if (options.useIgemm && (llvm::is_contained(dims.m, dim) ||
+                                    llvm::is_contained(dims.n, dim))) {
+      Value overpaddedDim = emitOverpaddedBound(builder, loc, problemDim);
+      problemDim = smt::IteOp::create(builder, loc, useIgemmTrue, overpaddedDim,
+                                      problemDim);
     }
     // dim % wg == 0.
     assertDivisible(
@@ -1050,8 +1172,9 @@ emitConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr,
 
   // Gate on contraction-like linalg ops.
   auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp);
-  if (!linalgOp || (!linalg::isaContractionOpInterface(linalgOp) &&
-                    !linalg::isaConvolutionOpInterface(linalgOp))) {
+
+  bool isConv = linalg::isaConvolutionOpInterface(linalgOp);
+  if (!linalgOp || (!linalg::isaContractionOpInterface(linalgOp) && !isConv)) {
     return success();
   }
 
@@ -1079,13 +1202,22 @@ emitConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr,
 
   MLIRContext *ctx = rootOp->getContext();
   OpBuilder builder(ctx);
+  SmallVector<unsigned> fusedIgemmKDims = {};
   DictionaryAttr knobs;
-  if (pipeline == IREE::GPU::LoweringPipeline::VectorDistribute) {
+  switch (pipeline) {
+  case IREE::GPU::LoweringPipeline::VectorDistribute:
     knobs =
         buildVectorDistributeKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs);
-  } else if (pipeline == IREE::GPU::LoweringPipeline::TileAndFuse) {
-    knobs = buildTileAndFuseKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs);
-  } else {
+    break;
+  case IREE::GPU::LoweringPipeline::TileAndFuse:
+    if (isConv) {
+      fusedIgemmKDims = getFusedIgemmKDimIndices(linalgOp, dims->k);
+    }
+    knobs = buildTileAndFuseKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs,
+                                      /*isConv=*/isConv,
+                                      /*fusedIgemmKDims=*/fusedIgemmKDims);
+    break;
+  default:
     return success();
   }
   auto pipelineAttr = IREE::GPU::PipelineAttr::get(ctx, pipeline);
@@ -1093,15 +1225,17 @@ emitConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr,
       createConstraintsOpShell(builder, rootOp, rootOpAttr, pipelineAttr, knobs,
                                loopInfo->numLoops, loopInfo->indexingMaps);
 
-  if (pipeline == IREE::GPU::LoweringPipeline::VectorDistribute) {
+  switch (pipeline) {
+  case IREE::GPU::LoweringPipeline::VectorDistribute:
     return emitVectorDistributeConstraints(builder, linalgOp, *dims, gpuTarget,
                                            shell.smtDimArgs, compatibleMMAs);
+  case IREE::GPU::LoweringPipeline::TileAndFuse:
+    return emitTileAndFuseConstraints(
+        builder, linalgOp, *dims, gpuTarget, shell.smtDimArgs, compatibleMMAs,
+        {/*useIgemm=*/isConv, /*fusedIgemmKDims=*/fusedIgemmKDims});
+  default:
+    return success();
   }
-  if (pipeline == IREE::GPU::LoweringPipeline::TileAndFuse) {
-    return emitTileAndFuseConstraints(builder, linalgOp, *dims, gpuTarget,
-                                      shell.smtDimArgs, compatibleMMAs);
-  }
-  return success();
 }
 
 /// Multiple root ops may be present in a set, e.g. <set = 0>:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -51,8 +51,10 @@ struct RootOpLoopInfo {
   SmallVector<AffineMap> indexingMaps;
 };
 
-/// Optional TileAndFuse constraint inputs for IGEMM convolution.
+/// TileAndFuse constraint options to allow branching on conv and IGEMM for
+/// knobs dict and smt constraints.
 struct TileAndFuseConstraintOptions {
+  bool isConv = false;
   bool useIgemm = false;
   ArrayRef<unsigned> fusedIgemmKDims = {};
 };
@@ -77,7 +79,7 @@ struct TileAndFuseConstraintOptions {
 //   subgroup_size = sg_size
 
 // Translation info knob list (TileAndFuse only):
-//   use_igemm_convolution = use_igemm_convolution ("true" or "false")
+//   use_igemm_convolution = use_igemm_idx (one_of_knob<bool>)
 
 constexpr StringLiteral kKnobWorkgroupKey = "workgroup";
 constexpr StringLiteral kKnobReductionKey = "reduction";
@@ -96,7 +98,7 @@ constexpr StringLiteral kKnobSgSizeName = "sg_size";
 constexpr StringLiteral kKnobWgSizeXName = "wg_size_x";
 constexpr StringLiteral kKnobWgSizeYName = "wg_size_y";
 constexpr StringLiteral kKnobWgSizeZName = "wg_size_z";
-constexpr StringLiteral kKnobUseIgemmConvolutionName = "use_igemm_convolution";
+constexpr StringLiteral kKnobUseIgemmConvolutionName = "use_igemm_idx";
 
 // SMT variable name prefixes.
 // The loop dim count varies per problem, so names are built at runtime
@@ -490,12 +492,15 @@ buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
 }
 
 /// Build the TileAndFuse knobs dict for contraction-like dims.
-/// When `useIgemm` is true, also adds the `use_igemm_convolution` one-of
-/// knob entry with string options "false"/"true".
-static DictionaryAttr buildTileAndFuseKnobsDict(
-    MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
-    const ContractionLikeDims &dims, ArrayRef<Attribute> compatibleMMAs,
-    bool isConv = false, ArrayRef<unsigned> fusedIgemmKDims = {}) {
+/// When `options.isConv` is true, exposes both use_igemm_convolution options
+/// in one_of_knob. The emitted constraints then pin a single branch.
+static DictionaryAttr
+buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
+                          const ContractionLikeDims &dims,
+                          ArrayRef<Attribute> compatibleMMAs,
+                          TileAndFuseConstraintOptions options = {}) {
+  bool isConv = options.isConv;
+  ArrayRef<unsigned> fusedIgemmKDims = options.fusedIgemmKDims;
   SmallVector<NamedAttribute> knobsEntries;
 
   unsigned layoutNumLoops = loopInfo.numLoops;
@@ -564,13 +569,13 @@ static DictionaryAttr buildTileAndFuseKnobsDict(
   knobsEntries.emplace_back(kKnobSubgroupSizeKey,
                             IntKnobAttr::get(ctx, kKnobSgSizeName));
 
-  // Conv-only: use_igemm_convolution one-of knob with options "false"/"true".
+  // Conv-only: expose both branches via one_of and pin inside constraints.
   if (isConv) {
+    SmallVector<Attribute> useIgemmOptions = {BoolAttr::get(ctx, false),
+                                              BoolAttr::get(ctx, true)};
     knobsEntries.emplace_back(
         kKnobUseIgemmConvolutionKey,
-        OneOfKnobAttr::get(
-            ctx, kKnobUseIgemmConvolutionName,
-            {StringAttr::get(ctx, "false"), StringAttr::get(ctx, "true")}));
+        OneOfKnobAttr::get(ctx, kKnobUseIgemmConvolutionName, useIgemmOptions));
   }
 
   return DictionaryAttr::get(ctx, knobsEntries);
@@ -844,10 +849,9 @@ static LogicalResult emitVectorDistributeConstraints(
 }
 
 /// Emit TileAndFuse constraints for contraction-like dims (matmul/conv).
-/// When `options.useIgemm` is true, also emits the `use_igemm_convolution`
-/// one-of knob and bounds constraints on its option index.
-/// `options.fusedIgemmKDims` lists original conv K indices that fuse in
-/// IGEMM, excluding innermost.
+/// TF matmul: no constraints on igemm knob.
+/// TF direct conv: same constraints as matmul, with igemm knob set to false.
+/// TF igemm conv: some k dims are fused, with igemm knob set to true.
 static LogicalResult emitTileAndFuseConstraints(
     OpBuilder &builder, linalg::LinalgOp linalgOp,
     const ContractionLikeDims &dims, IREE::GPU::TargetAttr gpuTarget,
@@ -902,6 +906,18 @@ static LogicalResult emitTileAndFuseConstraints(
   Value wgSizeX = mkKnob(builder, loc, kKnobWgSizeXName);
   Value wgSizeY = mkKnob(builder, loc, kKnobWgSizeYName);
   Value wgSizeZ = mkKnob(builder, loc, kKnobWgSizeZName);
+  if (options.isConv) {
+    Value useIgemmIdx = mkKnob(builder, loc, kKnobUseIgemmConvolutionName);
+    int64_t expectedUseIgemmIdx = options.useIgemm ? 1 : 0;
+    Value expectedUseIgemmIdxVal =
+        mkIntConst(builder, loc, expectedUseIgemmIdx);
+    Value useIgemmEq =
+        smt::EqOp::create(builder, loc, useIgemmIdx, expectedUseIgemmIdxVal);
+    AssertOp::create(builder, loc, useIgemmEq,
+                     options.useIgemm
+                         ? "use_igemm_idx == 1 (use_igemm_convolution=true)"
+                         : "use_igemm_idx == 0 (use_igemm_convolution=false)");
+  }
 
   // Create intermediate variables.
   // Do not create these as knobs because they are not in the knob dict
@@ -959,27 +975,15 @@ static LogicalResult emitTileAndFuseConstraints(
   Value alignedInnerK =
       emitAlignUpToMultiple(builder, loc, smtDimArgs[kInnerDim], mmaKLookup);
   Value problemInnerKAligned = alignedInnerK;
-  Value useIgemmTrue;
   if (options.useIgemm) {
-    // use_igemm_convolution knob, 0 -> direct conv, 1 -> IGEMM conv
-    Value useIgemmIdx = mkKnob(builder, loc, kKnobUseIgemmConvolutionName);
-    assertBounds(builder, loc, useIgemmIdx, kKnobUseIgemmConvolutionName,
-                 mkIntConst(builder, loc, 0), "0", mkIntConst(builder, loc, 1),
-                 "1");
-
     SmallVector<Value> fusedDimValues;
     fusedDimValues.reserve(options.fusedIgemmKDims.size());
     for (unsigned dim : options.fusedIgemmKDims) {
       fusedDimValues.push_back(smtDimArgs[dim]);
     }
     Value dimFused = emitProduct(builder, loc, fusedDimValues);
-    Value igemmInnerK = smt::IntMulOp::create(
+    problemInnerKAligned = smt::IntMulOp::create(
         builder, loc, ValueRange{smtDimArgs[kInnerDim], dimFused});
-
-    useIgemmTrue = smt::EqOp::create(builder, loc, useIgemmIdx,
-                                     mkIntConst(builder, loc, 1));
-    problemInnerKAligned = smt::IteOp::create(builder, loc, useIgemmTrue,
-                                              igemmInnerK, alignedInnerK);
   }
 
   // Constraint 0: Set concrete values for knobs.
@@ -1003,9 +1007,7 @@ static LogicalResult emitTileAndFuseConstraints(
       problemDim = problemInnerNAligned;
     } else if (options.useIgemm && (llvm::is_contained(dims.m, dim) ||
                                     llvm::is_contained(dims.n, dim))) {
-      Value overpaddedDim = emitOverpaddedBound(builder, loc, problemDim);
-      problemDim = smt::IteOp::create(builder, loc, useIgemmTrue, overpaddedDim,
-                                      problemDim);
+      problemDim = emitOverpaddedBound(builder, loc, problemDim);
     }
     // dim % wg == 0.
     assertDivisible(
@@ -1149,6 +1151,50 @@ static LogicalResult emitTileAndFuseConstraints(
 static LogicalResult
 emitVectorDistributeAttentionConstraintsForOp(Operation *rootOp,
                                               RootOpAttr rootOpAttr);
+/// Emit TileAndFuse ConstraintsOps for one root op. For convolution roots,
+/// emits two ops (one with use_igemm_convolution = false and one with true);
+/// for non-conv roots, emits a single op.
+static LogicalResult emitTileAndFuseConstraintsOps(
+    OpBuilder &builder, Operation *rootOp, linalg::LinalgOp linalgOp,
+    RootOpAttr rootOpAttr, IREE::GPU::PipelineAttr pipelineAttr,
+    const RootOpLoopInfo &loopInfo, const ContractionLikeDims &dims,
+    IREE::GPU::TargetAttr gpuTarget, ArrayRef<Attribute> compatibleMMAs,
+    bool isConv) {
+  MLIRContext *ctx = rootOp->getContext();
+
+  auto emitOne = [&](bool useIgemm) {
+    SmallVector<unsigned> fusedIgemmKDims;
+    if (useIgemm) {
+      fusedIgemmKDims = getFusedIgemmKDimIndices(linalgOp, dims.k);
+    }
+    assert((useIgemm || fusedIgemmKDims.empty()) &&
+           "fusedIgemmKDims must be empty when useIgemm is false");
+    TileAndFuseConstraintOptions options{/*isConv=*/isConv,
+                                         /*useIgemm=*/useIgemm,
+                                         /*fusedIgemmKDims=*/fusedIgemmKDims};
+    DictionaryAttr knobs =
+        buildTileAndFuseKnobsDict(ctx, loopInfo, dims, compatibleMMAs, options);
+    ConstraintsOpShell shell = createConstraintsOpShell(
+        builder, rootOp, rootOpAttr, pipelineAttr, knobs, loopInfo.numLoops,
+        loopInfo.indexingMaps);
+    return emitTileAndFuseConstraints(builder, linalgOp, dims, gpuTarget,
+                                      shell.smtDimArgs, compatibleMMAs,
+                                      options);
+  };
+
+  if (!isConv) {
+    return emitOne(/*useIgemm=*/false);
+  }
+  // Iterate {true, false} so the final IR order is {false, true}: each call
+  // resets the insertion point to right after `rootOp`, so the second emit
+  // lands between `rootOp` and the first emit.
+  for (bool useIgemm : {true, false}) {
+    if (failed(emitOne(useIgemm))) {
+      return failure();
+    }
+  }
+  return success();
+}
 
 /// Emit constraints for a single root op under a supported LLVMGPU pipeline.
 /// Supports linalg contraction/convolution under both VectorDistribute and
@@ -1202,37 +1248,22 @@ emitConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr,
 
   MLIRContext *ctx = rootOp->getContext();
   OpBuilder builder(ctx);
-  SmallVector<unsigned> fusedIgemmKDims = {};
-  DictionaryAttr knobs;
-  switch (pipeline) {
-  case IREE::GPU::LoweringPipeline::VectorDistribute:
-    knobs =
-        buildVectorDistributeKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs);
-    break;
-  case IREE::GPU::LoweringPipeline::TileAndFuse:
-    if (isConv) {
-      fusedIgemmKDims = getFusedIgemmKDimIndices(linalgOp, dims->k);
-    }
-    knobs = buildTileAndFuseKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs,
-                                      /*isConv=*/isConv,
-                                      /*fusedIgemmKDims=*/fusedIgemmKDims);
-    break;
-  default:
-    return success();
-  }
   auto pipelineAttr = IREE::GPU::PipelineAttr::get(ctx, pipeline);
-  ConstraintsOpShell shell =
-      createConstraintsOpShell(builder, rootOp, rootOpAttr, pipelineAttr, knobs,
-                               loopInfo->numLoops, loopInfo->indexingMaps);
 
   switch (pipeline) {
-  case IREE::GPU::LoweringPipeline::VectorDistribute:
+  case IREE::GPU::LoweringPipeline::VectorDistribute: {
+    DictionaryAttr knobs =
+        buildVectorDistributeKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs);
+    ConstraintsOpShell shell = createConstraintsOpShell(
+        builder, rootOp, rootOpAttr, pipelineAttr, knobs, loopInfo->numLoops,
+        loopInfo->indexingMaps);
     return emitVectorDistributeConstraints(builder, linalgOp, *dims, gpuTarget,
                                            shell.smtDimArgs, compatibleMMAs);
+  }
   case IREE::GPU::LoweringPipeline::TileAndFuse:
-    return emitTileAndFuseConstraints(
-        builder, linalgOp, *dims, gpuTarget, shell.smtDimArgs, compatibleMMAs,
-        {/*useIgemm=*/isConv, /*fusedIgemmKDims=*/fusedIgemmKDims});
+    return emitTileAndFuseConstraintsOps(builder, rootOp, linalgOp, rootOpAttr,
+                                         pipelineAttr, *loopInfo, *dims,
+                                         gpuTarget, compatibleMMAs, isConv);
   default:
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -182,22 +182,22 @@ static Value emitAlignUpToMultiple(OpBuilder &builder, Location loc, Value lhs,
   return smt::IntMulOp::create(builder, loc, ValueRange{div, rhs});
 }
 
-/// Emit tuner-style overpadded bound for a dimension.
+/// Emit overpadded bound for a dimension.
 /// If dim > 128: align up to 128. Else if dim > 32: align up to 32.
 /// Otherwise keep dim unchanged.
 static Value emitOverpaddedBound(OpBuilder &builder, Location loc, Value dim) {
-  Value c32 = mkIntConst(builder, loc, 32);
-  Value c33 = mkIntConst(builder, loc, 33);
-  Value c128 = mkIntConst(builder, loc, 128);
-  Value c129 = mkIntConst(builder, loc, 129);
-  Value align32 = emitAlignUpToMultiple(builder, loc, dim, c32);
-  Value align128 = emitAlignUpToMultiple(builder, loc, dim, c128);
-  Value gt32 =
-      smt::IntCmpOp::create(builder, loc, smt::IntPredicate::ge, dim, c33);
-  Value gt128 =
-      smt::IntCmpOp::create(builder, loc, smt::IntPredicate::ge, dim, c129);
-  Value padded32 = smt::IteOp::create(builder, loc, gt32, align32, dim);
-  return smt::IteOp::create(builder, loc, gt128, align128, padded32);
+  Value smallAlign = mkIntConst(builder, loc, 32);
+  Value largeAlign = mkIntConst(builder, loc, 128);
+  Value alignedSmall = emitAlignUpToMultiple(builder, loc, dim, smallAlign);
+  Value alignedLarge = emitAlignUpToMultiple(builder, loc, dim, largeAlign);
+  Value exceedsSmall = smt::IntCmpOp::create(
+      builder, loc, smt::IntPredicate::gt, dim, smallAlign);
+  Value exceedsLarge = smt::IntCmpOp::create(
+      builder, loc, smt::IntPredicate::gt, dim, largeAlign);
+  Value paddedSmall =
+      smt::IteOp::create(builder, loc, exceedsSmall, alignedSmall, dim);
+  return smt::IteOp::create(builder, loc, exceedsLarge, alignedLarge,
+                            paddedSmall);
 }
 
 /// Emit product(values[0], values[1], ..., values[n-1]).

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_llvm_gpu_constraints.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_llvm_gpu_constraints.mlir
@@ -120,10 +120,10 @@ func.func @conv_2d_nhwc_hwcf()
 // CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
 // CHECK-NEXT:  knobs = {
 // CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
-// CHECK-DAG:   reduction = [0, 0, 0, 0, 1, 1, #iree_codegen.smt.int_knob<"red_6">]
-// CHECK-DAG:   subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, #iree_codegen.smt.int_knob<"sg_2">, #iree_codegen.smt.int_knob<"sg_3">, 0, 0, 0]
+// CHECK-DAG:   reduction = [0, 0, 0, 0, #iree_codegen.smt.int_knob<"red_6">]
+// CHECK-DAG:   subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, #iree_codegen.smt.int_knob<"sg_2">, #iree_codegen.smt.int_knob<"sg_3">, 0]
 // CHECK-DAG:   subgroup_size = #iree_codegen.smt.int_knob<"sg_size">
-// CHECK-DAG:   workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, #iree_codegen.smt.int_knob<"wg_2">, #iree_codegen.smt.int_knob<"wg_3">, 0, 0, 0]
+// CHECK-DAG:   workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, #iree_codegen.smt.int_knob<"wg_2">, #iree_codegen.smt.int_knob<"wg_3">, 0]
 // CHECK-DAG:   workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]
 // CHECK-SAME:  }
 // CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<VectorDistribute>,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_llvm_gpu_constraints.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_llvm_gpu_constraints.mlir
@@ -59,6 +59,8 @@ func.func @matmul_and_fill() attributes {hal.executable.target = #exec_target} {
 // CHECK-DAG:   workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0]
 // CHECK-DAG:   workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]
 // CHECK-SAME:  }
+// CHECK-NOT:   use_igemm_convolution = #iree_codegen.smt.one_of_knob<"use_igemm_idx", [false, true]>
+
 // CHECK:       iree_codegen.smt.constraints target = <set = [[SET]]>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
 // CHECK-NEXT:  knobs = {
 // CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
@@ -68,6 +70,7 @@ func.func @matmul_and_fill() attributes {hal.executable.target = #exec_target} {
 // CHECK-DAG:   workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0]
 // CHECK-DAG:   workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]
 // CHECK-SAME:  }
+// CHECK-NOT:   use_igemm_convolution = #iree_codegen.smt.one_of_knob<"use_igemm_idx", [false, true]>
 // CHECK:       "dim_0 must be divisible by wg_0 ({} % {} == 0)"
 // CHECK:       "dim_1 must be divisible by wg_1 ({} % {} == 0)"
 // CHECK:       "dim_2 must be divisible by red_2 ({} % {} == 0)"
@@ -118,27 +121,17 @@ func.func @conv_2d_nhwc_hwcf()
 // CHECK:       linalg.conv_2d_nhwc_hwcf
 // CHECK-SAME:  #iree_codegen.root_op<set = 1>
 // CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
-// CHECK-NEXT:  knobs = {
-// CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
-// CHECK-DAG:   reduction = [0, 0, 0, 0, #iree_codegen.smt.int_knob<"red_6">]
-// CHECK-DAG:   subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, #iree_codegen.smt.int_knob<"sg_2">, #iree_codegen.smt.int_knob<"sg_3">, 0]
-// CHECK-DAG:   subgroup_size = #iree_codegen.smt.int_knob<"sg_size">
-// CHECK-DAG:   workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, #iree_codegen.smt.int_knob<"wg_2">, #iree_codegen.smt.int_knob<"wg_3">, 0]
-// CHECK-DAG:   workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]
-// CHECK-SAME:  }
-// CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
-// CHECK-NEXT:  knobs = {
-// CHECK-DAG:   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>
+// Non fused k dims for direct conv.
 // CHECK-DAG:   reduction = [0, 0, 0, 0, 1, 1, #iree_codegen.smt.int_knob<"red_6">]
-// CHECK-DAG{LITERAL}: subgroup_basis = [[1, 1, #iree_codegen.smt.int_knob<"sg_m_cnt">, #iree_codegen.smt.int_knob<"sg_n_cnt">, 1, 1, 1], [0, 1, 2, 3, 4, 5, 6]]
-// CHECK-DAG:   subgroup_size = #iree_codegen.smt.int_knob<"sg_size">
-// CHECK-DAG:   workgroup = [1, 1, #iree_codegen.smt.int_knob<"wg_2">, #iree_codegen.smt.int_knob<"wg_3">, 0, 0, 0]
-// CHECK-DAG:   workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]
-// CHECK-SAME:  }
-// CHECK:       "dim_2 must be divisible by wg_2 ({} % {} == 0)"
-// CHECK:       "dim_3 must be divisible by wg_3 ({} % {} == 0)"
-// CHECK:       "dim_6 must be divisible by red_6 ({} % {} == 0)"
-// CHECK-NOT:   "dim_{{[0-9]+}} must be divisible by {{.*}}"
+// CHECK-DAG:   use_igemm_convolution = #iree_codegen.smt.one_of_knob<"use_igemm_idx", [false, true]>
+// CHECK:       "use_igemm_idx == 0 (use_igemm_convolution=false)"
+// CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<TileAndFuse>,
+// k dims fused in igemm conv.
+// CHECK-DAG:   reduction = [0, 0, 0, 0, #iree_codegen.smt.int_knob<"red_6">]
+// CHECK-DAG:   use_igemm_convolution = #iree_codegen.smt.one_of_knob<"use_igemm_idx", [false, true]>
+// CHECK:       "use_igemm_idx == 1 (use_igemm_convolution=true)"
+// CHECK:       iree_codegen.smt.constraints target = <set = 1>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
+// CHECK-NOT:   use_igemm_convolution = #iree_codegen.smt.one_of_knob<"use_igemm_idx", [false, true]>
 
 #map_lhs = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
 #map_rhs = affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
@@ -181,6 +174,7 @@ func.func @expanded_matmul()
 // CHECK-DAG:   workgroup = [1, 1, #iree_codegen.smt.int_knob<"wg_2">, #iree_codegen.smt.int_knob<"wg_3">, 0]
 // CHECK-DAG:   workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]
 // CHECK-SAME:  }
+// CHECK-NOT:   use_igemm_convolution = #iree_codegen.smt.one_of_knob<"use_igemm_idx", [false, true]>
 // CHECK:       "dim_2 must be divisible by wg_2 ({} % {} == 0)"
 // CHECK:       "dim_3 must be divisible by wg_3 ({} % {} == 0)"
 // CHECK:       "dim_4 must be divisible by red_4 ({} % {} == 0)"


### PR DESCRIPTION
TF constraints for conv will emit one smt.constraints op for each IGEMM conv and Direct conv.

Each separated constraint set is tested to have the same amount of smt solutions as the old tuner constraints.
See the SMT-LIB string [comparison](https://github.com/nod-ai/amd-shark-ai/commit/5d517500239f564f0bfa782c689b704a44d9f8b9).

Issue: #23535 