### PR TITLE
Replace VM ValueLiveness dataflow with upstream mlir::Liveness

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/LinearScan/LiveIntervals.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/LinearScan/LiveIntervals.cpp
@@ -296,30 +296,27 @@ uint32_t LiveIntervals::findLastUse(Value value, ValueLiveness &liveness) {
   for (auto *block : blockOrder_) {
     // Check if value is live-in to this block (means it's live-out of
     // predecessor).
-    for (auto liveIn : liveness.getBlockLiveIns(block)) {
-      if (liveIn == value) {
-        // Value is live into this block, so it must be live until some use
-        // in this block or a successor. Find the last use in this block,
-        // including discards (see comment above about why).
-        for (auto &op : block->getOperations()) {
-          for (auto &operand : op.getOpOperands()) {
-            if (operand.get() == value) {
-              lastIndex = std::max(lastIndex, opToIndex_[&op]);
-            }
-          }
+    if (!liveness.isLiveIn(block, value)) {
+      continue;
+    }
+    // Value is live into this block, so it must be live until some use
+    // in this block or a successor. Find the last use in this block,
+    // including discards (see comment above about why).
+    for (auto &op : block->getOperations()) {
+      for (auto &operand : op.getOpOperands()) {
+        if (operand.get() == value) {
+          lastIndex = std::max(lastIndex, opToIndex_[&op]);
         }
-        // If the value is still needed (live-out), extend to block terminator.
-        // We check by seeing if any successor also has this value in liveIn.
-        Operation *terminator = block->getTerminator();
-        for (auto *successor : terminator->getSuccessors()) {
-          for (auto succLiveIn : liveness.getBlockLiveIns(successor)) {
-            if (succLiveIn == value) {
-              // Value is live-out of this block.
-              lastIndex = std::max(lastIndex, opToIndex_[terminator]);
-              break;
-            }
-          }
-        }
+      }
+    }
+    // If the value is still needed (live-out), extend to block terminator.
+    // We check by seeing if any successor also has this value in liveIn.
+    Operation *terminator = block->getTerminator();
+    for (auto *successor : terminator->getSuccessors()) {
+      if (liveness.isLiveIn(successor, value)) {
+        // Value is live-out of this block.
+        lastIndex = std::max(lastIndex, opToIndex_[terminator]);
+        break;
       }
     }
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
@@ -7,10 +7,7 @@
 #include "iree/compiler/Dialect/VM/Analysis/ValueLiveness.h"
 
 #include <algorithm>
-#include <cstring>
 
-#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
-#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -35,12 +32,19 @@ LogicalResult ValueLiveness::annotateIR(IREE::VM::FuncOp funcOp) {
   // Build mapping of Operations to values live during them.
   // This is not needed normally so we calculate it only in this debugging case.
   DenseMap<Operation *, llvm::SmallSetVector<Value, 8>> livePerOp;
-  for (auto &liveRange : liveness.liveRanges_) {
-    auto value = liveRange.getFirst();
-    auto &bitVector = liveRange.getSecond();
-    for (int opIndex : bitVector.set_bits()) {
-      auto *op = liveness.opsInOrder_[opIndex];
+  auto addLiveRange = [&](Value value) {
+    for (Operation *op : liveness.liveness_->resolveLiveness(value)) {
       livePerOp[op].insert(value);
+    }
+  };
+  for (auto &block : funcOp.getBlocks()) {
+    for (auto blockArg : block.getArguments()) {
+      addLiveRange(blockArg);
+    }
+    for (auto &op : block.getOperations()) {
+      for (auto result : op.getResults()) {
+        addLiveRange(result);
+      }
     }
   }
 
@@ -103,12 +107,34 @@ LogicalResult ValueLiveness::annotateIR(IREE::VM::FuncOp funcOp) {
   };
 
   for (auto &block : funcOp.getBlocks()) {
-    auto &blockLiveness = liveness.blockLiveness_[&block];
+    const auto *blockInfo = liveness.liveness_->getLiveness(&block);
 
-    addValuesAttr(block.front(), "block_live_in", blockLiveness.liveIn);
-    addValuesAttr(block.front(), "block_live", blockLiveness.live);
-    addValuesAttr(block.front(), "block_live_out", blockLiveness.liveOut);
-    addValuesAttr(block.front(), "block_defined", blockLiveness.defined);
+    // Values live on block entry/exit come from the upstream analysis.
+    llvm::SmallSetVector<Value, 8> liveIn(blockInfo->in().begin(),
+                                          blockInfo->in().end());
+    llvm::SmallSetVector<Value, 8> liveOut(blockInfo->out().begin(),
+                                           blockInfo->out().end());
+
+    // Local sets: all values defined within the block (block args and op
+    // results) and all values used by ops within the block.
+    llvm::SmallSetVector<Value, 8> defined;
+    llvm::SmallSetVector<Value, 8> live;
+    for (auto blockArg : block.getArguments()) {
+      defined.insert(blockArg);
+    }
+    for (auto &op : block.getOperations()) {
+      for (auto operand : op.getOperands()) {
+        live.insert(operand);
+      }
+      for (auto result : op.getResults()) {
+        defined.insert(result);
+      }
+    }
+
+    addValuesAttr(block.front(), "block_live_in", liveIn);
+    addValuesAttr(block.front(), "block_live", live);
+    addValuesAttr(block.front(), "block_live_out", liveOut);
+    addValuesAttr(block.front(), "block_defined", defined);
 
     // Add per-op live values.
     for (auto &op : block.getOperations()) {
@@ -127,205 +153,20 @@ LogicalResult ValueLiveness::annotateIR(IREE::VM::FuncOp funcOp) {
 }
 
 LogicalResult ValueLiveness::recalculate(IREE::VM::FuncOp funcOp) {
-  opsInOrder_.clear();
-  opOrdering_.clear();
-  blockLiveness_.clear();
-  liveRanges_.clear();
-
-  calculateOpOrdering(funcOp);
-  if (failed(computeLivenessSets(funcOp))) {
-    return funcOp.emitError() << "failed to compute liveness sets";
-  }
-  if (failed(computeLiveIntervals(funcOp))) {
-    return funcOp.emitError() << "failed to compute live intervals";
-  }
-
+  liveness_.emplace(funcOp.getOperation());
   return success();
 }
 
-void ValueLiveness::calculateOpOrdering(IREE::VM::FuncOp funcOp) {
-  int nextOrdinal = 0;
-  for (auto &block : funcOp.getBlocks()) {
-    for (auto &op : block.getOperations()) {
-      opOrdering_[&op] = nextOrdinal++;
-      opsInOrder_.push_back(&op);
-    }
-  }
+bool ValueLiveness::isLiveIn(Block *block, Value value) {
+  return liveness_->getLiveness(block)->isLiveIn(value);
 }
 
-LogicalResult
-ValueLiveness::computeInitialLivenessSets(IREE::VM::FuncOp funcOp) {
-  for (auto &block : funcOp.getBlocks()) {
-    auto &blockSets = blockLiveness_[&block];
-
-    // Block arguments are defined within the block, technically.
-    for (auto blockArg : block.getArguments()) {
-      blockSets.defined.insert(blockArg);
-    }
-
-    // Add all operands as live uses and all results as definitions.
-    for (auto &op : block.getOperations()) {
-      for (auto &operand : op.getOpOperands()) {
-        blockSets.live.insert(operand.get());
-      }
-      for (auto result : op.getResults()) {
-        blockSets.defined.insert(result);
-        for (auto &use : result.getUses()) {
-          if (use.getOwner()->getBlock() != &block) {
-            // Value escapes this block.
-            blockSets.liveOut.insert(result);
-          }
-        }
-      }
-    }
-  }
-  return success();
-}
-
-LogicalResult ValueLiveness::computeLivenessSets(IREE::VM::FuncOp funcOp) {
-  if (failed(computeInitialLivenessSets(funcOp))) {
-    return failure();
-  }
-
-  llvm::SmallSetVector<Block *, 32> worklist;
-  worklist.insert(&funcOp.getBlocks().front());
-
-  // Compute live-in set for each block.
-  for (auto &block : funcOp.getBlocks()) {
-    auto &blockSets = blockLiveness_[&block];
-    blockSets.liveIn = blockSets.live;
-    blockSets.liveIn.set_union(blockSets.liveOut);
-    blockSets.liveIn.set_subtract(blockSets.defined);
-
-    // If there are live-ins they may need to be propagated to predecessors.
-    if (!blockSets.liveIn.empty()) {
-      worklist.insert(block.getPredecessors().begin(),
-                      block.getPredecessors().end());
-    }
-  }
-
-  // Propagate liveness until a fixed point is reached.
-  while (!worklist.empty()) {
-    Block *block = worklist.pop_back_val();
-    auto &blockSets = blockLiveness_[block];
-
-    // Compute a new live-out set for the block.
-    auto liveOut = blockSets.liveOut;
-    for (Block *successor : block->getSuccessors()) {
-      liveOut.set_union(blockLiveness_[successor].liveIn);
-    }
-    blockSets.liveOut = liveOut;
-
-    // Compute the live-in set for the block.
-    auto liveIn = liveOut;
-    liveIn.set_union(blockSets.live);
-    liveIn.set_subtract(blockSets.defined);
-
-    // Propagate the liveness to predecessors if the live-in set changed.
-    if (blockSets.liveIn.size() != liveIn.size()) {
-      blockSets.liveIn = liveIn;
-      worklist.insert(block->getPredecessors().begin(),
-                      block->getPredecessors().end());
-    }
-  }
-
-  return success();
-}
-
-LogicalResult ValueLiveness::computeLiveIntervals(IREE::VM::FuncOp funcOp) {
-  // Adds a live range for |value| from |start| to |end|.
-  // Both |start| and |end| must be within the same Block.
-  auto addLiveRange = [this](Value value, Operation *start, Operation *end) {
-    assert(start->getBlock() == end->getBlock());
-    auto &bitVector = liveRanges_[value];
-    bitVector.resize(opOrdering_.size());
-    bitVector.set(opOrdering_[start], opOrdering_[end] + 1);
-  };
-
-  for (auto &block : funcOp.getBlocks()) {
-    auto &blockSets = blockLiveness_[&block];
-
-    // Handle values that escape the block.
-    for (auto value : blockSets.liveOut) {
-      if (blockSets.liveIn.count(value)) {
-        // Live in and live out covers the entire block.
-        addLiveRange(value, &block.front(), &block.back());
-      } else {
-        // Live out but not live in implies defined in the block.
-        Operation *firstUse =
-            value.getDefiningOp() ? value.getDefiningOp() : &block.front();
-        addLiveRange(value, firstUse, &block.back());
-      }
-    }
-
-    // Handle values entering the block and dying within.
-    for (auto value : blockSets.liveIn) {
-      if (blockSets.liveOut.contains(value)) {
-        continue;
-      }
-      Operation *lastUse = &block.front();
-      for (auto &use : value.getUses()) {
-        if (use.getOwner()->getBlock() != &block) {
-          continue;
-        }
-        if (lastUse == use.getOwner()) {
-          continue;
-        }
-        if (lastUse->isBeforeInBlock(use.getOwner())) {
-          lastUse = use.getOwner();
-        }
-      }
-      addLiveRange(value, &block.front(), lastUse);
-    }
-
-    // Handle values defined within the block and not escaping.
-    for (auto value : blockSets.defined) {
-      if (blockSets.liveOut.contains(value)) {
-        continue;
-      }
-      Operation *firstUse =
-          value.getDefiningOp() ? value.getDefiningOp() : &block.front();
-      Operation *lastUse = firstUse;
-      for (auto &use : value.getUses()) {
-        if (use.getOwner()->getBlock() != &block) {
-          continue;
-        }
-        if (lastUse->isBeforeInBlock(use.getOwner())) {
-          lastUse = use.getOwner();
-        }
-      }
-      addLiveRange(value, firstUse, lastUse);
-    }
-  }
-
-  return success();
-}
-
-ArrayRef<Value> ValueLiveness::getBlockLiveIns(Block *block) {
-  auto &blockSets = blockLiveness_[block];
-  return blockSets.liveIn.getArrayRef();
-}
-
-ArrayRef<Value> ValueLiveness::getBlockLiveOuts(Block *block) {
-  auto &blockSets = blockLiveness_[block];
-  return blockSets.liveOut.getArrayRef();
+bool ValueLiveness::isLiveOut(Block *block, Value value) {
+  return liveness_->getLiveness(block)->isLiveOut(value);
 }
 
 bool ValueLiveness::isLastValueUse(Value value, Operation *useOp) {
-  auto &blockSets = blockLiveness_[useOp->getBlock()];
-  if (blockSets.liveOut.contains(value)) {
-    // Value is escapes the block the useOp is in so it is definitely not the
-    // last use.
-    return false;
-  }
-  int opOrdinal = opOrdering_[useOp];
-  auto &liveRange = liveRanges_[value];
-  if (!useOp->hasTrait<OpTrait::IsTerminator>() &&
-      liveRange.test(opOrdinal + 1)) {
-    // The value is still live within the block after the useOp.
-    return false;
-  }
-  return true;
+  return liveness_->isDeadAfter(value, useOp);
 }
 
 bool ValueLiveness::isLastValueUse(Value value, Operation *useOp,
@@ -369,8 +210,7 @@ bool ValueLiveness::isLastRealValueUse(Value value, Operation *useOp,
   }
 
   // Check if value escapes block.
-  auto &blockSets = blockLiveness_[useOp->getBlock()];
-  if (blockSets.liveOut.contains(value)) {
+  if (isLiveOut(useOp->getBlock(), value)) {
     // Value is in liveOut. For non-terminators, this means the value has uses
     // after this block, so it's not at last use.
     if (!useOp->hasTrait<OpTrait::IsTerminator>()) {
@@ -410,8 +250,7 @@ bool ValueLiveness::isLastRealValueUse(Value value, Operation *useOp,
       // invariants: MaterializeRefDiscards places exactly one discard per
       // path at value death points, so liveIn && liveOut implies real
       // (non-discard) uses downstream.
-      BlockSets &succSets = blockLiveness_[succBlock];
-      if (succSets.liveIn.contains(value) && succSets.liveOut.contains(value)) {
+      if (isLiveIn(succBlock, value) && isLiveOut(succBlock, value)) {
         return false;
       }
     }

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
@@ -158,14 +158,23 @@ LogicalResult ValueLiveness::recalculate(IREE::VM::FuncOp funcOp) {
 }
 
 bool ValueLiveness::isLiveIn(Block *block, Value value) {
-  return liveness_->getLiveness(block)->isLiveIn(value);
+  const auto *blockInfo = liveness_->getLiveness(block);
+  assert(blockInfo && "block not covered by the liveness analysis (was the "
+                      "IR modified after recalculate?)");
+  return blockInfo->isLiveIn(value);
 }
 
 bool ValueLiveness::isLiveOut(Block *block, Value value) {
-  return liveness_->getLiveness(block)->isLiveOut(value);
+  const auto *blockInfo = liveness_->getLiveness(block);
+  assert(blockInfo && "block not covered by the liveness analysis (was the "
+                      "IR modified after recalculate?)");
+  return blockInfo->isLiveOut(value);
 }
 
 bool ValueLiveness::isLastValueUse(Value value, Operation *useOp) {
+  assert(liveness_->getLiveness(useOp->getBlock()) &&
+         "block not covered by the liveness analysis (was the IR modified "
+         "after recalculate?)");
   return liveness_->isDeadAfter(value, useOp);
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.h
@@ -7,10 +7,10 @@
 #ifndef IREE_COMPILER_DIALECT_VM_ANALYSIS_VALUELIVENESS_H_
 #define IREE_COMPILER_DIALECT_VM_ANALYSIS_VALUELIVENESS_H_
 
+#include <optional>
+
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
-#include "llvm/ADT/BitVector.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/SetVector.h"
+#include "mlir/Analysis/Liveness.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Support/LLVM.h"
@@ -18,9 +18,11 @@
 namespace mlir::iree_compiler {
 
 // SSA value liveness analysis.
-// Used to compute live ranges of values over all ops within a function CFG.
-// These live ranges can be queried for information such as whether two values
-// interfere or when a value is no longer live.
+// A thin VM-specific wrapper around the upstream mlir::Liveness analysis.
+// The upstream analysis provides the block live-in/live-out sets and
+// last-use queries; this wrapper adds the ref-aware "last real use" query
+// used by register allocation to place MOVE bits (ignoring vm.discard_refs
+// cleanup markers).
 class ValueLiveness {
 public:
   // Annotates the IR with the liveness information. This is only required if
@@ -41,11 +43,11 @@ public:
   // Recalculates the liveness information for the given function.
   LogicalResult recalculate(IREE::VM::FuncOp funcOp);
 
-  // Returns an unordered list of values live on block entry.
-  ArrayRef<Value> getBlockLiveIns(Block *block);
+  // Returns true if |value| is live on entry to |block|.
+  bool isLiveIn(Block *block, Value value);
 
-  // Returns an unordered list of values live on block exit.
-  ArrayRef<Value> getBlockLiveOuts(Block *block);
+  // Returns true if |value| is live on exit from |block|.
+  bool isLiveOut(Block *block, Value value);
 
   // Returns true if |useOp| has the last use of |value|.
   bool isLastValueUse(Value value, Operation *useOp);
@@ -60,49 +62,9 @@ public:
   bool isLastRealValueUse(Value value, Operation *useOp, int operandIndex);
 
 private:
-  // Produces an op ordering for the entire function.
-  // The ordering is only useful for computing bitmap ordinals as the CFG is not
-  // sorted in any defined order (don't rely on op A < op B meaning that A is
-  // executed before B).
-  void calculateOpOrdering(IREE::VM::FuncOp funcOp);
-
-  // Computes the initial liveness sets for blocks based entirely on information
-  // local to each block.
-  LogicalResult computeInitialLivenessSets(IREE::VM::FuncOp funcOp);
-
-  // Computes the blockLiveness_ liveness sets for each block using cross-block
-  // information.
-  LogicalResult computeLivenessSets(IREE::VM::FuncOp funcOp);
-
-  // Computes the liveRanges_ for the function with a bit for each operation a
-  // value is live during (including its last usage).
-  LogicalResult computeLiveIntervals(IREE::VM::FuncOp funcOp);
-
-  // All operations in the function indexed by their unique ordinal (the same
-  // as used in opOrdering_).
-  std::vector<Operation *> opsInOrder_;
-
-  // All operations within the function mapped to a unique integer index.
-  // This index is used when computing BitVectors across all of the operations.
-  DenseMap<Operation *, int> opOrdering_;
-
-  // For a Block defines the values that are defined or live within/across.
-  struct BlockSets {
-    // All values defined within the block (either by ops or block args).
-    llvm::SmallSetVector<Value, 8> defined;
-    // All values used within the block that are not defined there.
-    llvm::SmallSetVector<Value, 8> live;
-    // Values live on block entry (used in the block or successors).
-    llvm::SmallSetVector<Value, 8> liveIn;
-    // Values live on block exit (used in successors).
-    llvm::SmallSetVector<Value, 8> liveOut;
-  };
-  DenseMap<Block *, BlockSets> blockLiveness_;
-
-  // Liveness ranges indicating for which operations the value is live.
-  // Each bit in the BitVector corresponds to an operation with the matching
-  // ordinal in opOrdering_.
-  DenseMap<Value, llvm::BitVector> liveRanges_;
+  // Upstream liveness analysis providing block live-in/live-out sets and
+  // per-op last-use information. Reconstructed by recalculate().
+  std::optional<Liveness> liveness_;
 };
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/BUILD.bazel
@@ -39,7 +39,6 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/Conversion",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/VM/Analysis",
-        "//compiler/src/iree/compiler/Dialect/VM/Analysis:ValueLiveness",
         "//compiler/src/iree/compiler/Dialect/VM/IR",
         "//compiler/src/iree/compiler/Dialect/VM/Utils:CallingConvention",
         "//compiler/src/iree/compiler/Dialect/VM/Utils:TypeTable",

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/CMakeLists.txt
@@ -43,7 +43,6 @@ iree_cc_library(
     iree::compiler::Dialect::Util::Conversion
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::VM::Analysis
-    iree::compiler::Dialect::VM::Analysis::ValueLiveness
     iree::compiler::Dialect::VM::IR
     iree::compiler::Dialect::VM::Utils::CallingConvention
     iree::compiler::Dialect::VM::Utils::TypeTable

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/VMAnalysis.h
@@ -10,7 +10,6 @@
 #include <optional>
 
 #include "iree/compiler/Dialect/VM/Analysis/RegisterAllocation.h"
-#include "iree/compiler/Dialect/VM/Analysis/ValueLiveness.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
 #include "iree/compiler/Dialect/VM/IR/VMTypes.h"
 #include "iree/compiler/Dialect/VM/Utils/CallingConvention.h"
@@ -21,7 +20,7 @@
 namespace mlir::iree_compiler::IREE::VM {
 
 /// TODO(simon-camp): This struct grew from being a wrapper around the
-/// RegisterAllocation and ValueLiveness analyses to also cache other things
+/// RegisterAllocation analysis to also cache other things
 /// needed throughout the conversion. This led to hard to locate failures
 /// when only part of this struct was correctly initialized. This
 /// should be split into multiple structs each with a single responsibility.
@@ -37,7 +36,6 @@ struct FuncAnalysis {
       llvm::report_fatal_error("register allocation failed for emitc");
     }
     registerAllocation = std::move(regAlloc);
-    valueLiveness = ValueLiveness(funcOp.getOperation());
     originalFunctionType = funcOp.getFunctionType();
     callingConvention = makeCallingConventionString(funcOp).value();
     refs = DenseMap<int64_t, Value>{};
@@ -104,10 +102,9 @@ struct FuncAnalysis {
 
   bool isMove(Value ref, Operation *op) {
     assert(isa<IREE::VM::RefType>(ref.getType()));
-    assert(valueLiveness.has_value());
     // NOTE: EmitC codegen doesn't support MOVE semantics - always use
-    // retain/assign instead of move. The && false disables MOVE intentionally.
-    return valueLiveness.value().isLastValueUse(ref, op) && false;
+    // retain/assign instead of move.
+    return false;
   }
 
   void cacheLocalRef(int64_t ordinal, Value ref) {
@@ -147,7 +144,6 @@ struct FuncAnalysis {
 
 private:
   std::optional<RegisterAllocation> registerAllocation;
-  std::optional<ValueLiveness> valueLiveness;
   std::optional<DenseMap<int64_t, Value>> refs;
   std::optional<FunctionType> originalFunctionType;
   std::optional<std::string> callingConvention;

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
@@ -397,7 +397,6 @@ class MaterializeRefDiscardsPass
           }
         }
       }
-
     }
 
     // Apply all insertions, now that every liveness query has run. Edge

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
@@ -327,31 +327,19 @@ class MaterializeRefDiscardsPass
       }
     }
 
-    // Snapshot the blocks before inserting edge discards: splitting a
-    // critical edge creates new blocks that the liveness analysis computed
-    // above does not cover, and phase 2 must not query liveness on them.
-    // They only contain the discards inserted here and a branch forwarding
-    // the split edge's operands, so they need no mid-block discards either.
-    SmallVector<Block *> originalBlocks;
+    // Phase 2 (collection only): mid-block discards.
+    // Collect refs dying mid-block (last use is not at block end and ref is
+    // not live-out), grouped by insertion point for batching. All liveness
+    // queries in this pass (phase 1 above and this loop) run against the
+    // unmutated IR the analysis was computed on; every insertion happens
+    // below, after the last query. Phases 1 and 2 target disjoint refs, so
+    // deferring the insertions cannot double-discard: a mid-block discard
+    // requires the last use to be a non-terminator op and the ref to not be
+    // live-out, while an edge discard only applies to refs that are
+    // live-out of (or forwarded by) the block's terminator.
+    SmallVector<std::pair<Operation *, SmallVector<Value>>> midBlockDiscards;
+    llvm::DenseMap<Operation *, size_t> opToIndex;
     for (Block &block : funcOp.getBlocks()) {
-      originalBlocks.push_back(&block);
-    }
-
-    // Insert batched discards for each edge.
-    for (auto &[pred, succ, refs] : edgeDiscards) {
-      Location loc = pred->getTerminator()->getLoc();
-      insertDiscardOnEdge(builder, pred, succ, refs, loc);
-    }
-
-    // Phase 2: Mid-block discards.
-    // Collect refs dying mid-block (last use is not at block end and ref is not
-    // live-out), grouped by insertion point for batching.
-    for (Block *blockPtr : originalBlocks) {
-      Block &block = *blockPtr;
-      // Group refs by their insertion point (the op after which to insert).
-      // Key is the op, value is the list of refs dying after that op.
-      SmallVector<std::pair<Operation *, SmallVector<Value>>> midBlockDiscards;
-      llvm::DenseMap<Operation *, size_t> opToIndex;
 
       for (Operation &op : block) {
         if (isa<IREE::VM::DiscardRefsOp>(&op)) {
@@ -410,15 +398,26 @@ class MaterializeRefDiscardsPass
         }
       }
 
-      // Insert batched mid-block discards.
-      for (auto &[op, values] : midBlockDiscards) {
-        if (op->hasTrait<OpTrait::IsTerminator>()) {
-          builder.setInsertionPoint(op);
-        } else {
-          builder.setInsertionPointAfter(op);
-        }
-        IREE::VM::DiscardRefsOp::create(builder, op->getLoc(), values);
+    }
+
+    // Apply all insertions, now that every liveness query has run. Edge
+    // discards first: splitting a critical edge creates new blocks the
+    // analysis has never seen, which is safe here precisely because nothing
+    // queries liveness after this point. The new blocks contain only the
+    // inserted discards and a forwarding branch, so they need no mid-block
+    // discards; mid-block insertion points are operations, which keep their
+    // blocks across edge splitting.
+    for (auto &[pred, succ, refs] : edgeDiscards) {
+      Location loc = pred->getTerminator()->getLoc();
+      insertDiscardOnEdge(builder, pred, succ, refs, loc);
+    }
+    for (auto &[op, values] : midBlockDiscards) {
+      if (op->hasTrait<OpTrait::IsTerminator>()) {
+        builder.setInsertionPoint(op);
+      } else {
+        builder.setInsertionPointAfter(op);
       }
+      IREE::VM::DiscardRefsOp::create(builder, op->getLoc(), values);
     }
 
     // Phase 3: Unused refs.

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
@@ -327,6 +327,16 @@ class MaterializeRefDiscardsPass
       }
     }
 
+    // Snapshot the blocks before inserting edge discards: splitting a
+    // critical edge creates new blocks that the liveness analysis computed
+    // above does not cover, and phase 2 must not query liveness on them.
+    // They only contain the discards inserted here and a branch forwarding
+    // the split edge's operands, so they need no mid-block discards either.
+    SmallVector<Block *> originalBlocks;
+    for (Block &block : funcOp.getBlocks()) {
+      originalBlocks.push_back(&block);
+    }
+
     // Insert batched discards for each edge.
     for (auto &[pred, succ, refs] : edgeDiscards) {
       Location loc = pred->getTerminator()->getLoc();
@@ -336,7 +346,8 @@ class MaterializeRefDiscardsPass
     // Phase 2: Mid-block discards.
     // Collect refs dying mid-block (last use is not at block end and ref is not
     // live-out), grouped by insertion point for batching.
-    for (Block &block : funcOp.getBlocks()) {
+    for (Block *blockPtr : originalBlocks) {
+      Block &block = *blockPtr;
       // Group refs by their insertion point (the op after which to insert).
       // Key is the op, value is the list of refs dying after that op.
       SmallVector<std::pair<Operation *, SmallVector<Value>>> midBlockDiscards;

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/MaterializeRefDiscards.cpp
@@ -277,9 +277,6 @@ class MaterializeRefDiscardsPass
     for (Block &block : funcOp.getBlocks()) {
       Operation *terminator = block.getTerminator();
       for (Block *succ : block.getSuccessors()) {
-        auto succLiveIns = liveness.getBlockLiveIns(succ);
-        auto liveOuts = liveness.getBlockLiveOuts(&block);
-
         SmallVector<Value> dyingRefs;
         for (Value ref : allRefs) {
           if (escapingRefs.contains(ref)) {
@@ -287,7 +284,7 @@ class MaterializeRefDiscardsPass
           }
 
           // Check if ref should be discarded on this edge.
-          bool isInLiveOuts = llvm::is_contained(liveOuts, ref);
+          bool isInLiveOuts = liveness.isLiveOut(&block, ref);
           bool isForwardedOnAny = false;
           if (auto branchOp = dyn_cast<BranchOpInterface>(terminator)) {
             for (unsigned i = 0; i < terminator->getNumSuccessors(); ++i) {
@@ -304,7 +301,7 @@ class MaterializeRefDiscardsPass
           }
 
           // Skip if ref is live-in to successor.
-          if (llvm::is_contained(succLiveIns, ref)) {
+          if (liveness.isLiveIn(succ, ref)) {
             continue;
           }
 
@@ -364,8 +361,7 @@ class MaterializeRefDiscardsPass
           // Check if this is the last use and value doesn't escape via
           // live-outs.
           if (liveness.isLastValueUse(value, &op, operand.getOperandNumber())) {
-            auto liveOuts = liveness.getBlockLiveOuts(&block);
-            if (!llvm::is_contained(liveOuts, value)) {
+            if (!liveness.isLiveOut(&block, value)) {
               // For terminators, don't insert mid-block discards for their
               // operands. Terminator ref operands fall into three categories:
               // 1. Forwarded (branch args) → successor block takes ownership

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/materialize_ref_discards.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/materialize_ref_discards.mlir
@@ -1180,3 +1180,35 @@ vm.module @my_module {
     vm.return
   }
 }
+
+// -----
+
+// A ref dying on a critical edge (multi-successor pred, multi-predecessor
+// succ) forces the pass to split the edge and place the discard in a new
+// block, with the other ref forwarded through it. Regression test: the pass
+// used to query liveness on the block it had just created, which the
+// analysis does not cover.
+// CHECK-LABEL: @discard_on_critical_edge
+// CHECK-SAME: (%[[FWD:[a-z0-9]+]]: !vm.buffer, %[[DEAD:[a-z0-9]+]]: !vm.buffer, %[[COND:[a-z0-9]+]]: i32)
+vm.module @my_module {
+  vm.import private @consume(!vm.buffer)
+  vm.func @discard_on_critical_edge(%fwd: !vm.buffer, %dead: !vm.buffer, %cond: i32) {
+    // CHECK: vm.cond_br %[[COND]], ^[[BB1:[a-zA-Z0-9]+]], ^[[SPLIT:[a-zA-Z0-9]+]](%[[FWD]] : !vm.buffer)
+    vm.cond_br %cond, ^bb1, ^bb2(%fwd : !vm.buffer)
+  ^bb1:
+    // CHECK: ^[[BB1]]:
+    // CHECK: vm.call @consume(%[[DEAD]])
+    // CHECK: vm.br ^[[JOIN:[a-zA-Z0-9]+]](%[[FWD]] : !vm.buffer)
+    vm.call @consume(%dead) : (!vm.buffer) -> ()
+    vm.br ^bb2(%fwd : !vm.buffer)
+  ^bb2(%arg: !vm.buffer):
+    // The split block discards the dead ref and forwards the live one.
+    // CHECK: ^[[SPLIT]](%[[SPLITARG:[a-z0-9]+]]: !vm.buffer):
+    // CHECK-NEXT: vm.discard.refs %[[DEAD]]
+    // CHECK-NEXT: vm.br ^[[JOIN]](%[[SPLITARG]] : !vm.buffer)
+    // CHECK: ^[[JOIN]](%[[JOINARG:[a-z0-9]+]]: !vm.buffer):
+    // CHECK: vm.call @consume(%[[JOINARG]])
+    vm.call @consume(%arg) : (!vm.buffer) -> ()
+    vm.return
+  }
+}


### PR DESCRIPTION
Progress on #3859.

This deletes the hand-written dataflow in `ValueLiveness` and uses the upstream `mlir::Liveness` analysis instead. The old code computed the same information (block live-in/live-out sets and per-op liveness), so the class becomes a thin wrapper that keeps only the VM specific queries.

Before changing anything I checked what each consumer of the analysis actually needs:

* `RegisterAllocation` only calls `isLastRealValueUse`. The ref/MOVE/discard logic is VM specific and stays, but it now sits on the upstream primitives (`isLiveIn`, `isLiveOut`, `isDeadAfter`).
* `LiveIntervals` and `MaterializeRefDiscards` only did membership checks on `getBlockLiveIns`/`getBlockLiveOuts`, so those ArrayRef accessors are replaced with `isLiveIn(block, value)` / `isLiveOut(block, value)`.
* `annotateIR` (test passes only) is rebuilt from `resolveLiveness` and `LivenessBlockInfo::in()/out()`. The test output does not change because the attribute values were already sorted before printing, so the unordered upstream sets do not leak out.

The switch surfaced two places that queried liveness on IR modified after the analysis was computed. The old code silently returned empty sets for blocks it had never seen; upstream returns null:

1. VMToEmitC's `FuncAnalysis` computed a `ValueLiveness` only for `isMove`, which throws the result away (`&& false`, EmitC never uses MOVE semantics), and it queried mid-conversion after signature conversion replaced entry blocks. Removed the member since it was dead code.
2. `MaterializeRefDiscards` splits critical edges after computing liveness, and phase 2 then queried ops in the new blocks. This is what crashed PkgCI. With the old analysis phase 2 did nothing on those blocks anyway, so phase 2 now iterates a snapshot of the blocks taken before splitting. Also added asserts so a stale query fails with a message instead of a segfault, and a lit test with a ref dying on a critical edge.

Testing: all 106 Dialect/VM lit tests pass with no expectation changes, which I think answers the question on the issue about whether the upstream analysis is sufficient. The check_* modules that failed in CI compile now with the same flags.

Assisted-by: Claude Code
