### PR TITLE
[Doc] Fix 'eenvironments' typos in main documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p><img src="docs/website/docs/assets/images/IREE_Logo_Icon_Color.svg" width="48px"></p>
 
-IREE (**I**ntermediate **R**epresentation **E**xecution **E**environment,
+IREE (**I**ntermediate **R**epresentation **E**xecution **E**nvironment,
 pronounced as "eerie") is an [MLIR](https://mlir.llvm.org/)-based end-to-end
 compiler and runtime that lowers Machine Learning (ML) models to a unified IR
 that scales up to meet the needs of the datacenter and down to satisfy the

--- a/build_tools/linters/typos.toml
+++ b/build_tools/linters/typos.toml
@@ -12,6 +12,12 @@ extend-exclude = [
     "**/runtime/src/iree/tokenizer/testdata/",
 ]
 
+[default]
+extend-ignore-re = [
+    # Markdown emphasis for the IREE acronym expansion splits "Environment".
+    '\*\*I\*\*ntermediate \*\*R\*\*epresentation \*\*E\*\*xecution \*\*E\*\*nvironment',
+]
+
 [default.extend-words]
 # AMD Heterogeneous System Architecture.
 hsa = "hsa"

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -5,7 +5,7 @@ hide:
 
 # IREE
 
-IREE (**I**ntermediate **R**epresentation **E**xecution **E**environment[^1]) is
+IREE (**I**ntermediate **R**epresentation **E**xecution **E**nvironment[^1]) is
 an [MLIR](https://mlir.llvm.org/)-based end-to-end compiler and runtime that
 lowers Machine Learning (ML) models to a unified IR that scales up to meet the
 needs of the datacenter and down to satisfy the constraints and special


### PR DESCRIPTION
Also allow the Markdown phrase in the linter config.

Signed-off-by: Artem Gindinson <gindinson@roofline.ai>
Co-authored-by: Joern Schoendube <jorn.schondube@nxp.com>