### PR TITLE
[LinalgExt] Separate ins and outs of Sort op

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
@@ -184,9 +184,17 @@ struct SortOpConversion final : OpConversionPattern<mlir::stablehlo::SortOp> {
                                                 resultTypes))) {
       return failure();
     };
+    SmallVector<Value> outputs;
+    for (auto [input, resultType] :
+         llvm::zip_equal(adaptor.getOperands(), resultTypes)) {
+      auto resultTensorType = cast<RankedTensorType>(resultType);
+      outputs.push_back(tensor::EmptyOp::create(
+          rewriter, loc, tensor::getMixedSizes(rewriter, loc, input),
+          resultTensorType.getElementType()));
+    }
     auto sortOp = IREE::LinalgExt::SortOp::create(
-        rewriter, loc, resultTypes,
-        /*inputs=*/ValueRange{}, adaptor.getOperands(), op.getDimensionAttr());
+        rewriter, loc, resultTypes, adaptor.getOperands(), outputs,
+        op.getDimensionAttr());
     rewriter.inlineRegionBefore(op.getComparator(), sortOp.getRegion(),
                                 sortOp.getRegion().begin());
     Region &region = sortOp.getRegion();

--- a/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_linalg_ext.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_linalg_ext.mlir
@@ -13,9 +13,11 @@ func.func @sort_1d(%arg0: tensor<128xi32>) -> (tensor<128xi32>) {
   }) {dimension = 0 : i64, is_stable = false} : (tensor<128xi32>) -> (tensor<128xi32>)
   return %0 : tensor<128xi32>
 }
+// CHECK:         %[[OUT:.+]] = tensor.empty() : tensor<128xi32>
 // CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
 // CHECK-SAME:      dimension(0)
-// CHECK-SAME:      outs(%[[ARG0]] : tensor<128xi32>)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<128xi32>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<128xi32>)
 // CHECK:           ^bb0(%[[ARG1:.+]]: i32, %[[ARG2:.+]]: i32)
 // CHECK:             %[[CMP:.+]] = arith.cmpi sgt, %[[ARG1]], %[[ARG2]]
 // CHECK:             iree_linalg_ext.yield %[[CMP]]
@@ -35,9 +37,11 @@ func.func @sort_1d_ui(%arg0: tensor<128xui32>) -> (tensor<128xui32>) {
   return %0 : tensor<128xui32>
 }
 // CHECK:         %[[CAST:.+]] = builtin.unrealized_conversion_cast %[[ARG0]] : tensor<128xui32> to tensor<128xi32>
+// CHECK:         %[[OUT:.+]] = tensor.empty() : tensor<128xi32>
 // CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
 // CHECK-SAME:      dimension(0)
-// CHECK-SAME:      outs(%[[CAST]] : tensor<128xi32>)
+// CHECK-SAME:      ins(%[[CAST]] : tensor<128xi32>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<128xi32>)
 // CHECK:           ^bb0(%[[ARG1:.+]]: i32, %[[ARG2:.+]]: i32)
 // CHECK:             %[[CMP:.+]] = arith.cmpi ugt, %[[ARG1]], %[[ARG2]]
 // CHECK:             iree_linalg_ext.yield %[[CMP]]
@@ -60,7 +64,11 @@ func.func @sort_cst_capture(%arg0: tensor<1x10xi32>) -> tensor<1x10xi32> {
 }
 
 // CHECK:         %[[SCALAR:.+]] = arith.constant 0 : i32
-// CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort dimension(1) outs(%[[ARG0]] : tensor<1x10xi32>)  {
+// CHECK:         %[[OUT:.+]] = tensor.empty() : tensor<1x10xi32>
+// CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
+// CHECK-SAME:      dimension(1)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<1x10xi32>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<1x10xi32>)
 // CHECK:         ^bb0(%[[ARG1:.+]]: i32, %{{.*}}: i32)
 // CHECK:           %[[RES:.+]] = arith.cmpi slt, %[[ARG1]], %[[SCALAR]] : i32
 // CHECK:           iree_linalg_ext.yield %[[RES]] : i1
@@ -83,7 +91,11 @@ func.func @sort_argument_capture(%arg0: tensor<1x10xi32>, %arg1 : tensor<i32>) -
 }
 
 // CHECK:         %[[SCALAR:.+]] = tensor.extract %[[ARG1]][] : tensor<i32>
-// CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort dimension(1) outs(%[[ARG0]] : tensor<1x10xi32>)  {
+// CHECK:         %[[OUT:.+]] = tensor.empty() : tensor<1x10xi32>
+// CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
+// CHECK-SAME:      dimension(1)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<1x10xi32>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<1x10xi32>)
 // CHECK:         ^bb0(%[[ARG2:.+]]: i32, %{{.*}}: i32)
 // CHECK:           %[[RES:.+]] = arith.cmpi slt, %[[ARG2]], %[[SCALAR]] : i32
 // CHECK:           iree_linalg_ext.yield %[[RES]] : i1
@@ -103,9 +115,11 @@ func.func @sort_2d(%arg0: tensor<16x32xi32>) -> (tensor<16x32xi32>) {
   }) {dimension = 0 : i64, is_stable = false} : (tensor<16x32xi32>) -> (tensor<16x32xi32>)
   return %0 : tensor<16x32xi32>
 }
+// CHECK:         %[[OUT:.+]] = tensor.empty() : tensor<16x32xi32>
 // CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
 // CHECK-SAME:      dimension(0)
-// CHECK-SAME:      outs(%[[ARG0]] : tensor<16x32xi32>)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<16x32xi32>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<16x32xi32>)
 // CHECK:           ^bb0(%[[ARG1:.+]]: i32, %[[ARG2:.+]]: i32)
 // CHECK:             %[[CMP:.+]] = arith.cmpi sgt, %[[ARG1]], %[[ARG2]]
 // CHECK:             iree_linalg_ext.yield %[[CMP]]
@@ -127,9 +141,11 @@ func.func @sort_unsigned(%arg0: tensor<1x5xf32>) -> tensor<1x5xf32> {
   return %1 : tensor<1x5xf32>
 }
 
+// CHECK:         %[[OUT:.+]] = tensor.empty() : tensor<1x5xf32>
 // CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
 // CHECK-SAME:      dimension(1)
-// CHECK-SAME:      outs(%[[ARG0]] : tensor<1x5xf32>)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<1x5xf32>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<1x5xf32>)
 // CHECK:           ^bb0(%[[ARG1:.+]]: f32, %[[ARG2:.+]]: f32)
 // CHECK:             %[[CAST1:.+]] = arith.bitcast %[[ARG1]] : f32 to i32
 // CHECK:             %[[CAST2:.+]] = arith.bitcast %[[ARG2]] : f32 to i32
@@ -156,9 +172,11 @@ func.func @sort_unsigned_cst_capture(%arg0: tensor<1x5xf32>) -> tensor<1x5xf32> 
 // CHECK:         %[[UI32:.+]] = stablehlo.constant dense<2> : tensor<ui32>
 // CHECK:         %[[CONVERSION_CAST_CST:.+]] = builtin.unrealized_conversion_cast %[[UI32]] : tensor<ui32> to tensor<i32>
 // CHECK:         %[[EXTRACT_CST:.+]] = tensor.extract %[[CONVERSION_CAST_CST]][] : tensor<i32>
+// CHECK:         %[[OUT:.+]] = tensor.empty() : tensor<1x5xf32>
 // CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
 // CHECK-SAME:      dimension(1)
-// CHECK-SAME:      outs(%[[ARG0]] : tensor<1x5xf32>)
+// CHECK-SAME:      ins(%[[ARG0]] : tensor<1x5xf32>)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<1x5xf32>)
 // CHECK:           ^bb0(%[[ARG1:.+]]: f32, %[[ARG2:.+]]: f32)
 // CHECK:             %[[CAST1:.+]] = arith.bitcast %[[ARG1]] : f32 to i32
 // CHECK:             %[[CMP:.+]] = arith.cmpi ult, %[[CAST1]], %[[EXTRACT_CST]] : i32
@@ -187,9 +205,11 @@ func.func @sort_complex(%arg0: tensor<1x5xf32>, %arg1 : tensor<complex<f32>>) ->
   return %1 : tensor<1x5xf32>
 }
 
+// CHECK:         %[[OUT:.+]] = tensor.empty() : tensor<1x5xf32>
 // CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
 // CHECK-SAME:    dimension(1)
-// CHECK-SAME:    outs(%[[ARG0]] : tensor<1x5xf32>)
+// CHECK-SAME:    ins(%[[ARG0]] : tensor<1x5xf32>)
+// CHECK-SAME:    outs(%[[OUT]] : tensor<1x5xf32>)
 // CHECK:         ^bb0(%[[ARG1:.+]]: f32, %[[ARG2:.+]]: f32)
 // CHECK-NOT:       stablehlo.complex
 // CHECK:           %[[CMP:.+]] = arith.cmpf olt, %{{.+}}, %{{.+}} : f32
@@ -198,7 +218,9 @@ func.func @sort_complex(%arg0: tensor<1x5xf32>, %arg1 : tensor<complex<f32>>) ->
 
 // -----
 
-// CHECK-LABEL: func.func @topk
+// CHECK-LABEL: func.func @topk(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]: tensor<128xi32>
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]: tensor<128xi32>
 func.func @topk(%arg0: tensor<128xi32>, %arg1: tensor<128xi32>) -> (tensor<128xi32>) {
   %0:2 = "stablehlo.sort"(%arg0, %arg1) ( {
   ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<i32>):
@@ -207,11 +229,12 @@ func.func @topk(%arg0: tensor<128xi32>, %arg1: tensor<128xi32>) -> (tensor<128xi
   }) {dimension = 0 : i64, is_stable = false} : (tensor<128xi32>, tensor<128xi32>) -> (tensor<128xi32>, tensor<128xi32>)
   return %0#0 : tensor<128xi32>
 }
-// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK:         %[[OUT0:.+]] = tensor.empty() : tensor<128xi32>
+// CHECK:         %[[OUT1:.+]] = tensor.empty() : tensor<128xi32>
 // CHECK:         %[[SORT:.+]]:2 = iree_linalg_ext.sort
 // CHECK-SAME:      dimension(0)
-// CHECK-SAME:      outs(%[[ARG0]], %[[ARG1]] : tensor<128xi32>, tensor<128xi32>)
+// CHECK-SAME:      ins(%[[ARG0]], %[[ARG1]] : tensor<128xi32>, tensor<128xi32>)
+// CHECK-SAME:      outs(%[[OUT0]], %[[OUT1]] : tensor<128xi32>, tensor<128xi32>)
 // CHECK:           ^bb0(%[[ARG2:.+]]: i32, %[[ARG3:.+]]: i32, %{{.*}}: i32, %{{.*}}: i32)
 // CHECK:             %[[CMP:.+]] = arith.cmpi sgt, %[[ARG2]], %[[ARG3]]
 // CHECK:             iree_linalg_ext.yield %[[CMP]]

--- a/compiler/plugins/input/Torch/InputConversion/BUILD.bazel
+++ b/compiler/plugins/input/Torch/InputConversion/BUILD.bazel
@@ -83,6 +83,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TensorUtils",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
         "@torch-mlir//:TorchMLIRConversionPasses",

--- a/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
@@ -63,6 +63,7 @@ iree_cc_library(
     MLIRSCFDialect
     MLIRSupport
     MLIRTensorDialect
+    MLIRTensorUtils
     MLIRTransformUtils
     MLIRTransforms
     iree::compiler::Dialect::Flow::IR

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorOps.h"
@@ -97,6 +98,30 @@ struct ScatterOpConversion
     rewriter.inlineRegionBefore(op.getRegion(), scatterOp.getRegion(),
                                 scatterOp.getRegion().begin());
     rewriter.replaceOp(op, scatterOp->getResults());
+    return success();
+  }
+};
+
+struct SortOpConversion
+    : public OpRewritePattern<mlir::torch::TMTensor::SortOp> {
+  using Base::Base;
+  LogicalResult matchAndRewrite(mlir::torch::TMTensor::SortOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    SmallVector<Value> outputs;
+    for (auto [input, result] :
+         llvm::zip_equal(op.getOutputs(), op.getResults())) {
+      auto resultType = cast<RankedTensorType>(result.getType());
+      outputs.push_back(tensor::EmptyOp::create(
+          rewriter, loc, tensor::getMixedSizes(rewriter, loc, input),
+          resultType.getElementType()));
+    }
+    auto sortOp = IREE::LinalgExt::SortOp::create(
+        rewriter, loc, op.getResultTypes(), op.getOutputs(), outputs,
+        op.getDimensionAttr());
+    rewriter.inlineRegionBefore(op.getRegion(), sortOp.getRegion(),
+                                sortOp.getRegion().begin());
+    rewriter.replaceOp(op, sortOp->getResults());
     return success();
   }
 };
@@ -232,10 +257,10 @@ public:
 
     INSERT_TMTENSOR_CONVERSION_PATTERN(YieldOp);
     INSERT_TMTENSOR_CONVERSION_PATTERN(ScanOp);
-    INSERT_TMTENSOR_CONVERSION_PATTERN(SortOp);
 
 #undef INSERT_TMTENSOR_CONVERSION_PATTERN
 
+    patterns.add<SortOpConversion>(context);
     patterns.add<ScatterOpConversion>(context);
     patterns.add<AttentionOpConversion>(context);
 

--- a/compiler/plugins/input/Torch/InputConversion/test/sort.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/sort.mlir
@@ -8,15 +8,19 @@ func.func @sort(%arg0: tensor<3x4xf32>, %arg1: tensor<3x4xi64>) -> (tensor<3x4xf
   } -> tensor<3x4xf32>, tensor<3x4xi64>
   return %0#0, %0#1 : tensor<3x4xf32>, tensor<3x4xi64>
 }
-// CHECK-LABEL:   func.func @sort(
-// CHECK-SAME:            %[[INPUT:.*]]: tensor<3x4xf32>, %[[INDICES:.*]]: tensor<3x4xi64>) -> (tensor<3x4xf32>, tensor<3x4xi64>) {
-// CHECK:          %[[SORT:.*]]:2 = iree_linalg_ext.sort
-// CHECK-SAME:            dimension(1)
-// CHECK-SAME:            outs(%[[INPUT]], %[[INDICES]] : tensor<3x4xf32>, tensor<3x4xi64>) {
-// CHECK:          ^bb0(%[[INP1:.*]]: f32, %[[INP2:.*]]: f32, %{{.*}}: i64, %{{.*}}: i64):
-// CHECK:            %[[PREDICATE:.*]] = arith.cmpf ole, %[[INP1]], %[[INP2]] : f32
-// CHECK:            iree_linalg_ext.yield %[[PREDICATE]] : i1
-// CHECK:          } -> tensor<3x4xf32>, tensor<3x4xi64>
-// CHECK:          return %[[SORT]]#0, %[[SORT]]#1 : tensor<3x4xf32>, tensor<3x4xi64>
+// CHECK-LABEL: func.func @sort(
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]: tensor<3x4xf32>
+// CHECK-SAME:    %[[INDICES:[a-zA-Z0-9]+]]: tensor<3x4xi64>
+// CHECK:        %[[EMPTY_INPUT:.+]] = tensor.empty() : tensor<3x4xf32>
+// CHECK:        %[[EMPTY_INDICES:.+]] = tensor.empty() : tensor<3x4xi64>
+// CHECK:        %[[SORT:.+]]:2 = iree_linalg_ext.sort
+// CHECK-SAME:     dimension(1)
+// CHECK-SAME:     ins(%[[INPUT]], %[[INDICES]] : tensor<3x4xf32>, tensor<3x4xi64>)
+// CHECK-SAME:     outs(%[[EMPTY_INPUT]], %[[EMPTY_INDICES]] : tensor<3x4xf32>, tensor<3x4xi64>) {
+// CHECK:        ^bb0(%[[INP1:.+]]: f32, %[[INP2:.+]]: f32, %{{.*}}: i64, %{{.*}}: i64):
+// CHECK:          %[[PREDICATE:.+]] = arith.cmpf ole, %[[INP1]], %[[INP2]] : f32
+// CHECK:          iree_linalg_ext.yield %[[PREDICATE]] : i1
+// CHECK:        } -> tensor<3x4xf32>, tensor<3x4xi64>
+// CHECK:        return %[[SORT]]#0, %[[SORT]]#1 : tensor<3x4xf32>, tensor<3x4xi64>
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_alloc_private_memory_for_dps_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_alloc_private_memory_for_dps_ops.mlir
@@ -3,10 +3,12 @@
 
 // CHECK-LABEL: func.func @unused_result_copied
 // CHECK-DAG: %[[SRC:.*]] = bufferization.alloc_tensor() copy(%{{.*}}) {memory_space = #gpu.address_space<private>} : tensor<1x10xf32>
-// CHECK-DAG: iree_linalg_ext.sort{{.*}} dimension(1) outs(%[[SRC]], %{{.*}} : tensor<1x10xf32>, tensor<1x10xi64>)
+// CHECK-DAG: iree_linalg_ext.sort{{.*}} dimension(1) ins(%{{.*}}, %arg1 : tensor<1x10xf32>, tensor<1x10xi64>) outs(%[[SRC]], %{{.*}} : tensor<1x10xf32>, tensor<1x10xi64>)
 func.func @unused_result_copied(%arg0: !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x10xf32>>, %arg1: tensor<1x10xi64>) -> tensor<1x10xi64> {
   %2 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [1, 10], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x10xf32>> -> tensor<1x10xf32>
-  %3:2 = iree_linalg_ext.sort dimension(1) outs(%2, %arg1 :tensor<1x10xf32>, tensor<1x10xi64>) {
+  %empty = tensor.empty() : tensor<1x10xf32>
+  %empty_0 = tensor.empty() : tensor<1x10xi64>
+  %3:2 = iree_linalg_ext.sort dimension(1) ins(%2, %arg1 : tensor<1x10xf32>, tensor<1x10xi64>) outs(%empty, %empty_0 : tensor<1x10xf32>, tensor<1x10xi64>) {
     ^bb0(%arg4: f32, %arg5: f32, %arg6: i64, %arg7: i64):
     %16 = arith.cmpf oge, %arg4, %arg5 : f32
     iree_linalg_ext.yield %16 : i1
@@ -20,7 +22,9 @@ func.func @unused_result_copied(%arg0: !iree_tensor_ext.dispatch.tensor<readonly
 // CHECK-NOT: bufferization.alloc_tensor()
 func.func @big_result_not_copied(%arg0: !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x33xf32>>, %arg1: tensor<1x33xi64>) -> tensor<1x33xi64> {
   %2 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [1, 33], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x33xf32>> -> tensor<1x33xf32>
-  %3:2 = iree_linalg_ext.sort dimension(1) outs(%2, %arg1 :tensor<1x33xf32>, tensor<1x33xi64>) {
+  %empty = tensor.empty() : tensor<1x33xf32>
+  %empty_0 = tensor.empty() : tensor<1x33xi64>
+  %3:2 = iree_linalg_ext.sort dimension(1) ins(%2, %arg1 : tensor<1x33xf32>, tensor<1x33xi64>) outs(%empty, %empty_0 : tensor<1x33xf32>, tensor<1x33xi64>) {
     ^bb0(%arg4: f32, %arg5: f32, %arg6: i64, %arg7: i64):
     %16 = arith.cmpf oge, %arg4, %arg5 : f32
     iree_linalg_ext.yield %16 : i1
@@ -34,7 +38,9 @@ func.func @big_result_not_copied(%arg0: !iree_tensor_ext.dispatch.tensor<readonl
 // CHECK-NOT: bufferization.alloc_tensor()
 func.func @used_result_not_copied(%arg0: !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x10xf32>>, %arg1: tensor<1x10xi64>) -> (tensor<1x10xf32>, tensor<1x10xi64>) {
   %2 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [1, 10], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1x10xf32>> -> tensor<1x10xf32>
-  %3:2 = iree_linalg_ext.sort dimension(1) outs(%2, %arg1 :tensor<1x10xf32>, tensor<1x10xi64>) {
+  %empty = tensor.empty() : tensor<1x10xf32>
+  %empty_0 = tensor.empty() : tensor<1x10xi64>
+  %3:2 = iree_linalg_ext.sort dimension(1) ins(%2, %arg1 : tensor<1x10xf32>, tensor<1x10xi64>) outs(%empty, %empty_0 : tensor<1x10xf32>, tensor<1x10xi64>) {
     ^bb0(%arg4: f32, %arg5: f32, %arg6: i64, %arg7: i64):
     %16 = arith.cmpf oge, %arg4, %arg5 : f32
     iree_linalg_ext.yield %16 : i1

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2324,7 +2324,8 @@ func.func @sort1D() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4xi32>>
   %1 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [4], strides = [1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4xi32>> -> tensor<4xi32>
-  %2 = iree_linalg_ext.sort dimension(0) outs(%1 : tensor<4xi32>) {
+  %empty = tensor.empty() : tensor<4xi32>
+  %2 = iree_linalg_ext.sort dimension(0) ins(%1 : tensor<4xi32>) outs(%empty : tensor<4xi32>) {
   ^bb0(%arg0: i32, %arg1: i32):
     %3 = arith.cmpi slt, %arg0, %arg1 : i32
     iree_linalg_ext.yield %3 : i1
@@ -2334,8 +2335,9 @@ func.func @sort1D() {
 }
 // CHECK-LABEL: func.func @sort1D
 // CHECK:        %[[BUF:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0) alignment(64) offset(%c0) : memref<4xi32, #hal.descriptor_type<storage_buffer>>
+// CHECK:        %[[ALLOC:.+]] = memref.alloc() : memref<4xi32>
 // CHECK:        iree_linalg_ext.sort
-// CHECK-SAME:     outs(%[[BUF]] : memref<4xi32{{.+}}>)
+// CHECK-SAME:     ins(%[[BUF]] : memref<4xi32{{.+}}>) outs(%[[ALLOC]] : memref<4xi32>)
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/test_partitionable_loops_interface.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/test_partitionable_loops_interface.mlir
@@ -143,10 +143,15 @@ func.func @mmt4d_unit_dim(%lhs : tensor<1x?x?x?xf32>, %rhs : tensor<?x?x?x?xf32>
 // -----
 
 func.func @sort(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %empty = tensor.empty(%d0, %d1) : tensor<?x?xf32>
   %0 = iree_linalg_ext.sort
       {__test_interface__ = true}
       dimension(0)
-      outs(%arg0 : tensor<?x?xf32>) {
+      ins(%arg0 : tensor<?x?xf32>) outs(%empty : tensor<?x?xf32>) {
         ^bb0(%arg1 : f32, %arg2 : f32):
           %1  = arith.cmpf ogt, %arg1, %arg2 : f32
           iree_linalg_ext.yield %1 : i1
@@ -159,10 +164,13 @@ func.func @sort(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
 // -----
 
 func.func @sort_unit_dim(%arg0 : tensor<?x1xf32>) -> tensor<?x1xf32> {
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x1xf32>
+  %empty = tensor.empty(%d0) : tensor<?x1xf32>
   %0 = iree_linalg_ext.sort
       {__test_interface__ = true}
       dimension(0)
-      outs(%arg0 : tensor<?x1xf32>) {
+      ins(%arg0 : tensor<?x1xf32>) outs(%empty : tensor<?x1xf32>) {
         ^bb0(%arg1 : f32, %arg2 : f32):
           %1  = arith.cmpf ogt, %arg1, %arg2 : f32
           iree_linalg_ext.yield %1 : i1

--- a/compiler/src/iree/compiler/Codegen/Common/test/type_propagation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/type_propagation.mlir
@@ -537,7 +537,9 @@ func.func @sort() {
   %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [1], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1xi8>> -> tensor<1xi8>
   %3 = arith.trunci %2 : tensor<1xi8> to tensor<1xi1>
   %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [1], strides = [1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xi32>> -> tensor<1xi32>
-  %5:2 = iree_linalg_ext.sort dimension(0) outs(%3, %4 : tensor<1xi1>, tensor<1xi32>) {
+  %empty0 = tensor.empty() : tensor<1xi1>
+  %empty1 = tensor.empty() : tensor<1xi32>
+  %5:2 = iree_linalg_ext.sort dimension(0) ins(%3, %4 : tensor<1xi1>, tensor<1xi32>) outs(%empty0, %empty1 : tensor<1xi1>, tensor<1xi32>) {
   ^bb0(%arg0: i1, %arg1: i1, %arg2: i32, %arg3: i32):
     %6 = arith.cmpi ult, %arg0, %arg1 : i1
     iree_linalg_ext.yield %6 : i1
@@ -551,8 +553,10 @@ func.func @sort() {
 //   CHECK-DAG:   %[[B:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //   CHECK-DAG:   %[[A_TENSOR:.+]] = iree_tensor_ext.dispatch.tensor.load %[[A]]
 //   CHECK-DAG:   %[[B_TENSOR:.+]] = iree_tensor_ext.dispatch.tensor.load %[[B]]
+//  CHECK:         %[[EMPTY0:.+]] = tensor.empty() : tensor<1xi8>
+//  CHECK:         %[[EMPTY1:.+]] = tensor.empty() : tensor<1xi32>
 //       CHECK:   %[[SORT:.+]]:2 = iree_linalg_ext.sort dimension(0)
-//  CHECK-SAME:       outs(%[[A_TENSOR]], %[[B_TENSOR]] : tensor<1xi8>, tensor<1xi32>)
+//  CHECK-SAME:       ins(%[[A_TENSOR]], %[[B_TENSOR]] : tensor<1xi8>, tensor<1xi32>) outs(%[[EMPTY0]], %[[EMPTY1]] : tensor<1xi8>, tensor<1xi32>)
 //  CHECK-NEXT:     ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: i8, %[[ARG1:[a-zA-Z0-9]+]]: i8, %[[ARG2:[a-zA-Z0-9]+]]: i32, %[[ARG3:[a-zA-Z0-9]+]]: i32)
 //   CHECK-DAG:       %[[TRUNC_A_1:.+]] = arith.trunci %[[ARG0]] : i8 to i1
 //   CHECK-DAG:       %[[TRUNC_A_2:.+]] = arith.trunci %[[ARG1]] : i8 to i1
@@ -573,7 +577,9 @@ func.func @sort_secondary() {
   %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [1], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1xi32>> -> tensor<1xi32>
   %3 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0], sizes = [1], strides = [1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<1xi8>> -> tensor<1xi8>
   %4 = arith.trunci %3 : tensor<1xi8> to tensor<1xi1>
-  %5:2 = iree_linalg_ext.sort dimension(0) outs(%2, %4 : tensor<1xi32>, tensor<1xi1>) {
+  %empty0 = tensor.empty() : tensor<1xi32>
+  %empty1 = tensor.empty() : tensor<1xi1>
+  %5:2 = iree_linalg_ext.sort dimension(0) ins(%2, %4 : tensor<1xi32>, tensor<1xi1>) outs(%empty0, %empty1 : tensor<1xi32>, tensor<1xi1>) {
   ^bb0(%arg0: i32, %arg1: i32, %arg2: i1, %arg3: i1):
     %6 = arith.cmpi ult, %arg0, %arg1 : i32
     iree_linalg_ext.yield %6 : i1
@@ -588,8 +594,10 @@ func.func @sort_secondary() {
 //   CHECK-DAG:   %[[B:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //   CHECK-DAG:   %[[A_TENSOR:.+]] = iree_tensor_ext.dispatch.tensor.load %[[A]]
 //   CHECK-DAG:   %[[B_TENSOR:.+]] = iree_tensor_ext.dispatch.tensor.load %[[B]]
+//  CHECK:         %[[EMPTY0:.+]] = tensor.empty() : tensor<1xi32>
+//  CHECK:         %[[EMPTY1:.+]] = tensor.empty() : tensor<1xi8>
 //       CHECK:   %[[SORT:.+]]:2 = iree_linalg_ext.sort dimension(0)
-//  CHECK-SAME:       outs(%[[A_TENSOR]], %[[B_TENSOR]] : tensor<1xi32>, tensor<1xi8>)
+//  CHECK-SAME:       ins(%[[A_TENSOR]], %[[B_TENSOR]] : tensor<1xi32>, tensor<1xi8>) outs(%[[EMPTY0]], %[[EMPTY1]] : tensor<1xi32>, tensor<1xi8>)
 //  CHECK-NEXT:     ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: i32, %[[ARG1:[a-zA-Z0-9]+]]: i32, %[[ARG2:[a-zA-Z0-9]+]]: i8, %[[ARG3:[a-zA-Z0-9]+]]: i8)
 //   CHECK-DAG:       %[[CMPI:.+]] = arith.cmpi ult, %[[ARG0]], %[[ARG1]] : i32
 //       CHECK:       iree_linalg_ext.yield %[[CMPI]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_sort.mlir
@@ -2,7 +2,8 @@
 // RUN: FileCheck %s
 
 func.func @sort1D(%1: tensor<4xi32>) -> tensor<4xi32> {
-  %2 = iree_linalg_ext.sort dimension(0) outs(%1 : tensor<4xi32>) {
+  %empty = tensor.empty() : tensor<4xi32>
+  %2 = iree_linalg_ext.sort dimension(0) ins(%1 : tensor<4xi32>) outs(%empty : tensor<4xi32>) {
   ^bb0(%arg0: i32, %arg1: i32):
     %3 = arith.cmpi slt, %arg0, %arg1 : i32
     iree_linalg_ext.yield %3 : i1
@@ -20,7 +21,8 @@ func.func @sort1D(%1: tensor<4xi32>) -> tensor<4xi32> {
 // -----
 
 func.func @sort2D_static_shape(%1: tensor<2000x30000xi32>) -> tensor<2000x30000xi32> {
-  %2 = iree_linalg_ext.sort dimension(1) outs(%1 : tensor<2000x30000xi32>) {
+  %empty = tensor.empty() : tensor<2000x30000xi32>
+  %2 = iree_linalg_ext.sort dimension(1) ins(%1 : tensor<2000x30000xi32>) outs(%empty : tensor<2000x30000xi32>) {
   ^bb0(%arg0: i32, %arg1: i32):
     %3 = arith.cmpi slt, %arg0, %arg1 : i32
     iree_linalg_ext.yield %3 : i1
@@ -36,7 +38,8 @@ func.func @sort2D_static_shape(%1: tensor<2000x30000xi32>) -> tensor<2000x30000x
 
 // -----
 func.func @sort3D_dynamic_shape(%4: index, %6: tensor<?x2x4xi32>) -> tensor<?x2x4xi32> {
-  %7 = iree_linalg_ext.sort dimension(2) outs(%6 : tensor<?x2x4xi32>) {
+  %empty = tensor.empty(%4) : tensor<?x2x4xi32>
+  %7 = iree_linalg_ext.sort dimension(2) ins(%6 : tensor<?x2x4xi32>) outs(%empty : tensor<?x2x4xi32>) {
   ^bb0(%arg0: i32, %arg1: i32):
     %8 = arith.cmpi slt, %arg0, %arg1 : i32
     iree_linalg_ext.yield %8 : i1
@@ -52,7 +55,8 @@ func.func @sort3D_dynamic_shape(%4: index, %6: tensor<?x2x4xi32>) -> tensor<?x2x
 
 // -----
 func.func @sort5D_static_shape(%1: tensor<4x100x100x200x300xi32>) -> tensor<4x100x100x200x300xi32> {
-  %2 = iree_linalg_ext.sort dimension(0) outs(%1 : tensor<4x100x100x200x300xi32>) {
+  %empty = tensor.empty() : tensor<4x100x100x200x300xi32>
+  %2 = iree_linalg_ext.sort dimension(0) ins(%1 : tensor<4x100x100x200x300xi32>) outs(%empty : tensor<4x100x100x200x300xi32>) {
   ^bb0(%arg0: i32, %arg1: i32):
     %3 = arith.cmpi sgt, %arg0, %arg1 : i32
     iree_linalg_ext.yield %3 : i1

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/sort_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/sort_pipeline_test.mlir
@@ -10,7 +10,8 @@ module {
     %c0 = arith.constant 0 : index
     %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4xi32>>
     %1 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0], sizes = [4], strides = [1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<4xi32>> -> tensor<4xi32>
-    %2 = iree_linalg_ext.sort {lowering_config = #lowering_config} dimension(0) outs(%1 : tensor<4xi32>) {
+    %empty = tensor.empty() : tensor<4xi32>
+    %2 = iree_linalg_ext.sort {lowering_config = #lowering_config} dimension(0) ins(%1 : tensor<4xi32>) outs(%empty : tensor<4xi32>) {
     ^bb0(%arg0: i32, %arg1: i32):
       %3 = arith.cmpi slt, %arg0, %arg1 : i32
       iree_linalg_ext.yield %3 : i1
@@ -33,7 +34,8 @@ module {
     %c0 = arith.constant 0 : index
     %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<2000x30000xi32>>
     %1 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2, 4], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<2000x30000xi32>> -> tensor<2000x30000xi32>
-    %2 = iree_linalg_ext.sort {lowering_config = #lowering_config} dimension(1) outs(%1 : tensor<2000x30000xi32>) {
+    %empty = tensor.empty() : tensor<2000x30000xi32>
+    %2 = iree_linalg_ext.sort {lowering_config = #lowering_config} dimension(1) ins(%1 : tensor<2000x30000xi32>) outs(%empty : tensor<2000x30000xi32>) {
     ^bb0(%arg0: i32, %arg1: i32):
       %3 = arith.cmpi slt, %arg0, %arg1 : i32
       iree_linalg_ext.yield %3 : i1
@@ -63,7 +65,8 @@ module {
     %4 = iree_tensor_ext.dispatch.workload.ordinal %3, 0 : index
     %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%2) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x2x4xi32>>{%4}
     %6 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0, 0], sizes = [%4, 2, 4], strides = [1, 1, 1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x2x4xi32>>{%4} -> tensor<?x2x4xi32>
-    %7 = iree_linalg_ext.sort {lowering_config = #lowering_config} dimension(2) outs(%6 : tensor<?x2x4xi32>) {
+    %empty = tensor.empty(%4) : tensor<?x2x4xi32>
+    %7 = iree_linalg_ext.sort {lowering_config = #lowering_config} dimension(2) ins(%6 : tensor<?x2x4xi32>) outs(%empty : tensor<?x2x4xi32>) {
     ^bb0(%arg0: i32, %arg1: i32):
       %8 = arith.cmpi slt, %arg0, %arg1 : i32
       iree_linalg_ext.yield %8 : i1

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -1,7 +1,8 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=vp_android_baseline_2022@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
 func.func @static_1d_sort(%1: tensor<1000xi32>) -> tensor<1000xi32> {
-  %2 = iree_linalg_ext.sort dimension(0) outs(%1 : tensor<1000xi32>) {
+  %empty = tensor.empty() : tensor<1000xi32>
+  %2 = iree_linalg_ext.sort dimension(0) ins(%1 : tensor<1000xi32>) outs(%empty : tensor<1000xi32>) {
   ^bb0(%arg0: i32, %arg1: i32):
     %3 = arith.cmpi slt, %arg0, %arg1 : i32
     iree_linalg_ext.yield %3 : i1
@@ -26,7 +27,7 @@ func.func @static_3d_sort(%0: memref<64x32x128xi32>, %1: memref<64x32x128xi32>) 
   ^bb0(%in: i32, %out: i32):
     linalg.yield %in : i32
   }
-  iree_linalg_ext.sort dimension(1) outs(%1 : memref<64x32x128xi32>) {
+  iree_linalg_ext.sort dimension(1) ins(%1 : memref<64x32x128xi32>) outs(%1 : memref<64x32x128xi32>) {
   ^bb0(%arg0: i32, %arg1: i32):
     %2 = arith.cmpi slt, %arg0, %arg1 : i32
     iree_linalg_ext.yield %2 : i1

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -19,7 +19,7 @@ hal.executable private @static_3d_sort  {
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %1 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
         %subview = memref.subview %0[%workgroup_id_y, 0, %1] [1, 32, 64] [1, 1, 1] : memref<64x32x128xi32, #hal.descriptor_type<storage_buffer>> to memref<1x32x64xi32, strided<[4096, 128, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
-        iree_linalg_ext.sort {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 0, 64], [1, 0, 1]]>} dimension(1) outs(%subview : memref<1x32x64xi32, strided<[4096, 128, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>) {
+        iree_linalg_ext.sort {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 0, 64], [1, 0, 1]]>} dimension(1) ins(%subview : memref<1x32x64xi32, strided<[4096, 128, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>) outs(%subview : memref<1x32x64xi32, strided<[4096, 128, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>) {
         ^bb0(%arg0: i32, %arg1: i32):
           %2 = arith.cmpi slt, %arg0, %arg1 : i32
           iree_linalg_ext.yield %2 : i1

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -999,18 +999,23 @@ void MapStoreOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 LogicalResult SortOp::verify() {
   Operation *op = getOperation();
-  if (getNumDpsInputs()) {
-    return op->emitOpError("does not expect to take any inputs");
+  if (getNumDpsInputs() == 0) {
+    return op->emitOpError("expected at least one `ins` operand");
   }
   if (getNumDpsInits() == 0) {
     return op->emitOpError("expected at least one `outs` operand");
   }
+  if (getNumDpsInputs() != getNumDpsInits()) {
+    return op->emitOpError(
+               "expected the same number of `ins` and `outs` operands, got ")
+           << getNumDpsInputs() << " and " << getNumDpsInits();
+  }
 
   Block &block = getRegion().front();
-  size_t numOutputs = getNumDpsInits();
-  if (block.getNumArguments() != 2 * numOutputs) {
+  size_t numInputs = getNumDpsInputs();
+  if (block.getNumArguments() != 2 * numInputs) {
     return op->emitOpError("region block should have ")
-           << 2 * numOutputs << " arguments";
+           << 2 * numInputs << " arguments";
   }
 
   int64_t rank = getOperandRank();
@@ -1020,7 +1025,7 @@ LogicalResult SortOp::verify() {
   }
 
   ArrayRef<int64_t> shape = getOperandShape();
-  for (auto [index, operand] : llvm::enumerate(getOutputs())) {
+  for (auto [index, operand] : llvm::enumerate(getInputs())) {
     auto operandType = getOperandType(index);
     if (operandType.getRank() != rank) {
       return op->emitOpError("expected operand ")
@@ -1038,6 +1043,20 @@ LogicalResult SortOp::verify() {
                << i << " should be of type " << elemType << " but got "
                << argType;
       }
+    }
+
+    auto outputType = cast<ShapedType>(getOutputs()[index].getType());
+    if (outputType.getRank() != rank) {
+      return op->emitOpError("expected output ")
+             << index << " to be rank " << rank << ", same as inputs";
+    }
+    if (outputType.getShape() != shape) {
+      return op->emitOpError("expected output ")
+             << index << " to have same shape as inputs";
+    }
+    if (outputType.getElementType() != operandType.getElementType()) {
+      return op->emitOpError("expected output ")
+             << index << " to have the same element type as input " << index;
     }
   }
 
@@ -1069,8 +1088,11 @@ namespace {
 ///
 /// For example:
 ///
-/// %0:2 = iree_linalg_ext.sort dimension(1) outs(%arg0, %arg1:
-/// tensor<?x10xf32>, tensor<?x10xi64>) {
+/// %empty0 = tensor.empty(...) : tensor<?x10xf32>
+/// %empty1 = tensor.empty(...) : tensor<?x10xi64>
+/// %0:2 = iree_linalg_ext.sort dimension(1)
+/// ins(%arg0, %arg1: tensor<?x10xf32>, tensor<?x10xi64>)
+/// outs(%empty0, %empty1: tensor<?x10xf32>, tensor<?x10xi64>) {
 ///   ^bb0(%arg2: f32, %arg3: f32, %arg4: i64, %arg5: i64):
 ///    %42 = arith.cmpf oge, %arg2, %arg3 : f32
 ///    iree_linalg_ext.yield %42 : i1
@@ -1078,7 +1100,9 @@ namespace {
 ///
 /// ->
 ///
-/// %0 = iree_linalg_ext.sort dimension(1) outs(%arg0: tensor<?x10xf32>) {
+/// %0 = iree_linalg_ext.sort dimension(1)
+/// ins(%arg0: tensor<?x10xf32>)
+/// outs(%empty0: tensor<?x10xf32>) {
 ///   ^bb0(%arg2: f32, %arg3: f32):
 ///    %42 = arith.cmpf oge, %arg2, %arg3 : f32
 ///    iree_linalg_ext.yield %42 : i1
@@ -1094,7 +1118,8 @@ struct RemoveUnusedSortOpResults : OpRewritePattern<IREE::LinalgExt::SortOp> {
     // To avoid problems in dispatches associated with unused results, prune
     // them here.
     Location loc = sortOp->getLoc();
-    auto operands = sortOp.getOutputs();
+    auto inputs = sortOp.getInputs();
+    auto outputs = sortOp.getOutputs();
     auto results = sortOp.getResults();
     unsigned numRes = sortOp.getNumResults();
 
@@ -1106,14 +1131,15 @@ struct RemoveUnusedSortOpResults : OpRewritePattern<IREE::LinalgExt::SortOp> {
 
     Block &block = sortOp.getRegion().front();
     auto blockArgs = block.getArguments();
-    SmallVector<Value> usedBlockArgs, usedOperands, usedResults;
+    SmallVector<Value> usedInputs, usedOutputs, usedResults;
     SmallVector<Type> usedResultTypes;
     BitVector eraseArg(numRes * 2, false);
     for (auto idx : llvm::seq<unsigned>(numRes)) {
       // If result or associated block arg is used, do not erase.
       if (!results[idx].use_empty() || !blockArgs[2 * idx].use_empty() ||
           !blockArgs[2 * idx + 1].use_empty()) {
-        usedOperands.push_back(operands[idx]);
+        usedInputs.push_back(inputs[idx]);
+        usedOutputs.push_back(outputs[idx]);
         usedResults.push_back(results[idx]);
         usedResultTypes.push_back(results[idx].getType());
         continue;
@@ -1130,7 +1156,7 @@ struct RemoveUnusedSortOpResults : OpRewritePattern<IREE::LinalgExt::SortOp> {
     // args.
     auto newSortOp = IREE::LinalgExt::SortOp::create(
         rewriter, loc, usedResultTypes,
-        /*inputs=*/ValueRange{}, usedOperands, sortOp.getDimension());
+        /*inputs=*/usedInputs, usedOutputs, sortOp.getDimension());
     newSortOp.getRegion().takeBody(sortOp.getRegion());
     newSortOp.getRegion().front().eraseArguments(eraseArg);
     rewriter.replaceAllUsesWith(usedResults, newSortOp.getResults());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -502,8 +502,8 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
     See https://www.tensorflow.org/xla/operation_semantics#sort.
   }];
 
-  let arguments = (ins Variadic<AnyType>:$inputs,
-                       Variadic<AnyShaped>:$outputs,
+  let arguments = (ins Variadic<AnyRankedTensorOrMemRef>:$inputs,
+                       Variadic<AnyRankedTensorOrMemRef>:$outputs,
                        I64Attr:$dimension
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
@@ -516,9 +516,6 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
     $region (`->` type($results)^)?
   }];
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    Value getOperand(int index) {
-      return getOutputs()[index];
-    }
     ShapedType getOperandType(int index) {
       return cast<ShapedType>(getOperand(index).getType());
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -867,7 +867,7 @@ SmallVector<Range> SortOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   OpFoldResult zero = builder.getIndexAttr(0);
   OpFoldResult one = builder.getIndexAttr(1);
-  Value source = getOperand(0);
+  Value source = getInputs()[0];
   for (auto dim : llvm::seq<int64_t>(0, operandRank)) {
     loopBounds[dim].offset = zero;
     loopBounds[dim].size = getDim(builder, loc, source, dim);
@@ -886,16 +886,27 @@ SortOp::getTiledImplementation(OpBuilder &builder,
   auto oneAttr = builder.getI64IntegerAttr(1);
   SmallVector<OpFoldResult> strides(rank, oneAttr);
   SmallVector<Operation *> slices;
-  SmallVector<Value> tiledOperands(getOutputs().size());
+  SmallVector<Value> tiledInputs(getInputs().size());
+  SmallVector<Value> tiledOutputs(getOutputs().size());
+  SmallVector<Value> tiledOperands;
+  tiledOperands.reserve(getInputs().size() + getOutputs().size());
+  for (auto [idx, input] : llvm::enumerate(getInputs())) {
+    Operation *slice =
+        getSlice(builder, getLoc(), input, offsets, sizes, strides);
+    tiledInputs[idx] = slice->getResult(0);
+    tiledOperands.push_back(tiledInputs[idx]);
+    slices.push_back(slice);
+  }
   for (auto [idx, output] : llvm::enumerate(getOutputs())) {
     Operation *slice =
         getSlice(builder, getLoc(), output, offsets, sizes, strides);
-    tiledOperands[idx] = slice->getResult(0);
+    tiledOutputs[idx] = slice->getResult(0);
+    tiledOperands.push_back(tiledOutputs[idx]);
     slices.push_back(slice);
   }
   SmallVector<Type, 4> resultTypes;
   if (getNumResults()) {
-    resultTypes = llvm::map_to_vector<4>(tiledOperands,
+    resultTypes = llvm::map_to_vector<4>(tiledOutputs,
                                          [&](Value v) { return v.getType(); });
   }
   Operation *tiledSortOp =
@@ -978,14 +989,32 @@ LogicalResult SortOp::generateScalarImplementation(OpBuilder &b, Location loc,
   auto sortDim = getDimension();
   Value zero = arith::ConstantIndexOp::create(b, loc, 0);
   Value one = arith::ConstantIndexOp::create(b, loc, 1);
-  Value ub;
+  Value sortDimSize;
   if (getOperandType(0).isDynamicDim(sortDim)) {
-    ub = memref::DimOp::create(b, loc, getOperand(0), sortDim);
+    sortDimSize = memref::DimOp::create(b, loc, getInputs()[0], sortDim);
   } else {
-    ub = arith::ConstantIndexOp::create(b, loc,
-                                        getOperandType(0).getDimSize(sortDim));
+    sortDimSize = arith::ConstantIndexOp::create(
+        b, loc, getOperandType(0).getDimSize(sortDim));
   }
-  ub = arith::SubIOp::create(b, loc, ub, one);
+  SmallVector<Value> indices(ivs);
+  Value firstSortPass = arith::CmpIOp::create(b, loc, arith::CmpIPredicate::eq,
+                                              indices[sortDim], zero);
+  scf::IfOp::create(b, loc, firstSortPass, [&](OpBuilder &b, Location loc) {
+    scf::ForOp::create(
+        b, loc, zero, sortDimSize, one, ValueRange{},
+        [&](OpBuilder &b, Location loc, Value iv, ValueRange iters) {
+          SmallVector<Value> indices(ivs);
+          indices[sortDim] = iv;
+          for (auto [input, output] :
+               llvm::zip_equal(getDpsInputs(), getDpsInits())) {
+            Value v = memref::LoadOp::create(b, loc, input, indices);
+            memref::StoreOp::create(b, loc, v, output, indices);
+          }
+          scf::YieldOp::create(b, loc);
+        });
+    scf::YieldOp::create(b, loc);
+  });
+  Value ub = arith::SubIOp::create(b, loc, sortDimSize, one);
   SmallVector<Value> compareOperands(getDpsInits().begin(),
                                      getDpsInits().end());
   emitBubbleSortSweep(b, loc, zero, one, ub, sortDim, ivs, compareOperands,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -2,7 +2,13 @@
 
 func.func @sort_drop_unused_results(%arg0 : tensor<?x10xf32>,
     %arg1 : tensor<?x10xi64>) -> tensor<?x10xf32> {
-  %0:2 = iree_linalg_ext.sort dimension(1) outs(%arg0, %arg1: tensor<?x10xf32>,
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x10xf32>
+  %d1 = tensor.dim %arg1, %c0 : tensor<?x10xi64>
+  %empty0 = tensor.empty(%d0) : tensor<?x10xf32>
+  %empty1 = tensor.empty(%d1) : tensor<?x10xi64>
+  %0:2 = iree_linalg_ext.sort dimension(1) ins(%arg0, %arg1 : tensor<?x10xf32>,
+      tensor<?x10xi64>) outs(%empty0, %empty1 : tensor<?x10xf32>,
       tensor<?x10xi64>) {
   ^bb0(%arg2: f32, %arg3: f32, %arg4: i64, %arg5: i64):
     %42 = arith.cmpf oge, %arg2, %arg3 : f32
@@ -13,7 +19,13 @@ func.func @sort_drop_unused_results(%arg0 : tensor<?x10xf32>,
 // CHECK-LABEL: func.func @sort_drop_unused_results
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x10xf32>
 //  CHECK-SAME:     %[[ARG1:.+]]: tensor<?x10xi64>
-//       CHECK:   %[[SORT:.+]] = iree_linalg_ext.sort dimension(1) outs(%[[ARG0]] : tensor<?x10xf32>)
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x10xf32>
+//       CHECK:   %[[EMPTY0:.+]] = tensor.empty(%[[D0]]) : tensor<?x10xf32>
+//       CHECK:   %[[SORT:.+]] = iree_linalg_ext.sort
+//       CHECK:       dimension(1)
+//       CHECK:       ins(%[[ARG0]] : tensor<?x10xf32>) outs(%[[EMPTY0]] : tensor<?x10xf32>)
+//       CHECK:   return %[[SORT]] : tensor<?x10xf32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -1,9 +1,11 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics %s
 
 func.func @sort_invalid_dimension(%arg0: tensor<128xi32>) -> tensor<128xi32> {
+  %empty = tensor.empty() : tensor<128xi32>
   // expected-error @+1 {{dimension must be within (0, 1]}}
   %0 = iree_linalg_ext.sort dimension(1)
-    outs(%arg0 : tensor<128xi32>) {
+    ins(%arg0 : tensor<128xi32>)
+    outs(%empty : tensor<128xi32>) {
   ^bb0(%arg1: i32, %arg2: i32):
     %1 = arith.cmpi sgt, %arg1, %arg2 : i32
     iree_linalg_ext.yield %1 : i1
@@ -15,9 +17,16 @@ func.func @sort_invalid_dimension(%arg0: tensor<128xi32>) -> tensor<128xi32> {
 
 func.func @sort_mismatch_rank(%arg0: tensor<?x?xi32>, %arg1: tensor<?xf32>)
     -> (tensor<?x?xi32>, tensor<?xf32>) {
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
+  %d1 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
+  %d2 = tensor.dim %arg1, %c0 : tensor<?xf32>
+  %empty0 = tensor.empty(%d0, %d1) : tensor<?x?xi32>
+  %empty1 = tensor.empty(%d2) : tensor<?xf32>
   // expected-error @+1 {{expected operand 1 to be rank 2, same as other operands}}
   %0:2 = iree_linalg_ext.sort dimension(0)
-      outs(%arg0, %arg1 : tensor<?x?xi32>, tensor<?xf32>) {
+      ins(%arg0, %arg1 : tensor<?x?xi32>, tensor<?xf32>)
+      outs(%empty0, %empty1 : tensor<?x?xi32>, tensor<?xf32>) {
       ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %1 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %1 : i1
@@ -29,9 +38,14 @@ func.func @sort_mismatch_rank(%arg0: tensor<?x?xi32>, %arg1: tensor<?xf32>)
 
 func.func @sort_mismatch_shape(%arg0: tensor<?xi32>, %arg1: tensor<42xf32>)
     -> (tensor<?xi32>, tensor<42xf32>) {
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?xi32>
+  %empty0 = tensor.empty(%d0) : tensor<?xi32>
+  %empty1 = tensor.empty() : tensor<42xf32>
   // expected-error @+1 {{expected operand 1 to have same shape as other operands}}
   %0:2 = iree_linalg_ext.sort dimension(0)
-      outs(%arg0, %arg1 : tensor<?xi32>, tensor<42xf32>) {
+      ins(%arg0, %arg1 : tensor<?xi32>, tensor<42xf32>)
+      outs(%empty0, %empty1 : tensor<?xi32>, tensor<42xf32>) {
       ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %1 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %1 : i1

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -1,9 +1,10 @@
 // RUN: iree-opt --split-input-file %s | FileCheck %s
 
 func.func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
+  %empty = tensor.empty() : tensor<128xi32>
   %0 = iree_linalg_ext.sort
     dimension(0)
-    outs(%arg0 : tensor<128xi32>) {
+    ins(%arg0 : tensor<128xi32>) outs(%empty : tensor<128xi32>) {
   ^bb0(%arg1: i32, %arg2: i32):
     %1 = arith.cmpi sgt, %arg1, %arg2 : i32
     iree_linalg_ext.yield %1 : i1
@@ -11,16 +12,17 @@ func.func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
   return %0 : tensor<128xi32>
 }
 // CHECK-LABEL: func.func @sort_tensor(
-// CHECK:         iree_linalg_ext.sort
-// CHECK-SAME:      dimension(0)
-// CHECK-SAME:      outs({{.*}})
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<128xi32>
+// CHECK:         %[[SORT:.+]] = iree_linalg_ext.sort
+// CHECK:           dimension(0)
+// CHECK:           ins(%{{.+}} : tensor<128xi32>) outs(%[[EMPTY]] : tensor<128xi32>)
 // CHECK:           iree_linalg_ext.yield
 
 // -----
 
 func.func @sort_memref(%arg0: memref<128xi32>) {
   iree_linalg_ext.sort dimension(0)
-    outs(%arg0 : memref<128xi32>) {
+    ins(%arg0 : memref<128xi32>) outs(%arg0 : memref<128xi32>) {
   ^bb0(%arg1: i32, %arg2: i32):
     %0 = arith.cmpi sgt, %arg1, %arg2 : i32
     iree_linalg_ext.yield %0 : i1
@@ -38,8 +40,16 @@ func.func @sort_memref(%arg0: memref<128xi32>) {
 func.func @sort_multi_result_tensor(
     %arg0: tensor<?x?xi32>, %arg1: tensor<?x?xf32>)
     -> (tensor<?x?xi32>, tensor<?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
+  %c1 = arith.constant 1 : index
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
+  %d2 = tensor.dim %arg1, %c0 : tensor<?x?xf32>
+  %d3 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %empty0 = tensor.empty(%d0, %d1) : tensor<?x?xi32>
+  %empty1 = tensor.empty(%d2, %d3) : tensor<?x?xf32>
   %0:2 = iree_linalg_ext.sort dimension(0)
-      outs(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xf32>) {
+      ins(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xf32>) outs(%empty0, %empty1 : tensor<?x?xi32>, tensor<?x?xf32>) {
       ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %1 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %1 : i1
@@ -49,8 +59,18 @@ func.func @sort_multi_result_tensor(
 // CHECK-LABEL: func.func @sort_multi_result_tensor(
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xi32>
 //  CHECK-SAME:   %[[ARG1:.+]]: tensor<?x?xf32>
-//       CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.sort dimension(0)
-//  CHECK-SAME:      outs(%[[ARG0]], %[[ARG1]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?xi32>
+//   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?xi32>
+//   CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG1]], %[[C0]] : tensor<?x?xf32>
+//   CHECK-DAG:   %[[D3:.+]] = tensor.dim %[[ARG1]], %[[C1]] : tensor<?x?xf32>
+//   CHECK-DAG:   %[[EMPTY0:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xi32>
+//   CHECK-DAG:   %[[EMPTY1:.+]] = tensor.empty(%[[D2]], %[[D3]]) : tensor<?x?xf32>
+//       CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.sort
+//       CHECK:       dimension(0)
+//       CHECK:       ins(%[[ARG0]], %[[ARG1]] : tensor<?x?xi32>,
+//       CHECK:           tensor<?x?xf32>) outs(%[[EMPTY0]], %[[EMPTY1]] : tensor<?x?xi32>, tensor<?x?xf32>)
 //       CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
 
 // -----
@@ -58,7 +78,7 @@ func.func @sort_multi_result_tensor(
 func.func @sort_multi_result_memref(
     %arg0: memref<?x?xi32>, %arg1: memref<?x?xf32>) {
   iree_linalg_ext.sort dimension(0)
-     outs(%arg0, %arg1 : memref<?x?xi32>, memref<?x?xf32>) {
+     ins(%arg0, %arg1 : memref<?x?xi32>, memref<?x?xf32>) outs(%arg0, %arg1 : memref<?x?xi32>, memref<?x?xf32>) {
      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
        %1 = arith.cmpf ogt, %arg4, %arg5 : f32
        iree_linalg_ext.yield %1 : i1

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -2,7 +2,7 @@
 
 func.func @sort_1d(%arg0: memref<128xi32>) {
   iree_linalg_ext.sort dimension(0)
-    outs(%arg0 : memref<128xi32>) {
+    ins(%arg0 : memref<128xi32>) outs(%arg0 : memref<128xi32>) {
   ^bb0(%arg2: i32, %arg3: i32):
     %0 = arith.cmpi sgt, %arg2, %arg3 : i32
     iree_linalg_ext.yield %0 : i1
@@ -30,7 +30,7 @@ func.func @sort_1d(%arg0: memref<128xi32>) {
 
 func.func @sort_2d(%arg0: memref<16x32xi32>) {
   iree_linalg_ext.sort dimension(0)
-    outs(%arg0 : memref<16x32xi32>) {
+    ins(%arg0 : memref<16x32xi32>) outs(%arg0 : memref<16x32xi32>) {
   ^bb0(%arg2: i32, %arg3: i32):
     %0 = arith.cmpi sgt, %arg2, %arg3 : i32
     iree_linalg_ext.yield %0 : i1
@@ -61,7 +61,7 @@ func.func @sort_2d(%arg0: memref<16x32xi32>) {
 func.func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
   iree_linalg_ext.sort
     dimension(0)
-    outs(%arg0, %arg1 : memref<128xf32>, memref<128xi32>) {
+    ins(%arg0, %arg1 : memref<128xf32>, memref<128xi32>) outs(%arg0, %arg1 : memref<128xf32>, memref<128xi32>) {
   ^bb0(%arg2: f32, %arg3: f32, %arg4: i32, %arg5: i32):
     %0 = arith.cmpf ogt, %arg2, %arg3 : f32
     iree_linalg_ext.yield %0 : i1

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/distribution.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/distribution.mlir
@@ -68,7 +68,7 @@ func.func @sort_3d_multi_result_distribute(
   -> (tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
   %0, %1 = iree_linalg_ext.sort
       dimension(2)
-      outs(%arg0, %arg1 : tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
+      ins(%arg0, %arg1 : tensor<?x?x?xi32>, tensor<?x?x?xf32>) outs(%arg0, %arg1 : tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
       ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %2 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %2 : i1
@@ -126,7 +126,7 @@ func.func @sort_3d_multi_result_distribute_memref(
   %arg0: memref<?x?x?xi32>, %arg1 : memref<?x?x?xf32>) {
   iree_linalg_ext.sort
       dimension(2)
-      outs(%arg0, %arg1 : memref<?x?x?xi32>, memref<?x?x?xf32>) {
+      ins(%arg0, %arg1 : memref<?x?x?xi32>, memref<?x?x?xf32>) outs(%arg0, %arg1 : memref<?x?x?xi32>, memref<?x?x?xf32>) {
       ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %0 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %0 : i1

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -243,9 +243,13 @@ module attributes { transform.with_named_sequence } {
 
 
 func.func @sort_1d(%arg0: tensor<?xi32>) -> tensor<?xi32> {
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?xi32>
+  %empty = tensor.empty(%d0) : tensor<?xi32>
   %0 = iree_linalg_ext.sort
        dimension(0)
-       outs(%arg0 : tensor<?xi32>) {
+       ins(%arg0 : tensor<?xi32>)
+       outs(%empty : tensor<?xi32>) {
        ^bb0(%arg2: i32, %arg3: i32):
          %0 = arith.cmpi sgt, %arg2, %arg3 : i32
          iree_linalg_ext.yield %0 : i1
@@ -261,16 +265,26 @@ module attributes { transform.with_named_sequence } {
 }
 //      CHECK: func.func @sort_1d(
 // CHECK-SAME:   %[[OPERAND:.+]]: tensor<?xi32>
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[OPERAND]], %[[C0]] : tensor<?xi32>
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[D0]]) : tensor<?xi32>
 //      CHECK:   %[[RESULT:.+]] = iree_linalg_ext.sort
-// CHECK-SAME:       outs(%[[OPERAND]] :
+//      CHECK:       dimension(0)
+//      CHECK:       ins(%[[OPERAND]] : tensor<?xi32>)
+//      CHECK:       outs(%[[EMPTY]] : tensor<?xi32>)
 //      CHECK:   return %[[RESULT]]
 
 // -----
 
 func.func @sort_2d(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
+  %empty = tensor.empty(%d0, %d1) : tensor<?x?xi32>
   %0 = iree_linalg_ext.sort
        dimension(1)
-       outs(%arg0 : tensor<?x?xi32>) {
+       ins(%arg0 : tensor<?x?xi32>) outs(%empty : tensor<?x?xi32>) {
        ^bb0(%arg2: i32, %arg3: i32):
          %0 = arith.cmpi sgt, %arg2, %arg3 : i32
          iree_linalg_ext.yield %0 : i1
@@ -292,24 +306,29 @@ module attributes { transform.with_named_sequence } {
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[OPERAND]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[OPERAND]], %[[C1]]
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xi32>
 //       CHECK:   %[[RESULT:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[D0]] step %[[TILESIZE]]
-//  CHECK-SAME:       iter_args(%[[INIT:.+]] = %[[OPERAND]])
+//       CHECK:       iter_args(%[[INIT:.+]] = %[[EMPTY]])
 //   CHECK-DAG:     %[[USED_TILESIZE:.+]] = affine.min #[[MAP]](%[[IV]])[%[[D0]]]
-//       CHECK:     %[[OPERAND_SLICE:.+]] = tensor.extract_slice %[[INIT]][%[[IV]], 0]
-//  CHECK-SAME:         [%[[USED_TILESIZE]], %[[D1]]]
-//       CHECK:     %[[SORT_TILE:.+]] = iree_linalg_ext.sort
-//  CHECK-SAME:         outs(%[[OPERAND_SLICE]]
-//       CHECK:     %[[YIELD:.+]] = tensor.insert_slice %[[SORT_TILE]] into %[[INIT]][%[[IV]], 0]
-//  CHECK-SAME:         [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[OPERAND_SLICE:.+]] = tensor.extract_slice %[[OPERAND]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[INIT_SLICE:.+]] = tensor.extract_slice %[[INIT]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[SORT_TILE:.+]] = iree_linalg_ext.sort dimension(1) ins(%[[OPERAND_SLICE]] : tensor<?x?xi32>) outs(%[[INIT_SLICE]] : tensor<?x?xi32>)
+//       CHECK:     %[[YIELD:.+]] = tensor.insert_slice %[[SORT_TILE]] into %[[INIT]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
 //       CHECK:     scf.yield %[[YIELD]]
 //       CHECK:   return %[[RESULT]]
 
 // -----
 
 func.func @sort_2d_inner_parallel(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
+  %empty = tensor.empty(%d0, %d1) : tensor<?x?xi32>
   %0 = iree_linalg_ext.sort
        dimension(0)
-       outs(%arg0 : tensor<?x?xi32>) {
+       ins(%arg0 : tensor<?x?xi32>)
+       outs(%empty : tensor<?x?xi32>) {
        ^bb0(%arg2: i32, %arg3: i32):
          %0 = arith.cmpi sgt, %arg2, %arg3 : i32
          iree_linalg_ext.yield %0 : i1
@@ -331,15 +350,14 @@ module attributes { transform.with_named_sequence } {
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[OPERAND]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[OPERAND]], %[[C1]]
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xi32>
 //       CHECK:   %[[RESULT:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[D1]] step %[[TILESIZE]]
-//  CHECK-SAME:       iter_args(%[[INIT:.+]] = %[[OPERAND]])
+//       CHECK:       iter_args(%[[INIT:.+]] = %[[EMPTY]])
 //   CHECK-DAG:     %[[USED_TILESIZE:.+]] = affine.min #[[MAP]](%[[IV]])[%[[D1]]]
-//       CHECK:     %[[OPERAND_SLICE:.+]] = tensor.extract_slice %[[INIT]][0, %[[IV]]]
-//  CHECK-SAME:         [%[[D0]], %[[USED_TILESIZE]]]
-//       CHECK:     %[[SORT_TILE:.+]] = iree_linalg_ext.sort
-//  CHECK-SAME:         outs(%[[OPERAND_SLICE]]
-//       CHECK:     %[[YIELD:.+]] = tensor.insert_slice %[[SORT_TILE]] into %[[INIT]][0, %[[IV]]]
-//  CHECK-SAME:         [%[[D0]], %[[USED_TILESIZE]]]
+//       CHECK:     %[[OPERAND_SLICE:.+]] = tensor.extract_slice %[[OPERAND]][0, %[[IV]]] [%[[D0]], %[[USED_TILESIZE]]]
+//       CHECK:     %[[INIT_SLICE:.+]] = tensor.extract_slice %[[INIT]][0, %[[IV]]] [%[[D0]], %[[USED_TILESIZE]]]
+//       CHECK:     %[[SORT_TILE:.+]] = iree_linalg_ext.sort dimension(0) ins(%[[OPERAND_SLICE]] : tensor<?x?xi32>) outs(%[[INIT_SLICE]] : tensor<?x?xi32>)
+//       CHECK:     %[[YIELD:.+]] = tensor.insert_slice %[[SORT_TILE]] into %[[INIT]][0, %[[IV]]] [%[[D0]], %[[USED_TILESIZE]]]
 //       CHECK:     scf.yield %[[YIELD]]
 //       CHECK:   return %[[RESULT]]
 
@@ -348,9 +366,17 @@ module attributes { transform.with_named_sequence } {
 func.func @sort_2d_multi_result(
     %arg0: tensor<?x?xi32>, %arg1: tensor<?x?xf32>)
     -> (tensor<?x?xi32>, tensor<?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xi32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xi32>
+  %d2 = tensor.dim %arg1, %c0 : tensor<?x?xf32>
+  %d3 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %empty0 = tensor.empty(%d0, %d1) : tensor<?x?xi32>
+  %empty1 = tensor.empty(%d2, %d3) : tensor<?x?xf32>
   %0:2 = iree_linalg_ext.sort
        dimension(1)
-       outs(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xf32>) {
+       ins(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xf32>) outs(%empty0, %empty1 : tensor<?x?xi32>, tensor<?x?xf32>) {
        ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
          %1 = arith.cmpf ogt, %arg4, %arg5 : f32
          iree_linalg_ext.yield %1 : i1
@@ -368,24 +394,25 @@ module attributes { transform.with_named_sequence } {
 //       CHECK: func.func @sort_2d_multi_result(
 //  CHECK-SAME:   %[[OPERAND1:.+]]: tensor<?x?xi32>
 //  CHECK-SAME:   %[[OPERAND2:.+]]: tensor<?x?xf32>
-//   CHECK-DAG:   %[[TILESIZE:.+]] = arith.constant 10 : index
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[OPERAND1]], %[[C0]]
 //   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[OPERAND1]], %[[C1]]
+//   CHECK-DAG:   %[[DIM_1:.+]] = tensor.dim %[[OPERAND2]], %[[C0]]
+//   CHECK-DAG:   %[[DIM_2:.+]] = tensor.dim %[[OPERAND2]], %[[C1]]
+//   CHECK-DAG:   %[[EMPTY0:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xi32>
+//   CHECK-DAG:   %[[EMPTY1:.+]] = tensor.empty(%[[DIM_1]], %[[DIM_2]]) : tensor<?x?xf32>
+//   CHECK-DAG:   %[[TILESIZE:.+]] = arith.constant 10 : index
 //       CHECK:   %[[RESULT:.+]]:2 = scf.for %[[IV:.+]] = %[[C0]] to %[[D0]] step %[[TILESIZE]]
-//  CHECK-SAME:       iter_args(%[[INIT1:.+]] = %[[OPERAND1]], %[[INIT2:.+]] = %[[OPERAND2]])
+//       CHECK:       iter_args(%[[INIT1:.+]] = %[[EMPTY0]], %[[INIT2:.+]] = %[[EMPTY1]])
 //   CHECK-DAG:     %[[USED_TILESIZE:.+]] = affine.min #[[MAP]](%[[IV]])[%[[D0]]]
-//       CHECK:     %[[OPERAND1_SLICE:.+]] = tensor.extract_slice %[[INIT1]][%[[IV]], 0]
-//  CHECK-SAME:         [%[[USED_TILESIZE]], %[[D1]]]
-//       CHECK:     %[[OPERAND2_SLICE:.+]] = tensor.extract_slice %[[INIT2]][%[[IV]], 0]
-//  CHECK-SAME:         [%[[USED_TILESIZE]], %[[D1]]]
-//       CHECK:     %[[SORT_TILE:.+]]:2 = iree_linalg_ext.sort
-//  CHECK-SAME:         outs(%[[OPERAND1_SLICE]], %[[OPERAND2_SLICE]]
-//       CHECK:     %[[YIELD1:.+]] = tensor.insert_slice %[[SORT_TILE]]#0 into %[[INIT1]][%[[IV]], 0]
-//  CHECK-SAME:         [%[[USED_TILESIZE]], %[[D1]]]
-//       CHECK:     %[[YIELD2:.+]] = tensor.insert_slice %[[SORT_TILE]]#1 into %[[INIT2]][%[[IV]], 0]
-//  CHECK-SAME:         [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[OPERAND1_SLICE:.+]] = tensor.extract_slice %[[OPERAND1]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[OPERAND2_SLICE:.+]] = tensor.extract_slice %[[OPERAND2]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[INIT1_SLICE:.+]] = tensor.extract_slice %[[INIT1]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[INIT2_SLICE:.+]] = tensor.extract_slice %[[INIT2]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[SORT_TILE:.+]]:2 = iree_linalg_ext.sort dimension(1) ins(%[[OPERAND1_SLICE]], %[[OPERAND2_SLICE]] : tensor<?x?xi32>, tensor<?x?xf32>) outs(%[[INIT1_SLICE]], %[[INIT2_SLICE]] : tensor<?x?xi32>, tensor<?x?xf32>)
+//       CHECK:     %[[YIELD1:.+]] = tensor.insert_slice %[[SORT_TILE]]#0 into %[[INIT1]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
+//       CHECK:     %[[YIELD2:.+]] = tensor.insert_slice %[[SORT_TILE]]#1 into %[[INIT2]][%[[IV]], 0] [%[[USED_TILESIZE]], %[[D1]]]
 //       CHECK:     scf.yield %[[YIELD1]], %[[YIELD2]]
 //       CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
 
@@ -395,6 +422,7 @@ func.func @sort_2d_multi_result_memref(
     %arg0: memref<?x?xi32>, %arg1: memref<?x?xf32>) {
   iree_linalg_ext.sort
      dimension(0)
+     ins(%arg0, %arg1 : memref<?x?xi32>, memref<?x?xf32>)
      outs(%arg0, %arg1 : memref<?x?xi32>, memref<?x?xf32>) {
      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
        %0 = arith.cmpf ogt, %arg4, %arg5 : f32

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
@@ -809,7 +809,6 @@ util.func public @dynamic_slice(%arg0: tensor<?x?xi32>, %arg1: tensor<i32>, %arg
 //   CHECK-DAG:     iree_tensor_ext.dispatch.tensor.load %[[ARG2_CAPTURE]]
 //   CHECK-DAG:     iree_tensor_ext.dispatch.tensor.load %[[ARG1_CAPTURE]]
 //   CHECK-DAG:     arith.minsi
-//   CHECK-DAG:     arith.minsi
 //   CHECK-DAG:     arith.maxsi
 //   CHECK-DAG:     arith.maxsi
 //   CHECK-DAG:     index_cast
@@ -892,13 +891,24 @@ util.func public @scatter(
 
 util.func public @sort_3d(%arg0: tensor<?x?x?xi32>, %arg1 : tensor<?x?x?xf32>)
     -> (tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
-  %0, %1 = iree_linalg_ext.sort dimension(0)
-      outs(%arg0, %arg1 : tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %0 = tensor.dim %arg0, %c0 : tensor<?x?x?xi32>
+  %1 = tensor.dim %arg0, %c1 : tensor<?x?x?xi32>
+  %2 = tensor.dim %arg0, %c2 : tensor<?x?x?xi32>
+  %3 = tensor.dim %arg1, %c0 : tensor<?x?x?xf32>
+  %4 = tensor.dim %arg1, %c1 : tensor<?x?x?xf32>
+  %5 = tensor.dim %arg1, %c2 : tensor<?x?x?xf32>
+  %6 = tensor.empty(%0, %1, %2) : tensor<?x?x?xi32>
+  %7 = tensor.empty(%3, %4, %5) : tensor<?x?x?xf32>
+  %8, %9 = iree_linalg_ext.sort dimension(0)
+      ins(%arg0, %arg1 : tensor<?x?x?xi32>, tensor<?x?x?xf32>) outs(%6, %7 : tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
       ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
-        %2 = arith.cmpf ogt, %arg4, %arg5 : f32
-        iree_linalg_ext.yield %2 : i1
+        %10 = arith.cmpf ogt, %arg4, %arg5 : f32
+        iree_linalg_ext.yield %10 : i1
       } -> tensor<?x?x?xi32>, tensor<?x?x?xf32>
-  util.return %0, %1 : tensor<?x?x?xi32>, tensor<?x?x?xf32>
+  util.return %8, %9 : tensor<?x?x?xi32>, tensor<?x?x?xf32>
 }
 //      CHECK: util.func public @sort_3d(
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x?x?xi32>
@@ -915,10 +925,12 @@ util.func public @sort_3d(%arg0: tensor<?x?x?xi32>, %arg1 : tensor<?x?x?xf32>)
 //      CHECK:   %[[RESULT_OUT:.+]]:2 = flow.dispatch.workgroups[
 // CHECK-SAME:       %[[ARG0_D0]], %[[ARG0_D1]], %[[ARG0_D2]], %[[ARG1_D0]], %[[ARG1_D1]], %[[ARG1_D2]]]
 // CHECK-SAME:       (%[[ARG0]], %[[ARG1]], %[[ARG0_D0]], %[[ARG0_D1]], %[[ARG0_D2]], %[[ARG1_D0]], %[[ARG1_D1]], %[[ARG1_D2]])
-// CHECK-NEXT:       (%[[ARG0_CAPTURE:[a-zA-Z0-9_]+]]: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xi32>>
-// CHECK-SAME:        %[[ARG1_CAPTURE:[a-zA-Z0-9_]+]]: !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?x?x?xf32>>,
+// CHECK-NEXT:       (%[[ARG0_CAPTURE:[a-zA-Z0-9_]+]]: !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xi32>>
+// CHECK-SAME:        %[[ARG1_CAPTURE:[a-zA-Z0-9_]+]]: !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x?x?xf32>>,
 // CHECK-SAME:        %[[ARG0_D0_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG0_D1_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG0_D2_CAPTURE:[a-zA-Z0-9_]+]]: index,
-// CHECK-SAME:        %[[ARG1_D0_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG1_D1_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG1_D2_CAPTURE:[a-zA-Z0-9_]+]]: index) {
+// CHECK-SAME:        %[[ARG1_D0_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG1_D1_CAPTURE:[a-zA-Z0-9_]+]]: index, %[[ARG1_D2_CAPTURE:[a-zA-Z0-9_]+]]: index,
+// CHECK-SAME:        %[[OUT0_CAPTURE:[a-zA-Z0-9_]+]]: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x?xi32>>
+// CHECK-SAME:        %[[OUT1_CAPTURE:[a-zA-Z0-9_]+]]: !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?x?xf32>>) {
 //  CHECK-DAG:     %[[ARG0_D0_W:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ARG0_D0_CAPTURE]], 0
 //  CHECK-DAG:     %[[ARG0_D1_W:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ARG0_D1_CAPTURE]], 1
 //  CHECK-DAG:     %[[ARG0_D2_W:.+]] = iree_tensor_ext.dispatch.workload.ordinal %[[ARG0_D2_CAPTURE]], 2
@@ -929,8 +941,10 @@ util.func public @sort_3d(%arg0: tensor<?x?x?xi32>, %arg1 : tensor<?x?x?xf32>)
 // CHECK-SAME:         offsets = [0, 0, 0], sizes = [%[[ARG0_D0_W]], %[[ARG0_D1_W]], %[[ARG0_D2_W]]]
 //      CHECK:     %[[OUT2:.+]] = iree_tensor_ext.dispatch.tensor.load %[[ARG1_CAPTURE]]
 // CHECK-SAME:         offsets = [0, 0, 0], sizes = [%[[ARG1_D0_W]], %[[ARG1_D1_W]], %[[ARG1_D2_W]]]
+//  CHECK-DAG:     %[[INIT1:.+]] = tensor.empty(%[[ARG0_D0_W]], %[[ARG0_D1_W]], %[[ARG0_D2_W]])
+//  CHECK-DAG:     %[[INIT2:.+]] = tensor.empty(%[[ARG1_D0_W]], %[[ARG1_D1_W]], %[[ARG1_D2_W]])
 //      CHECK:     %[[RESULT:.+]]:2 = iree_linalg_ext.sort dimension(0)
-// CHECK-SAME:         outs(%[[OUT1]], %[[OUT2]] : tensor<?x?x?xi32>, tensor<?x?x?xf32>)
+// CHECK-SAME:         ins(%[[OUT1]], %[[OUT2]] : tensor<?x?x?xi32>, tensor<?x?x?xf32>) outs(%[[INIT1]], %[[INIT2]] : tensor<?x?x?xi32>, tensor<?x?x?xf32>)
 //      CHECK:     iree_tensor_ext.dispatch.tensor.store %[[RESULT]]#0
 // CHECK-SAME:         offsets = [0, 0, 0], sizes = [%[[ARG0_D0_W]], %[[ARG0_D1_W]], %[[ARG0_D2_W]]]
 //      CHECK:     iree_tensor_ext.dispatch.tensor.store %[[RESULT]]#1

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -649,6 +649,16 @@ struct LinalgOpTiedOpInterface
     return {linalgOp.getDpsInitsMutable()[resultIndex].getOperandNumber()};
   }
 
+  std::pair<unsigned, unsigned>
+  getTiedOperandsIndexAndLength(Operation *op) const {
+    auto linalgOp = cast<OpTy>(op);
+    MutableOperandRange inits = linalgOp.getDpsInitsMutable();
+    if (inits.empty()) {
+      return {op->getNumOperands(), 0};
+    }
+    return {inits.begin()->getOperandNumber(), inits.size()};
+  }
+
   SmallVector<int64_t> getTiedResultOperandIndices(Operation *op) const {
     SmallVector<int64_t> result;
     for (unsigned i = 0; i < op->getNumResults(); ++i) {

--- a/tests/e2e/linalg_ext_ops/sort.mlir
+++ b/tests/e2e/linalg_ext_ops/sort.mlir
@@ -1,6 +1,8 @@
 func.func @sort2D() {
   %input = util.unfoldable_constant dense<[[5, 6], [3, 7]]> : tensor<2x2xi32>
-  %0 = iree_linalg_ext.sort dimension(0) outs(%input : tensor<2x2xi32>) {
+  %empty = tensor.empty() : tensor<2x2xi32>
+  %0 = iree_linalg_ext.sort dimension(0)
+      ins(%input : tensor<2x2xi32>) outs(%empty : tensor<2x2xi32>) {
     ^bb0(%arg2: i32, %arg3: i32):
       %1 = arith.cmpi slt, %arg2, %arg3 : i32
       iree_linalg_ext.yield %1 : i1

--- a/tests/e2e/linalg_ext_ops/topk_v2.mlir
+++ b/tests/e2e/linalg_ext_ops/topk_v2.mlir
@@ -196,8 +196,11 @@ func.func @unsorted() {
         iree_linalg_ext.yield %0 : i1
       } -> tensor<3xf32>, tensor<3xi32>
 
+  %sorted_values_empty = tensor.empty() : tensor<3xf32>
+  %sorted_indices_empty = tensor.empty() : tensor<3xi32>
   %sorted:2 = iree_linalg_ext.sort dimension(0)
-      outs(%0#0, %0#1 : tensor<3xf32>, tensor<3xi32>) {
+      ins(%0#0, %0#1 : tensor<3xf32>, tensor<3xi32>)
+      outs(%sorted_values_empty, %sorted_indices_empty : tensor<3xf32>, tensor<3xi32>) {
       ^bb0(%arg0 : f32, %arg1 : f32, %arg2 : i32, %arg3 : i32):
         %1 = arith.cmpf ogt, %arg0, %arg1 : f32
         iree_linalg_ext.yield %1 : i1

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan_rdna3_O0.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan_rdna3_O0.json
@@ -16,7 +16,10 @@
     "onnx/node/generated/test_group_normalization_example_expanded",
     "onnx/node/generated/test_nonmaxsuppression_two_batches"
   ],
-  "skip_run_tests": [],
+  "skip_run_tests": [
+    "onnx/node/generated/test_nonmaxsuppression_flipped_coordinates",
+    "onnx/node/generated/test_nonmaxsuppression_suppress_by_IOU_and_scores"
+  ],
   "expected_compile_failures": [
     "onnx/node/generated/test_affine_grid_2d",
     "onnx/node/generated/test_affine_grid_2d_align_corners",
@@ -110,12 +113,6 @@
     "onnx/node/generated/test_nllloss_NCd1d2d3_none_no_weight_negative_ii",
     "onnx/node/generated/test_nllloss_NCd1d2d3d4d5_mean_weight",
     "onnx/node/generated/test_nllloss_NCd1d2d3d4d5_none_no_weight",
-    "onnx/node/generated/test_nonmaxsuppression_center_point_box_format",
-    "onnx/node/generated/test_nonmaxsuppression_flipped_coordinates",
-    "onnx/node/generated/test_nonmaxsuppression_identical_boxes",
-    "onnx/node/generated/test_nonmaxsuppression_limit_output_size",
-    "onnx/node/generated/test_nonmaxsuppression_suppress_by_IOU",
-    "onnx/node/generated/test_nonmaxsuppression_suppress_by_IOU_and_scores",
     "onnx/node/generated/test_nonmaxsuppression_two_classes",
     "onnx/node/generated/test_nonzero_example",
     "onnx/node/generated/test_quantizelinear_axis",


### PR DESCRIPTION
Currently, the Sort op is defined to take no ins() operands, and instead takes the input tensors as outs(). After bufferization, it modifies those outs() in-place. This is inconsistent with other LinalgExt ops.

For that reason, we re-define the Sort op to take input tensors as ins() and inits as outs().
```mlir
// before
%sorted = iree_linalg_ext.sort
  dimension(0)
  outs(%arr : tensor<?xi64>) {
  // ...
} -> tensor<?xi64>
// after
%sorted = iree_linalg_ext.sort
  dimension(0)
  ins(%arr : tensor<?xi64>)
  outs(%sorted_init : tensor<?xi64>) {
// ...
} -> tensor<?xi64>
```

Lit and E2E tests had to be converted to the new syntax.