### PR TITLE
Integrate LLVM to llvm/llvm-project@c4484e842274

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/GlobalTable.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/GlobalTable.cpp
@@ -175,9 +175,9 @@ void GlobalTable::eraseGlobal(StringRef globalName) {
   assert(global.loadOps.empty() && "must not be used");
   assert(global.referencingOps.empty() && "must not be referenced");
   global.eraseStores();
+  global.op.erase();
   globalMap.erase(globalName);
   llvm::erase(globalOrder, globalName);
-  global.op.erase();
 }
 
 } // namespace mlir::iree_compiler::IREE::Util


### PR DESCRIPTION
Fix a use-after-free bug in GlobalTable::eraseGlobal() that only triggered with the updated LLVM version.

With this integration, IREE is at a clean LLVM upstream commit again.