### PR TITLE
Integrate LLVM to llvm/llvm-project@66e5a889c807

### DIFF
--- a/compiler/lit.cfg.py
+++ b/compiler/lit.cfg.py
@@ -17,7 +17,9 @@ import lit.formats
 
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
-config.test_format = lit.formats.ShTest(execute_external=True)
+config.test_format = lit.formats.ShTest(
+    execute_external=True, force_execute_external=True
+)
 
 # Forward all IREE environment variables, as well as some passthroughs.
 # Note: env vars are case-insensitive on Windows, so check matches carefully.

--- a/integrations/tensorflow/lit.cfg.py
+++ b/integrations/tensorflow/lit.cfg.py
@@ -17,7 +17,9 @@ import lit.formats
 
 config.name = "IREE TensorFlow Integrations"
 config.suffixes = [".mlir", ".txt"]
-config.test_format = lit.formats.ShTest(execute_external=True)
+config.test_format = lit.formats.ShTest(
+    execute_external=True, force_execute_external=True
+)
 
 # Use the most preferred temp directory.
 config.test_exec_root = (

--- a/llvm-external-projects/iree-dialects/test/lit.cfg.py
+++ b/llvm-external-projects/iree-dialects/test/lit.cfg.py
@@ -23,7 +23,10 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = "IREE_DIALECTS"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(
+    execute_external=not llvm_config.use_lit_shell,
+    force_execute_external=not llvm_config.use_lit_shell,
+)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".mlir", ".py"]

--- a/runtime/lit.cfg.py
+++ b/runtime/lit.cfg.py
@@ -17,7 +17,9 @@ import lit.formats
 
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
-config.test_format = lit.formats.ShTest(execute_external=True)
+config.test_format = lit.formats.ShTest(
+    execute_external=True, force_execute_external=True
+)
 # Forward all IREE environment variables
 passthrough_env_vars = ["VK_ICD_FILENAMES"]
 config.environment.update(

--- a/samples/lit.cfg.py
+++ b/samples/lit.cfg.py
@@ -17,7 +17,9 @@ import lit.formats
 
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
-config.test_format = lit.formats.ShTest(execute_external=True)
+config.test_format = lit.formats.ShTest(
+    execute_external=True, force_execute_external=True
+)
 # Forward all IREE environment variables
 passthrough_env_vars = ["VK_ICD_FILENAMES"]
 config.environment.update(

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -17,7 +17,9 @@ import lit.formats
 
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
-config.test_format = lit.formats.ShTest(execute_external=True)
+config.test_format = lit.formats.ShTest(
+    execute_external=True, force_execute_external=True
+)
 
 # Forward all IREE environment variables, as well as some passthroughs.
 # Note: env vars are case-insensitive on Windows, so check matches carefully.

--- a/tools/lit.cfg.py
+++ b/tools/lit.cfg.py
@@ -18,7 +18,9 @@ import lit.formats
 
 config.name = "IREE"
 config.suffixes = [".mlir", ".td", ".txt"]
-config.test_format = lit.formats.ShTest(execute_external=True)
+config.test_format = lit.formats.ShTest(
+    execute_external=True, force_execute_external=True
+)
 # Forward all IREE environment variables
 passthrough_env_vars = ["VK_ICD_FILENAMES"]
 config.environment.update(


### PR DESCRIPTION
Add a fix for a use-after-free from
e79e056ee982 [mlir][CSE] Remove the opsToErase container and immediately delete dead ops. (#203702) (will be upstreamed to LLVM in parallel)