### PR TITLE
[Codegen][Tuner] Add extra config attributes to the constraint knobs

### DIFF
--- a/compiler/bindings/python/test/api/tuner_api_test.py
+++ b/compiler/bindings/python/test/api/tuner_api_test.py
@@ -746,11 +746,14 @@ _MATERIALIZE_CONSTRAINTS_MODULE = """
     module {
         iree_codegen.smt.constraints
             target = <set = 0>,
-            pipeline = #iree_gpu.pipeline<VectorDistribute>,
+            pipeline = #iree_gpu.pipeline<TileAndFuse>,
             knobs = {
                 workgroup = [#iree_codegen.smt.int_knob<"wg_0">, 1, 1],
                 workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, 1, 1],
-                subgroup_size = #iree_codegen.smt.int_knob<"sg_size">
+                subgroup_size = #iree_codegen.smt.int_knob<"sg_size">,
+                gpu_pipeline_options = {prefetch_num_stages = #iree_codegen.smt.int_knob<"prefetch_num_stages">,
+                                        no_reduce_shared_memory_bank_conflicts = false,
+                                        use_igemm_convolution = #iree_codegen.smt.one_of_knob<"use_igemm_convolution", [false, true]>}
             }
             dims() {
             }
@@ -775,6 +778,8 @@ def test_materialize_compilation_info_happy_path():
             "wg_0": 64,
             "wg_size_x": 128,
             "sg_size": 64,
+            "prefetch_num_stages": 2,
+            "use_igemm_convolution": False,
         },
     )
     assert isinstance(compilation_info, iree_codegen.CompilationInfoAttr)
@@ -786,7 +791,15 @@ def test_materialize_compilation_info_happy_path():
     )
     assert list(translation_info.workgroup_size) == [128, 1, 1]
     assert translation_info.subgroup_size == 64
-    assert str(translation_info.pass_pipeline) == "#iree_gpu.pipeline<VectorDistribute>"
+    assert str(translation_info.pass_pipeline) == "#iree_gpu.pipeline<TileAndFuse>"
+
+    translation_info_str = str(translation_info)
+    assert (
+        "gpu_pipeline_options = #iree_gpu.pipeline_options<"
+        "prefetch_num_stages = 2, "
+        "no_reduce_shared_memory_bank_conflicts = false, "
+        "use_igemm_convolution = false>"
+    ) in translation_info_str
 
 
 @run
@@ -799,6 +812,8 @@ def test_materialize_compilation_info_error_diagnostic():
             {
                 "wg_size_x": 128,
                 "sg_size": 64,
+                "prefetch_num_stages": 2,
+                "use_igemm_convolution": False,
             },
         )
         assert False, "expected missing wg_0 assignment to fail"

--- a/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
@@ -183,19 +183,37 @@ buildCombinedConfigDict(IREE::GPU::LoweringConfigAttr gpuConfig,
   entries.emplace_back("subgroup_size",
                        b.getI64IntegerAttr(translationInfo.getSubgroupSize()));
 
-  // TODO(#23535): This is a temporary hack to add the use_igemm_convolution
-  // knob from translation info config to support IGEMM convolution. It should
-  // be automatically handled by each backend in the future.
+  // TODO(#23535): This is a temporary hack to add GPU pipeline-options knobs
+  // from translation info config. It should be automatically handled by each
+  // backend in the future.
+  int64_t prefetchNumStages = 0;
+  bool noReduceSharedMemoryBankConflicts = false;
   bool useIgemmConvolution = false;
   if (DictionaryAttr config = translationInfo.getConfiguration()) {
     if (auto pipelineOptions =
             dyn_cast_or_null<IREE::GPU::GPUPipelineOptionsAttr>(config.get(
                 IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()))) {
+      if (std::optional<int64_t> prefetchAttr =
+              pipelineOptions.getPrefetchNumStages()) {
+        prefetchNumStages = *prefetchAttr;
+      }
+      if (BoolAttr noReduceAttr =
+              pipelineOptions.getNoReduceSharedMemoryBankConflicts()) {
+        noReduceSharedMemoryBankConflicts = noReduceAttr.getValue();
+      }
       if (BoolAttr useIgemmAttr = pipelineOptions.getUseIgemmConvolution()) {
         useIgemmConvolution = useIgemmAttr.getValue();
       }
     }
   }
+  DictionaryAttr gpuPipelineOptionsDict = DictionaryAttr::get(
+      ctx, {{b.getStringAttr("prefetch_num_stages"),
+             b.getI64IntegerAttr(prefetchNumStages)},
+            {b.getStringAttr("no_reduce_shared_memory_bank_conflicts"),
+             b.getBoolAttr(noReduceSharedMemoryBankConflicts)},
+            {b.getStringAttr("use_igemm_convolution"),
+             b.getBoolAttr(useIgemmConvolution)}});
+  entries.emplace_back("gpu_pipeline_options", gpuPipelineOptionsDict);
   entries.emplace_back("use_igemm_convolution",
                        BoolAttr::get(ctx, useIgemmConvolution));
   return DictionaryAttr::get(ctx, entries);

--- a/compiler/src/iree/compiler/Codegen/Common/test/insert_smt_constraints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/insert_smt_constraints.mlir
@@ -49,10 +49,27 @@ hal.executable @matmul_f32_ex {
 // CHECK-NOT:       iree_codegen.smt.constraints
 // CHECK:           linalg.matmul
 // CHECK:           iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<TileAndFuse>
-// CHECK-NEXT{LITERAL}: knobs = {mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>, reduction = [0, 0, #iree_codegen.smt.int_knob<"red_2">], subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, 0], subgroup_size = #iree_codegen.smt.int_knob<"sg_size">, workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0], workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]}
+// CHECK-NEXT{LITERAL}: knobs = {
+// CHECK-SAME{LITERAL}: gpu_pipeline_options = {no_reduce_shared_memory_bank_conflicts = false, prefetch_num_stages = #iree_codegen.smt.int_knob<"prefetch_num_stages">, use_igemm_convolution = false},
+// CHECK-SAME{LITERAL}: mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>,
+// CHECK-SAME{LITERAL}: promote_operands = [0, 1],
+// CHECK-SAME{LITERAL}: reduction = [0, 0, #iree_codegen.smt.int_knob<"red_2">],
+// CHECK-SAME{LITERAL}: subgroup = [#iree_codegen.smt.int_knob<"sg_0">, #iree_codegen.smt.int_knob<"sg_1">, 0],
+// CHECK-SAME{LITERAL}: subgroup_size = #iree_codegen.smt.int_knob<"sg_size">,
+// CHECK-SAME{LITERAL}: workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0],
+// CHECK-SAME{LITERAL}: workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]}
 //
 // CHECK:           iree_codegen.smt.constraints target = <set = 0>, pipeline = #iree_gpu.pipeline<VectorDistribute>,
-// CHECK-NEXT{LITERAL}: knobs = {mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>, reduction = [0, 0, #iree_codegen.smt.int_knob<"red_2">], subgroup_basis = [[#iree_codegen.smt.int_knob<"sg_m_cnt">, #iree_codegen.smt.int_knob<"sg_n_cnt">, 1], [0, 1, 2]], subgroup_size = #iree_codegen.smt.int_knob<"sg_size">, workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0], workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]}
+// CHECK-NEXT{LITERAL}: knobs = {
+// CHECK-SAME{LITERAL}: gpu_pipeline_options = {no_reduce_shared_memory_bank_conflicts = false, prefetch_num_stages = #iree_codegen.smt.int_knob<"prefetch_num_stages">, use_igemm_convolution = false},
+// CHECK-SAME{LITERAL}: mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", [#iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>]>,
+// CHECK-SAME{LITERAL}: promote_operands = [0, 1],
+// CHECK-SAME{LITERAL}: promotion_types = [#iree_gpu.derived_thread_config, #iree_gpu.derived_thread_config],
+// CHECK-SAME{LITERAL}: reduction = [0, 0, #iree_codegen.smt.int_knob<"red_2">],
+// CHECK-SAME{LITERAL}: subgroup_basis = [[#iree_codegen.smt.int_knob<"sg_m_cnt">, #iree_codegen.smt.int_knob<"sg_n_cnt">, 1], [0, 1, 2]],
+// CHECK-SAME{LITERAL}: subgroup_size = #iree_codegen.smt.int_knob<"sg_size">,
+// CHECK-SAME{LITERAL}: workgroup = [#iree_codegen.smt.int_knob<"wg_0">, #iree_codegen.smt.int_knob<"wg_1">, 0],
+// CHECK-SAME{LITERAL}: workgroup_size = [#iree_codegen.smt.int_knob<"wg_size_x">, #iree_codegen.smt.int_knob<"wg_size_y">, #iree_codegen.smt.int_knob<"wg_size_z">]}
 // CHECK:           ^bb0(%[[M:.+]]: !smt.int, %[[N:.+]]: !smt.int, %[[K:.+]]: !smt.int):
 //
 // Common: static dims.

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_smt_constraints_e2e.mlir
@@ -20,7 +20,11 @@
     {iree_codegen.target_info = #gpu_target}>
 #translation = #iree_codegen.translation_info<
     pipeline = #iree_gpu.pipeline<VectorDistribute>
-    workgroup_size = [64, 1, 1] subgroup_size = 64>
+    workgroup_size = [64, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<
+        prefetch_num_stages = 2,
+        no_reduce_shared_memory_bank_conflicts = false,
+        use_igemm_convolution = false>}>
 
 func.func @matmul_e2e_generated_violation_vd(
     %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
@@ -38,6 +42,9 @@ func.func @matmul_e2e_generated_violation_vd(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [48, 64, 0],
           reduction = [0, 0, 16],
+          promote_operands = [0, 1],
+          promotion_types = [#iree_gpu.derived_thread_config,
+                             #iree_gpu.derived_thread_config],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup_basis = [[1, 1, 1], [0, 1, 2]]}>,
       root_op = #iree_codegen.root_op<set = 0>}
@@ -61,7 +68,11 @@ func.func @matmul_e2e_generated_violation_vd(
     {iree_codegen.target_info = #gpu_target}>
 #translation = #iree_codegen.translation_info<
     pipeline = #iree_gpu.pipeline<VectorDistribute>
-    workgroup_size = [64, 1, 1] subgroup_size = 64>
+    workgroup_size = [64, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<
+        prefetch_num_stages = 2,
+        no_reduce_shared_memory_bank_conflicts = false,
+        use_igemm_convolution = false>}>
 
 func.func @matmul_e2e_missing_required_knob_vd(
     %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
@@ -100,7 +111,11 @@ func.func @matmul_e2e_missing_required_knob_vd(
     {iree_codegen.target_info = #gpu_target}>
 #translation = #iree_codegen.translation_info<
     pipeline = #iree_gpu.pipeline<TileAndFuse>
-    workgroup_size = [64, 1, 1] subgroup_size = 64>
+    workgroup_size = [64, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<
+        prefetch_num_stages = 2,
+        no_reduce_shared_memory_bank_conflicts = false,
+        use_igemm_convolution = false>}>
 
 func.func @matmul_e2e_generated_violation_tf(
     %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
@@ -118,6 +133,7 @@ func.func @matmul_e2e_generated_violation_tf(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [48, 64, 0],
           reduction = [0, 0, 16],
+          promote_operands = [0, 1],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup = [1, 1, 0]}>,
       root_op = #iree_codegen.root_op<set = 0>}
@@ -141,7 +157,11 @@ func.func @matmul_e2e_generated_violation_tf(
     {iree_codegen.target_info = #gpu_target}>
 #translation = #iree_codegen.translation_info<
     pipeline = #iree_gpu.pipeline<VectorDistribute>
-    workgroup_size = [64, 1, 1] subgroup_size = 64>
+    workgroup_size = [64, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<
+        prefetch_num_stages = 2,
+        no_reduce_shared_memory_bank_conflicts = false,
+        use_igemm_convolution = false>}>
 
 func.func @conv_e2e_generated_violation_vd(
     %input: tensor<1x18x130x64xf32>, %filter: tensor<3x3x64x128xf32>)
@@ -160,6 +180,7 @@ func.func @conv_e2e_generated_violation_vd(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [1, 1, 48, 64, 0, 0, 0],
           reduction = [0, 0, 0, 0, 1, 1, 16],
+          promote_operands = [0, 1],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup_basis = [[1, 1, 1, 1, 1, 1, 1],
                             [0, 1, 2, 3, 4, 5, 6]]}>,
@@ -186,7 +207,11 @@ func.func @conv_e2e_generated_violation_vd(
     {iree_codegen.target_info = #gpu_target}>
 #translation = #iree_codegen.translation_info<
     pipeline = #iree_gpu.pipeline<TileAndFuse>
-    workgroup_size = [64, 1, 1] subgroup_size = 64>
+    workgroup_size = [64, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<
+        prefetch_num_stages = 2,
+        no_reduce_shared_memory_bank_conflicts = false,
+        use_igemm_convolution = false>}>
 
 func.func @conv_e2e_generated_violation_tf(
     %input: tensor<1x18x130x64xf32>, %filter: tensor<3x3x64x128xf32>)
@@ -205,6 +230,7 @@ func.func @conv_e2e_generated_violation_tf(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [1, 1, 48, 64, 0, 0, 0],
           reduction = [0, 0, 0, 0, 1, 1, 16],
+          promote_operands = [0, 1],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup = [1, 1, 1, 1, 0, 0, 0]}>,
       root_op = #iree_codegen.root_op<set = 1>,
@@ -233,7 +259,11 @@ func.func @conv_e2e_generated_violation_tf(
     {iree_codegen.target_info = #gpu_target}>
 #translation = #iree_codegen.translation_info<
     pipeline = #iree_gpu.pipeline<VectorDistribute>
-    workgroup_size = [64, 1, 1] subgroup_size = 64>
+    workgroup_size = [64, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<
+        prefetch_num_stages = 2,
+        no_reduce_shared_memory_bank_conflicts = false,
+        use_igemm_convolution = false>}>
 
 func.func @matmul_e2e_constraints_erased_vd(
     %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
@@ -249,6 +279,9 @@ func.func @matmul_e2e_constraints_erased_vd(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [32, 64, 0],
           reduction = [0, 0, 16],
+          promote_operands = [0, 1],
+          promotion_types = [#iree_gpu.derived_thread_config,
+                             #iree_gpu.derived_thread_config],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup_basis = [[1, 1, 1], [0, 1, 2]]}>,
       root_op = #iree_codegen.root_op<set = 0>}
@@ -276,6 +309,7 @@ func.func @conv_e2e_constraints_erased_vd(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [1, 1, 64, 64, 0, 0, 0],
           reduction = [0, 0, 0, 0, 1, 1, 16],
+          promote_operands = [0, 1],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup_basis = [[1, 1, 1, 1, 1, 1, 1],
                             [0, 1, 2, 3, 4, 5, 6]]}>,
@@ -306,7 +340,11 @@ func.func @conv_e2e_constraints_erased_vd(
     {iree_codegen.target_info = #gpu_target}>
 #translation = #iree_codegen.translation_info<
     pipeline = #iree_gpu.pipeline<TileAndFuse>
-    workgroup_size = [64, 1, 1] subgroup_size = 64>
+    workgroup_size = [64, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<
+        prefetch_num_stages = 2,
+        no_reduce_shared_memory_bank_conflicts = false,
+        use_igemm_convolution = false>}>
 
 func.func @matmul_e2e_constraints_erased_tf(
     %lhs: tensor<128x64xf32>, %rhs: tensor<64x256xf32>)
@@ -322,6 +360,7 @@ func.func @matmul_e2e_constraints_erased_tf(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [16, 16, 0],
           reduction = [0, 0, 16],
+          promote_operands = [0, 1],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup = [1, 1, 0]}>,
       root_op = #iree_codegen.root_op<set = 0>}
@@ -349,6 +388,7 @@ func.func @conv_e2e_constraints_erased_tf(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [1, 1, 16, 64, 0, 0, 0],
           reduction = [0, 0, 0, 0, 1, 1, 16],
+          promote_operands = [0, 1],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup = [0, 1, 0, 1, 1, 0, 0]}>,
       root_op = #iree_codegen.root_op<set = 1>,
@@ -576,6 +616,7 @@ func.func @conv_e2e_generated_violation_tf_direct_conv(
       lowering_config = #iree_gpu.lowering_config<{
           workgroup = [1, 1, 48, 64, 0, 0, 0],
           reduction = [0, 0, 0, 0, 1, 1, 16],
+          promote_operands = [0, 1],
           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
           subgroup = [1, 1, 1, 1, 0, 0, 0]}>,
       root_op = #iree_codegen.root_op<set = 2>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -85,7 +85,7 @@ static bool isDefaultTranslationInfoKey(StringRef key) {
 }
 
 static bool isTranslationInfoConfigKey(StringRef key) {
-  return llvm::is_contained({kGpuPipelineOptionsKey}, key);
+  return key == kGpuPipelineOptionsKey;
 }
 
 static bool isFlatMetadataKey(StringRef key) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -72,9 +72,20 @@ constexpr StringLiteral kSubgroupSizeKey = "subgroup_size";
 constexpr StringLiteral kTranslationInfoKey = "translation_info";
 constexpr StringLiteral kPipelineKey = "pipeline";
 constexpr StringLiteral kCodegenSpecKey = "codegen_spec";
+constexpr StringLiteral kGpuPipelineOptionsKey = "gpu_pipeline_options";
+constexpr StringLiteral kPrefetchNumStagesKey = "prefetch_num_stages";
+constexpr StringLiteral kNoReduceSharedMemoryBankConflictsKey =
+    "no_reduce_shared_memory_bank_conflicts";
+constexpr StringLiteral kUseIgemmConvolutionKey = "use_igemm_convolution";
+constexpr StringLiteral kReorderWorkgroupsStrategyKey =
+    "reorder_workgroups_strategy";
 
-static bool isTranslationInfoKey(StringRef key) {
+static bool isDefaultTranslationInfoKey(StringRef key) {
   return llvm::is_contained({kWorkgroupSizeKey, kSubgroupSizeKey}, key);
+}
+
+static bool isTranslationInfoConfigKey(StringRef key) {
+  return llvm::is_contained({kGpuPipelineOptionsKey}, key);
 }
 
 static bool isFlatMetadataKey(StringRef key) {
@@ -105,7 +116,9 @@ appendLoweringConfigEntries(DictionaryAttr source,
                             bool flatSource) {
   for (NamedAttribute entry : source) {
     StringRef key = entry.getName().getValue();
-    if (flatSource && (isFlatMetadataKey(key) || isTranslationInfoKey(key))) {
+    if (flatSource &&
+        (isFlatMetadataKey(key) || isDefaultTranslationInfoKey(key) ||
+         isTranslationInfoConfigKey(key))) {
       continue;
     }
     entries.push_back(entry);
@@ -117,12 +130,76 @@ static DictionaryAttr buildTranslationConfiguration(MLIRContext *ctx,
   SmallVector<NamedAttribute> entries;
   for (NamedAttribute entry : source) {
     StringRef key = entry.getName().getValue();
-    if (isTranslationInfoKey(key) || key == kCodegenSpecKey) {
+    if (isDefaultTranslationInfoKey(key) || key == kCodegenSpecKey) {
       continue;
     }
     entries.push_back(entry);
   }
   return DictionaryAttr::get(ctx, entries);
+}
+
+static FailureOr<DictionaryAttr> buildGpuPipelineOptionsConfiguration(
+    MLIRContext *ctx, Attribute gpuPipelineOptions,
+    function_ref<InFlightDiagnostic()> emitError) {
+  auto optionsDict = dyn_cast<DictionaryAttr>(gpuPipelineOptions);
+  if (!optionsDict) {
+    emitError() << "expected '" << kGpuPipelineOptionsKey
+                << "' to be a dictionary";
+    return failure();
+  }
+
+  unsigned prefetchNumStages = 0;
+  if (Attribute prefetchAttr = optionsDict.get(kPrefetchNumStagesKey)) {
+    auto prefetchInt = dyn_cast<IntegerAttr>(prefetchAttr);
+    if (!prefetchInt || prefetchInt.getInt() < 0) {
+      emitError() << "expected '" << kPrefetchNumStagesKey
+                  << "' to be a non-negative integer";
+      return failure();
+    }
+    prefetchNumStages = static_cast<unsigned>(prefetchInt.getInt());
+  }
+
+  bool noReduceSharedMemoryBankConflicts = false;
+  if (Attribute noReduceAttr =
+          optionsDict.get(kNoReduceSharedMemoryBankConflictsKey)) {
+    auto noReduceBool = dyn_cast<BoolAttr>(noReduceAttr);
+    if (!noReduceBool) {
+      emitError() << "expected '" << kNoReduceSharedMemoryBankConflictsKey
+                  << "' to be a boolean";
+      return failure();
+    }
+    noReduceSharedMemoryBankConflicts = noReduceBool.getValue();
+  }
+
+  bool useIgemmConvolution = false;
+  if (Attribute useIgemmAttr = optionsDict.get(kUseIgemmConvolutionKey)) {
+    auto useIgemmBool = dyn_cast<BoolAttr>(useIgemmAttr);
+    if (!useIgemmBool) {
+      emitError() << "expected '" << kUseIgemmConvolutionKey
+                  << "' to be a boolean";
+      return failure();
+    }
+    useIgemmConvolution = useIgemmBool.getValue();
+  }
+
+  std::optional<ReorderWorkgroupsStrategy> reorderWorkgroupsStrategy;
+  if (Attribute reorderStrategyAttr =
+          optionsDict.get(kReorderWorkgroupsStrategyKey)) {
+    auto reorderAttr =
+        dyn_cast<ReorderWorkgroupsStrategyAttr>(reorderStrategyAttr);
+    if (!reorderAttr) {
+      emitError() << "expected '" << kReorderWorkgroupsStrategyKey
+                  << "' to be a reorder strategy attr";
+      return failure();
+    }
+    reorderWorkgroupsStrategy = reorderAttr.getValue();
+  }
+
+  auto typedOptions = GPUPipelineOptionsAttr::get(
+      ctx, prefetchNumStages, noReduceSharedMemoryBankConflicts,
+      useIgemmConvolution, reorderWorkgroupsStrategy);
+  return DictionaryAttr::get(
+      ctx, {{StringAttr::get(ctx, kGpuPipelineOptionsKey), typedOptions}});
 }
 
 static int64_t extractI64(Attribute attr) {
@@ -3520,6 +3597,15 @@ FailureOr<Attribute> PipelineAttr::materializeConfigurationAttr(
   DictionaryAttr configuration;
   if (nestedTranslationSource) {
     configuration = buildTranslationConfiguration(ctx, translationSource);
+  } else if (Attribute gpuPipelineOptions =
+                 materializedKnobs.get(kGpuPipelineOptionsKey)) {
+    FailureOr<DictionaryAttr> optionsConfig =
+        buildGpuPipelineOptionsConfiguration(ctx, gpuPipelineOptions,
+                                             emitError);
+    if (failed(optionsConfig)) {
+      return failure();
+    }
+    configuration = *optionsConfig;
   }
 
   Attribute pipeline = *this;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -67,16 +67,29 @@ struct TileAndFuseConstraintOptions {
 //   reduction = [..., ..., red_#], only innermost K dim is knobbed.
 //   mma_kind = mma_idx
 //   subgroup_basis = [[..., sg_m_cnt, sg_n_cnt, ...], [0, 1, 2, ...]]
+//   promote_operands = [0, 1]
+//   promotion_types=[#iree_gpu.derived_thread_config, ...] optional for matmul
+
+// Translation info knob list (VD):
+//   workgroup_size = [wg_size_x, wg_size_y, wg_size_z]
+//   subgroup_size = sg_size
+//   gpu_pipeline_options = {prefetch_num_stages = prefetch_num_stages,
+//   no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution =
+//   false}
 
 // Lowering config knob list for TileAndFuse (TF):
 //   workgroup = [wg_#, wg_#, ...], B, M, N dims are knobbed.
 //   reduction = [..., ..., red_#], only innermost K dim is knobbed.
 //   mma_kind = mma_idx
 //   subgroup = [sg_#, sg_#, ...], M and N dims are knobbed.
+//   promote_operands = [0, 1]
 
 // Translation info knob list (shared by both pipelines):
 //   workgroup_size = [wg_size_x, wg_size_y, wg_size_z]
 //   subgroup_size = sg_size
+//   gpu_pipeline_options = {prefetch_num_stages = prefetch_num_stages,
+//   no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution =
+//   use_igemm_idx}
 
 // Translation info knob list (TileAndFuse only):
 //   use_igemm_convolution = use_igemm_idx (one_of_knob<bool>)
@@ -88,6 +101,12 @@ constexpr StringLiteral kKnobSubgroupBasisKey = "subgroup_basis";
 constexpr StringLiteral kKnobSubgroupKey = "subgroup";
 constexpr StringLiteral kKnobWorkgroupSizeKey = "workgroup_size";
 constexpr StringLiteral kKnobSubgroupSizeKey = "subgroup_size";
+constexpr StringLiteral kKnobPromoteOperandsKey = "promote_operands";
+constexpr StringLiteral kKnobPromotionTypesKey = "promotion_types";
+constexpr StringLiteral kKnobGpuPipelineOptionsKey = "gpu_pipeline_options";
+constexpr StringLiteral kKnobPrefetchNumStagesKey = "prefetch_num_stages";
+constexpr StringLiteral kKnobNoReduceSharedMemoryBankConflictsKey =
+    "no_reduce_shared_memory_bank_conflicts";
 constexpr StringLiteral kKnobUseIgemmConvolutionKey = "use_igemm_convolution";
 
 // SMT variable names for knob values used in constraints.
@@ -120,7 +139,6 @@ constexpr int64_t kUnitTileDimVal = 1;
 // codegen output from KernelConfig.cpp's setAttention...: `workgroup`,
 // `reduction`, `promote_operands` + `promotion_types`,
 // `decomposition_config`).
-constexpr StringLiteral kKnobPromoteOperandsKey = "promote_operands";
 // `kDecompositionConfigKey` lives in IREECodegenAttrs.h so the
 // materializer reads back the same string this emitter writes.
 
@@ -414,11 +432,11 @@ getFusedIgemmKDimIndices(linalg::LinalgOp linalgOp,
   return fusedConvKDims;
 }
 
-/// Build the VectorDistribute knobs dict for contraction-like dims.
-static DictionaryAttr
-buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
-                               const ContractionLikeDims &dims,
-                               ArrayRef<Attribute> compatibleMMAs) {
+/// Build the VectorDistribute knob dictionary entries for contraction-like
+/// dims.
+static SmallVector<NamedAttribute> buildVectorDistributeBasicKnobsDict(
+    MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
+    const ContractionLikeDims &dims, ArrayRef<Attribute> compatibleMMAs) {
   SmallVector<NamedAttribute> knobsEntries;
 
   // Build workgroup entries from lowering config semantics: untiled dims get 0,
@@ -488,19 +506,61 @@ buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
   knobsEntries.emplace_back(kKnobSubgroupSizeKey,
                             IntKnobAttr::get(ctx, kKnobSgSizeName));
 
-  return DictionaryAttr::get(ctx, knobsEntries);
+  return knobsEntries;
 }
 
-/// Build the TileAndFuse knobs dict for contraction-like dims.
-/// When `options.isConv` is true, exposes both use_igemm_convolution options
-/// in one_of_knob. The emitted constraints then pin a single branch.
-static DictionaryAttr
-buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
-                          const ContractionLikeDims &dims,
-                          ArrayRef<Attribute> compatibleMMAs,
-                          TileAndFuseConstraintOptions options = {}) {
-  bool isConv = options.isConv;
-  ArrayRef<unsigned> fusedIgemmKDims = options.fusedIgemmKDims;
+/// Build the VectorDistribute knob dictionary entries for contraction-like
+/// dims.
+static SmallVector<NamedAttribute>
+buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
+                               const ContractionLikeDims &dims,
+                               ArrayRef<Attribute> compatibleMMAs,
+                               bool isConv) {
+  SmallVector<NamedAttribute> knobsEntries =
+      buildVectorDistributeBasicKnobsDict(ctx, loopInfo, dims, compatibleMMAs);
+
+  // TODO: IREE constraints currently hardcoded some optional knob attr for VD
+  // matmul and conv: promote_operands = [0, 1]
+  SmallVector<Attribute> promoteOperandsEntries = {makeIntAttr(ctx, 0),
+                                                   makeIntAttr(ctx, 1)};
+  knobsEntries.emplace_back(kKnobPromoteOperandsKey,
+                            ArrayAttr::get(ctx, promoteOperandsEntries));
+
+  // TODO: This is hardcoded by IREE constraints:
+  // promotion_types = [#iree_gpu.derived_thread_config,
+  // #iree_gpu.derived_thread_config]
+  if (!isConv) {
+    SmallVector<Attribute> promotionTypesEntries(
+        2, IREE::GPU::DerivedThreadConfigAttr::get(ctx));
+    knobsEntries.emplace_back(kKnobPromotionTypesKey,
+                              ArrayAttr::get(ctx, promotionTypesEntries));
+  }
+
+  // Add gpu pipeline options as a nested translation config entry.
+  // TODO: This is hardcoded by IREE constraints:
+  // prefetch_num_stages = IntKnob, default to 2 later on in the constraints.
+  // no_reduce_shared_memory_bank_conflicts = false
+  // use_igemm_convolution = false
+  DictionaryAttr gpuPipelineOptionsEntries = DictionaryAttr::get(
+      ctx, {{StringAttr::get(ctx, kKnobPrefetchNumStagesKey),
+             IntKnobAttr::get(ctx, kKnobPrefetchNumStagesKey)},
+            {StringAttr::get(ctx, kKnobNoReduceSharedMemoryBankConflictsKey),
+             BoolAttr::get(ctx, false)},
+            {StringAttr::get(ctx, kKnobUseIgemmConvolutionKey),
+             BoolAttr::get(ctx, false)}});
+  knobsEntries.emplace_back(kKnobGpuPipelineOptionsKey,
+                            gpuPipelineOptionsEntries);
+
+  return knobsEntries;
+}
+
+/// Build the basic TileAndFuse knob dictionary entries for contraction-like
+/// dims.
+static SmallVector<NamedAttribute>
+buildTileAndFuseBasicKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
+                               const ContractionLikeDims &dims,
+                               ArrayRef<Attribute> compatibleMMAs,
+                               ArrayRef<unsigned> fusedIgemmKDims = {}) {
   SmallVector<NamedAttribute> knobsEntries;
 
   unsigned layoutNumLoops = loopInfo.numLoops;
@@ -569,14 +629,55 @@ buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
   knobsEntries.emplace_back(kKnobSubgroupSizeKey,
                             IntKnobAttr::get(ctx, kKnobSgSizeName));
 
-  // Conv-only: expose both branches via one_of and pin inside constraints.
+  // TODO: IREE constraints currently hardcoded some optional knob attr for TF
+  // matmul and conv:
+  // promote_operands = [0, 1]
+  SmallVector<Attribute> promoteOperandsEntries = {makeIntAttr(ctx, 0),
+                                                   makeIntAttr(ctx, 1)};
+  knobsEntries.emplace_back(kKnobPromoteOperandsKey,
+                            ArrayAttr::get(ctx, promoteOperandsEntries));
+
+  return knobsEntries;
+}
+
+/// Build the TileAndFuse knobs dict for contraction-like dims.
+/// For convolution, gpu_pipeline_options.use_igemm_convolution is emitted as a
+/// one_of_knob<bool>. The emitted constraints then pin a single branch.
+static DictionaryAttr
+buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
+                          const ContractionLikeDims &dims,
+                          ArrayRef<Attribute> compatibleMMAs,
+                          TileAndFuseConstraintOptions options = {}) {
+  bool isConv = options.isConv;
+  SmallVector<NamedAttribute> knobsEntries = buildTileAndFuseBasicKnobsDict(
+      ctx, loopInfo, dims, compatibleMMAs, options.fusedIgemmKDims);
+
+  // TODO: This is hardcoded by IREE constraints:
+  // no_reduce_shared_memory_bank_conflicts = false
+  // use_igemm_convolution = false(matmul), one_of_knob<bool>(conv)
+  // prefetch_num_stages is an IntKnob and is pinned in constraints.
+  Attribute useIgemmConvolutionAttr = BoolAttr::get(ctx, false);
   if (isConv) {
     SmallVector<Attribute> useIgemmOptions = {BoolAttr::get(ctx, false),
                                               BoolAttr::get(ctx, true)};
-    knobsEntries.emplace_back(
-        kKnobUseIgemmConvolutionKey,
-        OneOfKnobAttr::get(ctx, kKnobUseIgemmConvolutionName, useIgemmOptions));
+    useIgemmConvolutionAttr =
+        OneOfKnobAttr::get(ctx, kKnobUseIgemmConvolutionName, useIgemmOptions);
   }
+  DictionaryAttr gpuPipelineOptionsEntries = DictionaryAttr::get(
+      ctx, {{StringAttr::get(ctx, kKnobPrefetchNumStagesKey),
+             IntKnobAttr::get(ctx, kKnobPrefetchNumStagesKey)},
+            {StringAttr::get(ctx, kKnobNoReduceSharedMemoryBankConflictsKey),
+             BoolAttr::get(ctx, false)},
+            {StringAttr::get(ctx, kKnobUseIgemmConvolutionKey),
+             useIgemmConvolutionAttr}});
+  knobsEntries.emplace_back(kKnobGpuPipelineOptionsKey,
+                            gpuPipelineOptionsEntries);
+
+  // TODO: Enable support for optional TF matmul/conv knob attrs:
+  // promotion_types = [...]
+  // padding = [...]
+  // padding_conv = [...]
+  // convert_acc_gemm = ...
 
   return DictionaryAttr::get(ctx, knobsEntries);
 }
@@ -655,6 +756,7 @@ static LogicalResult emitVectorDistributeConstraints(
   Value wgSizeX = mkKnob(builder, loc, kKnobWgSizeXName);
   Value wgSizeY = mkKnob(builder, loc, kKnobWgSizeYName);
   Value wgSizeZ = mkKnob(builder, loc, kKnobWgSizeZName);
+  Value prefetchNumStages = mkKnob(builder, loc, kKnobPrefetchNumStagesKey);
 
   // Create intermediate variables.
   // Do not create these as knobs because they are not in the knob dict
@@ -845,6 +947,14 @@ static LogicalResult emitVectorDistributeConstraints(
       builder, loc, redK, mmaMLookup,
       llvm::join_items("", redKName, " must be divisible by mma_m"));
 
+  // Constraint 10: Add gpu pipeline options.
+  // TODO: Expand prefetch_num_stages tunable values, currently set to
+  // default 2.
+  Value prefetchNumStagesEq = smt::EqOp::create(builder, loc, prefetchNumStages,
+                                                mkIntConst(builder, loc, 2));
+  AssertOp::create(builder, loc, prefetchNumStagesEq,
+                   "prefetch_num_stages == 2");
+
   return success();
 }
 
@@ -906,6 +1016,7 @@ static LogicalResult emitTileAndFuseConstraints(
   Value wgSizeX = mkKnob(builder, loc, kKnobWgSizeXName);
   Value wgSizeY = mkKnob(builder, loc, kKnobWgSizeYName);
   Value wgSizeZ = mkKnob(builder, loc, kKnobWgSizeZName);
+  Value prefetchNumStages = mkKnob(builder, loc, kKnobPrefetchNumStagesKey);
   if (options.isConv) {
     Value useIgemmIdx = mkKnob(builder, loc, kKnobUseIgemmConvolutionName);
     int64_t expectedUseIgemmIdx = options.useIgemm ? 1 : 0;
@@ -1143,6 +1254,19 @@ static LogicalResult emitTileAndFuseConstraints(
       smt::EqOp::create(builder, loc, wgSizeZ, mkIntConst(builder, loc, 1));
   AssertOp::create(builder, loc, wgZEq, "wg_size_z == 1");
 
+  // Constraint 7: Add gpu pipeline options.
+  // TODO: Expand prefetch_num_stages tunable values, currently pinned to
+  // default value 2 for matmul and igemm conv, 0 for direct conv.
+  int64_t expectedPrefetchNumStages = options.useIgemm ? 0 : 2;
+  Value prefetchNumStagesEq =
+      smt::EqOp::create(builder, loc, prefetchNumStages,
+                        mkIntConst(builder, loc, expectedPrefetchNumStages));
+  AssertOp::create(
+      builder, loc, prefetchNumStagesEq,
+      options.useIgemm
+          ? "prefetch_num_stages == 0 (use_igemm_convolution=true)"
+          : "prefetch_num_stages == 2 (use_igemm_convolution=false)");
+
   return success();
 }
 
@@ -1151,6 +1275,23 @@ static LogicalResult emitTileAndFuseConstraints(
 static LogicalResult
 emitVectorDistributeAttentionConstraintsForOp(Operation *rootOp,
                                               RootOpAttr rootOpAttr);
+/// Emit VectorDistribute ConstraintsOps for one contraction-like root op.
+static LogicalResult emitVectorDistributeConstraintsOps(
+    OpBuilder &builder, Operation *rootOp, linalg::LinalgOp linalgOp,
+    RootOpAttr rootOpAttr, IREE::GPU::PipelineAttr pipelineAttr,
+    const RootOpLoopInfo &loopInfo, const ContractionLikeDims &dims,
+    IREE::GPU::TargetAttr gpuTarget, ArrayRef<Attribute> compatibleMMAs,
+    bool isConv) {
+  MLIRContext *ctx = rootOp->getContext();
+  SmallVector<NamedAttribute> knobEntries = buildVectorDistributeKnobsDict(
+      ctx, loopInfo, dims, compatibleMMAs, isConv);
+  DictionaryAttr knobs = DictionaryAttr::get(ctx, knobEntries);
+  ConstraintsOpShell shell =
+      createConstraintsOpShell(builder, rootOp, rootOpAttr, pipelineAttr, knobs,
+                               loopInfo.numLoops, loopInfo.indexingMaps);
+  return emitVectorDistributeConstraints(builder, linalgOp, dims, gpuTarget,
+                                         shell.smtDimArgs, compatibleMMAs);
+}
 /// Emit TileAndFuse ConstraintsOps for one root op. For convolution roots,
 /// emits two ops (one with use_igemm_convolution = false and one with true);
 /// for non-conv roots, emits a single op.
@@ -1251,15 +1392,10 @@ emitConstraintsForOp(Operation *rootOp, RootOpAttr rootOpAttr,
   auto pipelineAttr = IREE::GPU::PipelineAttr::get(ctx, pipeline);
 
   switch (pipeline) {
-  case IREE::GPU::LoweringPipeline::VectorDistribute: {
-    DictionaryAttr knobs =
-        buildVectorDistributeKnobsDict(ctx, *loopInfo, *dims, compatibleMMAs);
-    ConstraintsOpShell shell = createConstraintsOpShell(
-        builder, rootOp, rootOpAttr, pipelineAttr, knobs, loopInfo->numLoops,
-        loopInfo->indexingMaps);
-    return emitVectorDistributeConstraints(builder, linalgOp, *dims, gpuTarget,
-                                           shell.smtDimArgs, compatibleMMAs);
-  }
+  case IREE::GPU::LoweringPipeline::VectorDistribute:
+    return emitVectorDistributeConstraintsOps(
+        builder, rootOp, linalgOp, rootOpAttr, pipelineAttr, *loopInfo, *dims,
+        gpuTarget, compatibleMMAs, isConv);
   case IREE::GPU::LoweringPipeline::TileAndFuse:
     return emitTileAndFuseConstraintsOps(builder, rootOp, linalgOp, rootOpAttr,
                                          pipelineAttr, *loopInfo, *dims,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConstraintGenerator.cpp
@@ -521,8 +521,8 @@ buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
 
   // TODO: IREE constraints currently hardcoded some optional knob attr for VD
   // matmul and conv: promote_operands = [0, 1]
-  SmallVector<Attribute> promoteOperandsEntries = {makeIntAttr(ctx, 0),
-                                                   makeIntAttr(ctx, 1)};
+  Attribute promoteOperandsEntries[] = {makeIntAttr(ctx, 0),
+                                        makeIntAttr(ctx, 1)};
   knobsEntries.emplace_back(kKnobPromoteOperandsKey,
                             ArrayAttr::get(ctx, promoteOperandsEntries));
 
@@ -530,8 +530,9 @@ buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
   // promotion_types = [#iree_gpu.derived_thread_config,
   // #iree_gpu.derived_thread_config]
   if (!isConv) {
-    SmallVector<Attribute> promotionTypesEntries(
-        2, IREE::GPU::DerivedThreadConfigAttr::get(ctx));
+    Attribute promotionTypesEntries[] = {
+        IREE::GPU::DerivedThreadConfigAttr::get(ctx),
+        IREE::GPU::DerivedThreadConfigAttr::get(ctx)};
     knobsEntries.emplace_back(kKnobPromotionTypesKey,
                               ArrayAttr::get(ctx, promotionTypesEntries));
   }
@@ -542,12 +543,11 @@ buildVectorDistributeKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
   // no_reduce_shared_memory_bank_conflicts = false
   // use_igemm_convolution = false
   DictionaryAttr gpuPipelineOptionsEntries = DictionaryAttr::get(
-      ctx, {{StringAttr::get(ctx, kKnobPrefetchNumStagesKey),
-             IntKnobAttr::get(ctx, kKnobPrefetchNumStagesKey)},
-            {StringAttr::get(ctx, kKnobNoReduceSharedMemoryBankConflictsKey),
-             BoolAttr::get(ctx, false)},
-            {StringAttr::get(ctx, kKnobUseIgemmConvolutionKey),
-             BoolAttr::get(ctx, false)}});
+      ctx,
+      {{kKnobPrefetchNumStagesKey,
+        IntKnobAttr::get(ctx, kKnobPrefetchNumStagesKey)},
+       {kKnobNoReduceSharedMemoryBankConflictsKey, BoolAttr::get(ctx, false)},
+       {kKnobUseIgemmConvolutionKey, BoolAttr::get(ctx, false)}});
   knobsEntries.emplace_back(kKnobGpuPipelineOptionsKey,
                             gpuPipelineOptionsEntries);
 
@@ -632,8 +632,8 @@ buildTileAndFuseBasicKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
   // TODO: IREE constraints currently hardcoded some optional knob attr for TF
   // matmul and conv:
   // promote_operands = [0, 1]
-  SmallVector<Attribute> promoteOperandsEntries = {makeIntAttr(ctx, 0),
-                                                   makeIntAttr(ctx, 1)};
+  Attribute promoteOperandsEntries[] = {makeIntAttr(ctx, 0),
+                                        makeIntAttr(ctx, 1)};
   knobsEntries.emplace_back(kKnobPromoteOperandsKey,
                             ArrayAttr::get(ctx, promoteOperandsEntries));
 
@@ -664,12 +664,11 @@ buildTileAndFuseKnobsDict(MLIRContext *ctx, const RootOpLoopInfo &loopInfo,
         OneOfKnobAttr::get(ctx, kKnobUseIgemmConvolutionName, useIgemmOptions);
   }
   DictionaryAttr gpuPipelineOptionsEntries = DictionaryAttr::get(
-      ctx, {{StringAttr::get(ctx, kKnobPrefetchNumStagesKey),
-             IntKnobAttr::get(ctx, kKnobPrefetchNumStagesKey)},
-            {StringAttr::get(ctx, kKnobNoReduceSharedMemoryBankConflictsKey),
-             BoolAttr::get(ctx, false)},
-            {StringAttr::get(ctx, kKnobUseIgemmConvolutionKey),
-             useIgemmConvolutionAttr}});
+      ctx,
+      {{kKnobPrefetchNumStagesKey,
+        IntKnobAttr::get(ctx, kKnobPrefetchNumStagesKey)},
+       {kKnobNoReduceSharedMemoryBankConflictsKey, BoolAttr::get(ctx, false)},
+       {kKnobUseIgemmConvolutionKey, useIgemmConvolutionAttr}});
   knobsEntries.emplace_back(kKnobGpuPipelineOptionsKey,
                             gpuPipelineOptionsEntries);
 


### PR DESCRIPTION
This PR adds missing required knobs, such as `promote_operand=[...], gpu_pipeline_options={...}` to the dict. This produces the same `compilation_info` config for tuning candidates as the old tuner.

This PR does not modify the constraint boundary. The newly added constraints are assigned fixed constants as placeholders.