### PR TITLE
[LLVMGPU] Fix hardcoded LHS transpose shape in NV mma.sync lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1259,10 +1259,9 @@ static Value createMmaOp(OpBuilder &builder, Location loc,
         .getResult();
   }
   if (isNvMmaSync(intrinsic)) {
-    // Transpose the two outer dims to model mma.sync's column-major register
-    // order: reshape to {outer_M, outer_K, element_K}, swap outer_M/outer_K.
-    // Shape is derived from the LHS layout (not hardcoded {2, 2, 2}) since
-    // element[K] varies by intrinsic (e.g. FP8 packs 4 vs. F16/BF16's 2).
+    // Transpose outer M/K dims for mma.sync's column-major register order.
+    // Derive the non-unit shape from the LHS layout because element[K] varies
+    // by intrinsic.
     Type elementType = cast<VectorType>(lhs.getType()).getElementType();
     auto lhsLayout = getSingleSubgroupLayout(intrinsic, kMMAOperandLhs);
     int64_t outerM = lhsLayout.outer[0];

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1259,14 +1259,17 @@ static Value createMmaOp(OpBuilder &builder, Location loc,
         .getResult();
   }
   if (isNvMmaSync(intrinsic)) {
-    // Transpose the two outer dimensions to model the column-major register
-    // ordering expected by mma.sync. The input shape differs between pipelines:
-    // VectorDistribute produces 2x2x1x2, TileAndFuse produces 2x1x2x2.
-    // Remove the unit dimension to simplify the transpose.
-    // Preserve the operand element type so BF16 fragments are not reshaped as
-    // f16.
+    // Transpose the two outer dims to model mma.sync's column-major register
+    // order: reshape to {outer_M, outer_K, element_K}, swap outer_M/outer_K.
+    // Shape is derived from the LHS layout (not hardcoded {2, 2, 2}) since
+    // element[K] varies by intrinsic (e.g. FP8 packs 4 vs. F16/BF16's 2).
     Type elementType = cast<VectorType>(lhs.getType()).getElementType();
-    auto nonUnitVecType = VectorType::get({2, 2, 2}, elementType);
+    auto lhsLayout = getSingleSubgroupLayout(intrinsic, kMMAOperandLhs);
+    int64_t outerM = lhsLayout.outer[0];
+    int64_t outerK = lhsLayout.outer[1];
+    int64_t elemSize = lhsLayout.element[0] * lhsLayout.element[1];
+    auto nonUnitVecType =
+        VectorType::get({outerM, outerK, elemSize}, elementType);
     auto reshaped =
         vector::ShapeCastOp::create(builder, loc, nonUnitVecType, lhs);
     auto permAttr = builder.getDenseI64ArrayAttr({1, 0, 2});

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_tile_and_fuse_mma_sync.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_tile_and_fuse_mma_sync.mlir
@@ -139,3 +139,54 @@ func.func @matmul_tile_and_fuse_mma_sync_bf16()
 // Verify nvgpu.mma.sync is generated with correct shape for BF16
 // CHECK-COUNT-8: nvgpu.mma.sync({{.*}}) {mmaShape = [16, 8, 16]} : ({{.*}}) -> vector<2x2xf32>
 //       CHECK:   scf.yield
+
+// -----
+
+// Test FP8 (E4M3FN) matmul lowering through TileAndFuse pipeline.
+// m16n8k32: K doubles vs F16/BF16, so reduction tile = 4 (4x32=128 K-per-iter).
+// LHS transpose reshapes to {outer_M, outer_K, element_K} = {2, 2, 4} for FP8
+// (vs {2, 2, 2} for FP16 m16n8k16).
+
+#executable_target_cuda_fp8 = #hal.executable.target<"cuda", "cuda-nvptx-fb">
+#pipeline_layout_fp8 = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#config_fp8e4m3fn = #iree_gpu.lowering_config<{
+  workgroup = [64, 64, 0],
+  reduction = [0, 0, 4],
+  subgroup = [2, 4],
+  mma_kind = #iree_gpu.mma_layout<NV_MMA_SYNC_F32_16x8x32_F8E4M3FN>,
+  promote_operands = [0, 1]
+}>
+func.func @matmul_tile_and_fuse_mma_sync_fp8e4m3fn()
+  attributes {
+    hal.executable.target = #executable_target_cuda_fp8,
+    translation_info = #iree_codegen.translation_info<pipeline = #iree_gpu.pipeline<TileAndFuse> workgroup_size = [128, 1, 1] subgroup_size = 32>} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout_fp8) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf8E4M3FN>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout_fp8) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x10240xf8E4M3FN>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout_fp8) binding(2) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+  %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1280], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<2048x1280xf8E4M3FN>> -> tensor<2048x1280xf8E4M3FN>
+  %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1280, 10240], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1280x10240xf8E4M3FN>> -> tensor<1280x10240xf8E4M3FN>
+  %5 = tensor.empty() : tensor<2048x10240xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+  %7 = linalg.matmul {lowering_config = #config_fp8e4m3fn} ins(%3, %4 : tensor<2048x1280xf8E4M3FN>, tensor<1280x10240xf8E4M3FN>) outs(%6 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+  iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 10240], strides = [1, 1] : tensor<2048x10240xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+  return
+}
+
+// CHECK-LABEL: func @matmul_tile_and_fuse_mma_sync_fp8e4m3fn
+//   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf8E4M3FN, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf8E4M3FN, #gpu.address_space<workgroup>>
+//       CHECK:   scf.for
+// Verify LHS transpose for mma.sync column-major ordering (FP8 element[K]=4)
+// TileAndFuse produces 2x1x2x4 -> reshape to 2x2x4 -> transpose [1,0,2] -> reshape to 4x4
+//       CHECK:       vector.shape_cast {{.*}} : vector<2x1x2x4xf8E4M3FN> to vector<2x2x4xf8E4M3FN>
+//       CHECK:       vector.transpose {{.*}}, [1, 0, 2] : vector<2x2x4xf8E4M3FN> to vector<2x2x4xf8E4M3FN>
+//       CHECK:       vector.shape_cast {{.*}} : vector<2x2x4xf8E4M3FN> to vector<4x4xf8E4M3FN>
+// Verify nvgpu.mma.sync is generated with m16n8k32 shape for FP8
+// CHECK-COUNT-8: nvgpu.mma.sync({{.*}}) {mmaShape = [16, 8, 32]} : ({{.*}}) -> vector<2x2xf32>
+//       CHECK:   scf.yield

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_tile_and_fuse_mma_sync.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_tile_and_fuse_mma_sync.mlir
@@ -142,10 +142,8 @@ func.func @matmul_tile_and_fuse_mma_sync_bf16()
 
 // -----
 
-// Test FP8 (E4M3FN) matmul lowering through TileAndFuse pipeline.
-// m16n8k32: K doubles vs F16/BF16, so reduction tile = 4 (4x32=128 K-per-iter).
-// LHS transpose reshapes to {outer_M, outer_K, element_K} = {2, 2, 4} for FP8
-// (vs {2, 2, 2} for FP16 m16n8k16).
+// Test FP8 E4M3FN m16n8k32 matmul lowering to nvgpu.mma.sync.
+// FP8 uses reduction = 4 and element[K] = 4.
 
 #executable_target_cuda_fp8 = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 #pipeline_layout_fp8 = #hal.pipeline.layout<bindings = [
@@ -182,11 +180,9 @@ func.func @matmul_tile_and_fuse_mma_sync_fp8e4m3fn()
 //   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf8E4M3FN, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   memref.alloc() : memref<{{.*}}xf8E4M3FN, #gpu.address_space<workgroup>>
 //       CHECK:   scf.for
-// Verify LHS transpose for mma.sync column-major ordering (FP8 element[K]=4)
-// TileAndFuse produces 2x1x2x4 -> reshape to 2x2x4 -> transpose [1,0,2] -> reshape to 4x4
+// Verify the FP8 LHS mma.sync transpose and m16n8k32 lowering.
 //       CHECK:       vector.shape_cast {{.*}} : vector<2x1x2x4xf8E4M3FN> to vector<2x2x4xf8E4M3FN>
 //       CHECK:       vector.transpose {{.*}}, [1, 0, 2] : vector<2x2x4xf8E4M3FN> to vector<2x2x4xf8E4M3FN>
 //       CHECK:       vector.shape_cast {{.*}} : vector<2x2x4xf8E4M3FN> to vector<4x4xf8E4M3FN>
-// Verify nvgpu.mma.sync is generated with m16n8k32 shape for FP8
 // CHECK-COUNT-8: nvgpu.mma.sync({{.*}}) {mmaShape = [16, 8, 32]} : ({{.*}}) -> vector<2x2xf32>
 //       CHECK:   scf.yield


### PR DESCRIPTION
This PR is stacked on:
- [x] https://github.com/iree-org/iree/pull/24659

## Description

`createMmaOp()` hardcoded the LHS reshape shape to `{2, 2, 2}` when lowering NV `mma.sync`. This held for all NV intrinsics that existed at the time (F16/BF16 m16n8k16, `element[K]=2`), but FP8 m16n8k32 packs `element[K]=4`, so the reshape produced 16 elements while the hardcoded target expected 8:


> error: 'vector.shape_cast' op has different number of elements at source (16) and result (8)
> note: see current operation: %73 = "vector.shape_cast"(%70) : (vector<2x1x2x4xf8E4M3FN>) -> vector<2x2x2xf8E4M3FN>

This computes the reshape shape from `getSingleSubgroupLayout()` instead of hardcoding it, so it adapts to any `element[K]` size. F16/BF16 behavior is unchanged (`{2, 2, 2}` still holds for them).

Adds an FP8 (E4M3FN) TileAndFuse pipeline test.

## Testing

```bash
/workspace/iree-build/tools/iree-opt \
    --split-input-file \
    --iree-codegen-llvmgpu-nvvm-lowering-pipeline="include-llvm-lowering=false" \
    compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_tile_and_fuse_mma_sync.mlir \
    | /workspace/iree-build/llvm-project/bin/FileCheck \
      compiler/src/iree/compiler/Codegen/LLVMGPU/test/NVVM/pipeline_tile_and_fuse_mma_sync.mlir
