### PR TITLE
[Codegen] Cap hoisted statically-bound allocations at the stack budget.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/hoist_statically_bound_allocations.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/hoist_statically_bound_allocations.mlir
@@ -249,3 +249,28 @@ func.func @nested_op_scalable_alloc_linalg_use(%arg0 : index) {
 // CHECK-UNBOUNDED-VSCALE-LABEL: func @nested_op_scalable_alloc_linalg_use(
 //       CHECK-UNBOUNDED-VSCALE: scf.for
 //       CHECK-UNBOUNDED-VSCALE:   memref.alloc
+
+// -----
+
+// An unconstrained dynamic dimension bounds only to the `index` umax, so
+// padding the alloca to that bound would be a multi-petabyte stack allocation
+// (iree-org/iree#24483). The pass must decline to hoist such an allocation and
+// leave it dynamic, in the loop, instead of materializing a bogus static one.
+func.func @no_hoist_umax_bounded_alloca(%arg0 : index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c42 = arith.constant 42 : i32
+  %assumed = util.assume.int %arg0<umin = 0, umax = 9007199254740991> : index
+  %dim = affine.apply affine_map<()[s0] -> (s0 ceildiv 2)>()[%assumed]
+  scf.for %iv = %c0 to %c1 step %c1 {
+    %1 = memref.alloca(%dim) : memref<?xi32>
+    memref.store %c42, %1[%iv] : memref<?xi32>
+    scf.yield
+  }
+  return
+}
+// CHECK-LABEL: func @no_hoist_umax_bounded_alloca(
+//   CHECK-NOT:   memref.alloca() :
+//       CHECK:   scf.for
+//       CHECK:     memref.alloca(%{{.+}}) : memref<?xi32>
+//   CHECK-NOT:   memref.alloca() :

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -123,6 +123,24 @@ cloneOffsetsSizesAndStrides(OpBuilder &builder,
       loadOp.getMixedSizes(), loadOp.getMixedStrides(), loadOp.getSourceDims());
 }
 
+// Upper bound, in bytes, on an allocation that hoisting is allowed to pad to
+// static bounds. Hoisting replaces a dynamic allocation with a static one of
+// its computed upper bound; when a dynamic dimension is unconstrained, that
+// bound defaults to the `index` type maximum and the padded allocation becomes
+// absurdly large (see iree-org/iree#24483). Past this cap we decline to hoist
+// and leave the allocation dynamic instead.
+static int64_t getHoistedAllocationByteCap(mlir::FunctionOpInterface funcOp) {
+  if (auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp)) {
+    if (auto attr = targetAttr.getConfiguration().getAs<IntegerAttr>(
+            "max_stack_allocation_size")) {
+      return attr.getInt();
+    }
+  }
+  // No target budget available (e.g. unit tests): fall back to a cap far above
+  // any realistic tile allocation but far below a bogus unbounded one.
+  return int64_t{1} << 30;
+}
+
 template <typename AllocLikeOpType>
 std::optional<Value> hoistOneStaticallyBoundAllocation(
     mlir::FunctionOpInterface funcOp, OpBuilder &builder, Location loc,
@@ -217,6 +235,36 @@ std::optional<Value> hoistOneStaticallyBoundAllocation(
 
       allocSizes.push_back(*ub);
       subviewSizes.push_back(dynamicSize);
+    }
+
+    // Decline to hoist if padding to the computed bounds would exceed the
+    // target's allocation budget. An unconstrained dynamic dimension carries
+    // only the `index` type maximum as its bound, which would pad the
+    // allocation to a bogus multi-petabyte size (iree-org/iree#24483).
+    // Leaving the allocation dynamic is always correct; it just isn't hoisted.
+    {
+      int64_t capElements =
+          getHoistedAllocationByteCap(funcOp) /
+          std::max<int64_t>(
+              1, llvm::divideCeil(allocLikeType.getElementTypeBitWidth(), 8));
+      int64_t numElements = 1;
+      bool boundsAreConstant = true, exceedsCap = false;
+      for (OpFoldResult allocSize : allocSizes) {
+        std::optional<int64_t> dimSize = getConstantIntValue(allocSize);
+        if (!dimSize) {
+          // A non-constant bound (e.g. a scalable-vector bound) — skip the cap.
+          boundsAreConstant = false;
+          break;
+        }
+        if (*dimSize > 0 && numElements > capElements / *dimSize) {
+          exceedsCap = true;
+          break;
+        }
+        numElements *= *dimSize;
+      }
+      if (boundsAreConstant && exceedsCap) {
+        return std::nullopt;
+      }
     }
 
     // FIXME: The `AllocLikeOp::build()` method for OpFoldResult drops the


### PR DESCRIPTION
`hoistOneStaticallyBoundAllocation` pads a dynamic allocation to its computed upper bound. An unconstrained dynamic dimension carries only the `index` type maximum as its bound, so padding yields a bogus multi- petabyte allocation (iree-org/iree#24483). Decline to hoist past the target's `max_stack_allocation_size`; declining to hoist is always valid -- it simply leaves the IR's existing dynamic allocation in place.

Extent of the #24483 fix: this is partial. It implements the first of the three fixes proposed in that issue -- the hoist itself no longer turns an `index`-umax-derived bound into a bogus static `alloca` (which fed poison strides into codegen and silently dropped data). It does not on its own make the originally-affected pipeline -- dynamic-shape `inner_tiled` data-tiling -- compile: as #24483 notes, capping leaves a dynamic CPU stack allocation, which is itself rejected downstream. What this commit guarantees is only that the failure mode is no longer a *silent miscompile*. The dynamic-shape `inner_tiled` pipeline is fully unblocked by a later commit in this series ("Fold reshape-containing encoding relayouts to map_store"), which removes the whole-tensor `pack` so the unbounded allocation never arises. #24483 is therefore not fully resolved by this commit alone.

Progress towards #24515.