### PR TITLE
[Codegen] Don't hoist statically-bound allocations with bogus huge bounds

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/hoist_statically_bound_allocations.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/hoist_statically_bound_allocations.mlir
@@ -249,3 +249,30 @@ func.func @nested_op_scalable_alloc_linalg_use(%arg0 : index) {
 // CHECK-UNBOUNDED-VSCALE-LABEL: func @nested_op_scalable_alloc_linalg_use(
 //       CHECK-UNBOUNDED-VSCALE: scf.for
 //       CHECK-UNBOUNDED-VSCALE:   memref.alloc
+
+// -----
+
+// An unconstrained `index` operand carries the trivial type-level upper bound
+// (~2^53), which `ceildiv 2` turns into a 2^52 static dimension. The hoist must
+// not materialize that as a static alloca (see #24483); it stays dynamic.
+func.func @no_hoist_umax_bounded_alloca(%arg0: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c42 = arith.constant 42 : i32
+  %assumed = util.assume.int %arg0<umin = 0, umax = 9007199254740991> : index
+  %dim = affine.apply affine_map<()[s0] -> (s0 ceildiv 2)>()[%assumed]
+  scf.for %iv = %c0 to %c1 step %c1 {
+    %a = memref.alloca(%dim) : memref<?xi32>
+    memref.store %c42, %a[%iv] : memref<?xi32>
+    scf.yield
+  }
+  return
+}
+// CHECK-LABEL: func @no_hoist_umax_bounded_alloca(
+//   CHECK-NOT:   memref.alloca() :
+//       CHECK:   scf.for
+//       CHECK:     memref.alloca(%{{.+}}) : memref<?xi32>
+
+// CHECK-UNBOUNDED-VSCALE-LABEL: func @no_hoist_umax_bounded_alloca(
+//   CHECK-UNBOUNDED-VSCALE-NOT:   memref.alloca() :
+//       CHECK-UNBOUNDED-VSCALE:   memref.alloca(%{{.+}}) : memref<?xi32>

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -219,6 +219,26 @@ std::optional<Value> hoistOneStaticallyBoundAllocation(
       subviewSizes.push_back(dynamicSize);
     }
 
+    // Refuse to hoist when the bounded shape is implausibly large. An
+    // unconstrained `index` operand carries the trivial type-level upper bound
+    // (~2^53), so a single `affine.apply` can turn it into a multi-petabyte
+    // static dimension. Materializing that as a static alloca silently
+    // overflows the downstream stride/size computation (see #24483); leaving
+    // the allocation dynamic lets it be handled or diagnosed later instead.
+    constexpr int64_t kMaxHoistedAllocationElements = int64_t(1) << 32;
+    int64_t numElements = 1;
+    for (OpFoldResult allocSize : allocSizes) {
+      std::optional<int64_t> dim = getConstantIntValue(allocSize);
+      if (!dim) {
+        // A dynamic (e.g. scalable) bound; cannot reason about it statically.
+        break;
+      }
+      if (*dim > 0 && numElements > kMaxHoistedAllocationElements / *dim) {
+        return std::nullopt;
+      }
+      numElements *= *dim;
+    }
+
     // FIXME: The `AllocLikeOp::build()` method for OpFoldResult drops the
     // layout, so we have to resolve the static/dynamic values here.
     SmallVector<int64_t> staticShape;


### PR DESCRIPTION
## Problem

`hoistOneStaticallyBoundAllocation` (`Codegen/Transforms/Transforms.cpp`) used
the result of `computeConstantBound` verbatim as the static dimension of a
hoisted `memref.alloca`. An unconstrained `index` operand carries the trivial
type-level upper bound `2^53 - 1`, so a single `affine.apply` (e.g. `ceildiv 2`,
as data tiling emits when sizing a packed-outer dim) turns it into a
~2^52-element static alloca (~16 PiB), emitted silently with no diagnostic.
Downstream stride/size computation then overflows `i64` to poison, and the
dispatch reads/writes undefined memory. This is issue #24483 (it surfaces as the
`e2e_matmul_cpu_dt_inner_tiled_*` generic-scalar variants silently dropping the
accumulator operand).

## Fix

Refuse to hoist when the bounded static shape exceeds a generous element-count
cap (2^32), leaving the allocation dynamic so the existing
`LLVMCPUCheckIRBeforeLLVMConversion` stack-allocation check handles or diagnoses
it, rather than fabricating a bogus static shape that corrupts memory silently.

The cap is intentionally backend-agnostic. The precise per-target limit
(`getConfigMaxStackAllocationSize`) lives in `Codegen/LLVMCPU`, which the
backend-independent `Codegen/Transforms` library cannot depend on (it would be
circular), and the check pass still enforces the real limit downstream. The
2^32-element cap separates legitimate stack tiles (KB to MB) from this bug by a
large margin, so it does not change behavior for any existing hoist.

## Testing

- New lit case `@no_hoist_umax_bounded_alloca` in
  `hoist_statically_bound_allocations.mlir`: the umax-derived dim stays dynamic
  under both RUN configs.
- Existing tests in that file pass unchanged (no regression to legitimate
  hoists).
- Verified by reproduction on current `main`: before, the pass emits
  `memref.alloca() : memref<4503599627370496xi32>`; after, it leaves
  `memref.alloca(%dim) : memref<?xi32>`.

Fixes #24483.
