### PR TITLE
[Security] Fix uint64 additive overflow in VM bytecode rodata segment verifier

### DIFF
--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -72,9 +72,13 @@ iree_status_t iree_vm_bytecode_module_flatbuffer_verify(
         iree_vm_RodataSegmentDef_external_data_offset(segment);
     uint64_t segment_length =
         iree_vm_RodataSegmentDef_external_data_length(segment);
-    uint64_t segment_end =
-        archive_rodata_offset + segment_offset + segment_length;
-    if (segment_end > archive_contents.data_length) {
+    // Use non-overflowing comparisons instead of summing three uint64_t values:
+    // archive_rodata_offset + segment_offset + segment_length could wrap 2^64,
+    // producing a small segment_end that falsely passes the bounds check.
+    iree_host_size_t avail = archive_contents.data_length;
+    if (archive_rodata_offset > avail ||
+        segment_offset > avail - archive_rodata_offset ||
+        segment_length > avail - archive_rodata_offset - segment_offset) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "rodata[%zu] external reference out of range", i);
     }


### PR DESCRIPTION
## Summary

\`verifier.c:75-77\` computes \`segment_end = archive_rodata_offset + segment_offset + segment_length\` as a plain 64-bit unsigned addition. FlatBuffer \`uint64\` scalars carry no per-field cap, so attacker-controlled \`external_data_offset + external_data_length\` values can wrap past 2^64, producing a small \`segment_end\` that falsely passes the \`> data_length\` check.

\`module.c:1015-1018\` then constructs the rodata buffer span from the original unwrapped values (comment: *"Note that we've already verified the referenced range is in bounds"*), yielding a wild pointer. The runtime guard in \`buffer.c\` validates against the attacker-controlled length, not the true archive bounds.

## Fix

Replaced the additive sum with non-overflowing subtraction comparisons that reject any \`segment_offset\` or \`segment_length\` that would exceed available archive space.

## Also flagged

The same unchecked-add pattern exists in \`archive.c:184\` (\`iree_vm_bytecode_archive_infer_size\`) and should be addressed similarly.