### PR TITLE
[Vulkan] Require explicit --iree-vulkan-target instead of a hidden default

### DIFF
--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -98,10 +98,11 @@ private:
 };
 
 struct VulkanSPIRVTargetOptions {
-  // Use vp_android_baseline_2022 profile as the default target--it's a good
-  // lowest common denominator to guarantee the generated SPIR-V is widely
-  // accepted for now. Eventually we want to use a list for multi-targeting.
-  std::string target = "vp_android_baseline_2022";
+  // No default target: Vulkan devices vary widely in supported features
+  // (subgroup size, fp16/int8/int64 support, etc.), so silently falling back
+  // to a generic profile can produce incorrect results or poor performance.
+  // Users must specify a target explicitly.
+  std::string target;
   std::string targetFeatures;
   VulkanDispatchAbi dispatchAbi = VulkanDispatchAbi::Descriptors;
 
@@ -110,10 +111,11 @@ struct VulkanSPIRVTargetOptions {
     binder.opt<std::string>(
         "iree-vulkan-target", target,
         llvm::cl::desc(
-            "Vulkan target controlling the SPIR-V environment. Given the wide "
-            "support of Vulkan, this option supports a few schemes: 1) LLVM "
-            "CodeGen backend style: e.g., 'gfx*' for AMD GPUs and 'sm_*' for "
-            "NVIDIA GPUs; 2) architecture code name style: e.g., "
+            "Vulkan target controlling the SPIR-V environment. This option "
+            "is required; there is no default. Given the wide support of "
+            "Vulkan, this option supports a few schemes: 1) LLVM CodeGen "
+            "backend style: e.g., 'gfx*' for AMD GPUs and 'sm_*' for NVIDIA "
+            "GPUs; 2) architecture code name style: e.g., "
             "'rdna3'/'valhall4'/'ampere'/'adreno' for AMD/ARM/NVIDIA/Qualcomm "
             "GPUs; 3) product name style: 'rx7900xtx'/'rtx4090' for AMD/NVIDIA "
             "GPUs. See "
@@ -314,16 +316,21 @@ public:
       MLIRContext *context, StringRef deviceID, DictionaryAttr deviceConfigAttr,
       SmallVectorImpl<IREE::HAL::ExecutableTargetAttr> &executableTargetAttrs)
       const final {
+    auto addTargetIfValid = [&](bool useBdaRootAbi) {
+      if (auto target = getExecutableTarget(context, useBdaRootAbi)) {
+        executableTargetAttrs.push_back(target);
+      }
+    };
     switch (options_.dispatchAbi) {
     case VulkanDispatchAbi::Descriptors:
-      executableTargetAttrs.push_back(getExecutableTarget(context, false));
+      addTargetIfValid(false);
       break;
     case VulkanDispatchAbi::Bda:
-      executableTargetAttrs.push_back(getExecutableTarget(context, true));
+      addTargetIfValid(true);
       break;
     case VulkanDispatchAbi::All:
-      executableTargetAttrs.push_back(getExecutableTarget(context, true));
-      executableTargetAttrs.push_back(getExecutableTarget(context, false));
+      addTargetIfValid(true);
+      addTargetIfValid(false);
       break;
     }
   }
@@ -332,6 +339,20 @@ public:
   getExecutableTarget(MLIRContext *context, bool useBdaRootAbi) const {
     Builder b(context);
     SmallVector<NamedAttribute, 1> configItems;
+    if (options_.target.empty()) {
+      emitError(b.getUnknownLoc(),
+                "Vulkan target not specified; pass '--iree-vulkan-target=' "
+                "with an explicit target (e.g. an architecture code name "
+                "such as 'rdna3'/'valhall4'/'ampere'/'adreno', or a product "
+                "name such as 'rx7900xtx'/'rtx4090'). See "
+                "https://iree.dev/guides/deployment-configurations/"
+                "gpu-vulkan/ for more details. There is no default target "
+                "because Vulkan devices vary widely in supported features "
+                "(subgroup size, fp16/int8/int64 support, etc.) and picking "
+                "one implicitly can silently produce incorrect results or "
+                "poor performance.");
+      return nullptr;
+    }
     if (auto target = GPU::getVulkanTargetDetails(options_.target, context)) {
       if (!options_.targetFeatures.empty()) {
         target = IREE::GPU::TargetAttr::get(context, target.getArch(),

--- a/compiler/plugins/target/VulkanSPIRV/test/hal_target_device_attributes.mlir
+++ b/compiler/plugins/target/VulkanSPIRV/test/hal_target_device_attributes.mlir
@@ -1,10 +1,12 @@
-// RUN: iree-compile --compile-to=preprocessing --iree-hal-target-device=vulkan %s \
+// RUN: iree-compile --compile-to=preprocessing --iree-hal-target-device=vulkan \
+// RUN:              --iree-vulkan-target=vp_android_baseline_2022 %s \
 // RUN: | FileCheck %s --check-prefix=CHECK-DESCRIPTOR
 //
 // CHECK-DESCRIPTOR: #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb"
 // CHECK-DESCRIPTOR-SAME: features = "spirv:v1.3,cap:Shader"
 //
 // RUN: iree-compile --compile-to=preprocessing --iree-hal-target-device=vulkan \
+// RUN:              --iree-vulkan-target=vp_android_baseline_2022 \
 // RUN:              --iree-vulkan-dispatch-abi=bda %s \
 // RUN: | FileCheck %s --check-prefix=CHECK-BDA
 //
@@ -14,6 +16,7 @@
 // CHECK-BDA-SAME: ext:SPV_KHR_physical_storage_buffer
 //
 // RUN: iree-compile --compile-to=preprocessing --iree-hal-target-device=vulkan \
+// RUN:              --iree-vulkan-target=vp_android_baseline_2022 \
 // RUN:              --iree-vulkan-dispatch-abi=all %s \
 // RUN: | FileCheck %s --check-prefix=CHECK-ALL
 //
@@ -22,6 +25,7 @@
 //
 // Replace the default features
 // RUN: iree-compile --compile-to=preprocessing --iree-hal-target-device=vulkan \
+// RUN:              --iree-vulkan-target=vp_android_baseline_2022 \
 // RUN:              --iree-vulkan-target-features=spirv:v1.6,cap:Shader,cap:Int64,cap:PhysicalStorageBufferAddresses,ext:SPV_KHR_physical_storage_buffer %s \
 // RUN: | FileCheck %s --check-prefix=CHECK-FEATURES
 //

--- a/samples/simple_embedding/BUILD.bazel
+++ b/samples/simple_embedding/BUILD.bazel
@@ -276,6 +276,7 @@ iree_bytecode_module(
     c_identifier = "iree_samples_simple_embedding_test_module_vulkan",
     flags = [
         "--iree-hal-target-device=vulkan",
+        "--iree-vulkan-target=vp_android_baseline_2022",
         "--iree-llvmcpu-debug-symbols=false",
     ],
 )

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -244,6 +244,7 @@ iree_bytecode_module(
     "iree_samples_simple_embedding_test_module_vulkan"
   FLAGS
     "--iree-hal-target-device=vulkan"
+    "--iree-vulkan-target=vp_android_baseline_2022"
     "--iree-llvmcpu-debug-symbols=false"
   PUBLIC
 )

--- a/tests/external/iree-test-suites/onnx_models/onnx_models_gpu_vulkan.json
+++ b/tests/external/iree-test-suites/onnx_models/onnx_models_gpu_vulkan.json
@@ -1,7 +1,8 @@
 {
   "config_name": "gpu_vulkan",
   "iree_compile_flags": [
-    "--iree-hal-target-device=vulkan"
+    "--iree-hal-target-device=vulkan",
+    "--iree-vulkan-target=vp_android_baseline_2022"
   ],
   "iree_run_module_flags": [
     "--device=vulkan"

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan_rdna3_O0.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan_rdna3_O0.json
@@ -2,6 +2,7 @@
   "config_name": "gpu_vulkan_rdna3",
   "iree_compile_flags": [
     "--iree-hal-target-device=vulkan",
+    "--iree-vulkan-target=rdna3",
     "--iree-input-demote-f64-to-f32",
     "--iree-opt-level=O0"
   ],

--- a/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_rdna3_O3.json
+++ b/tests/external/iree-test-suites/torch_ops/torch_ops_gpu_vulkan_rdna3_O3.json
@@ -2,6 +2,7 @@
   "config_name": "gpu_vulkan_rdna3",
   "iree_compile_flags": [
     "--iree-hal-target-device=vulkan",
+    "--iree-vulkan-target=rdna3",
     "--iree-opt-level=O3"
   ],
   "iree_run_module_flags": [


### PR DESCRIPTION
Remove the implicit `vp_android_baseline_2022` default for `--iree-vulkan-target`. It silently produced wrong results or poor performance on devices it didn't match. 

The target is now required, and compilation fails with a clear error if unset, with an error pointing users to `--iree-vulkan-target`, instead of silently picking a profile that may not fit the device.

Fixes #24688