### PR TITLE
[Torch] Wire MatchQuantizedCustomOps into the torch input pipeline

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -44,6 +44,14 @@ void createTorchToIREEPipeline(
     // now be simplified.
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   }
+  // Convert `torch.operator "quantized_decomposed.*"` custom ops (emitted by
+  // torch pt2e / torchao quantization) into first-class torch quantized ops
+  // (Aten_MakePerChannelQuantizedTensorOp + AtenDequantizeSelfOp), which the
+  // downstream torch->linalg path can lower. Must run before
+  // RecomposeComplexOps/DecomposeComplexOps and the torch->linalg conversions,
+  // otherwise the unmatched custom ops fail to legalize.
+  pm.addNestedPass<func::FuncOp>(
+      torch::Torch::createMatchQuantizedCustomOpsPass());
   pm.addNestedPass<func::FuncOp>(torch::Torch::createRecomposeComplexOpsPass());
   pm.addNestedPass<func::FuncOp>(createBitCastTensorPass());
   pm.addNestedPass<func::FuncOp>(


### PR DESCRIPTION
## Summary

`torch-mlir`'s `MatchQuantizedCustomOpsPass` converts
`torch.operator "quantized_decomposed.*"` custom ops (emitted by PyTorch
`pt2e` / `torchao` quantization) into first-class torch quantized ops
that the downstream torch→linalg path can lower.

This pass was **not** wired into IREE's `createTorchToIREEPipeline`, so
any model quantized via `torch.export` + `torchao`/`pt2e` failed with:

```
error: failed to legalize operation 'torch.operator' that was explicitly
       marked illegal
```

(`torch.operator "torch.quantized_decomposed.dequantize_per_tensor"` /
`"...per_channel"` are not recognized by the downstream passes.)

## Change

Single `pm.addNestedPass` call in `Passes.cpp`, placed **before**
`RecomposeComplexOps` / `DecomposeComplexOps` and the torch→linalg
conversions (the point at which the unmatched custom ops become fatal).
The pass itself (`createMatchQuantizedCustomOpsPass`) already exists in
the bundled `torch-mlir` and requires no new code.

## Testing

End-to-end on Qwen2.5-0.5B with per-channel int8 quantization via
`torch.export` + `torchao` pt2e pipeline:
- Model compiles without errors (previously failed at legalization)
- Routes to `s8s8s32` mmt4d ukernel for all 168 decode projections
- Faithfulness vs torch reference: cosine similarity 0.9972, top-1 7/8

A lit-test addition (verifying `dequantize_per_tensor` is lowered and
does not appear in output) would complete the review; happy to add if
that's the preferred pattern for this subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification (rebased onto current `main`, 2026-08-09)

Minimal repro — a `torch.operator "torch.quantized_decomposed.dequantize_per_tensor"` module compiled with `--iree-input-type=torch --iree-hal-target-backends=llvm-cpu`:

| | result |
|---|---|
| current `main` | `error: failed to legalize operation 'torch.operator' that was explicitly marked illegal` |
| with this PR | compiles cleanly to a `.vmfb` (only the usual generic-CPU perf warning on stderr) |

`ctest -R "input/Torch/InputConversion"` — 16/17 pass. The one failure (`func_conversion_sync_invalid.mlir`) is pre-existing and unrelated: it checks a flag-conflict diagnostic for `--iree-torch-emit-async-entry-points=false --iree-torch-externalize-transients`, and fails identically on unpatched `main`.

`createMatchQuantizedCustomOpsPass()` is declared and implemented in the currently pinned `third_party/torch-mlir` (`ec8720b`), and the required header is already included by this file, so no new include is needed.
