### PR TITLE
Integrate LLVM to llvm/llvm-project@696f4d562847

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferize.cpp
@@ -153,16 +153,19 @@ static IREEOneShotBufferizationOptions getBufferizationOptions() {
 
   // This type converter converts tensor types to memref types when no exact
   // memref type can be inferred from the context.
-  options.unknownTypeConverterFn = [](TensorType tensorType,
-                                      Attribute memorySpace,
-                                      const BufferizationOptions &options) {
+  options.unknownTypeConverterFn =
+      [](bufferization::TensorLikeType tensorLikeType, Attribute memorySpace,
+         const BufferizationOptions &options) -> bufferization::BufferLikeType {
+    auto tensorType = cast<TensorType>(tensorLikeType);
     if (tensorType.hasStaticShape()) {
-      return bufferization::getMemRefTypeWithStaticIdentityLayout(tensorType,
-                                                                  memorySpace);
+      return cast<bufferization::BufferLikeType>(
+          bufferization::getMemRefTypeWithStaticIdentityLayout(tensorType,
+                                                               memorySpace));
     }
     // Default case: Fully dynamic layout map for best compatibility.
-    return bufferization::getMemRefTypeWithFullyDynamicLayout(tensorType,
-                                                              memorySpace);
+    return cast<bufferization::BufferLikeType>(
+        bufferization::getMemRefTypeWithFullyDynamicLayout(tensorType,
+                                                           memorySpace));
   };
 
   return options;
@@ -282,7 +285,7 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
   // backend-specific optimizations (e.g., scalar reads on AMDGPU).
   if (isGPUBackend(IREE::HAL::ExecutableTargetAttr::lookup(funcOp))) {
     options.defaultMemorySpaceFn =
-        [](TensorType t) -> std::optional<Attribute> {
+        [](bufferization::TensorLikeType t) -> std::optional<Attribute> {
       return gpu::AddressSpaceAttr::get(t.getContext(),
                                         gpu::AddressSpace::Constant);
     };
@@ -311,7 +314,8 @@ void IREEBufferizeConstantsPass::runOnOperation() {
   // Place constants in the GPU constant address space to enable
   // backend-specific optimizations (e.g., scalar reads on AMDGPU).
   if (isGPUBackend(IREE::HAL::ExecutableTargetAttr::lookup(getOperation()))) {
-    opt.defaultMemorySpaceFn = [](TensorType t) -> std::optional<Attribute> {
+    opt.defaultMemorySpaceFn =
+        [](bufferization::TensorLikeType t) -> std::optional<Attribute> {
       return gpu::AddressSpaceAttr::get(t.getContext(),
                                         gpu::AddressSpace::Constant);
     };

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -859,16 +859,19 @@ static IREEOneShotBufferizationOptions getBufferizationOptions() {
 
   // This type converter converts tensor types to memref types when no exact
   // memref type can be inferred from the context.
-  options.unknownTypeConverterFn = [](TensorType tensorType,
-                                      Attribute memorySpace,
-                                      const BufferizationOptions &options) {
+  options.unknownTypeConverterFn =
+      [](bufferization::TensorLikeType tensorLikeType, Attribute memorySpace,
+         const BufferizationOptions &options) -> bufferization::BufferLikeType {
+    auto tensorType = cast<TensorType>(tensorLikeType);
     if (tensorType.hasStaticShape()) {
-      return bufferization::getMemRefTypeWithStaticIdentityLayout(tensorType,
-                                                                  memorySpace);
+      return cast<bufferization::BufferLikeType>(
+          bufferization::getMemRefTypeWithStaticIdentityLayout(tensorType,
+                                                               memorySpace));
     }
     // Default case: Fully dynamic layout map for best compatibility.
-    return bufferization::getMemRefTypeWithFullyDynamicLayout(tensorType,
-                                                              memorySpace);
+    return cast<bufferization::BufferLikeType>(
+        bufferization::getMemRefTypeWithFullyDynamicLayout(tensorType,
+                                                           memorySpace));
   };
 
   return options;
@@ -933,7 +936,7 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
 
   if (getTargetGpu()) {
     options.defaultMemorySpaceFn =
-        [&](TensorType t) -> std::optional<Attribute> {
+        [&](bufferization::TensorLikeType t) -> std::optional<Attribute> {
       Attribute addressSpaceAttr = gpu::AddressSpaceAttr::get(
           t.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
       return addressSpaceAttr;

--- a/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
@@ -73,7 +73,8 @@ struct TensorLikeTypeExternalModel
       llvm::function_ref<mlir::InFlightDiagnostic()> emitError) const {
     auto dispatchTensorType = cast<IREE::TensorExt::DispatchTensorType>(type);
     auto tensorType = cast<TensorType>(dispatchTensorType.asRankedTensorType());
-    auto memSpace = options.defaultMemorySpaceFn(tensorType);
+    auto memSpace = options.defaultMemorySpaceFn(
+        cast<bufferization::TensorLikeType>(tensorType));
     if (!memSpace.has_value()) {
       return emitError() << "could not infer memory space";
     }


### PR DESCRIPTION
Adapted usage of TensorType to TensorLikeType and similar types required by: 696f4d562847 [AMDGPU] Fix immediate parsing for packed types (#202417)