### PR TITLE
[Flow] Fix out-of-bounds write in flow.tensor.update folder

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -1121,6 +1121,15 @@ static ElementsAttr tensorUpdate(ElementsAttr update, ElementsAttr target,
   auto startIndex = llvm::map_to_vector(startIndicesAttrs, [](Attribute value) {
     return cast<IntegerAttr>(value).getValue().getZExtValue();
   });
+  // The op verifier does not check that the update region fits within the
+  // target at the start offsets. If it does not, the row-major writes below
+  // would run past `targetValues`; decline to fold in that case.
+  for (int64_t j = 0; j < rank; ++j) {
+    if (static_cast<int64_t>(startIndex[j]) + updateType.getDimSize(j) >
+        targetType.getDimSize(j)) {
+      return {};
+    }
+  }
   auto targetValues = llvm::to_vector(target.getValues<Attribute>());
   // target indices start from startIndicesAttrs and update indices start from
   // all zeros.

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -1151,6 +1151,35 @@ static ElementsAttr tensorUpdate(ElementsAttr update, ElementsAttr target,
   return DenseElementsAttr::get(targetType, targetValues);
 }
 
+// Returns true if the `update` region placed at `startIndicesAttrs` lies
+// entirely within `target`. The op verifier only checks dynamic dimension
+// counts, so a well-formed op may still describe an out-of-range region.
+static bool isUpdateInBounds(ElementsAttr update, ElementsAttr target,
+                             ArrayRef<Attribute> startIndicesAttrs) {
+  auto updateType = cast<ShapedType>(update.getType());
+  auto targetType = cast<ShapedType>(target.getType());
+  // These cases write nothing, so there is nothing to bound.
+  if (updateType.getNumElements() == 0 || targetType.getNumElements() == 0) {
+    return true;
+  }
+  int64_t rank = targetType.getRank();
+  if (rank == 0) {
+    return true;
+  }
+  if (static_cast<int64_t>(startIndicesAttrs.size()) != rank) {
+    return false;
+  }
+  for (int64_t j = 0; j < rank; ++j) {
+    uint64_t start =
+        cast<IntegerAttr>(startIndicesAttrs[j]).getValue().getZExtValue();
+    if (static_cast<int64_t>(start) + updateType.getDimSize(j) >
+        targetType.getDimSize(j)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 OpFoldResult TensorUpdateOp::fold(FoldAdaptor operands) {
   bool allIndicesConstant =
       llvm::count(operands.getStartIndices(), nullptr) == 0;
@@ -1159,6 +1188,11 @@ OpFoldResult TensorUpdateOp::fold(FoldAdaptor operands) {
     auto update = dyn_cast<ElementsAttr>(operands.getUpdate());
     auto target = dyn_cast<ElementsAttr>(operands.getTarget());
     if (!update || !target) {
+      return {};
+    }
+    // Only fold when the update region is fully in range; tensorUpdate would
+    // otherwise write past the target constant (out-of-bounds).
+    if (!isUpdateInBounds(update, target, operands.getStartIndices())) {
       return {};
     }
     return tensorUpdate(update, target, operands.getStartIndices());

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -1103,6 +1103,10 @@ void TensorSliceOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // flow.tensor.update
 //===----------------------------------------------------------------------===//
 
+// Performs the update of `target` with `update` at `startIndicesAttrs`.
+// Requires that the update region fits within the target at those offsets
+// (see `isUpdateInBounds`); otherwise the row-major writes below run past
+// `targetValues`.
 static ElementsAttr tensorUpdate(ElementsAttr update, ElementsAttr target,
                                  ArrayRef<Attribute> startIndicesAttrs) {
   auto updateType = cast<ShapedType>(update.getType());
@@ -1121,15 +1125,6 @@ static ElementsAttr tensorUpdate(ElementsAttr update, ElementsAttr target,
   auto startIndex = llvm::map_to_vector(startIndicesAttrs, [](Attribute value) {
     return cast<IntegerAttr>(value).getValue().getZExtValue();
   });
-  // The op verifier does not check that the update region fits within the
-  // target at the start offsets. If it does not, the row-major writes below
-  // would run past `targetValues`; decline to fold in that case.
-  for (int64_t j = 0; j < rank; ++j) {
-    if (static_cast<int64_t>(startIndex[j]) + updateType.getDimSize(j) >
-        targetType.getDimSize(j)) {
-      return {};
-    }
-  }
   auto targetValues = llvm::to_vector(target.getValues<Attribute>());
   // target indices start from startIndicesAttrs and update indices start from
   // all zeros.
@@ -1157,14 +1152,47 @@ static ElementsAttr tensorUpdate(ElementsAttr update, ElementsAttr target,
   return DenseElementsAttr::get(targetType, targetValues);
 }
 
+// Returns true if the `update` region placed at `startIndicesAttrs` lies
+// entirely within `target`. The op verifier only checks dynamic dimension
+// counts, so a well-formed op may still describe an out-of-range region.
+static bool isUpdateInBounds(ElementsAttr update, ElementsAttr target,
+                             ArrayRef<Attribute> startIndicesAttrs) {
+  auto updateType = cast<ShapedType>(update.getType());
+  auto targetType = cast<ShapedType>(target.getType());
+  // These cases write nothing, so there is nothing to bound.
+  if (updateType.getNumElements() == 0 || targetType.getNumElements() == 0) {
+    return true;
+  }
+  int64_t rank = targetType.getRank();
+  if (rank == 0) {
+    return true;
+  }
+  if (static_cast<int64_t>(startIndicesAttrs.size()) != rank) {
+    return false;
+  }
+  for (int64_t j = 0; j < rank; ++j) {
+    uint64_t start =
+        cast<IntegerAttr>(startIndicesAttrs[j]).getValue().getZExtValue();
+    if (static_cast<int64_t>(start) + updateType.getDimSize(j) >
+        targetType.getDimSize(j)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 OpFoldResult TensorUpdateOp::fold(FoldAdaptor operands) {
   bool allIndicesConstant =
       llvm::count(operands.getStartIndices(), nullptr) == 0;
   if (operands.getUpdate() && operands.getTarget() && allIndicesConstant) {
+    auto update = cast<ElementsAttr>(operands.getUpdate());
+    auto target = cast<ElementsAttr>(operands.getTarget());
+    // Only fold when the update region is in range; tensorUpdate requires it.
+    if (!isUpdateInBounds(update, target, operands.getStartIndices())) {
+      return {};
+    }
     // Fully constant arguments so we can perform the update here.
-    return tensorUpdate(cast<ElementsAttr>(operands.getUpdate()),
-                        cast<ElementsAttr>(operands.getTarget()),
-                        operands.getStartIndices());
+    return tensorUpdate(update, target, operands.getStartIndices());
   } else {
     // Replace the entire tensor when the sizes match.
     auto updateType = cast<ShapedType>(getUpdate().getType());

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -823,6 +823,21 @@ util.func public @updateConst2DUpdate2x2() -> tensor<3x4xi32> {
 
 // -----
 
+// Regression: an out-of-bounds update (start offset + update extent exceeds the
+// target) must not be folded; folding it would index past the target constant.
+// CHECK-LABEL: @updateConst2DUpdateOutOfBounds
+util.func public @updateConst2DUpdateOutOfBounds() -> tensor<3x4xi32> {
+  %0 = arith.constant dense<[[12, 13], [14, 15]]> : tensor<2x2xi32>
+  %1 = arith.constant dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]> : tensor<3x4xi32>
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  // CHECK: flow.tensor.update
+  %2 = flow.tensor.update %0, %1[%c2, %c3] : tensor<2x2xi32> -> tensor<3x4xi32>
+  util.return %2 : tensor<3x4xi32>
+}
+
+// -----
+
 // CHECK-LABEL: @updateConst3DUpdate1x2x3
 util.func public @updateConst3DUpdate1x2x3() -> tensor<2x3x3xi32> {
   %0 = arith.constant dense<[[[18, 19, 20], [21, 22, 23]]]> : tensor<1x2x3xi32>


### PR DESCRIPTION
### Problem
The constant folder for `flow.tensor.update` can write out of bounds when the update region does not fit within the target at the given start offsets.

### Root cause
In `tensorUpdate` (`FlowOpFolders.cpp`), `targetValues` has exactly `targetType.getNumElements()` entries, and the write
```cpp
targetValues[getFlattenedIndex(targetType, targetIndex)] = ...;
```
uses `getFlattenedIndex`, which computes a raw row-major offset with no bounds clamping. `targetIndex` starts at the constant `start_indices` and is advanced by the update's extents, so if `start_indices[j] + update_dim[j] > target_dim[j]` for any dim, the flattened offset exceeds `targetValues.size()` and the assignment is an out-of-bounds write (assertions are compiled out in release builds).

`TensorUpdateOp::verify` only checks dynamic-dim counts; it does not verify that the update fits within the target. So IR like `flow.tensor.update %u, %t[%c2, %c3] : tensor<2x2xi32> -> tensor<3x4xi32>` (a 2x2 update at offset `[2, 3]` into a 3x4 target) passes verification and then triggers the OOB write during `--canonicalize`.

### Fix
Bail out of the fold (`return {}`, leaving the op un-folded) when the update would not fit within the target at the start offsets. This mirrors the sibling non-foldable path that already returns `{}`, and is safe because valid, in-bounds updates are unaffected.

### Test
`updateConst2DUpdateOutOfBounds` in `Dialect/Flow/IR/test/tensor_folding.mlir` checks that an out-of-bounds update is left un-folded (this path crashed the folder before the change in asserts builds).
