### PR TITLE
[TensorExt] Reject negative ragged_dim in cast_to_ragged_shape verifier

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.cpp
@@ -446,6 +446,10 @@ LogicalResult CastToRaggedShapeOp::verify() {
   // Check that the ragged row dimensions `raggedRowDim` < rank(`result`) - 1.
   int64_t raggedDim = getRaggedDim().getSExtValue();
   ShapedType sourceType = getSourceType();
+  if (raggedDim < 0) {
+    return emitOpError("expected `ragged_dim` to be non-negative, but got ")
+           << raggedDim;
+  }
   if (raggedDim >= sourceType.getRank()) {
     return emitOpError("expected `ragged_dim` to be less than ")
            << sourceType.getRank() << ", i.e the rank of source";

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/invalid.mlir
@@ -64,6 +64,17 @@ util.func public @test(memref<?xf32, #iree_tensor_ext.ragged_shape<0>>) {
 // iree_tensor_ext.cast_to_ragged_shape
 //===----------------------------------------------------------------------===//
 
+// Error if the ragged_dim value is negative.
+util.func public @raggedDimNegative(%source : tensor<10x20x30xf32>,
+    %columnLengths : tensor<4xindex>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>> {
+  // expected-error @+1 {{expected `ragged_dim` to be non-negative, but got -1}}
+  %0 = iree_tensor_ext.cast_to_ragged_shape %source ragged_dim(-1) column_lengths(%columnLengths)
+      : (tensor<10x20x30xf32>, tensor<4xindex>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>>
+  util.return %0 : tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>>
+}
+
+// -----
+
 // Error if the ragged_dim value is greater than the rank of the source.
 util.func public @raggedDimError(%source : tensor<10x20x30xf32>,
     %columnLengths : tensor<4xindex>) -> tensor<10x3x8x30xf32, #iree_tensor_ext.ragged_shape<1>> {


### PR DESCRIPTION
### Problem
`CastToRaggedShapeOp::verify` reads `ragged_dim` and only bounds-checks it from above, so a negative `ragged_dim` is later used as a dimension index and reads out of bounds.

### Root cause
```cpp
int64_t raggedDim = getRaggedDim().getSExtValue();
ShapedType sourceType = getSourceType();
if (raggedDim >= sourceType.getRank()) { ... }   // only the upper bound
...
resultType.isDynamicDim(raggedDim)               // raggedDim used as index
resultType.getDimSize(raggedDim)
```
`raggedDim` comes from `getSExtValue()` and can be negative (e.g. `ragged_dim(-1)`). The verifier only rejects `raggedDim >= rank`, never `raggedDim < 0`, so a negative value flows into `resultType.isDynamicDim(raggedDim)` / `getDimSize(raggedDim)`. Those take an `unsigned`, so `-1` becomes a huge index and reads past the shape (the `idx < rank` assert is debug-only, so release builds do an out-of-bounds read). The op's documented constraint is `0 <= ragged_dim < rank(source)`.

### Fix
Reject a negative `ragged_dim` up front, before it is used to index. Keeps the existing `>= rank` diagnostic unchanged.

### Test
`raggedDimNegative` in `Dialect/TensorExt/IR/test/invalid.mlir` checks that `ragged_dim(-1)` is now rejected with a diagnostic instead of reaching the out-of-bounds index.
