### PR TITLE
[LLVMCPU] Add SME lowering-strategy tests for f64 and unsupported i8 matmuls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -56,6 +56,7 @@ iree_lit_test_suite(
             "scalable_tile_and_vectorize_matmul.mlir",
             "select_aarch64_lowering_strategy.mlir",
             "select_aarch64_sme_lowering_strategy.mlir",
+            "select_aarch64_ssve_lowering_strategy.mlir",
             "select_aarch64_sve_lowering_strategy.mlir",
             "select_aarch64_sve_lowering_strategy_peeling.mlir",
             "select_riscv_lowering_strategy.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_lit_test_suite(
     "scalable_tile_and_vectorize_matmul.mlir"
     "select_aarch64_lowering_strategy.mlir"
     "select_aarch64_sme_lowering_strategy.mlir"
+    "select_aarch64_ssve_lowering_strategy.mlir"
     "select_aarch64_sve_lowering_strategy.mlir"
     "select_aarch64_sve_lowering_strategy_peeling.mlir"
     "select_riscv_lowering_strategy.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s --check-prefixes=CHECK,WITH-SME
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --iree-llvmcpu-disable-arm-sme-tiling --split-input-file %s | FileCheck %s --check-prefixes=DISABLE-ARM-SME
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --iree-llvmcpu-disable-arm-sme-tiling --split-input-file %s | FileCheck %s --check-prefixes=CHECK,DISABLE-ARM-SME
 
 #executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
 func.func @transpose_f32(%2: tensor<32x32xf32>) -> tensor<32x32xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
@@ -10,8 +10,9 @@ func.func @transpose_f32(%2: tensor<32x32xf32>) -> tensor<32x32xf32> attributes 
   } -> tensor<32x32xf32>
   return %4 : tensor<32x32xf32>
 }
-//   CHECK: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [4, 32], vector_common_parallel = {{\[}}[4], [4]]>
-//   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [4, 32], vector_common_parallel = {{\[}}[4], [4]]>
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 32], vector_common_parallel = [4, 4]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
 //       CHECK: func.func @transpose_f32(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.generic
@@ -28,8 +29,9 @@ func.func @transpose_output_indexing_map_f32(%2: tensor<32x32xf32>) -> tensor<32
   } -> tensor<32x32xf32>
   return %4 : tensor<32x32xf32>
 }
-//   CHECK: #[[CONFIG:.+]] =  #iree_cpu.lowering_config<distribution = [4, 32], vector_common_parallel = {{\[}}[4], [4]]>
-//   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//   WITH-SME-DAG: #[[CONFIG:.+]] =  #iree_cpu.lowering_config<distribution = [4, 32], vector_common_parallel = {{\[}}[4], [4]]>
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 32], vector_common_parallel = [4, 4]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
 //       CHECK: func.func @transpose_output_indexing_map_f32(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.generic
@@ -46,8 +48,9 @@ func.func @transpose_f64(%2: tensor<32x32xf64>) -> tensor<32x32xf64> attributes 
    } -> tensor<32x32xf64>
    return %4 : tensor<32x32xf64>
 }
-//   CHECK: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [4, 32], vector_common_parallel = {{\[}}[2], [2]]>
-//   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [4, 32], vector_common_parallel = {{\[}}[2], [2]]>
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [32, 32], vector_common_parallel = [2, 2]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
 //       CHECK: func.func @transpose_f64(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.generic
@@ -97,18 +100,12 @@ func.func @matmul_tensors(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?
   return %10 : tensor<?x?xf32>
 }
 //  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
-//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//      DISABLE-ARM-SME: func.func @matmul_tensors(
-//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       DISABLE-ARM-SME: linalg.matmul
-//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
-
 //   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = {{\[}}[8], [8], 0], vector_reduction = [0, 0, 1]>
-//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//       WITH-SME: func.func @matmul_tensors(
-//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       WITH-SME: linalg.matmul
-//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//       CHECK: func.func @matmul_tensors(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -120,18 +117,12 @@ func.func @matmul_tensors_f64(%7: tensor<?x?xf64>, %8: tensor<?x?xf64>, %9: tens
   return %10 : tensor<?x?xf64>
 }
 //  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [4], 0], vector_reduction = [0, 0, 2]>
-//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//      DISABLE-ARM-SME: func.func @matmul_tensors_f64(
-//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       DISABLE-ARM-SME: linalg.matmul
-//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
-
 //   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = {{\[}}[4], [8], 0], vector_reduction = [0, 0, 1]>
-//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//       WITH-SME: func.func @matmul_tensors_f64(
-//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       WITH-SME: linalg.matmul
-//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//       CHECK: func.func @matmul_tensors_f64(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -143,19 +134,12 @@ func.func @matmul_tensors_i8i8_i32_with_sme(%7: tensor<?x?xi8>, %8: tensor<?x?xi
   %10 = linalg.matmul ins(%7, %8 : tensor<?x?xi8>, tensor<?x?xi8>) outs(%9 : tensor<?x?xi32>) -> tensor<?x?xi32>
   return %10 : tensor<?x?xi32>
 }
-//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
-//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//      DISABLE-ARM-SME: func.func @matmul_tensors_i8i8_i32_with_sme(
-//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       DISABLE-ARM-SME: linalg.matmul
-//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
-
-//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
-//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//       WITH-SME: func.func @matmul_tensors_i8i8_i32_with_sme(
-//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       WITH-SME: linalg.matmul
-//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//       CHECK: func.func @matmul_tensors_i8i8_i32_with_sme(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
 
@@ -170,7 +154,10 @@ func.func @matmul_tensors_i8i8_i32_with_sme(%7: tensor<?x?xi8>, %8: tensor<?x?xi
 // fallback available (below), since the regular SVE tiling heuristic
 // requires +sve. To target SSVE (streaming SVE) on a target that only has
 // +sme, that fallback heuristic needs to learn to treat +sme as implying
-// streaming-SVE support.
+// streaming-SVE support. Note --iree-llvmcpu-force-arm-streaming does not
+// change this: it's consumed by a later pass in the full lowering-to-LLVM
+// pipeline (addLowerToLLVMPasses), not by iree-llvmcpu-select-lowering-
+// strategy, so it has no effect on the tile sizes selected here.
 #executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
 func.func @matmul_tensors_sme_no_sve(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
   %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
@@ -179,16 +166,10 @@ func.func @matmul_tensors_sme_no_sve(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %
 // SME tiling disabled: falls back to non-scalable NEON tile sizes, since the
 // SVE fallback heuristic requires +sve (see TODO above).
 //  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = [8, 8, 0], vector_reduction = [0, 0, 4]>
-//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {enable_loop_peeling}>
-//      DISABLE-ARM-SME: func.func @matmul_tensors_sme_no_sve(
-//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       DISABLE-ARM-SME: linalg.matmul
-//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
-
 // SME tiling enabled: still picks scalable [8]x[8] SME tile sizes.
 //   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = {{\[}}[8], [8], 0], vector_reduction = [0, 0, 1]>
-//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {enable_loop_peeling}>
-//       WITH-SME: func.func @matmul_tensors_sme_no_sve(
-//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       WITH-SME: linalg.matmul
-//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {enable_loop_peeling}>
+//       CHECK: func.func @matmul_tensors_sme_no_sve(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
@@ -140,36 +140,3 @@ func.func @matmul_tensors_i8i8_i32_with_sme(%7: tensor<?x?xi8>, %8: tensor<?x?xi
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.matmul
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
-
-// -----
-
-// A target with +sme but not +sve (i.e. no non-streaming SVE) still picks
-// scalable SME tile sizes when SME tiling is enabled: matmul lowering does
-// not itself require +sve. Note this goes through a different
-// pre-processing strategy than the +sve,+sme case (Peeling, with an extra
-// `cache_parallel` tiling level) because `hasAnySVEFeature` does not count
-// +sme - see getVectorPreProcStrategy() in KernelDispatch.cpp.
-//
-// TODO: When SME tiling is disabled here there is no scalable
-// fallback available (below), since the regular SVE tiling heuristic
-// requires +sve. To target SSVE (streaming SVE) on a target that only has
-// +sme, that fallback heuristic needs to learn to treat +sme as implying
-// streaming-SVE support. Note --iree-llvmcpu-force-arm-streaming does not
-// change this: it's consumed by a later pass in the full lowering-to-LLVM
-// pipeline (addLowerToLLVMPasses), not by iree-llvmcpu-select-lowering-
-// strategy, so it has no effect on the tile sizes selected here.
-#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
-func.func @matmul_tensors_sme_no_sve(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
-  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %10 : tensor<?x?xf32>
-}
-// SME tiling disabled: falls back to non-scalable NEON tile sizes, since the
-// SVE fallback heuristic requires +sve (see TODO above).
-//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = [8, 8, 0], vector_reduction = [0, 0, 4]>
-// SME tiling enabled: still picks scalable [8]x[8] SME tile sizes.
-//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = {{\[}}[8], [8], 0], vector_reduction = [0, 0, 1]>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {enable_loop_peeling}>
-//       CHECK: func.func @matmul_tensors_sme_no_sve(
-//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
-//       CHECK: linalg.matmul
-//  CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s --check-prefixes=CHECK,WITH-SME
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --iree-llvmcpu-disable-arm-sme-tiling --split-input-file %s | FileCheck %s --check-prefixes=DISABLE-ARM-SME
 
 #executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
 func.func @transpose_f32(%2: tensor<32x32xf32>) -> tensor<32x32xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
@@ -87,3 +88,107 @@ func.func @transpose_unsupported_not_simple_transpose(%2: tensor<32x32xf32>) -> 
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.generic
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
+//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//      DISABLE-ARM-SME: func.func @matmul_tensors(
+//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       DISABLE-ARM-SME: linalg.matmul
+//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
+
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = {{\[}}[8], [8], 0], vector_reduction = [0, 0, 1]>
+//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//       WITH-SME: func.func @matmul_tensors(
+//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       WITH-SME: linalg.matmul
+//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// f64 matmul uses different SME tile sizes than f32: [4]x[8] instead of [8]x[8]
+// (each SME tile only holds half as many f64 elements per row as f32 ones).
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_f64(%7: tensor<?x?xf64>, %8: tensor<?x?xf64>, %9: tensor<?x?xf64>) -> tensor<?x?xf64> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf64>, tensor<?x?xf64>) outs(%9 : tensor<?x?xf64>) -> tensor<?x?xf64>
+  return %10 : tensor<?x?xf64>
+}
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [4], 0], vector_reduction = [0, 0, 2]>
+//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//      DISABLE-ARM-SME: func.func @matmul_tensors_f64(
+//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       DISABLE-ARM-SME: linalg.matmul
+//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
+
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = {{\[}}[4], [8], 0], vector_reduction = [0, 0, 1]>
+//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//       WITH-SME: func.func @matmul_tensors_f64(
+//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       WITH-SME: linalg.matmul
+//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// SME tiling only supports f32 and f64 matmuls, so an i8 matmul should fall
+// back to the regular SVE tiling heuristic regardless of whether SME tiling
+// is enabled or disabled.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_i8i8_i32_with_sme(%7: tensor<?x?xi8>, %8: tensor<?x?xi8>, %9: tensor<?x?xi32>) -> tensor<?x?xi32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xi8>, tensor<?x?xi8>) outs(%9 : tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %10 : tensor<?x?xi32>
+}
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
+//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//      DISABLE-ARM-SME: func.func @matmul_tensors_i8i8_i32_with_sme(
+//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       DISABLE-ARM-SME: linalg.matmul
+//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
+
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
+//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//       WITH-SME: func.func @matmul_tensors_i8i8_i32_with_sme(
+//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       WITH-SME: linalg.matmul
+//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// A target with +sme but not +sve (i.e. no non-streaming SVE) still picks
+// scalable SME tile sizes when SME tiling is enabled: matmul lowering does
+// not itself require +sve. Note this goes through a different
+// pre-processing strategy than the +sve,+sme case (Peeling, with an extra
+// `cache_parallel` tiling level) because `hasAnySVEFeature` does not count
+// +sme - see getVectorPreProcStrategy() in KernelDispatch.cpp.
+//
+// TODO: When SME tiling is disabled here there is no scalable
+// fallback available (below), since the regular SVE tiling heuristic
+// requires +sve. To target SSVE (streaming SVE) on a target that only has
+// +sme, that fallback heuristic needs to learn to treat +sme as implying
+// streaming-SVE support.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_sme_no_sve(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+// SME tiling disabled: falls back to non-scalable NEON tile sizes, since the
+// SVE fallback heuristic requires +sve (see TODO above).
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = [8, 8, 0], vector_reduction = [0, 0, 4]>
+//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {enable_loop_peeling}>
+//      DISABLE-ARM-SME: func.func @matmul_tensors_sme_no_sve(
+//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       DISABLE-ARM-SME: linalg.matmul
+//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
+
+// SME tiling enabled: still picks scalable [8]x[8] SME tile sizes.
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = {{\[}}[8], [8], 0], vector_reduction = [0, 0, 1]>
+//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {enable_loop_peeling}>
+//       WITH-SME: func.func @matmul_tensors_sme_no_sve(
+//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       WITH-SME: linalg.matmul
+//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_ssve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_ssve_lowering_strategy.mlir
@@ -4,18 +4,8 @@
 // A target with +sme but not +sve (i.e. no non-streaming SVE) still picks
 // scalable SME tile sizes when SME tiling is enabled: matmul lowering does
 // not itself require +sve. Note this goes through a different
-// pre-processing strategy than the +sve,+sme case (Peeling, with an extra
-// `cache_parallel` tiling level) because `hasAnySVEFeature` does not count
-// +sme - see getVectorPreProcStrategy() in KernelDispatch.cpp.
-//
-// TODO: When SME tiling is disabled here there is no scalable
-// fallback available (below), since the regular SVE tiling heuristic
-// requires +sve. To target SSVE (streaming SVE) on a target that only has
-// +sme, that fallback heuristic needs to learn to treat +sme as implying
-// streaming-SVE support. Note --iree-llvmcpu-force-arm-streaming does not
-// change this: it's consumed by a later pass in the full lowering-to-LLVM
-// pipeline (addLowerToLLVMPasses), not by iree-llvmcpu-select-lowering-
-// strategy, so it has no effect on the tile sizes selected here.
+// pre-processing strategy than the +sve,+sme case: peeling, with an extra
+// `cache_parallel` tiling level.
 #executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
 func.func @matmul_tensors_sme_no_sve(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
   %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_ssve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_ssve_lowering_strategy.mlir
@@ -1,0 +1,33 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s --check-prefixes=CHECK,WITH-SME
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --iree-llvmcpu-disable-arm-sme-tiling --split-input-file %s | FileCheck %s --check-prefixes=CHECK,DISABLE-ARM-SME
+
+// A target with +sme but not +sve (i.e. no non-streaming SVE) still picks
+// scalable SME tile sizes when SME tiling is enabled: matmul lowering does
+// not itself require +sve. Note this goes through a different
+// pre-processing strategy than the +sve,+sme case (Peeling, with an extra
+// `cache_parallel` tiling level) because `hasAnySVEFeature` does not count
+// +sme - see getVectorPreProcStrategy() in KernelDispatch.cpp.
+//
+// TODO: When SME tiling is disabled here there is no scalable
+// fallback available (below), since the regular SVE tiling heuristic
+// requires +sve. To target SSVE (streaming SVE) on a target that only has
+// +sme, that fallback heuristic needs to learn to treat +sme as implying
+// streaming-SVE support. Note --iree-llvmcpu-force-arm-streaming does not
+// change this: it's consumed by a later pass in the full lowering-to-LLVM
+// pipeline (addLowerToLLVMPasses), not by iree-llvmcpu-select-lowering-
+// strategy, so it has no effect on the tile sizes selected here.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_sme_no_sve(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %10 : tensor<?x?xf32>
+}
+// SME tiling disabled: falls back to non-scalable NEON tile sizes, since the
+// SVE fallback heuristic requires +sve (see TODO above).
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = [8, 8, 0], vector_reduction = [0, 0, 4]>
+// SME tiling enabled: still picks scalable [8]x[8] SME tile sizes.
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<cache_parallel = [64, 64, 0], distribution = [64, 64, 0], vector_common_parallel = {{\[}}[8], [8], 0], vector_reduction = [0, 0, 1]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>, {enable_loop_peeling}>
+//       CHECK: func.func @matmul_tensors_sme_no_sve(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -73,9 +73,7 @@ func.func @static_tensors_1x1(%3: tensor<1x1xf32>, %4: tensor<1x1xf32>, %5: tens
 
 // -----
 
-// f64 matmul on an SVE-only target (no SME) should use the regular SVE
-// tiling heuristic. See select_aarch64_sme_lowering_strategy.mlir for the
-// SME-specific f64 tile sizes.
+// f64 matmul on an SVE-only target.
 #executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
 func.func @matmul_tensors_f64(%7: tensor<?x?xf64>, %8: tensor<?x?xf64>, %9: tensor<?x?xf64>) -> tensor<?x?xf64> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
   %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf64>, tensor<?x?xf64>) outs(%9 : tensor<?x?xf64>) -> tensor<?x?xf64>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -96,6 +96,46 @@ func.func @matmul_tensors(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?
 
 // -----
 
+// f64 matmul uses different SME tile sizes than f32: [4]x[8] instead of [8]x[8]
+// (each SME tile only holds half as many f64 elements per row as f32 ones).
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_f64(%7: tensor<?x?xf64>, %8: tensor<?x?xf64>, %9: tensor<?x?xf64>) -> tensor<?x?xf64> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf64>, tensor<?x?xf64>) outs(%9 : tensor<?x?xf64>) -> tensor<?x?xf64>
+  return %10 : tensor<?x?xf64>
+}
+//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [4], 0], vector_reduction = [0, 0, 2]>
+//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//      DISABLE-ARM-SME: func.func @matmul_tensors_f64(
+//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       DISABLE-ARM-SME: linalg.matmul
+//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
+
+//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = {{\[}}[4], [8], 0], vector_reduction = [0, 0, 1]>
+//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//       WITH-SME: func.func @matmul_tensors_f64(
+//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
+//       WITH-SME: linalg.matmul
+//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// SME tiling only supports f32 and f64 matmuls, so an i8 matmul should fall
+// back to the regular SVE tiling heuristic regardless of whether SME tiling
+// is enabled or disabled.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @matmul_tensors_i8i8_i32_with_sme(%7: tensor<?x?xi8>, %8: tensor<?x?xi8>, %9: tensor<?x?xi32>) -> tensor<?x?xi32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xi8>, tensor<?x?xi8>) outs(%9 : tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %10 : tensor<?x?xi32>
+}
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
+//       CHECK: func.func @matmul_tensors_i8i8_i32_with_sme(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.matmul
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -1,7 +1,5 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' \
-// RUN:   --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s --check-prefixes=CHECK,WITH-SME
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' \
-// RUN:   --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file --iree-llvmcpu-disable-arm-sme-tiling %s | FileCheck %s --check-prefixes=CHECK,DISABLE-ARM-SME
+// RUN:   --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s
 
 #executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
 func.func @matmul_tensors(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
@@ -75,61 +73,17 @@ func.func @static_tensors_1x1(%3: tensor<1x1xf32>, %4: tensor<1x1xf32>, %5: tens
 
 // -----
 
-#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
-func.func @matmul_tensors(%7: tensor<?x?xf32>, %8: tensor<?x?xf32>, %9: tensor<?x?xf32>) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
-  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %10 : tensor<?x?xf32>
-}
-//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
-//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//      DISABLE-ARM-SME: func.func @matmul_tensors(
-//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       DISABLE-ARM-SME: linalg.matmul
-//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
-
-//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = {{\[}}[8], [8], 0], vector_reduction = [0, 0, 1]>
-//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//       WITH-SME: func.func @matmul_tensors(
-//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       WITH-SME: linalg.matmul
-//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
-
-// -----
-
-// f64 matmul uses different SME tile sizes than f32: [4]x[8] instead of [8]x[8]
-// (each SME tile only holds half as many f64 elements per row as f32 ones).
-#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+// f64 matmul on an SVE-only target (no SME) should use the regular SVE
+// tiling heuristic. See select_aarch64_sme_lowering_strategy.mlir for the
+// SME-specific f64 tile sizes.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
 func.func @matmul_tensors_f64(%7: tensor<?x?xf64>, %8: tensor<?x?xf64>, %9: tensor<?x?xf64>) -> tensor<?x?xf64> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
   %10 = linalg.matmul ins(%7, %8 : tensor<?x?xf64>, tensor<?x?xf64>) outs(%9 : tensor<?x?xf64>) -> tensor<?x?xf64>
   return %10 : tensor<?x?xf64>
 }
-//  DISABLE-ARM-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [4], 0], vector_reduction = [0, 0, 2]>
-//  DISABLE-ARM-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//      DISABLE-ARM-SME: func.func @matmul_tensors_f64(
-//  DISABLE-ARM-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       DISABLE-ARM-SME: linalg.matmul
-//  DISABLE-ARM-SME-SAME:     lowering_config = #[[CONFIG]]
-
-//   WITH-SME-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = {{\[}}[4], [8], 0], vector_reduction = [0, 0, 1]>
-//   WITH-SME-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//       WITH-SME: func.func @matmul_tensors_f64(
-//  WITH-SME-SAME:     translation_info = #[[TRANSLATION]]
-//       WITH-SME: linalg.matmul
-//  WITH-SME-SAME:     lowering_config = #[[CONFIG]]
-
-// -----
-
-// SME tiling only supports f32 and f64 matmuls, so an i8 matmul should fall
-// back to the regular SVE tiling heuristic regardless of whether SME tiling
-// is enabled or disabled.
-#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
-func.func @matmul_tensors_i8i8_i32_with_sme(%7: tensor<?x?xi8>, %8: tensor<?x?xi8>, %9: tensor<?x?xi32>) -> tensor<?x?xi32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
-  %10 = linalg.matmul ins(%7, %8 : tensor<?x?xi8>, tensor<?x?xi8>) outs(%9 : tensor<?x?xi32>) -> tensor<?x?xi32>
-  return %10 : tensor<?x?xi32>
-}
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [8], 0], vector_reduction = [0, 0, 4]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64, 0], vector_common_parallel = [8, [4], 0], vector_reduction = [0, 0, 2]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DoubleTilingExpert>>
-//       CHECK: func.func @matmul_tensors_i8i8_i32_with_sme(
+//       CHECK: func.func @matmul_tensors_f64(
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.matmul
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]


### PR DESCRIPTION
Hi Folks :D
 `getMatmulAArch64SMEVectorSizes` (within `KernelDispatch.cpp`) only had test coverage for the f32 matmul case.

This PR add two tests:
- `f64` which uses `[4]x[8]` SME tiles instead of the `[8]x[8]` used for f32.
    https://github.com/iree-org/iree/blob/50d0addfb49254e0b7b746959b360c79437281cc/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp#L1465-L1471
- `i8` which SME does not support
    https://github.com/iree-org/iree/blob/50d0addfb49254e0b7b746959b360c79437281cc/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp#L1488-L1502

_AI disclaimer_: I used `Claude:Sonnet5` to write the checks.

@AGindinson @egebeysel 