### PR TITLE
[Docs] Add notice about pthread sync fallbacks

### DIFF
--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -124,6 +124,20 @@ set(IREE_BUILD_SAMPLES ON)
     Clean the list up after [#6353](https://github.com/iree-org/iree/issues/6353)
     is fixed.
 
+!!! info 
+    Disabling threading does not remove all internal synchronization primitives.
+    By default, the runtime base threading layer (found in [`runtime/src/iree/base/threading`](https://github.com/iree-org/iree/tree/main/runtime/src/iree/base/threading)) falls back on primitives from `<pthread.h>`.
+
+    Depending on your environment, you have two choices:
+
+    - **Strictly single-threaded use**: compile with `IREE_SYNCHRONIZATION_DISABLE_UNSAFE=ON`.
+    - **With custom synchronization**: provide a small pthread/C11-thread surface to be used by the generic sync fallback.
+    
+    Run the following from the root of the IREE repository for details:
+    ```bash
+    cd runtime/src/iree/base/threading && grep -iC 1 pthread *.h
+    ```
+
 Also, set the toolchain-specific cmake file to match the tool path, target
 architecture, target abi, linker script, system library path, etc.
 

--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -125,7 +125,7 @@ set(IREE_BUILD_SAMPLES ON)
     is fixed.
 
 !!! info 
-    Disabling threading does not remove all internal synchronization primitives.
+    Disabling threading (`IREE_ENABLE_THREADING OFF`) does not eliminate the need for all synchronization primitives. IREE still relies on the implementation of some internal synchronization primitives, and thus retains its dependency on a threading library.
     By default, the runtime base threading layer (found in [`runtime/src/iree/base/threading`](https://github.com/iree-org/iree/tree/main/runtime/src/iree/base/threading)) falls back on primitives from `<pthread.h>`.
 
     Depending on your environment, you have two choices:

--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -125,8 +125,13 @@ set(IREE_BUILD_SAMPLES ON)
     is fixed.
 
 !!! info
-    Disabling threading (`IREE_ENABLE_THREADING OFF`) does not eliminate the need for all synchronization primitives. IREE still relies on the implementation of some internal synchronization primitives, and thus retains its dependency on a threading library.
-    For the generic platform, the runtime base threading layer (found in [`runtime/src/iree/base/threading`](https://github.com/iree-org/iree/tree/main/runtime/src/iree/base/threading)) falls back on primitives from `<pthread.h>`.
+    Disabling threading (`IREE_ENABLE_THREADING OFF`) does not eliminate the
+    need for all synchronization primitives. IREE still relies on the
+    implementation of some internal synchronization primitives, and thus
+    retains its dependency on a threading library. For the generic platform,
+    the runtime base threading layer (found in
+    [`runtime/src/iree/base/threading`](https://github.com/iree-org/iree/tree/main/runtime/src/iree/base/threading))
+    falls back on primitives from `<pthread.h>`.
 
     Depending on your environment, you have two choices:
 

--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -131,7 +131,7 @@ set(IREE_BUILD_SAMPLES ON)
     Depending on your environment, you have two choices:
 
     - **Strictly single-threaded use**: compile with `IREE_SYNCHRONIZATION_DISABLE_UNSAFE=ON`.
-    - **With custom synchronization**: provide a small pthread/C11-thread surface to be used by the generic sync fallback.
+    - **With custom synchronization**: provide a small pthread surface to be used by the runtime base threading layer.
         Run the following from the root of the IREE repository for details:
         ```bash
         cd runtime/src/iree/base/threading && grep -iC 1 pthread *.h

--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -132,11 +132,10 @@ set(IREE_BUILD_SAMPLES ON)
 
     - **Strictly single-threaded use**: compile with `IREE_SYNCHRONIZATION_DISABLE_UNSAFE=ON`.
     - **With custom synchronization**: provide a small pthread/C11-thread surface to be used by the generic sync fallback.
-    
-    Run the following from the root of the IREE repository for details:
-    ```bash
-    cd runtime/src/iree/base/threading && grep -iC 1 pthread *.h
-    ```
+        Run the following from the root of the IREE repository for details:
+        ```bash
+        cd runtime/src/iree/base/threading && grep -iC 1 pthread *.h
+        ```
 
 Also, set the toolchain-specific cmake file to match the tool path, target
 architecture, target abi, linker script, system library path, etc.

--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -126,7 +126,7 @@ set(IREE_BUILD_SAMPLES ON)
 
 !!! info 
     Disabling threading (`IREE_ENABLE_THREADING OFF`) does not eliminate the need for all synchronization primitives. IREE still relies on the implementation of some internal synchronization primitives, and thus retains its dependency on a threading library.
-    By default, the runtime base threading layer (found in [`runtime/src/iree/base/threading`](https://github.com/iree-org/iree/tree/main/runtime/src/iree/base/threading)) falls back on primitives from `<pthread.h>`.
+    For the generic platform, the runtime base threading layer (found in [`runtime/src/iree/base/threading`](https://github.com/iree-org/iree/tree/main/runtime/src/iree/base/threading)) falls back on primitives from `<pthread.h>`.
 
     Depending on your environment, you have two choices:
 

--- a/docs/website/docs/guides/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/guides/deployment-configurations/bare-metal.md
@@ -124,7 +124,7 @@ set(IREE_BUILD_SAMPLES ON)
     Clean the list up after [#6353](https://github.com/iree-org/iree/issues/6353)
     is fixed.
 
-!!! info 
+!!! info
     Disabling threading (`IREE_ENABLE_THREADING OFF`) does not eliminate the need for all synchronization primitives. IREE still relies on the implementation of some internal synchronization primitives, and thus retains its dependency on a threading library.
     For the generic platform, the runtime base threading layer (found in [`runtime/src/iree/base/threading`](https://github.com/iree-org/iree/tree/main/runtime/src/iree/base/threading)) falls back on primitives from `<pthread.h>`.
 


### PR DESCRIPTION
The generic platform with IREE_ENABLE_THREADING OFF requires pthread types/functions:

 `pthread_once_t` / `pthread_once`
 `pthread_mutex_t` / `pthread_mutex_*`
 `pthread_cond_t` / `pthread_cond_*`

Added a notice in the bare metal runtime documentation about the dependency.

relates to #24604