### PR TITLE
[Codegen][LLVMCPU] enable vectorization of scalable mmt4d without masks

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -22,6 +22,9 @@
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-generic-vectorization"
@@ -166,6 +169,37 @@ static LogicalResult isWithinVectorSizeLimit(linalg::LinalgOp linalgOp,
   return success(maxFlatVecSize < maxVectorSize);
 }
 
+static void
+fillVectorizationOptions(IRRewriter &rewriter, MLIRContext *context,
+                         Operation *op, bool vectorizeToTransferGather,
+                         SmallVectorImpl<NamedAttribute> &linalgOptionsList) {
+  linalgOptionsList.push_back(
+      rewriter.getNamedAttr("vectorizeNDExtract", rewriter.getBoolAttr(true)));
+  if (vectorizeToTransferGather) {
+    linalgOptionsList.push_back(rewriter.getNamedAttr(
+        "vectorizeToTransferGather", rewriter.getBoolAttr(true)));
+  }
+  // Add operation-specific options.
+  // We can assume that the dynamic dims match vector sizes for
+  // operations in the data-tiled layout. Currently this is limited to
+  // mmt4d-like operations.
+  bool assumeDynamicDimsMatchVecSizes =
+      isa<linalg::Mmt4DOp, linalg::BatchMmt4DOp>(op);
+  linalgOptionsList.push_back(rewriter.getNamedAttr(
+      "assumeDynamicDimsMatchVecSizes",
+      rewriter.getBoolAttr(assumeDynamicDimsMatchVecSizes)));
+  // For mmt4d operations with equal input operand types, we can
+  // directly vectorize to contractions instead of multi_reduction.
+  bool createNamedContraction = false;
+  if (auto cOp = dyn_cast<linalg::ContractionOpInterface>(op)) {
+    createNamedContraction =
+        isa<linalg::Mmt4DOp, linalg::BatchMmt4DOp>(op) &&
+        (getElementTypeOrSelf(cOp.lhs()) == getElementTypeOrSelf(cOp.rhs()));
+  }
+  linalgOptionsList.push_back(rewriter.getNamedAttr(
+      "createNamedContraction", rewriter.getBoolAttr(createNamedContraction)));
+}
+
 class GenericVectorizationPass final
     : public impl::GenericVectorizationPassBase<GenericVectorizationPass> {
 public:
@@ -184,17 +218,6 @@ void GenericVectorizationPass::runOnOperation() {
   mlir::FunctionOpInterface funcOp = getOperation();
 
   IRRewriter rewriter(context);
-
-  // Build DictionaryAttr options from pass options. These are forwarded to
-  // upstream linalg::vectorize().
-  SmallVector<NamedAttribute, 2> linalgOptionsList;
-  linalgOptionsList.push_back(
-      rewriter.getNamedAttr("vectorizeNDExtract", rewriter.getBoolAttr(true)));
-  if (vectorizeToTransferGather) {
-    linalgOptionsList.push_back(rewriter.getNamedAttr(
-        "vectorizeToTransferGather", rewriter.getBoolAttr(true)));
-  }
-  auto linalgOptions = DictionaryAttr::get(context, linalgOptionsList);
 
   SmallVector<VectorizableOpInterface> candidates;
   funcOp.walk([&](VectorizableOpInterface op) {
@@ -247,7 +270,12 @@ void GenericVectorizationPass::runOnOperation() {
     }
     // Pad scalable dims with `false` to match the vector sizes.
     scalableVecDims.resize(vectorSizes.size());
-
+    // Build DictionaryAttr options from pass options. These are forwarded to
+    // upstream linalg::vectorize().
+    SmallVector<NamedAttribute, 4> linalgOptionsList;
+    fillVectorizationOptions(rewriter, context, op, vectorizeToTransferGather,
+                             linalgOptionsList);
+    auto linalgOptions = DictionaryAttr::get(context, linalgOptionsList);
     if (!vectorizableOp.isVectorizable(vectorSizes, scalableVecDims,
                                        linalgOptions)) {
       continue;

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_unmasked.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization_unmasked.mlir
@@ -21,6 +21,38 @@ func.func @matmul(%lhs: tensor<3x4xf16>, %rhs: tensor<4x5xf16>, %acc: tensor<3x5
 
 // -----
 
+#config = #iree_cpu.lowering_config<distribution = [16, 16, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, 8, 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+func.func @mmt4d_bf16_static_inner_tiles(%lhs: tensor<1x1x8x1xbf16>, %rhs: tensor<1x1x8x1xbf16>, %acc: tensor<1x1x8x8xf32>) -> tensor<1x1x8x8xf32> {
+  %0 = linalg.mmt4d {lowering_config = #config} ins(%lhs, %rhs : tensor<1x1x8x1xbf16>, tensor<1x1x8x1xbf16>) outs(%acc : tensor<1x1x8x8xf32>) -> tensor<1x1x8x8xf32>
+  return %0 : tensor<1x1x8x8xf32>
+}
+// CHECK-MASK-LABEL: func.func @mmt4d_bf16_static_inner_tiles(
+// CHECK-MASK:         %[[LHS_VEC:.+]] = vector.transfer_read {{.+}} : tensor<1x1x8x1xbf16>, vector<1x1x8x1xbf16>
+// CHECK-MASK:         %[[RHS_VEC:.+]] = vector.transfer_read {{.+}} : tensor<1x1x8x1xbf16>, vector<1x1x8x1xbf16>
+// CHECK-MASK:         %[[OUT_VEC:.+]] = vector.transfer_read {{.+}} : tensor<1x1x8x8xf32>, vector<1x1x8x8xf32>
+// Named contractions do not get any extf in-between, generic lowering of mmt4d gets them.
+// CHECK-MASK-NOT:     arith.extf
+// CHECK-MASK:         %[[CONTRACT:.+]] = vector.contract {{.+}} %[[LHS_VEC]], %[[RHS_VEC]], %[[OUT_VEC]] : vector<1x1x8x1xbf16>, vector<1x1x8x1xbf16> into vector<1x1x8x8xf32>
+// CHECK-MASK:         vector.transfer_write %[[CONTRACT]]
+
+// -----
+
+#config = #iree_cpu.lowering_config<distribution = [32, 16, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 8, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
+func.func @mmt4d_bf16_scalable_inner_tiles(%lhs: tensor<1x1x8x1xbf16>, %rhs: tensor<1x1x?x1xbf16>, %acc: tensor<1x1x8x?xf32>) -> tensor<1x1x8x?xf32> {
+  %0 = linalg.mmt4d {lowering_config = #config} ins(%lhs, %rhs : tensor<1x1x8x1xbf16>, tensor<1x1x?x1xbf16>) outs(%acc : tensor<1x1x8x?xf32>) -> tensor<1x1x8x?xf32>
+  return %0 : tensor<1x1x8x?xf32>
+}
+// CHECK-MASK-LABEL: func.func @mmt4d_bf16_scalable_inner_tiles(
+// CHECK-MASK:         %[[LHS_VEC:.+]] = vector.transfer_read {{.+}} : tensor<1x1x8x1xbf16>, vector<1x1x8x1xbf16>
+// CHECK-MASK:         %[[RHS_VEC:.+]] = vector.transfer_read {{.+}} : tensor<1x1x?x1xbf16>, vector<1x1x[8]x1xbf16>
+// CHECK-MASK:         %[[OUT_VEC:.+]] = vector.transfer_read {{.+}} : tensor<1x1x8x?xf32>, vector<1x1x8x[8]xf32>
+// Named contractions do not get any extf in-between, generic lowering of mmt4d gets them.
+// CHECK-MASK-NOT:     arith.extf
+// CHECK-MASK:         %[[CONTRACT:.+]] = vector.contract {{.+}} %[[LHS_VEC]], %[[RHS_VEC]], %[[OUT_VEC]] : vector<1x1x8x1xbf16>, vector<1x1x[8]x1xbf16> into vector<1x1x8x[8]xf32>
+// CHECK-MASK:         vector.transfer_write %[[CONTRACT]]
+
+// -----
+
 #map = affine_map<(d0) -> (-d0 + 13, 2)>
 #map1 = affine_map<(d0) -> (-d0 + 51, 4)>
 #map2 = affine_map<(d0) -> (d0 * 2)>

--- a/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/VectorizableOpInterface.cpp
@@ -1098,6 +1098,8 @@ struct LinalgStructuredOpVectorizationModel
         getBoolOption(options, "flatten1DDepthwiseConv");
     bool createNamedContraction =
         getBoolOption(options, "createNamedContraction");
+    bool assumeDynamicDimsMatchVecSizes =
+        getBoolOption(options, "assumeDynamicDimsMatchVecSizes");
 
     // Handle gather-like generic vectorization via TransferGather.
     if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
@@ -1122,7 +1124,7 @@ struct LinalgStructuredOpVectorizationModel
 
     FailureOr<linalg::VectorizationResult> result = linalg::vectorize(
         rewriter, op, vectorSizes, scalableDims, vectorizeNDExtract,
-        flatten1DDepthwiseConv, /*assumeDynamicDimsMatchVecSizes=*/false,
+        flatten1DDepthwiseConv, assumeDynamicDimsMatchVecSizes,
         createNamedContraction);
 
     if (failed(result)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -136,9 +136,6 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
     });
   }
 
-  // TODO(egebeysel): setting this per target is not the nicest approach.
-  // Ideally, we would use a control function here so that we can do this on a
-  // more fine granular basis.
   if (isX86(targetConfig) ||
       (isRISCV(targetConfig) && !isScalableVectorizationEnabled())) {
     pipelineOpts.useConfiguredVectorSizes = false;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -136,7 +136,11 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
     });
   }
 
-  if (isX86(targetConfig) || isRISCV(targetConfig)) {
+  // TODO(egebeysel): setting this per target is not the nicest approach.
+  // Ideally, we would use a control function here so that we can do this on a
+  // more fine granular basis.
+  if (isX86(targetConfig) ||
+      (isRISCV(targetConfig) && !isScalableVectorizationEnabled())) {
     pipelineOpts.useConfiguredVectorSizes = false;
   }
   pipelineOpts.decomposePackUnPackOps =


### PR DESCRIPTION
This PR makes sure that we can vectorize `(batch_)mmt4d` operations without masks (this is not necesary due to data-tiling having padding semantics).

Additionally, current vectorization path for mmt4d (or other contractions for that matter) vectorizes the operations in the linalg body to a `multi_reduction`, which for `BF16xBF16->FP32` or `INT8xINT8->INT32` has `exti/extf`semantics on the operands. This is not ideal since target ISAs might have specific instructions that could be used for these contractions. If these extensions do not exist, then the extension semantics are inserted by vector lowering passes anyways.

Tests for the assume flags reside upstream, but these tests also showcase this.