### PR TITLE
[C++20 compat] avoid capture clauses not valid in C++20

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -874,7 +874,7 @@ struct LLVMCPUSession final
   void populateHALTargetBackends(IREE::HAL::TargetBackendList &targets) final {
     // #hal.executable.target<"llvm-cpu", ...
     // Use session-scoped codegen options bound in createUninitializedSession.
-    targets.add("llvm-cpu", [=]() {
+    targets.add("llvm-cpu", [this]() {
       return std::make_shared<LLVMCPUTargetBackend>(options.getTargetOptions(),
                                                     codegenOptions);
     });

--- a/compiler/plugins/target/Local/LocalTarget.cpp
+++ b/compiler/plugins/target/Local/LocalTarget.cpp
@@ -18,7 +18,7 @@ struct LocalSession
                     PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetDevices(IREE::HAL::TargetDeviceList &targets) {
     // #hal.device.target<"local", ...
-    targets.add("local", [=]() {
+    targets.add("local", [this]() {
       return std::make_shared<IREE::HAL::LocalDevice>(options);
     });
   }

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -328,12 +328,13 @@ struct MetalSPIRVSession final
                     PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetDevices(IREE::HAL::TargetDeviceList &targets) final {
     // #hal.device.target<"metal", ...
-    targets.add("metal",
-                [=]() { return std::make_shared<MetalTargetDevice>(options); });
+    targets.add("metal", [this]() {
+      return std::make_shared<MetalTargetDevice>(options);
+    });
   }
   void populateHALTargetBackends(IREE::HAL::TargetBackendList &targets) final {
     // #hal.executable.target<"metal-spirv", ...
-    targets.add("metal-spirv", [=]() {
+    targets.add("metal-spirv", [this]() {
       return std::make_shared<MetalSPIRVTargetBackend>(options);
     });
   }

--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -268,10 +268,11 @@ struct VMVXSession final
                     PluginActivationPolicy::DefaultActivated> {
   void populateHALTargetBackends(IREE::HAL::TargetBackendList &targets) final {
     // #hal.executable.target<"vmvx", ...
-    targets.add("vmvx",
-                [=]() { return std::make_shared<VMVXTargetBackend>(options); });
+    targets.add("vmvx", [this]() {
+      return std::make_shared<VMVXTargetBackend>(options);
+    });
     // #hal.executable.target<"vmvx-inline", ...
-    targets.add("vmvx-inline", [=]() {
+    targets.add("vmvx-inline", [this]() {
       return std::make_shared<VMVXInlineTargetBackend>(options);
     });
   }

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -24,7 +24,7 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
   addConversion([](IndexType indexType) { return indexType; });
   addConversion([](FloatType floatType) { return floatType; });
   addConversion([](MemRefType memrefType) { return memrefType; });
-  addConversion([=](RankedTensorType type) {
+  addConversion([this](RankedTensorType type) {
     return cast<RankedTensorType>(getLayoutAttr().convertType(type));
   });
   addConversion([&](IREE::TensorExt::DispatchTensorType dispatchTensorType) {
@@ -47,7 +47,8 @@ MaterializeEncodingConversionTarget::MaterializeEncodingConversionTarget(
       return isa<IREE::Encoding::ContractionEncodingAttrInterface,
                  IREE::Encoding::LayoutAttr>(tensorType.getEncoding());
     };
-    auto valueHasDataTilingEncoding = [=](Value v) -> bool {
+    auto valueHasDataTilingEncoding =
+        [typeHasDataTilingEncoding](Value v) -> bool {
       return typeHasDataTilingEncoding(v.getType());
     };
     bool hasOperandOrResultsWithEncoding =

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -345,7 +345,9 @@ struct VectorReductionToGPUPass final
         funcOp->emitOpError("missing subgroup size");
         return signalPassFailure();
       }
-      auto groupReductionFn = [=](Location loc, OpBuilder &builder, Value input,
+      auto groupReductionFn = [subgroupSize, &expandSubgroupReduction =
+                                                 this->expandSubgroupReduction](
+                                  Location loc, OpBuilder &builder, Value input,
                                   vector::CombiningKind kind,
                                   uint32_t size) -> Value {
         return emitGPUGroupReduction(loc, builder, input, kind, size,

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -125,9 +125,10 @@ public:
   // IdentityResolverAttr is returned.
   IREE::Stream::ResolveLayoutAttrFn
   makeLayoutAttrResolver(ModuleOp moduleOp) const {
-    return [=](ArrayRef<IREE::Stream::AffinityAndOpPair> batchQueries,
-               llvm::DenseMap<IREE::Stream::AffinityAndOpPair,
-                              SetVector<Attribute>> &layoutAttrs)
+    return [this,
+            moduleOp](ArrayRef<IREE::Stream::AffinityAndOpPair> batchQueries,
+                      llvm::DenseMap<IREE::Stream::AffinityAndOpPair,
+                                     SetVector<Attribute>> &layoutAttrs)
                -> LogicalResult {
       // This needs to be in the lambda because the moduleOp could be modified.
       IREE::HAL::DeviceAnalysis deviceAnalysis(moduleOp);


### PR DESCRIPTION
This change adapts capture clauses that valid in C++17 but not in in C++20 to a version that is valid in C++17 and C++20. It's a small step improving C++20 compatibility of the code base. It does not hurt in C++17, which is the current C++ standard.