### PR TITLE
[Preprocessing] Guard rank-reduced insert_slice in strided-insert conversions

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertStridedInsertSliceToGeneric.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertStridedInsertSliceToGeneric.cpp
@@ -79,6 +79,14 @@ public:
     auto srcTy = cast<RankedTensorType>(src.getType());
     auto destTy = cast<RankedTensorType>(dest.getType());
 
+    // The reassociation groups below are built from the destination and used to
+    // index the source, i.e. this assumes source dim i corresponds to dest dim
+    // i. A rank-reduced insert_slice source (unit slice dims dropped) breaks
+    // that assumption and would index the source out of bounds, so decline it.
+    if (srcTy.getRank() != destTy.getRank()) {
+      return failure();
+    }
+
     unsigned origRank = destTy.getRank();
     auto elemTy = destTy.getElementType();
     Location loc = op.getLoc();

--- a/compiler/src/iree/compiler/Preprocessing/Common/SwapStridedInsertSliceWithContraction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/SwapStridedInsertSliceWithContraction.cpp
@@ -117,6 +117,12 @@ public:
     Value source = insertOp.getSource();
     auto sourceTy = cast<RankedTensorType>(source.getType());
     auto scatteredTy = cast<RankedTensorType>(insertOp.getResult().getType());
+    // The strided dims below index the source and the scattered result by the
+    // same dim index. A rank-reduced insert_slice source (unit slice dims
+    // dropped) would make that index run past the source, so decline it.
+    if (sourceTy.getRank() != scatteredTy.getRank()) {
+      return failure();
+    }
     auto resultTy = cast<RankedTensorType>(genericOp.getResultTypes()[0]);
     AffineMap scatterMap = genericOp.getMatchingIndexingMap(scatterOperand);
     AffineMap resultMap = genericOp.getIndexingMapsArray().back();

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/convert_strided_insert_slice_to_generic.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/convert_strided_insert_slice_to_generic.mlir
@@ -29,6 +29,21 @@ util.func public @stride2_no_passthrough(%src: tensor<4x4xf16>) -> tensor<9x9xf1
 
 // -----
 
+// A rank-reduced strided insert_slice (source rank < dest rank) must not be
+// converted: the conversion indexes the source with dest-derived dims and would
+// read past the source. Regression test.
+util.func public @rank_reduced_source_not_converted(%src: tensor<4x8xf32>) -> tensor<8x1x16xf32> {
+  %cst = arith.constant dense<0.000000e+00> : tensor<8x1x16xf32>
+  %0 = tensor.insert_slice %src into %cst[0, 0, 0] [4, 1, 8] [2, 1, 2] : tensor<4x8xf32> into tensor<8x1x16xf32>
+  util.return %0 : tensor<8x1x16xf32>
+}
+
+// CHECK-LABEL: @rank_reduced_source_not_converted
+// CHECK:       tensor.insert_slice
+// CHECK-NOT:   linalg.generic
+
+// -----
+
 // Converted: stride-3 with non-zero offsets.
 util.func public @stride3_no_passthrough(%src: tensor<3x3xf32>) -> tensor<10x10xf32> {
   %cst = arith.constant dense<0.000000e+00> : tensor<10x10xf32>


### PR DESCRIPTION
### Problem
Two `tensor.insert_slice` conversions in the backward-data-conv preprocessing pipeline index the insert_slice **source** with a **destination-rank** dimension index. `tensor.insert_slice` allows a rank-reduced source (unit slice dims dropped), so for such an input the index runs past the source shape — an out-of-bounds access (assertion crash in asserts builds, garbage read + invalid IR in release).

### Details
- **`ConvertStridedInsertSliceToGeneric`**: `origRank`/`reassociation` are derived only from the destination, and the collapse loop evaluates `srcTy.getDimSize(idx)` for `idx` up to `destRank - 1` (`for (int64_t idx : group) { ... srcDim *= srcTy.getDimSize(idx); }`). No rank-equality check exists between the `srcTy` cast and that loop.
- **`SwapStridedInsertSliceWithContraction`**: `rank = scatteredTy.getRank()` is the destination rank, and the strided-dim loop calls `sourceTy.getDimSize(d)` with that dest-rank index `d`.

Both patterns match verifier-valid IR: `tensor.insert_slice`'s static offsets/sizes/strides are always destination-rank length, but the source may be rank-reduced, and a non-unit stride on a dropped (unit) dim still verifies. Example that reaches the first bug:
```mlir
%z = arith.constant dense<0.0> : tensor<8x1x16xf32>
%0 = tensor.insert_slice %s into %z[0, 0, 0] [4, 1, 8] [2, 1, 2]
       : tensor<4x8xf32> into tensor<8x1x16xf32>
```
Here the reassociation group `{2}` triggers `srcTy.getDimSize(2)` on a rank-2 source.

### Fix
The algorithms assume source dim `i` corresponds to dest dim `i` throughout, so decline the rank-reduced case: `if (srcTy.getRank() != destTy.getRank()) return failure();` in each pattern. This prevents the OOB and falls back to the default lowering; the intended equal-rank cases (all existing tests) are unaffected.

### Test
`rank_reduced_source_not_converted` in `convert_strided_insert_slice_to_generic.mlir` checks that a rank-reduced strided insert_slice is left unconverted. (`SwapStridedInsertSliceWithContraction` gets the identical guard; happy to add a dedicated rank-reduced contraction test for it too if you'd like — its match requires a full contraction `linalg.generic`, so I kept the added test to the simpler pattern.)
