### PR TITLE
Integrate Torch-MLIR to llvm/torch-mlir@1828c5053

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -181,6 +181,7 @@ if(IREE_INPUT_TORCH)
     ADD_TO_PARENT IREEPythonSources
     ROOT_DIR "${TORCH_MLIR_ROOT_DIR}/python/torch_mlir"
     SOURCES
+      extras/fx_as_strided.py
       extras/fx_importer.py
       extras/onnx_importer.py
   )

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O0.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O0.json
@@ -310,7 +310,6 @@
     "onnx/node/generated/test_bernoulli_double",
     "onnx/node/generated/test_bernoulli_double_expanded",
     "onnx/node/generated/test_bernoulli_expanded",
-    "onnx/node/generated/test_convtranspose_output_shape",
     "onnx/node/generated/test_det_2d",
     "onnx/node/generated/test_gridsample_nearest",
     "onnx/node/generated/test_gridsample_nearest_align_corners_0_additional_1",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O2.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync_O2.json
@@ -311,7 +311,6 @@
     "onnx/node/generated/test_bernoulli_double",
     "onnx/node/generated/test_bernoulli_double_expanded",
     "onnx/node/generated/test_bernoulli_expanded",
-    "onnx/node/generated/test_convtranspose_output_shape",
     "onnx/node/generated/test_det_2d",
     "onnx/node/generated/test_gridsample_nearest",
     "onnx/node/generated/test_gridsample_nearest_align_corners_0_additional_1",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_cuda_O0.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_cuda_O0.json
@@ -112,7 +112,6 @@
     "onnx/node/generated/test_compress_negative_axis",
     "onnx/node/generated/test_convtranspose_autopad_same",
     "onnx/node/generated/test_convtranspose_kernel_shape",
-    "onnx/node/generated/test_convtranspose_output_shape",
     "onnx/node/generated/test_cumsum_1d",
     "onnx/node/generated/test_cumsum_1d_exclusive",
     "onnx/node/generated/test_cumsum_1d_reverse",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3_O0.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3_O0.json
@@ -314,7 +314,6 @@
     "onnx/node/generated/test_cast_FLOAT_to_BFLOAT16",
     "onnx/node/generated/test_castlike_FLOAT_to_BFLOAT16",
     "onnx/node/generated/test_castlike_FLOAT_to_BFLOAT16_expanded",
-    "onnx/node/generated/test_convtranspose_output_shape",
     "onnx/node/generated/test_gridsample_nearest",
     "onnx/node/generated/test_gridsample_nearest_align_corners_0_additional_1",
     "onnx/node/generated/test_gridsample_nearest_align_corners_1_additional_1",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3_O3.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna3_O3.json
@@ -308,7 +308,7 @@
     "onnx/node/generated/test_bernoulli_double",
     "onnx/node/generated/test_bernoulli_double_expanded",
     "onnx/node/generated/test_bernoulli_expanded",
-    "onnx/node/generated/test_convtranspose_output_shape",
+    "onnx/node/generated/",
     "onnx/node/generated/test_det_2d",
     "onnx/node/generated/test_gridsample_nearest",
     "onnx/node/generated/test_gridsample_nearest_align_corners_0_additional_1",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna4_O3.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_hip_rdna4_O3.json
@@ -308,7 +308,6 @@
     "onnx/node/generated/test_bernoulli_double",
     "onnx/node/generated/test_bernoulli_double_expanded",
     "onnx/node/generated/test_bernoulli_expanded",
-    "onnx/node/generated/test_convtranspose_output_shape",
     "onnx/node/generated/test_det_2d",
     "onnx/node/generated/test_gridsample_nearest",
     "onnx/node/generated/test_gridsample_nearest_align_corners_0_additional_1",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan_rdna3_O0.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan_rdna3_O0.json
@@ -330,7 +330,6 @@
     "onnx/node/generated/test_castlike_FLOAT_to_DOUBLE_expanded",
     "onnx/node/generated/test_castlike_FLOAT_to_FLOAT16",
     "onnx/node/generated/test_castlike_FLOAT_to_FLOAT16_expanded",
-    "onnx/node/generated/test_convtranspose_output_shape",
     "onnx/node/generated/test_det_2d",
     "onnx/node/generated/test_dynamicquantizelinear",
     "onnx/node/generated/test_dynamicquantizelinear_expanded",


### PR DESCRIPTION
Integrate Torch-MLIR to llvm/torch-mlir@1828c5053.

Integrates Torch-MLIR via `iree-org/torch-mlir/sm-iree-integrates/torch-20260707` branch.

Includes a CMake fix for commit https://github.com/llvm/torch-mlir/commit/35010fc69.
Promotes ONNX ops test case `test_convtranspose_output_shape` to an expected pass.

On top of the integrated upstream commit, the 3 latest fixes from `sm-iree-integrates/llvm-20260617` are carried over:

"Adaptions to llvm/llvm-project@75b7809248cc for integrating LLVM into IREE" by @schuermans-roofline as commit ec8720b
"Adaptions to llvm/llvm-project@917117ceeebf for integrating LLVM into IREE" by @schuermans-roofline as commit 67c8c41
"Bump LLVM to llvm/llvm-project@0f3ca6bb9ca5" by @lialan as commit ba9dad2