### PR TITLE
[Codegen][Tuner] Add codegen flag to emit pipeline constraints in configured IR

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -567,9 +567,11 @@ public:
     modulePassManager.addPass(createLLVMGPUSelectLoweringStrategyPass(
         LLVMGPUSelectLoweringStrategyPassOptions{codegenOptions}));
     if (shouldEmitPipelineConstraints()) {
-      FunctionLikeNest(modulePassManager)
-          .addPass(createInsertSMTConstraintsPass)
-          .addPass(createVerifySMTConstraintsPass);
+      FunctionLikeNest funcPassManager(modulePassManager);
+      funcPassManager.addPass(createInsertSMTConstraintsPass);
+      if (shouldVerifyPipelineConstraints()) {
+        funcPassManager.addPass(createVerifySMTConstraintsPass);
+      }
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VerifyPipelineConstraints.cpp
@@ -517,8 +517,12 @@ void VerifySMTConstraintsPass::runOnOperation() {
     return;
   }
 
-  // Erase all constraints ops on scope exit regardless of outcome.
+  // Erase all constraints ops on scope exit unless the caller explicitly wants
+  // the configured IR to carry the constraints for external tools.
   llvm::scope_exit eraseAll([&]() {
+    if (shouldPreservePipelineConstraints()) {
+      return;
+    }
     for (IREE::Codegen::ConstraintsOp op : constraintsOps) {
       op.erase();
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -44,10 +44,20 @@ static ArrayAttr getIndexArrayAttr(MLIRContext *context,
 
 bool shouldSetTunerAttributes() {
   return CodegenOptions::setTunerAttributes ||
+         CodegenOptions::verifyPipelineConstraints ||
          CodegenOptions::emitPipelineConstraints;
 }
 
 bool shouldEmitPipelineConstraints() {
+  return CodegenOptions::verifyPipelineConstraints ||
+         CodegenOptions::emitPipelineConstraints;
+}
+
+bool shouldVerifyPipelineConstraints() {
+  return CodegenOptions::verifyPipelineConstraints;
+}
+
+bool shouldPreservePipelineConstraints() {
   return CodegenOptions::emitPipelineConstraints;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -31,6 +31,10 @@ using ScalableTileFlagsListTypeRef = ArrayRef<SmallVector<bool>>;
 bool shouldSetTunerAttributes();
 /// Returns whether pipeline constraints should be emitted for root ops.
 bool shouldEmitPipelineConstraints();
+/// Returns whether emitted pipeline constraints should be verified.
+bool shouldVerifyPipelineConstraints();
+/// Returns whether emitted pipeline constraints should remain in the IR.
+bool shouldPreservePipelineConstraints();
 } // namespace mlir::iree_compiler
 
 // clang-format off

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1151,9 +1151,11 @@ static void buildLLVMGPUCodegenConfigurationPassPipelineImpl(
   modulePassManager.addPass(createMaterializeUserConfigsPass());
   modulePassManager.addPass(createLLVMGPUSelectLoweringStrategyPass());
   if (shouldEmitPipelineConstraints()) {
-    FunctionLikeNest(modulePassManager)
-        .addPass(createInsertSMTConstraintsPass)
-        .addPass(createVerifySMTConstraintsPass);
+    FunctionLikeNest funcPassManager(modulePassManager);
+    funcPassManager.addPass(createInsertSMTConstraintsPass);
+    if (shouldVerifyPipelineConstraints()) {
+      funcPassManager.addPass(createVerifySMTConstraintsPass);
+    }
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -54,6 +54,7 @@ void applyOptLevelDefaults(CodegenOptionsT &opts,
 
 std::string CodegenOptions::tuningSpecPath = "";
 bool CodegenOptions::setTunerAttributes = false;
+bool CodegenOptions::verifyPipelineConstraints = false;
 bool CodegenOptions::emitPipelineConstraints = false;
 
 llvm::OptimizationLevel
@@ -94,9 +95,16 @@ void CodegenOptions::bindOptions(OptionsBinder &binder) {
 
   binder.opt<bool>(
       "iree-codegen-experimental-verify-pipeline-constraints",
-      emitPipelineConstraints, llvm::cl::cat(category),
+      verifyPipelineConstraints, llvm::cl::cat(category),
       llvm::cl::desc("Emit and verify SMT pipeline constraints for root ops. "
                      "Implies --iree-codegen-add-tuner-attributes."));
+  binder.opt<bool>(
+      "iree-codegen-emit-pipeline-constraints", emitPipelineConstraints,
+      llvm::cl::cat(category),
+      llvm::cl::desc("Emit SMT pipeline constraints and keep them in the IR. "
+                     "Implies --iree-codegen-add-tuner-attributes. Intended "
+                     "for use with "
+                     "--compile-to=executable-configurations."));
 }
 
 void CPUCodegenOptions::setWithOptLevel(llvm::OptimizationLevel level) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -38,7 +38,10 @@ struct CodegenOptions {
   // Whether to add attributes for the tuner on root ops.
   static bool setTunerAttributes;
 
-  // Whether to emit pipeline constraints for root ops.
+  // Whether to emit and verify pipeline constraints for root ops.
+  static bool verifyPipelineConstraints;
+
+  // Whether to emit and keep pipeline constraints in the IR.
   static bool emitPipelineConstraints;
 
   void bindOptions(OptionsBinder &binder);


### PR DESCRIPTION
This added flag will emit constraints in the benchmark IR for the tuner to walk and collect.