### PR TITLE
[ROCDL] Set relaxed buffer OOB mode

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -881,6 +881,12 @@ public:
         // that our CI or users may not be prepared for.
         llvmModule->addModuleFlag(llvm::Module::Error,
                                   "amdhsa_code_object_version", abiVersion);
+
+        // Set the buffer OOB mode to "relaxed", since IREE does its own, more
+        // precise, mitigations for partially OOB buffer reads of underalligned
+        // vectors.
+        llvmModule->addModuleFlag(llvm::Module::Max, "amdgpu.buffer.oob.mode",
+                                  1);
       }
 
       for (llvm::Function &f : llvmModule->functions()) {


### PR DESCRIPTION
Recent LLVM changes to ptr addrspace(7)/fat buffer lowering (LLVM PRs https://github.com/llvm/llvm-project/pull/134329 and https://github.com/llvm/llvm-project/pull/134734 ) mean that underalligned loads from buffer pointers get devectorized unless "relaxed mode" is enabled. IREE already has mitigations for the issues that this OOB mode handles, so we must enable relaxed mode to prevent severe regressions as seen in #24690.

Sadly there's no test for this one as we don't currently have tests for the module translation and this is a hotfix so I want to keep it minimal.