### PR TITLE
[Codegen] Fix GPU allocation size calculation overflows

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -24,32 +25,6 @@ static unsigned getDatalayoutIndexBitwidth(mlir::FunctionOpInterface func) {
   return options.getIndexBitwidth();
 }
 
-static int shapedTypeStaticSize(
-    memref::AllocOp allocOp, ShapedType shapedType,
-    std::function<unsigned(mlir::FunctionOpInterface)> getIndexBitwidth) {
-  int allocSize = 1;
-  for (auto dimSize : shapedType.getShape()) {
-    if (ShapedType::isDynamic(dimSize)) {
-      continue;
-    }
-    allocSize *= dimSize;
-  }
-  if (auto elementType = dyn_cast<ShapedType>(shapedType.getElementType())) {
-    allocSize *= shapedTypeStaticSize(allocOp, elementType, getIndexBitwidth);
-  } else {
-    auto eltTy = shapedType.getElementType();
-    if (eltTy.isIndex()) {
-      auto func = allocOp->getParentOfType<mlir::FunctionOpInterface>();
-      assert(getIndexBitwidth &&
-             "getIndexBitwidth should have been set earlier");
-      allocSize *= getIndexBitwidth(func);
-    } else {
-      allocSize *= IREE::Util::getTypeBitWidth(shapedType.getElementType());
-    }
-  }
-  return allocSize;
-}
-
 /// Returns success if the total shared memory allocation size is less than the
 /// limit.
 static LogicalResult checkGPUAllocationSize(
@@ -65,7 +40,7 @@ static LogicalResult checkGPUAllocationSize(
     return success();
   }
 
-  int cumSize = 0;
+  int64_t cumSize = 0;
   for (auto allocOp : allocOps) {
     auto allocType = cast<MemRefType>(allocOp.getType());
     if (!hasSharedMemoryAddressSpace(allocType)) {
@@ -77,7 +52,24 @@ static LogicalResult checkGPUAllocationSize(
           "has unsupported dynamic shared memory allocations");
     }
 
-    int allocSize = shapedTypeStaticSize(allocOp, allocType, getIndexBitwidth);
+    auto func = allocOp->getParentOfType<mlir::FunctionOpInterface>();
+    FailureOr<int64_t> allocSizeBits = getStaticShapeSizeInBits(
+        allocType, [&](Type elementType) -> int64_t {
+          if (elementType.isIndex()) {
+            assert(getIndexBitwidth &&
+                   "getIndexBitwidth should have been set earlier");
+            return getIndexBitwidth(func);
+          }
+          return IREE::Util::getTypeBitWidth(elementType);
+        });
+    if (failed(allocSizeBits)) {
+      return emitError(funcOp->getLoc())
+             << "function '" << funcOp.getName()
+             << "' shared memory allocation size overflows the size "
+                "computation; exceeded the limit of "
+             << limit << " bytes";
+    }
+    int64_t allocSize = *allocSizeBits;
     if (allocOp.getAlignment()) {
       int64_t alignmentInBits = *allocOp.getAlignment() * 8;
       allocSize =

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/ScalableValueBoundsConstraintSet.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
@@ -71,14 +72,16 @@ checkStackAllocationSize(mlir::FunctionOpInterface funcOp) {
           "all stack allocations need to be hoisted to the entry block of the "
           "function");
     }
-    int64_t allocaSize = 1;
     auto allocaType = cast<ShapedType>(allocaOp.getType());
-    for (auto dimSize : allocaType.getShape()) {
-      if (ShapedType::isDynamic(dimSize)) {
-        continue;
-      }
-      allocaSize *= dimSize;
+    FailureOr<int64_t> staticSizeBits = getStaticShapeSizeInBits(
+        allocaType, [](Type elementType) -> int64_t {
+          return IREE::Util::getTypeBitWidth(elementType);
+        });
+    if (failed(staticSizeBits)) {
+      return allocaOp->emitOpError(
+          "stack allocation size overflows the size computation");
     }
+    int64_t allocaSize = *staticSizeBits;
     for (auto operand : allocaOp.getDynamicSizes()) {
       // Assume vscale is `clAssumedVscaleValue` for determining if the alloca
       // is within the stack limit. This should always resolve to a constant
@@ -90,12 +93,16 @@ checkStackAllocationSize(mlir::FunctionOpInterface funcOp) {
           /*vscaleMin=*/assumedVscale,
           /*vscaleMax=*/assumedVscale, presburger::BoundType::UB);
       if (succeeded(ub)) {
-        allocaSize *= ub->getSize()->baseSize;
+        if (llvm::MulOverflow(allocaSize,
+                              static_cast<int64_t>(ub->getSize()->baseSize),
+                              allocaSize)) {
+          return allocaOp->emitOpError(
+              "stack allocation size overflows the size computation");
+        }
         continue;
       }
       return allocaOp.emitOpError("expected no unbounded stack allocations");
     }
-    allocaSize *= IREE::Util::getTypeBitWidth(allocaType.getElementType());
     if (allocaOp.getAlignment()) {
       int64_t alignmentInBits = *allocaOp.getAlignment() * 8;
       allocaSize =

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/DebugLog.h"
+#include "llvm/Support/MathExtras.h"
 #include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Analysis/SliceAnalysis.h"
@@ -92,6 +93,31 @@ getDispatchConfigOp(mlir::FunctionOpInterface funcOp) {
 
 bool isEntryPoint(mlir::FunctionOpInterface func) {
   return func.isPublic() && getEntryPoint(func);
+}
+
+FailureOr<int64_t>
+getStaticShapeSizeInBits(ShapedType shapedType,
+                         std::function<int64_t(Type)> getElementBitWidth) {
+  int64_t size = 1;
+  for (int64_t dimSize : shapedType.getShape()) {
+    if (ShapedType::isDynamic(dimSize)) {
+      continue;
+    }
+    if (llvm::MulOverflow(size, dimSize, size)) {
+      return failure();
+    }
+  }
+  Type elementType = shapedType.getElementType();
+  if (auto shapedElementType = dyn_cast<ShapedType>(elementType)) {
+    FailureOr<int64_t> elementBits =
+        getStaticShapeSizeInBits(shapedElementType, getElementBitWidth);
+    if (failed(elementBits) || llvm::MulOverflow(size, *elementBits, size)) {
+      return failure();
+    }
+  } else if (llvm::MulOverflow(size, getElementBitWidth(elementType), size)) {
+    return failure();
+  }
+  return size;
 }
 
 std::optional<StringRef> getConfigCpuFeatures(DictionaryAttr targetConfig) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -46,6 +46,17 @@ bool isEntryPoint(mlir::FunctionOpInterface func);
 std::optional<IREE::HAL::ExecutableExportOp>
 getEntryPoint(mlir::FunctionOpInterface funcOp);
 
+/// Returns the static size in bits of `shapedType` -- the product of its static
+/// extents and the element size -- accumulated with 64-bit overflow checking.
+/// Dynamic dimensions are skipped; callers apply their own policy for those.
+/// `getElementBitWidth` returns the bit width of a leaf (non-shaped) element
+/// type, letting callers control e.g. the target's index-type width. Returns
+/// failure on integer overflow: such an allocation necessarily exceeds any real
+/// resource limit, so callers should treat failure as "over the limit".
+FailureOr<int64_t>
+getStaticShapeSizeInBits(ShapedType shapedType,
+                         std::function<int64_t(Type)> getElementBitWidth);
+
 /// Returns the dispatch_config op for the `funcOp` by looking up the parent
 /// module for a matching function_ref. Returns nullptr if not found.
 IREE::Codegen::DispatchConfigOp


### PR DESCRIPTION
allocation size calculation should not be done in int
unify between GPU and CPU

Co-authored: Claude (which apprently loves lambdas)
needs a bit of cleanup