### PR TITLE
base/string_view: honor the base argument in atoi_int32_base

### DIFF
--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -384,7 +384,7 @@ IREE_API_EXPORT bool iree_string_view_atoi_int32_base(iree_string_view_t value,
   // Attempt to parse.
   errno = 0;
   char* end = NULL;
-  long parsed_value = strtol(temp, &end, 0);
+  long parsed_value = strtol(temp, &end, base);
   if (temp == end) return false;
   if ((parsed_value == LONG_MIN || parsed_value == LONG_MAX) &&
       errno == ERANGE) {

--- a/runtime/src/iree/base/string_view_test.cc
+++ b/runtime/src/iree/base/string_view_test.cc
@@ -386,6 +386,26 @@ TEST(StringViewTest, Substr) {
   EXPECT_EQ(substr("abc", 0, IREE_STRING_VIEW_NPOS), "abc");
 }
 
+TEST(StringViewTest, AtoiInt32Base) {
+  auto atoi = [](const char* value, int base) -> int32_t {
+    int32_t result = 0;
+    EXPECT_TRUE(iree_string_view_atoi_int32_base(iree_make_cstring_view(value),
+                                                 base, &result));
+    return result;
+  };
+  // The base argument must be honored (it was previously ignored and the value
+  // was always parsed with base 0 / C auto-detection).
+  EXPECT_EQ(atoi("10", 10), 10);
+  EXPECT_EQ(atoi("10", 16), 16);
+  EXPECT_EQ(atoi("10", 2), 2);
+  EXPECT_EQ(atoi("ff", 16), 255);
+  EXPECT_EQ(atoi("-20", 8), -16);
+  // base 0 keeps C auto-detection: "0x" -> hex, leading "0" -> octal.
+  EXPECT_EQ(atoi("0x1a", 0), 26);
+  EXPECT_EQ(atoi("010", 0), 8);
+  EXPECT_EQ(atoi("10", 0), 10);
+}
+
 TEST(StringViewTest, Split) {
   auto split =
       [](const char* value,


### PR DESCRIPTION
### Problem
`iree_string_view_atoi_int32_base` ignores its `base` argument.

### Root cause
`runtime/src/iree/base/string_view.c:387` calls `strtol(temp, &end, 0)` — the `base` parameter is never used, so any requested radix is silently discarded and the string is parsed with C auto-detection (leading `0x` → hex, leading `0` → octal, else decimal). The three sibling `_base` functions forward the argument correctly: `strtoul(temp, &end, base)` (uint32, :413), `strtoll(..., base)` (int64, :436), `strtoull(..., base)` (uint64, :462). The non-`base` wrapper `iree_string_view_atoi_int32` already passes `0` explicitly (:399), so the `_base` variant is clearly meant to honor a caller-supplied radix. A caller requesting base 16 or 2 gets wrong values (e.g. base=16 `"10"` → 10 instead of 16).

### Fix
Forward `base` to `strtol`, matching the sibling `_base` functions.

### Verification
Static reasoning + sibling consistency; trivially checkable: `strtol("10", &e, 16) == 16` vs the current `strtol("10", &e, 0) == 10`. (No full runtime build on my machine — happy to add a unit test if useful.)
