### PR TITLE
[Metal] Fix indirect dispatch retaining stack garbage as a resource

### DIFF
--- a/runtime/src/iree/hal/drivers/metal/direct_command_buffer.m
+++ b/runtime/src/iree/hal/drivers/metal/direct_command_buffer.m
@@ -865,7 +865,7 @@ static iree_status_t iree_hal_metal_command_buffer_prepare_dispatch(
     resources[resource_count++] = config.workgroup_count_ref.buffer;
   }
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_resource_set_insert(command_buffer->resource_set, resource_count, &executable));
+      z0, iree_hal_resource_set_insert(command_buffer->resource_set, resource_count, resources));
 
   const iree_hal_metal_pipeline_t* pipeline = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(


### PR DESCRIPTION
iree_hal_metal_command_buffer_prepare_dispatch built a resources[2] array for direct/indirect dispatch but passed &executable (the address of the parameter) to iree_hal_resource_set_insert instead of the resources array. For indirect dispatch (resource_count==2) this read the stack word adjacent to the parameter and retained it as a resource, corrupting the resource set and crashing on command-buffer teardown (release dereferenced a NULL vtable).

Pass resources so both the executable and the indirect workgroup-count buffer are retained correctly. Fixes the DispatchIndirectParameters and QueueDispatchIndirectParameters CTS segfaults (ctest #1307, #1309).

Signed-off-by: Alex Vasile <48962821+Alex-Vasile@users.noreply.github.com>