### PR TITLE
feat(tiling): thread InnerTileAlignment through tile-and-distribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
@@ -28,6 +28,40 @@
 
 namespace mlir::iree_compiler {
 
+scf::InnerTileAlignmentFnTy
+makeInnerTileAlignmentFn(mlir::InnerTileAlignment kind) {
+  return
+      [kind](TilingInterface op, ArrayRef<OpFoldResult>,
+             ArrayRef<Operation *>) -> SmallVector<mlir::InnerTileAlignment> {
+        // Assert `kind` at each scalable (dynamic) inner tile, indexed in the
+        // pack/unpack op's own iteration domain; a static inner tile is left
+        // `Unknown` and handled by the existing static path.
+        auto markScalable = [kind](ArrayRef<int64_t> innerDimsPos,
+                                   ArrayRef<OpFoldResult> mixedTiles,
+                                   int64_t rank) {
+          SmallVector<mlir::InnerTileAlignment> alignments(
+              rank, mlir::InnerTileAlignment::Unknown);
+          for (auto [pos, tile] : llvm::zip_equal(innerDimsPos, mixedTiles)) {
+            if (!getConstantIntValue(tile)) {
+              alignments[pos] = kind;
+            }
+          }
+          return alignments;
+        };
+        if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op.getOperation())) {
+          return markScalable(
+              unpackOp.getInnerDimsPos(), unpackOp.getMixedTiles(),
+              cast<ShapedType>(unpackOp.getDest().getType()).getRank());
+        }
+        if (auto packOp = dyn_cast<linalg::PackOp>(op.getOperation())) {
+          return markScalable(
+              packOp.getInnerDimsPos(), packOp.getMixedTiles(),
+              cast<ShapedType>(packOp.getSource().getType()).getRank());
+        }
+        return {};
+      };
+}
+
 void fuseProducersOfSlices(RewriterBase &rewriter,
                            std::queue<Operation *> &worklist,
                            scf::SCFTileAndFuseOptions &options,
@@ -54,7 +88,9 @@ void fuseProducersOfSlices(RewriterBase &rewriter,
     // values produced by operations that implement the `TilingInterface`.
     // Add these operations to the worklist.
     std::optional<scf::SCFFuseProducerOfSliceResult> fusedResult =
-        scf::tileAndFuseProducerOfSlice(rewriter, candidateSlice, loops);
+        scf::tileAndFuseProducerOfSlice(
+            rewriter, candidateSlice, loops,
+            options.tilingOptions.innerTileAlignmentFn);
     if (!fusedResult) {
       continue;
     }
@@ -109,10 +145,11 @@ struct ConsumerFusionQueueEntry {
 };
 } // namespace
 
-FailureOr<std::queue<Operation *>>
-fuseConsumersIntoForall(RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
-                        MutableArrayRef<LoopLikeOpInterface> loops,
-                        std::function<bool(Operation *)> filterFn) {
+FailureOr<std::queue<Operation *>> fuseConsumersIntoForall(
+    RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
+    MutableArrayRef<LoopLikeOpInterface> loops,
+    std::function<bool(Operation *)> filterFn,
+    const scf::InnerTileAlignmentFnTy &innerTileAlignmentFn) {
   // Collect the candidate slices which can be potential consumers that can be
   // fused. Keep them in a vector reverse-sorted by dominance: the candidate
   // dominating others comes last (so it can be cheaply popped from the vector).
@@ -213,7 +250,8 @@ fuseConsumersIntoForall(RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
     ConsumerFusionQueueEntry entry = candidates.pop_back_val();
 
     FailureOr<scf::SCFFuseConsumerOfSliceResult> fusedResult =
-        mlir::scf::tileAndFuseConsumer(rewriter, entry.fusableUser, loops);
+        mlir::scf::tileAndFuseConsumer(rewriter, entry.fusableUser, loops,
+                                       innerTileAlignmentFn);
     if (failed(fusedResult)) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
@@ -31,15 +31,26 @@ void fuseProducersOfSlices(RewriterBase &rewriter,
 void collectTiledAndFusedOps(Operation *rootOp,
                              llvm::SmallDenseSet<Operation *> &result);
 
+/// Returns an `scf::InnerTileAlignmentFnTy` control function that asserts
+/// `kind` (typically `Multiple` at the distribution level, `Equal` at the
+/// vector level) at each scalable (dynamic) inner tile of a tiled/fused
+/// linalg.pack/linalg.unpack op, computed in that op's own iteration domain;
+/// every other op gets no hint. IREE's KernelDispatch guarantees this
+/// relationship on scalable dims, so the assertion holds. The SCF driver
+/// invokes the function per op, so it threads correctly through intervening ops
+/// such as a transposing producer (see llvm/llvm-project#150185).
+scf::InnerTileAlignmentFnTy
+makeInnerTileAlignmentFn(mlir::InnerTileAlignment kind);
+
 /// Fuse all consumers of the given `tiledOps` into the surrounding `scf.forall`
 /// unless specified otherwise by `filterFn`. Returns a list of new
 /// `tensor.extract_slice` ops with new fusion opportunities.
 FailureOr<std::queue<Operation *>> fuseConsumersIntoForall(
     RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
     MutableArrayRef<LoopLikeOpInterface> loops,
-    std::function<bool(Operation *)> filterFn = [](Operation *) {
-      return true;
-    });
+    std::function<bool(Operation *)> filterFn =
+        [](Operation *) { return true; },
+    const scf::InnerTileAlignmentFnTy &innerTileAlignmentFn = nullptr);
 
 /// Apply a tile and fuse transformation to all payload ops and store both the
 /// tiled operation as well as the created tile loops.

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -267,10 +267,25 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
           context, funcOp.getLoc(), deviceMappingAttribute))) {
     return signalPassFailure();
   }
+  // Caller-asserted alignment of any tiled/fused linalg.pack/unpack inner tiles
+  // to the distribution loop tile sizes (InnerTileAlignment;
+  // llvm/llvm-project#150185). At the distribution/workgroup level the loop
+  // tile size is an integer MULTIPLE of the inner tile on scalable dims (the
+  // vector tile equals the inner tile, the distribution tile is a multiple of
+  // it), so each scalable dim is Multiple; static dims stay Unknown and are
+  // handled by the existing static path. The control function is evaluated by
+  // the SCF driver once per tiled/fused pack/unpack op, in that op's own
+  // iteration domain (keying off its scalable, i.e. dynamic, inner tiles), so
+  // it threads correctly through intervening ops such as a transposing
+  // producer; every other op gets no hint.
+  scf::InnerTileAlignmentFnTy innerTileAlignmentFn =
+      makeInnerTileAlignmentFn(mlir::InnerTileAlignment::Multiple);
+
   scf::SCFTilingOptions tilingOptions;
   tilingOptions.setTileSizes(tilingInfo->tileSizes);
   tilingOptions.setInterchange(tilingInfo->interchange);
   tilingOptions.setMapping(deviceMappingAttribute);
+  tilingOptions.setInnerTileAlignmentFn(innerTileAlignmentFn);
 
   IREE::Codegen::WorkgroupReorderingAttrInterface workgroupReorderingStrategy =
       getLoweringConfig(tilingInfo->tilableOp).getWorkgroupReorderingStrategy();
@@ -370,9 +385,11 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
     FailureOr<std::queue<Operation *>> newFusionOpportunities =
         fuseConsumersIntoForall(
             rewriter, tileAndFuseResult->tiledAndFusedOps.getArrayRef(),
-            tilingLoops, [&tiledAndFusedOps](Operation *op) {
+            tilingLoops,
+            [&tiledAndFusedOps](Operation *op) {
               return tiledAndFusedOps.contains(op);
-            });
+            },
+            innerTileAlignmentFn);
     if (failed(newFusionOpportunities)) {
       // Continue the work if the failure is allowed.
       if (!verifyComputeOpsAfterDistribution(funcOp)) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -1498,3 +1498,73 @@ func.func @arg_compare_fold_broadcast(
 //   CHECK-NOT:     linalg.broadcast
 //       CHECK:     scf.forall {{.*}} shared_outs(%{{.*}} = %[[INIT_F16]], %{{.*}} = %[[INIT_I32]])
 //       CHECK:       iree_linalg_ext.arg_compare
+
+// -----
+
+// Distribution of a scalable linalg.pack (inner tiles [8*vscale, 1]) with an
+// elementwise-add producer fused into the workgroup forall. The distribution
+// tile (64) on the packed dimension is a static *multiple* of the scalable
+// inner tile; the driver gets that relationship from the InnerTileAlignment
+// hint (llvm/llvm-project#150185) rather than re-deriving it from scalable IR.
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @scalable_pack_distribute_with_producer(%arg0: tensor<384x512xf32>, %arg1: tensor<384x512xf32>) -> tensor<?x512x?x1xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %0 = tensor.empty() : tensor<384x512xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<384x512xf32>, tensor<384x512xf32>) outs(%0 : tensor<384x512xf32>) attrs = {lowering_config = #config} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %3 = arith.addf %in, %in_0 : f32
+    linalg.yield %3 : f32
+  } -> tensor<384x512xf32>
+  %mouter = affine.apply affine_map<()[s0] -> (384 ceildiv s0)>()[%c8_vscale]
+  %2 = tensor.empty(%mouter, %c8_vscale) : tensor<?x512x?x1xf32>
+  %pack = linalg.pack %1 padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [%c8_vscale, 1] into %2 : tensor<384x512xf32> -> tensor<?x512x?x1xf32>
+  return %pack : tensor<?x512x?x1xf32>
+}
+// CHECK-LABEL: func.func @scalable_pack_distribute_with_producer
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}}
+// CHECK:         scf.forall {{.*}} = (0, 0) to (384, 512) step (64, 64)
+// CHECK:           %[[GEN:.+]] = linalg.generic
+// CHECK:             arith.addf
+// CHECK:           linalg.pack %[[GEN]]
+// CHECK-SAME:        inner_tiles = [%[[C8VS]], 1]
+// CHECK:           scf.forall.in_parallel
+// CHECK:             tensor.parallel_insert_slice
+// CHECK:         mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]
+
+// -----
+
+// Distribution of a scalable linalg.unpack (inner tiles [7, 8*vscale]) fused as
+// the producer of an elementwise-add consumer. The distribution tile (64) on
+// the unpacked N dimension is a static *multiple* of the scalable inner tile
+// (InnerTileAlignment hint; llvm/llvm-project#150185).
+#config = #iree_codegen.lowering_config<tile_sizes = [[84, 64]]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @scalable_unpack_distribute_with_consumer(%arg0: tensor<12x?x7x?xf32>, %arg1: tensor<80x320xf32>) -> tensor<80x320xf32> {
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %0 = tensor.empty() : tensor<80x320xf32>
+  %unpack = linalg.unpack %arg0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %0 : tensor<12x?x7x?xf32> -> tensor<80x320xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1, %unpack : tensor<80x320xf32>, tensor<80x320xf32>) outs(%0 : tensor<80x320xf32>) attrs = {lowering_config = #config} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %2 = arith.addf %in, %in_0 : f32
+    linalg.yield %2 : f32
+  } -> tensor<80x320xf32>
+  return %1 : tensor<80x320xf32>
+}
+// CHECK-LABEL: func.func @scalable_unpack_distribute_with_consumer
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}}
+// CHECK:         scf.forall {{.*}} = (0, 0) to (80, 320) step (84, 64)
+// CHECK:           %[[UNPACK:.+]] = linalg.unpack
+// CHECK-SAME:        inner_tiles = [7, %[[C8VS]]]
+// CHECK:           linalg.generic
+// CHECK-SAME:        ins(%{{.*}}, %[[UNPACK]]
+// CHECK:             arith.addf
+// CHECK:           scf.forall.in_parallel
+// CHECK:         mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/TilingInterfaceImpl.cpp
@@ -161,4 +161,12 @@ LogicalResult InnerTiledOp::getResultTilePosition(
   return success();
 }
 
+// Hint-bearing TilingInterface overload; InnerTiledOp does not consult the
+// hint (only linalg.pack/unpack do).
+FailureOr<TilingResult> InnerTiledOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
 } // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuseProducerConsumer.cpp
@@ -187,9 +187,22 @@ static FailureOr<Operation *> tileRootAndFuseProducerConsumer(
   tileSizes.resize(numLoops, 0);
   tileScalableFlags.resize(numLoops, false);
 
+  // Caller-asserted alignment of a tiled/fused linalg.pack/unpack op's inner
+  // tiles to the loop tile sizes (InnerTileAlignment;
+  // llvm/llvm-project#150185). IREE's KernelDispatch sets the vector tile size
+  // EQUAL to the inner tile on scalable dims, so each scalable dim is Equal;
+  // static dims stay Unknown and are handled by the existing static path. The
+  // control function is evaluated by the SCF driver once per tiled/fused
+  // pack/unpack op, in that op's own iteration domain (keying off its scalable,
+  // i.e. dynamic, inner tiles), so it threads correctly through intervening
+  // ops; every other op gets no hint.
+  scf::InnerTileAlignmentFnTy innerTileAlignmentFn =
+      makeInnerTileAlignmentFn(mlir::InnerTileAlignment::Equal);
+
   scf::SCFTilingOptions tilingOptions;
   setSCFTileSizes(tilingOptions, rootOp, std::move(tileSizes),
                   std::move(tileScalableFlags));
+  tilingOptions.setInnerTileAlignmentFn(innerTileAlignmentFn);
 
   // onlyFuseProducerInputOperands implies reduction tiling.
   if (!onlyFuseProducerInputOperands) {
@@ -262,7 +275,8 @@ static FailureOr<Operation *> tileRootAndFuseProducerConsumer(
             [&tiledAndFusedOps, &unfusableOps](Operation *op) {
               return tiledAndFusedOps.contains(op) &&
                      !unfusableOps.contains(op);
-            });
+            },
+            innerTileAlignmentFn);
 
     if (failed(newFusionOpportunities)) {
       LDBG() << "failed to fuse consumers, skip";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile_and_fuse_producer_consumer_anchoring_root_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile_and_fuse_producer_consumer_anchoring_root_op.mlir
@@ -416,3 +416,103 @@ func.func @infusible_pack(%arg0 : tensor<30xf32>) -> tensor<5x6xf32> {
 // CHECK:           linalg.generic
 // CHECK:         scf.forall.in_parallel
 // CHECK:         linalg.pack
+
+// -----
+
+// Scalable linalg.pack with an elementwise-add producer.
+// This test exercises the inner tile alignment hint `Equal` being passed.
+
+#config = #iree_cpu.lowering_config<distribution = [64, 64], vector_common_parallel = [[8], 1]>
+#config1 = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @scalable_pack_with_producer(%arg0: tensor<384x512xf32>, %arg1: tensor<384x512xf32>) -> tensor<?x512x?x1xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %0 = tensor.empty() : tensor<384x512xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<384x512xf32>, tensor<384x512xf32>) outs(%0 : tensor<384x512xf32>) attrs = {lowering_config = #config} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %3 = arith.addf %in, %in_0 : f32
+    linalg.yield %3 : f32
+  } -> tensor<384x512xf32>
+  %mouter = affine.apply affine_map<()[s0] -> (384 ceildiv s0)>()[%c8_vscale]
+  %2 = tensor.empty(%mouter, %c8_vscale) : tensor<?x512x?x1xf32>
+  %pack = linalg.pack %1 padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [%c8_vscale, 1] into %2 {lowering_config = #config1} : tensor<384x512xf32> -> tensor<?x512x?x1xf32>
+  return %pack : tensor<?x512x?x1xf32>
+}
+// CHECK-LABEL: func.func @scalable_pack_with_producer
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}} : index
+// CHECK:         scf.forall {{.*}} = (0, 0) to (384, 512) step (%[[C8VS]], 1)
+// CHECK:           %[[GEN:.+]] = linalg.generic
+// CHECK:           linalg.pack %[[GEN]]
+// CHECK-SAME:        inner_tiles = [%[[C8VS]], 1]
+// CHECK-SAME:        -> tensor<1x1x?x1xf32>
+// CHECK:           scf.forall.in_parallel
+
+// -----
+
+// Scalable linalg.unpack fused as the producer of an elementwise-add consumer.
+// This test exercises the inner tile alignment hint `Equal` being passed.
+
+#config = #iree_cpu.lowering_config<vector_common_parallel = [7, [8]]>
+#config1 = #iree_cpu.lowering_config<distribution = [84, 64], vector_common_parallel = [7, [8]]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @scalable_unpack_with_consumer(%arg0: tensor<12x?x7x?xf32>, %arg1: tensor<80x320xf32>) -> tensor<80x320xf32> {
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %0 = tensor.empty() : tensor<80x320xf32>
+  %unpack = linalg.unpack %arg0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %0 {lowering_config = #config} : tensor<12x?x7x?xf32> -> tensor<80x320xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1, %unpack : tensor<80x320xf32>, tensor<80x320xf32>) outs(%0 : tensor<80x320xf32>) attrs = {lowering_config = #config1} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %2 = arith.addf %in, %in_0 : f32
+    linalg.yield %2 : f32
+  } -> tensor<80x320xf32>
+  return %1 : tensor<80x320xf32>
+}
+// CHECK-LABEL: func.func @scalable_unpack_with_consumer
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}} : index
+// CHECK:         scf.forall {{.*}} = (0, 0) to (80, 320) step (7, %[[C8VS]])
+// CHECK:           %[[UNPACK:.+]] = linalg.unpack
+// CHECK-SAME:        inner_tiles = [7, %[[C8VS]]]
+// CHECK-SAME:        tensor<1x1x7x?xf32> -> tensor<?x?xf32>
+// CHECK:           linalg.generic
+// CHECK-SAME:        ins(%{{.*}}, %[[UNPACK]]
+// CHECK:           scf.forall.in_parallel
+
+// -----
+
+// Scalable linalg.mmt4d (N0 = 8*vscale) with a linalg.unpack consumer fused into
+// the mmt4d's tiling. This test exercises the inner tile alignment hint `Equal` being passed.
+
+#config = #iree_cpu.lowering_config<distribution = [5, 8, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 7, [8], 0]>
+#config1 = #iree_cpu.lowering_config<vector_common_parallel = [7, [8]]>
+func.func @scalable_mmt4d_with_unpack_consumer(%lhs: tensor<55x512x7x1xf32>, %rhs: tensor<?x512x?x1xf32>) -> tensor<385x?xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %nouter = tensor.dim %rhs, %c0 : tensor<?x512x?x1xf32>
+  %acc = tensor.empty(%nouter, %c8_vscale) : tensor<55x?x7x?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%acc : tensor<55x?x7x?xf32>) -> tensor<55x?x7x?xf32>
+  %mmt4d = linalg.mmt4d {lowering_config = #config} ins(%lhs, %rhs : tensor<55x512x7x1xf32>, tensor<?x512x?x1xf32>) outs(%fill : tensor<55x?x7x?xf32>) -> tensor<55x?x7x?xf32>
+  %n = arith.muli %nouter, %c8_vscale : index
+  %out = tensor.empty(%n) : tensor<385x?xf32>
+  %unpack = linalg.unpack %mmt4d outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %out {lowering_config = #config1} : tensor<55x?x7x?xf32> -> tensor<385x?xf32>
+  return %unpack : tensor<385x?xf32>
+}
+// CHECK-LABEL: func.func @scalable_mmt4d_with_unpack_consumer
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}} : index
+// CHECK:         scf.forall {{.*}} step (1, 1, %[[C8VS]])
+// CHECK:           %[[FILL:.+]] = linalg.fill
+// CHECK:           %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:        outs(%[[FILL]]
+// CHECK:           linalg.unpack %[[MMT4D]]
+// CHECK-SAME:        inner_tiles = [7, %[[C8VS]]]
+// CHECK-SAME:        tensor<1x1x7x?xf32> -> tensor<7x?xf32>
+// CHECK:           scf.forall.in_parallel

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -4005,6 +4005,219 @@ LogicalResult CustomOp::getResultTilePosition(
 // tensor::ConcatOp
 //===---------------------------------------------------------------------===//
 
+// InnerTileAlignment hint-bearing TilingInterface overloads. These ops do not
+// consult the hint (only linalg.pack/unpack do); the overloads exist so that
+// the ops -- which list the hint-less method in DeclareOpInterfaceMethods --
+// also define the defaulted hint-bearing arity and avoid C++ name hiding.
+FailureOr<TilingResult> ArgCompareOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> AttentionOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> CustomOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> ExpReductionOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> FftOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> GatherOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> MapLoadOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> MapStoreOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> OnlineAttentionOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> ScanOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> ScatterOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> SortOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> TopkOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> WinogradInputTransformOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> ArgCompareOp::generateResultTileValue(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return generateResultTileValue(builder, resultNumber, offsets, sizes);
+}
+
+FailureOr<TilingResult> AttentionOp::generateResultTileValue(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return generateResultTileValue(builder, resultNumber, offsets, sizes);
+}
+
+FailureOr<TilingResult> ExpReductionOp::generateResultTileValue(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return generateResultTileValue(builder, resultNumber, offsets, sizes);
+}
+
+FailureOr<TilingResult> GatherOp::generateResultTileValue(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return generateResultTileValue(builder, resultNumber, offsets, sizes);
+}
+
+FailureOr<TilingResult> MapLoadOp::generateResultTileValue(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return generateResultTileValue(builder, resultNumber, offsets, sizes);
+}
+
+// Additional hint-bearing TilingInterface overloads (ops added/extended since
+// the base of the InnerTileAlignment work). These ops ignore the hint.
+FailureOr<TilingResult> Im2colOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> TopkV2Op::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> WinogradFilterTransformOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
+    OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementation(builder, offsets, sizes);
+}
+
+FailureOr<TilingResult> Im2colOp::generateResultTileValue(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) {
+  return generateResultTileValue(builder, resultNumber, offsets, sizes);
+}
+
+FailureOr<TilingResult> MapLoadOp::getTiledImplementationFromOperandTiles(
+    OpBuilder &b, ArrayRef<unsigned> operandNumbers,
+    ArrayRef<SmallVector<OpFoldResult>> allOffsets,
+    ArrayRef<SmallVector<OpFoldResult>> allSizes,
+    ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementationFromOperandTiles(b, operandNumbers, allOffsets,
+                                                allSizes);
+}
+
+LogicalResult MapLoadOp::getIterationDomainTileFromOperandTiles(
+    OpBuilder &b, ArrayRef<unsigned> operandNumbers,
+    ArrayRef<SmallVector<OpFoldResult>> allOffsets,
+    ArrayRef<SmallVector<OpFoldResult>> allSizes,
+    SmallVectorImpl<OpFoldResult> &iterDomainOffsets,
+    SmallVectorImpl<OpFoldResult> &iterDomainSizes,
+    ArrayRef<mlir::InnerTileAlignment>) {
+  return getIterationDomainTileFromOperandTiles(b, operandNumbers, allOffsets,
+                                                allSizes, iterDomainOffsets,
+                                                iterDomainSizes);
+}
+
+FailureOr<TilingResult> MapStoreOp::getTiledImplementationFromOperandTiles(
+    OpBuilder &b, ArrayRef<unsigned> operandNumbers,
+    ArrayRef<SmallVector<OpFoldResult>> allOffsets,
+    ArrayRef<SmallVector<OpFoldResult>> allSizes,
+    ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementationFromOperandTiles(b, operandNumbers, allOffsets,
+                                                allSizes);
+}
+
+LogicalResult MapStoreOp::getIterationDomainTileFromOperandTiles(
+    OpBuilder &b, ArrayRef<unsigned> operandNumbers,
+    ArrayRef<SmallVector<OpFoldResult>> allOffsets,
+    ArrayRef<SmallVector<OpFoldResult>> allSizes,
+    SmallVectorImpl<OpFoldResult> &iterDomainOffsets,
+    SmallVectorImpl<OpFoldResult> &iterDomainSizes,
+    ArrayRef<mlir::InnerTileAlignment>) {
+  return getIterationDomainTileFromOperandTiles(b, operandNumbers, allOffsets,
+                                                allSizes, iterDomainOffsets,
+                                                iterDomainSizes);
+}
+
+FailureOr<TilingResult> ScatterOp::getTiledImplementationFromOperandTiles(
+    OpBuilder &b, ArrayRef<unsigned> operandNumbers,
+    ArrayRef<SmallVector<OpFoldResult>> allOffsets,
+    ArrayRef<SmallVector<OpFoldResult>> allSizes,
+    ArrayRef<mlir::InnerTileAlignment>) {
+  return getTiledImplementationFromOperandTiles(b, operandNumbers, allOffsets,
+                                                allSizes);
+}
+
+LogicalResult ScatterOp::getIterationDomainTileFromOperandTiles(
+    OpBuilder &b, ArrayRef<unsigned> operandNumbers,
+    ArrayRef<SmallVector<OpFoldResult>> allOffsets,
+    ArrayRef<SmallVector<OpFoldResult>> allSizes,
+    SmallVectorImpl<OpFoldResult> &iterDomainOffsets,
+    SmallVectorImpl<OpFoldResult> &iterDomainSizes,
+    ArrayRef<mlir::InnerTileAlignment>) {
+  return getIterationDomainTileFromOperandTiles(b, operandNumbers, allOffsets,
+                                                allSizes, iterDomainOffsets,
+                                                iterDomainSizes);
+}
+
 namespace {
 struct ConcatOpTilingExternalModel
     : TilingInterface::ExternalModel<ConcatOpTilingExternalModel,
@@ -4028,6 +4241,20 @@ struct ConcatOpTilingExternalModel
                           unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
                           ArrayRef<OpFoldResult> sizes) const {
     return getTiledImplementation(op, builder, offsets, sizes);
+  }
+
+  FailureOr<TilingResult> getTiledImplementation(
+      Operation *op, OpBuilder &builder, ArrayRef<OpFoldResult> offsets,
+      ArrayRef<OpFoldResult> sizes, ArrayRef<mlir::InnerTileAlignment>) const {
+    return getTiledImplementation(op, builder, offsets, sizes);
+  }
+
+  FailureOr<TilingResult>
+  generateResultTileValue(Operation *op, OpBuilder &builder,
+                          unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+                          ArrayRef<OpFoldResult> sizes,
+                          ArrayRef<mlir::InnerTileAlignment>) const {
+    return generateResultTileValue(op, builder, resultNumber, offsets, sizes);
   }
 
   LogicalResult


### PR DESCRIPTION
Install the InnerTileAlignment control function in TileAndDistributeToWorkgroupsUsingForall with Multiple alignment: the workgroup distribution tile size is a static multiple of the scalable linalg.pack/unpack inner tile, so scalable pack/unpack tile and fuse at the distribution level.

Adds lit coverage in tile_and_distribute_workgroups_using_forall.mlir.