### PR TITLE
[Codegen][CPU] Add x86 AVX-512 VNNI 16x16x2 i8 MMA intrinsic.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -930,6 +930,29 @@ getCombineRelayoutOpsControlFn(IREE::Codegen::RelayoutCombinationScope scope) {
       return isa<IREE::Codegen::StoreToBufferOp>(*leaf.getUsers().begin());
     };
     break;
+  // Control function for DispatchReshape scope. Like Dispatch, but additionally
+  // requires the backward relayout slice to contain a `tensor.expand_shape` or
+  // `tensor.collapse_shape` — the non-tileable reshape whose presence is what
+  // makes folding into a `map_store` necessary (see the enum doc comment).
+  case IREE::Codegen::RelayoutCombinationScope::DispatchReshape:
+    controlFn = [](OpResult leaf) {
+      if (leaf.getNumUses() != 1) {
+        return false;
+      }
+      if (!isa<IREE::Codegen::StoreToBufferOp>(*leaf.getUsers().begin())) {
+        return false;
+      }
+      llvm::SetVector<Operation *> slice;
+      BackwardSliceOptions options;
+      options.filter = isSupportedSingleInputRelayoutOpForResult;
+      options.inclusive = true;
+      if (failed(getBackwardSlice(leaf, &slice, options))) {
+        return false;
+      }
+      return llvm::any_of(
+          slice, llvm::IsaPred<tensor::CollapseShapeOp, tensor::ExpandShapeOp>);
+    };
+    break;
   // Control function for Workgroup scope. Filters to only relayout ops with
   // a single tensor.parallel_insert_slice user inside of a workgroup
   // scf.forall op. Relayout chains of only reshapes are also filtered out,

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -44,10 +44,18 @@ namespace IREE::Codegen {
 /// Enum defining the scope of the CombineResultLayoutTransformationPass.
 ///  - The `Dispatch` scope will combine layout transformation chains that are
 ///    consumed by an `iree_codegen.store_to_buffer` op.
+///  - The `DispatchReshape` scope is like `Dispatch`, but additionally
+///    restricted to chains whose backward slice contains a
+///    `tensor.expand_shape` or `tensor.collapse_shape`. Such a reshape does not
+///    implement `TilingInterface`, so when it sits between two tileable
+///    relayout ops it blocks producer fusion and leaves an untiled,
+///    whole-tensor intermediate (iree-org/iree#24483). Pure
+///    pack/unpack/transpose/pad chains tile fine via tile-and-fuse and do not
+///    need a `map_store`.
 ///  - The `Workgroup` scope will combine layout transformation chains that are
 ///    consumed by a `tensor.parallel_insert_slice` op at the end of an
 ///    scf.forall with an `iree_codegen.workgroup_mapping` attribute.
-enum class RelayoutCombinationScope { Dispatch, Workgroup };
+enum class RelayoutCombinationScope { Dispatch, DispatchReshape, Workgroup };
 } // namespace IREE::Codegen
 
 /// Get the corresponding control function for the given scope. The control

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -199,6 +199,8 @@ def CombineResultLayoutTransformationPass :
            ::llvm::cl::values(
              clEnumValN(IREE::Codegen::RelayoutCombinationScope::Dispatch, "dispatch",
                "Combine relayout ops starting from iree_codegen.store_to_buffer"),
+             clEnumValN(IREE::Codegen::RelayoutCombinationScope::DispatchReshape, "dispatch-reshape",
+               "Like dispatch, but only for chains containing an expand/collapse_shape"),
              clEnumValN(IREE::Codegen::RelayoutCombinationScope::Workgroup, "workgroup",
                "Combine relayout ops starting from workgroup forall terminator ops"))
            }]>

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_result_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_result_layout_transformation.mlir
@@ -2,6 +2,8 @@
 // RUN:   -split-input-file %s | FileCheck %s --check-prefixes=DISPATCH-SCOPE
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-combine-result-layout-transformation{scope=workgroup},canonicalize,cse))" \
 // RUN:   -split-input-file %s | FileCheck %s --check-prefixes=WORKGROUP-SCOPE
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-combine-result-layout-transformation{scope=dispatch-reshape},canonicalize,cse))" \
+// RUN:   -split-input-file %s | FileCheck %s --check-prefixes=RESHAPE-SCOPE
 
 func.func @fold_collapse_shape_op(%source : tensor<2x4x16xf32>, %result : memref<8x16xf32>) {
   %collapse = tensor.collapse_shape %source [[0, 1], [2]] : tensor<2x4x16xf32> into tensor<8x16xf32>
@@ -555,3 +557,46 @@ func.func @fold_pack_op_dynamic_inner_tiles(%source : tensor<250x250xf32>, %resu
 // Verify no second padding loop (inner tile size 1 needs no padding)
 //   DISPATCH-SCOPE-NOT:   scf.forall
 //       DISPATCH-SCOPE:   return
+
+// -----
+
+// The `dispatch-reshape` scope folds a relayout chain only when its backward
+// slice contains a non-tileable `expand_shape`/`collapse_shape`. Here the
+// chain is `expand_shape` -> `transpose`, so it folds into a single map_store.
+func.func @reshape_chain_folds_under_dispatch_reshape(
+    %source : tensor<8x16xf32>, %result : memref<4x16x2xf32>) {
+  %expand = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 4, 16]
+      : tensor<8x16xf32> into tensor<2x4x16xf32>
+  %init = tensor.empty() : tensor<4x16x2xf32>
+  %transposed = linalg.transpose ins(%expand : tensor<2x4x16xf32>)
+      outs(%init : tensor<4x16x2xf32>) permutation = [1, 2, 0]
+  iree_codegen.store_to_buffer %transposed, %result
+      : tensor<4x16x2xf32> into memref<4x16x2xf32>
+  return
+}
+// RESHAPE-SCOPE-LABEL: @reshape_chain_folds_under_dispatch_reshape
+//   RESHAPE-SCOPE-NOT:   tensor.expand_shape
+//   RESHAPE-SCOPE-NOT:   linalg.transpose
+//       RESHAPE-SCOPE:   iree_linalg_ext.map_store
+
+// -----
+
+// A pure transpose chain carries no reshape, so the `dispatch-reshape` scope
+// leaves it untouched for tile-and-fuse. The plain `dispatch` scope, which is
+// not gated on a reshape, still folds it into a map_store -- this contrast is
+// the whole point of the `dispatch-reshape` scope.
+func.func @pure_transpose_skipped_under_dispatch_reshape(
+    %source : tensor<2x4x16xf32>, %result : memref<4x16x2xf32>) {
+  %init = tensor.empty() : tensor<4x16x2xf32>
+  %transposed = linalg.transpose ins(%source : tensor<2x4x16xf32>)
+      outs(%init : tensor<4x16x2xf32>) permutation = [1, 2, 0]
+  iree_codegen.store_to_buffer %transposed, %result
+      : tensor<4x16x2xf32> into memref<4x16x2xf32>
+  return
+}
+// DISPATCH-SCOPE-LABEL: @pure_transpose_skipped_under_dispatch_reshape
+//       DISPATCH-SCOPE:   iree_linalg_ext.map_store
+//
+// RESHAPE-SCOPE-LABEL: @pure_transpose_skipped_under_dispatch_reshape
+//       RESHAPE-SCOPE:   linalg.transpose
+//   RESHAPE-SCOPE-NOT:   iree_linalg_ext.map_store

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -370,6 +370,10 @@ getRowMajorTilesMNKShape(MMAIntrinsic intrinsic) {
     return Tuple{1, 16, 4};
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
     return Tuple{16, 1, 4};
+  // 16x16x2: the LHS and RHS tiles *are* row-major (16x2 i8 panels); only the
+  // ACC tile has a non-row-major layout, hand-rolled in `getIntrinsicSwizzle`.
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16:
+    return Tuple{16, 16, 2};
   default:
     if (isGenericScalar(intrinsic)) {
       return Tuple{1, 1, 1};
@@ -464,6 +468,24 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
           Dim::internal(4, Dim::SymbolicMultiplier::ArmSveVLIn128bitUnits));
     }
     return fixupSwizzle(std::move(swizzle));
+  }
+
+  // 16x16x2 i8: LHS/RHS are plain row-major 16x2 i8 panels (handled by the
+  // row-major path below), but the 16x16 i32 ACC tile uses a block-interleaved
+  // layout that mirrors the mmt4d ukernel's in-register `acc[4][4]` scheme.
+  // The lowering computes ACC element (r, c) in the dword lane of intrinsic
+  // `vpdpwssd` #(i, cb) where i = r%4, cb = c%4... — concretely the 256 i32
+  // are ordered (rlo, chi, rhi, clo) with r = 4*rhi + rlo, c = 4*chi + clo.
+  // As a TileSwizzle: split M into [rhi(4), rlo(4)] and N into [chi(4),
+  // clo(4)] (expanded dims 0..3), then permute to (rlo, chi, rhi, clo).
+  if (mma == MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16 &&
+      operandIdx == 2) {
+    TileSwizzle swizzle;
+    swizzle.expandShape().resize(2);
+    swizzle.expandShape()[0] = {Dim::internal(4), Dim::internal(4)};
+    swizzle.expandShape()[1] = {Dim::internal(4), Dim::internal(4)};
+    swizzle.permutation() = {1, 2, 0, 3};
+    return swizzle;
   }
 
   auto maybeMnkTuple = getRowMajorTilesMNKShape(mma);
@@ -582,6 +604,7 @@ std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16:
     return {i8, i8, i32};
   // vpdpbusd: returned types preserve signedness for the cost model to
   // match against the encoding's `element_types`; tile types in IR are
@@ -686,12 +709,88 @@ DataTiledMMAAttr::getDistributionWorkerCount(OpBuilder &builder, Location loc,
   return OpFoldResult();
 }
 
+// Lowers one `MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16` intrinsic: a full
+// 16x16x2 i8 matmul tile, mirroring the mmt4d ukernel's hot loop.
+//
+// Operands (already distributed by the swizzle machinery):
+//   `lhs`, `rhs`: vector<32xi8>, a row-major 16x2 i8 panel.
+//   `acc`:        vector<256xi32>, the 16x16 i32 tile in the block-interleaved
+//                 layout from `getIntrinsicSwizzle` — ordered (rlo, chi, rhi,
+//                 clo) with r = 4*rhi + rlo, c = 4*chi + clo. So the 16 i32 at
+//                 offset (4*rlo + chi)*16 are one `vpdpwssd` accumulator: its
+//                 dword `4*rhi + clo` holds ACC element (r, c).
+//
+// Per call: one `vpmovsxbw` widen of each i8 panel to <32xi16>; 4 `vpshufd`
+// fan each LHS row across its 128-bit lane; 4 128-bit-block broadcasts spread
+// each group of 4 RHS columns across all lanes; 16 `vpdpwssd` over the grid.
+static Value lowerX86Avx512Vnni16x16x2I8(OpBuilder &b, Location loc, Value lhs,
+                                         Value rhs, Value acc) {
+  Type i16 = b.getI16Type();
+  Type i32 = b.getI32Type();
+  auto v32i16 = VectorType::get({32}, i16);
+  auto v16i32 = VectorType::get({16}, i32);
+
+  // Widen each i8 panel to i16 once (one `vpmovsxbw`), then view as 16 i32
+  // dwords so the dword shuffles below are lane-addressable. Dword `x` holds
+  // the (k=0, k=1) i16 pair of LHS row `x` (resp. RHS column `x`).
+  Value lhsDwords = vector::BitCastOp::create(
+      b, loc, v16i32, arith::ExtSIOp::create(b, loc, v32i16, lhs));
+  Value rhsDwords = vector::BitCastOp::create(
+      b, loc, v16i32, arith::ExtSIOp::create(b, loc, v32i16, rhs));
+
+  // lhsDup[i]: `vpshufd` broadcasting dword `4*lane + i` across each 128-bit
+  // lane, so lane L holds LHS row 4*L + i replicated to all 4 dwords.
+  // rhsBcast[cb]: broadcast the 128-bit block of columns [4*cb, 4*cb+4) to all
+  // 4 lanes (a `vbroadcasti32x4`).
+  SmallVector<Value, 4> lhsDup, rhsBcast;
+  for (int s = 0; s < 4; ++s) {
+    SmallVector<int64_t, 16> dupMask, bcastMask;
+    for (int lane = 0; lane < 4; ++lane) {
+      for (int e = 0; e < 4; ++e) {
+        dupMask.push_back(4 * lane + s);
+        bcastMask.push_back(4 * s + e);
+      }
+    }
+    lhsDup.push_back(
+        vector::ShuffleOp::create(b, loc, lhsDwords, lhsDwords, dupMask));
+    rhsBcast.push_back(
+        vector::ShuffleOp::create(b, loc, rhsDwords, rhsDwords, bcastMask));
+  }
+
+  // 16 `vpdpwssd` over the 4x4 grid. Accumulator #(rlo, chi) lives at flat
+  // offset (4*rlo + chi)*16 in the (rlo, chi, rhi, clo)-ordered ACC vector.
+  Value result = acc;
+  for (int rlo = 0; rlo < 4; ++rlo) {
+    for (int chi = 0; chi < 4; ++chi) {
+      int64_t offset = (4 * rlo + chi) * 16;
+      Value accZmm = vector::ExtractStridedSliceOp::create(
+          b, loc, result, ArrayRef<int64_t>{offset}, ArrayRef<int64_t>{16},
+          ArrayRef<int64_t>{1});
+      Value a16 = vector::BitCastOp::create(b, loc, v32i16, lhsDup[rlo]);
+      Value b16 = vector::BitCastOp::create(b, loc, v32i16, rhsBcast[chi]);
+      Value dot =
+          LLVM::CallIntrinsicOp::create(
+              b, loc, v16i32, b.getStringAttr("llvm.x86.avx512.vpdpwssd.512"),
+              ValueRange{accZmm, a16, b16})
+              .getResult(0);
+      result = vector::InsertStridedSliceOp::create(
+          b, loc, dot, result, ArrayRef<int64_t>{offset}, ArrayRef<int64_t>{1});
+    }
+  }
+  return result;
+}
+
 // Lowers a MMAIntrinsic to a llvm.call_intrinsic op, plus any necessary
 // additional ops (potentially broadcasting or widening LHS/RHS or creating an
 // add op if the intrinsic isn't already adding the accumulator).
 static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
                                        MMAIntrinsic intrinsic, Value lhs,
                                        Value rhs, Value acc) {
+  // The 16x16x2 i8 intrinsic processes whole panels and has its own widen /
+  // shuffle scheme; it bypasses the per-row widen + broadcast path below.
+  if (intrinsic == MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16) {
+    return lowerX86Avx512Vnni16x16x2I8(builder, loc, lhs, rhs, acc);
+  }
   // Sign-/float-extend a vector to a wider element type. Used by the
   // *_CASTF32 (f16 → f32) and *_CASTI16 (i8 → i16) variants where the
   // intrinsic only exists at the wider type.

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -154,6 +154,16 @@ def MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8
     : I32EnumAttrCase<"MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8", 0x13C4>;
 def MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8
     : I32EnumAttrCase<"MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8", 0x13C5>;
+// vpdpwssd-based i8 matmul on a full 16x16x2 tile. Unlike the 1x16x2 / 16x1x2
+// CASTI16 variants — which process one M (or N) row per intrinsic and pay an
+// i8->i16 widen + broadcast per row — this consumes whole 16x2 i8 panels:
+// one `vpmovsxbw` widen per panel, 4 `vpshufd` + 4 128-bit-block broadcasts to
+// fan the panels across the 4x4 grid, then 16 `vpdpwssd`. This mirrors the
+// mmt4d ukernel's hot loop. The 16x16 ACC tile is not row-major: it uses a
+// custom TileSwizzle (see `getIntrinsicSwizzle`). Square shape + identical
+// LHS/RHS types make it self-symmetric, so it has no M<->N-swapped sibling.
+def MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16
+    : I32EnumAttrCase<"MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16", 0x13C6>;
 
 // AArch64 SVE `fmla` (f32, f32): N×1×1 or 1×N×1 matmul tile; N is a scalable
 // vector of 4 f32 lanes per 128-bit chunk (see `ArmSveVLIn128bitUnits`).
@@ -205,6 +215,7 @@ def IREECPU_MMAIntrinsic
            MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16,
            MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8,
            MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8,
+           MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16,
 
            // Arm SVE
            MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32, MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32,

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -374,3 +374,48 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   %[[S_BCAST_I32:.+]] = vector.broadcast %{{.+}} : i32 to vector<16xi32>
 //       CHECK:   %[[S_RHS_FLAT:.+]] = vector.bitcast %[[S_BCAST_I32]] : vector<16xi32> to vector<64xi8>
 //       CHECK:   llvm.call_intrinsic "llvm.x86.avx512.vpdpbusd.512"(%{{.+}}, %[[S_RHS_FLAT]], %[[S_LHS_FLAT]])
+
+// -----
+
+// AVX-512 VNNI 16×16×2 i8 → i32. Unlike the 1×16×2 / 16×1×2 CASTI16 variants
+// (one row per intrinsic, with a per-row i8→i16 widen + broadcast), this
+// processes whole 16×2 i8 panels: one `vpmovsxbw` widen per panel, 4 in-lane
+// `vector.shuffle`s (→ `vpshufd`) fanning the LHS rows, 4 128-bit-block
+// `vector.shuffle`s (→ `vbroadcasti32x4`) fanning the RHS columns, then 16
+// `vpdpwssd` over the 4×4 grid. The ACC tile is the block-interleaved
+// `vector<4x4x4x4xi32>` from `getIntrinsicSwizzle`.
+
+#contraction_accesses_16x16 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_avx512vnni_16x16x2_i8(
+    %lhs: vector<16x2xi8>, %rhs: vector<16x2xi8>, %acc: vector<4x4x4x4xi32>)
+    -> vector<4x4x4x4xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_16x16,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<16x2xi8>, vector<16x2xi8> into vector<4x4x4x4xi32>
+  return %0 : vector<4x4x4x4xi32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_avx512vnni_16x16x2_i8
+//       CHECK:   arith.extsi {{.*}} : vector<32xi8> to vector<32xi16>
+//       CHECK:   arith.extsi {{.*}} : vector<32xi8> to vector<32xi16>
+//   CHECK-DAG:   vector.shuffle %{{.+}} [0, 0, 0, 0, 4, 4, 4, 4, 8, 8, 8, 8, 12, 12, 12, 12]
+//   CHECK-DAG:   vector.shuffle %{{.+}} [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
+//       CHECK-COUNT-16:   llvm.call_intrinsic "llvm.x86.avx512.vpdpwssd.512"

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -357,6 +357,7 @@ getMmaIntrinsicRequiredFeatures(IREE::CPU::MMAIntrinsic intr) {
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
+  case MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16:
     return {"+avx512vnni"};
   default:
     return {};
@@ -513,6 +514,7 @@ getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
         MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16,
         MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x4_I32_UI8_I8,
         MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8,
+        MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16,
     };
     for (MMAIntrinsic intr : kAllX86) {
       SmallVector<StringRef> required = getMmaIntrinsicRequiredFeatures(intr);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -652,7 +652,25 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
       .addPass(createConvertAccGEMMToGEMMPass)
       // TODO: Remove the following pass the plumb support for
       // #hal.descriptor_type memory space through the stack.
-      .addPass(createEraseHALDescriptorTypeFromMemRefPass);
+      .addPass(createEraseHALDescriptorTypeFromMemRefPass)
+      // Fold reshape-containing relayout chains (`pack` -> `expand_shape` ->
+      // `transpose`) emitted by encoding materialization for non-row-major
+      // swizzles into a single `iree_linalg_ext.map_store`, before the
+      // dispatch is tiled. This mirrors the GPU configuration pipeline.
+      // Without it, the intervening `tensor.expand_shape` (not a
+      // `TilingInterface` op) blocks producer fusion and leaves an untiled,
+      // whole-tensor `pack` intermediate whose dynamic `tensor.empty`
+      // bufferizes to a bogus unbounded allocation (iree-org/iree#24483);
+      // `map_store` is a scatter with no intermediate buffer. The
+      // `DispatchReshape` scope restricts this to reshape-containing chains so
+      // plain `pack` encodings (which tile fine) are left untouched.
+      .addPass(createBufferizeDispatchTensorLoadStorePass)
+      .addPass([] {
+        CombineResultLayoutTransformationPassOptions options;
+        options.scope =
+            IREE::Codegen::RelayoutCombinationScope::DispatchReshape;
+        return createCombineResultLayoutTransformationPass(options);
+      });
   modulePassManager.addPass(createLLVMCPUSelectLoweringStrategyPass());
   LLVM_DEBUG({
     llvm::dbgs() << "LLVMCPU codegen configuration pass pipeline:\n";

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Utils/CPUUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 
 #include <numeric>
 
@@ -56,7 +57,8 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
     }
 
     if (isa<TilingInterface>(op) &&
-        !isa<tensor::PadOp, linalg::PackOp, linalg::UnPackOp>(op)) {
+        !isa<tensor::PadOp, linalg::PackOp, linalg::UnPackOp,
+             IREE::LinalgExt::MapLoadOp, IREE::LinalgExt::MapStoreOp>(op)) {
       // All other operations that implement this interface are root ops.
       rootOperation = op;
       break;
@@ -74,9 +76,14 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
   }
 
   if (!rootOperation) {
-    // Check for pad/pack/unpack ops by themselves.
+    // Check for relayout ops (pad/pack/unpack and the map_load/map_store
+    // scatter/gather ops that encoding materialization folds into) by
+    // themselves. These are excluded from the sweeps above so that a real
+    // compute op in the same dispatch wins; a pure-relayout dispatch (e.g. a
+    // `set_encoding` dispatch) still picks one of them here.
     for (auto op : llvm::reverse(computeOps)) {
-      if (isa<tensor::PadOp, linalg::PackOp, linalg::UnPackOp>(op)) {
+      if (isa<tensor::PadOp, linalg::PackOp, linalg::UnPackOp,
+              IREE::LinalgExt::MapLoadOp, IREE::LinalgExt::MapStoreOp>(op)) {
         rootOperation = op;
         break;
       }


### PR DESCRIPTION
`MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16` processes a full 16x16x2 i8 matmul tile, mirroring the mmt4d ukernel's hot loop. Unlike the 1x16x2 / 16x1x2 CASTI16 variants -- one row per intrinsic, with a per-row i8->i16 widen + broadcast -- it consumes whole 16x2 i8 panels: one `vpmovsxbw` widen per panel, 4 in-lane + 4 128-bit-block shuffles to fan the panels across a 4x4 grid, then 16 `vpdpwssd`. The 16x16 accumulator uses a block-interleaved `TileSwizzle` so each `vpdpwssd` accumulator is a contiguous register.

i8 inner_tiled matmul, 4096x4096 on Zen 4: 72.5ms -> 52.9ms.

Progress towards #24515.