### PR TITLE
[Codegen][RISCV] Default mmt4d ukernels on all RV64, not just IME targets

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -209,10 +209,11 @@ static const char *getDefaultEnabledUkernels(DictionaryAttr targetConfig) {
   if (isAArch64(targetConfig)) {
     return "mmt4d";
   }
-  // Auto-enable mmt4d for IME-capable RISC-V targets so callers do not need
-  // --iree-llvmcpu-enable-ukernels=mmt4d explicitly. Plain +v targets are
-  // unaffected; they still require the explicit flag.
-  if (isRISCV64(targetConfig) && hasFeature(targetConfig, "+xsmtvdot")) {
+  // Auto-enable mmt4d on RISC-V 64 so callers do not need
+  // --iree-llvmcpu-enable-ukernels=mmt4d explicitly. This is not restricted to
+  // IME-capable targets: the generic s8s8s32 tiles are a large win on plain +v
+  // as well (measured 2.6x on rv64gcv, see commit message).
+  if (isRISCV64(targetConfig)) {
     return "mmt4d";
   }
   return kNone;


### PR DESCRIPTION
## Summary

#24706 made `getDefaultEnabledUkernels()` return `"mmt4d"` for RISC-V, but gated it on `+xsmtvdot` (SpaceMiT IME). Plain `+v` RV64 targets therefore still require `--iree-llvmcpu-enable-ukernels=mmt4d` explicitly, while x86_64 and AArch64 default to `"mmt4d"` unconditionally.

This PR drops the `+xsmtvdot` condition, so all RV64 targets get the same default.

```diff
-  if (isRISCV64(targetConfig) && hasFeature(targetConfig, "+xsmtvdot")) {
+  if (isRISCV64(targetConfig)) {
     return "mmt4d";
   }
```

## Why the gate is narrower than the data supports

The generic s8s8s32 mmt4d tiles are already a large win without IME.

**Microbenchmark, reproducible from this branch.** A single `128x512x1536` i8→i32 `linalg.matmul`, compiled for `riscv64` with `+m,+a,+f,+d,+zvl512b,+v` (no `+xsmtvdot`) and `--iree-opt-data-tiling=true`, run under QEMU 9.2 `rv64gcv` (`vlen=512`) with a TCG plugin counting dynamic instructions:

| | ukernels off | ukernels on (this PR's default) |
|---|---|---|
| Dynamic instructions | 72,537,504 | **43,225,266** (1.68x fewer) |
| Vector instructions | 11,351,485 | 2,720,821 |

**End-to-end.** On Qwen2.5-0.5B int8 decode under QEMU RV64 (`rv64gcv`), dynamic instruction count 3.57B → 1.38B (2.6x) with ukernels enabled.

Note that RVV *share* is not a good indicator of whether the ukernel fired: in the microbenchmark above the ukernel path executes far fewer but more productive vector instructions, so the vector share falls (15.7% → 6.3%) even though the s8s8s32 ukernel is definitely selected. The reliable check is the presence of `iree_codegen.ukernel.generic` ops.

## Verification

On a `riscv64` + `+v` target with no `+xsmtvdot`, counting `iree_codegen.ukernel.generic` ops in the compiled IR:

| | main | this PR |
|---|---|---|
| default (no flag) | 0 | **40** |
| `--iree-llvmcpu-enable-ukernels=mmt4d` | 40 | 40 |
| `--iree-llvmcpu-enable-ukernels=none` | 0 | 0 |

So the default now matches explicit `mmt4d`, and `none` still disables. x86_64 is unaffected.

`ctest -R riscv` passes (4/4). The full `Codegen` lit suite is unchanged by this patch — the only failures are 3 pre-existing LLVMGPU/ROCDL tests that fail identically on unpatched `main`.

## Impact on IME targets

None. `+xsmtvdot` targets still select the vmadot tiles in `CPUEncodingExternalModels.cpp`; this change only affects which targets get `mmt4d` in the *default* ukernel set, not tile selection.
