### PR TITLE
[CI] Fix spirv rocm filter when rocm is not build

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -6,6 +6,7 @@
 
 # Tests for common transforms.
 
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 
@@ -68,8 +69,6 @@ iree_lit_test_suite(
             "rocdl_pipeline_spirv_test.mlir",
             "rocdl_pipeline_test.mlir",
             "rocdl_prepare_for_spirv.mlir",
-            "rocm_spirv_serialize.mlir",
-            "rocm_spirv_serialize_target_attr.mlir",
             "sort_pipeline_test.mlir",
             "tensorcore_vectorization.mlir",
             "transform_dialect_bufferize.mlir",
@@ -93,6 +92,8 @@ iree_lit_test_suite(
         # tensor_dialect_*_spec is a an MLIR file that specifies a
         # transformation, it needs to be included as data.
         exclude = [
+            "rocm_spirv_serialize.mlir",
+            "rocm_spirv_serialize_target_attr.mlir",
             "transform_dialect_codegen_bufferize_spec.mlir",
             "transform_dialect_codegen_foreach_to_gpu_spec.mlir",
             "transform_dialect_codegen_vector_distribution_spec.mlir",
@@ -110,4 +111,31 @@ iree_lit_test_suite(
         "//tools:iree-opt",
         "@llvm-project//llvm:FileCheck",
     ],
+)
+
+iree_cmake_extra_content(
+    content = """
+if(IREE_TARGET_BACKEND_ROCM)
+""",
+    inline = True,
+)
+
+iree_lit_test_suite(
+    name = "lit_rocm",
+    srcs = [
+        "rocm_spirv_serialize.mlir",
+        "rocm_spirv_serialize_target_attr.mlir",
+    ],
+    cfg = "//compiler:lit.cfg.py",
+    tools = [
+        "//tools:iree-opt",
+        "@llvm-project//llvm:FileCheck",
+    ],
+)
+
+iree_cmake_extra_content(
+    content = """
+endif()
+""",
+    inline = True,
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -63,8 +63,6 @@ iree_lit_test_suite(
     "rocdl_pipeline_spirv_test.mlir"
     "rocdl_pipeline_test.mlir"
     "rocdl_prepare_for_spirv.mlir"
-    "rocm_spirv_serialize.mlir"
-    "rocm_spirv_serialize_target_attr.mlir"
     "sort_pipeline_test.mlir"
     "tensorcore_vectorization.mlir"
     "transform_dialect_bufferize.mlir"
@@ -92,5 +90,20 @@ iree_lit_test_suite(
     transform_dialect_codegen_vector_distribution_spec.mlir
     transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
 )
+
+if(IREE_TARGET_BACKEND_ROCM)
+
+iree_lit_test_suite(
+  NAME
+    lit_rocm
+  SRCS
+    "rocm_spirv_serialize.mlir"
+    "rocm_spirv_serialize_target_attr.mlir"
+  TOOLS
+    FileCheck
+    iree-opt
+)
+
+endif()
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
ci-extra: linux_arm64_clang,macos_x64_clang