### PR TITLE
[Aarch64] Fix release CI

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -224,7 +224,7 @@ function install_deps() {
     yum update -y
     # Required for Tracy
     yum install -y libzstd-devel
-    yum install -y clang lld
+    yum install -y clang-20.1.8-2.module_el8.10.0+4062+b20d4441 lld-20.1.8-2.module_el8.10.0+4062+b20d4441
   elif [[ "$uname_m" == "x86_64" ]]; then
     echo "The architecture is x86_64 so assume we are on a managed image with deps"
   else


### PR DESCRIPTION
The Aarch64 release job started failing after yum pulled a new clang that asserts when building MLIR. 

This pins it to the version before that was just working fine.