### PR TITLE
Integrate LLVM to llvm/llvm-project@1e0899794dd4

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_bindings.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_bindings.mlir
@@ -125,7 +125,7 @@ func.func @binding_ptrs_dynamic() {
   // CHECK: %[[INDEX1:.+]] = llvm.mul %[[STRIDE1]], %[[C5]]
   // CHECK: %[[T1:.+]] = llvm.add %[[INDEX2]], %[[INDEX1]]
   // CHECK: %[[T2:.+]] = llvm.add %[[T1]], %[[C3]]
-  // CHECK: %[[OFFSET_PTR1:.+]] = llvm.getelementptr inbounds|nuw %[[BYTE_PTR]][%[[T2]]]
+  // CHECK: %[[OFFSET_PTR1:.+]] = llvm.getelementptr inbounds %[[BYTE_PTR]][%[[T2]]]
   // CHECK: %[[VALUE:.+]] = llvm.load %[[OFFSET_PTR1]]
   %c3 = arith.constant 3 : index
   %c5 = arith.constant 5 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -110,14 +110,14 @@ hal.executable @abs_dynamic {
 //   CHECK-DAG: llvm.intr.assume %[[ARG6_CMP]]
 //   CHECK-DAG: %[[D2:.+]] = llvm.zext %[[ARG7]] : i32 to i64
 //   CHECK: %[[GEP1:.+]] = llvm.getelementptr %[[ARG1]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, f32
-//   CHECK: %[[GEP:.+]] = llvm.getelementptr inbounds|nuw %[[GEP1]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+//   CHECK: %[[GEP:.+]] = llvm.getelementptr inbounds %[[GEP1]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, f32
 //   CHECK: %[[LOAD:.+]] = llvm.load %[[GEP]] : !llvm.ptr -> f32
-//   CHECK: %[[GEP2:.+]] = llvm.getelementptr inbounds|nuw %[[ARG0]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+//   CHECK: %[[GEP2:.+]] = llvm.getelementptr inbounds %[[ARG0]][%{{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, i32
 //   CHECK: llvm.load %[[GEP2]] : !llvm.ptr -> i32
 //   CHECK: %[[FADD:.+]] = llvm.fadd %[[LOAD]], %{{.*}}  : f32
 //   CHECK: %[[ADD:.+]] = llvm.add
 //   CHECK: %[[ADD2:.+]] = llvm.add
-//   CHECK: %[[ADDR:.+]] = llvm.getelementptr inbounds|nuw %[[ARG2]][%[[ADD2]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+//   CHECK: %[[ADDR:.+]] = llvm.getelementptr inbounds %[[ARG2]][%[[ADD2]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
 //   CHECK: llvm.store %[[FADD]], %[[ADDR]] : f32, !llvm.ptr
 
 


### PR DESCRIPTION
Adapted a LLVMCPU and a LLVMGPU codegen test to not expect the previously incorrectly emitted "nuw" flag.
This has been fixed in LLVM in this commit:
[mlir][MemRefToLLVM] fix incorrect nuw on GEP/mul when lowering memref.load/store with negative strides (#204309)
    
Finding the commit that caused the change and understanding the effect has been assisted by Claude Code.
The changes to the tests have been manually checked. The strides are dynamic, so negative strides are possible and "nuw" should not be there.