### PR TITLE
Inlcude absi in MathToVM Pattern and add testcases for it

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/Patterns.cpp
@@ -86,6 +86,8 @@ void populateMathToVMPatterns(MLIRContext *context,
                               TypeConverter &typeConverter,
                               RewritePatternSet &patterns) {
   patterns.insert<
+      UnaryArithmeticOpConversion<math::AbsIOp, IREE::VM::AbsI32Op,
+                                  IREE::VM::AbsI64Op>,
       UnaryArithmeticOpConversion<math::AbsFOp, IREE::VM::AbsF32Op,
                                   IREE::VM::AbsF64Op>,
       UnaryArithmeticOpConversion<math::CeilOp, IREE::VM::CeilF32Op,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/test/arithmetic_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/test/arithmetic_ops.mlir
@@ -5,7 +5,10 @@ func.func @arithmetic_i32(%arg0: i32) -> i32 {
   // CHECK: vm.ctlz.i32
   %0 = math.ctlz %arg0 : i32
 
-  return %0 : i32
+  // CHECK: vm.abs.i32
+  %1 = math.absi %0 : i32
+
+  return %1 : i32
 }
 
 // -----
@@ -15,7 +18,10 @@ func.func @arithmetic_i64(%arg0: i64) -> i64 {
   // CHECK: vm.ctlz.i64
   %0 = math.ctlz %arg0 : i64
 
-  return %0 : i64
+  // CHECK: vm.abs.i64
+  %1 = math.absi %0 : i64
+
+  return %1 : i64
 }
 
 // -----


### PR DESCRIPTION
We have found some models, which failed to compile to vmvx, due to a missing conversion for math.absi.

#7080 already implemented vm.abs.i32 and vm.abs.i64 and included a GenericOpConversion in [VMToEmitC/ConvertVMToEmitC.cpp](https://github.com/iree-org/iree/blob/a9e91ecb68b23241349acfbb2ede00afa4c107b7/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp#L5037-L5038)

It only requies a simple addition to the patterns in MathToVM/Patterns.cpp, for the models to successfully compile to vmvx. I also expanded the tests in arithmetic_ops.mlir, to include a check for vm.abs.i32 and vm.abs.i64.

Signed-off-by: Hakan Eyilmez <eyilmez@roofline.ai>