### PR TITLE
[LLVMCPU] thread inner tile alignment hint for vector-level tiling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
@@ -28,6 +28,54 @@
 
 namespace mlir::iree_compiler {
 
+scf::InnerTileAlignmentFnTy
+makeInnerTileAlignmentFn(IREE::CPU::TilingLevel tilingLevel) {
+  mlir::InnerTileAlignment kind;
+  switch (tilingLevel) {
+  default:
+    kind = mlir::InnerTileAlignment::Unknown;
+    break;
+  case IREE::CPU::TilingLevel::DistributionTiles:
+    kind = mlir::InnerTileAlignment::Multiple;
+    break;
+  case IREE::CPU::TilingLevel::VectorCommonParallelTiles:
+  case IREE::CPU::TilingLevel::VectorReductionTiles:
+  case IREE::CPU::TilingLevel::VectorInnerParallelTiles:
+    kind = mlir::InnerTileAlignment::Equal;
+    break;
+  }
+  return
+      [kind](TilingInterface op, ArrayRef<OpFoldResult>,
+             ArrayRef<Operation *>) -> SmallVector<mlir::InnerTileAlignment> {
+        // Assert `kind` at each scalable (dynamic) inner tile, indexed in the
+        // pack/unpack op's own iteration domain; a static inner tile is left
+        // `Unknown` and handled by the existing static path.
+        auto markScalable = [kind](ArrayRef<int64_t> innerDimsPos,
+                                   ArrayRef<OpFoldResult> mixedTiles,
+                                   int64_t rank) {
+          SmallVector<mlir::InnerTileAlignment> alignments(
+              rank, mlir::InnerTileAlignment::Unknown);
+          for (auto [pos, tile] : llvm::zip_equal(innerDimsPos, mixedTiles)) {
+            if (!getConstantIntValue(tile)) {
+              alignments[pos] = kind;
+            }
+          }
+          return alignments;
+        };
+        if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op.getOperation())) {
+          return markScalable(
+              unpackOp.getInnerDimsPos(), unpackOp.getMixedTiles(),
+              cast<ShapedType>(unpackOp.getDest().getType()).getRank());
+        }
+        if (auto packOp = dyn_cast<linalg::PackOp>(op.getOperation())) {
+          return markScalable(
+              packOp.getInnerDimsPos(), packOp.getMixedTiles(),
+              cast<ShapedType>(packOp.getSource().getType()).getRank());
+        }
+        return {};
+      };
+}
+
 void fuseProducersOfSlices(RewriterBase &rewriter,
                            std::queue<Operation *> &worklist,
                            scf::SCFTileAndFuseOptions &options,
@@ -54,7 +102,9 @@ void fuseProducersOfSlices(RewriterBase &rewriter,
     // values produced by operations that implement the `TilingInterface`.
     // Add these operations to the worklist.
     std::optional<scf::SCFFuseProducerOfSliceResult> fusedResult =
-        scf::tileAndFuseProducerOfSlice(rewriter, candidateSlice, loops);
+        scf::tileAndFuseProducerOfSlice(
+            rewriter, candidateSlice, loops,
+            options.tilingOptions.innerTileAlignmentFn);
     if (!fusedResult) {
       continue;
     }
@@ -109,10 +159,11 @@ struct ConsumerFusionQueueEntry {
 };
 } // namespace
 
-FailureOr<std::queue<Operation *>>
-fuseConsumersIntoForall(RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
-                        MutableArrayRef<LoopLikeOpInterface> loops,
-                        std::function<bool(Operation *)> filterFn) {
+FailureOr<std::queue<Operation *>> fuseConsumersIntoForall(
+    RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
+    MutableArrayRef<LoopLikeOpInterface> loops,
+    std::function<bool(Operation *)> filterFn,
+    const scf::InnerTileAlignmentFnTy &innerTileAlignmentFn) {
   // Collect the candidate slices which can be potential consumers that can be
   // fused. Keep them in a vector reverse-sorted by dominance: the candidate
   // dominating others comes last (so it can be cheaply popped from the vector).
@@ -213,7 +264,8 @@ fuseConsumersIntoForall(RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
     ConsumerFusionQueueEntry entry = candidates.pop_back_val();
 
     FailureOr<scf::SCFFuseConsumerOfSliceResult> fusedResult =
-        mlir::scf::tileAndFuseConsumer(rewriter, entry.fusableUser, loops);
+        mlir::scf::tileAndFuseConsumer(rewriter, entry.fusableUser, loops,
+                                       innerTileAlignmentFn);
     if (failed(fusedResult)) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Casting.h"
@@ -21,12 +22,76 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/Interfaces/TilingInterface.h"
 
 #include <cassert>
 
 #define DEBUG_TYPE "iree-codegen-common-tile-and-fuse-utils"
 
 namespace mlir::iree_compiler {
+
+// Helper method that checks the tile sizes and scalable flags passed against
+// the inner tiles of pack/unpack operations and sets the corresponding inner
+// tile alignment hints on tile sizes corresponding to scalable inner tiles.
+static SmallVector<mlir::InnerTileAlignment>
+setAlignmentHints(ArrayRef<int64_t> innerDimsPos, ArrayRef<OpFoldResult> innerTiles,
+             int64_t rank, SizesAndScalableFlags sizesAndFlags) {
+  SmallVector<mlir::InnerTileAlignment> alignments(
+      rank, mlir::InnerTileAlignment::Unknown);
+  for (auto [pos, innerTile, tile, scalable] :
+       llvm::zip_equal(innerDimsPos, innerTiles, sizesAndFlags.first,
+                       sizesAndFlags.second)) {
+    // TODO: implement and check vscale ranges to decide if static tile
+    // sizes are multiples of scalable inner tile sizes.
+    if (!scalable) {
+      continue;
+    }
+    auto innerTileVal = dyn_cast<Value>(innerTile);
+    std::optional<int64_t> innerTileCst =
+        vector::getConstantVscaleMultiplier(innerTileVal);
+    // If we have a static or a non-scalable dynamic inner tile size, skip.
+    if (!innerTileCst) {
+      continue;
+    }
+    auto kind = mlir::InnerTileAlignment::Unknown;
+    if (tile == *innerTileCst) {
+      kind = mlir::InnerTileAlignment::Equal;
+    } else if (tile % *innerTileCst == 0) {
+      kind = mlir::InnerTileAlignment::Multiple;
+    }
+    alignments[pos] = kind;
+  }
+  return alignments;
+}
+
+scf::InnerTileAlignmentFnTy
+makeInnerTileAlignmentFn(IREE::CPU::TilingLevel tilingLevel) {
+  return [tilingLevel](
+             TilingInterface op, ArrayRef<OpFoldResult>,
+             ArrayRef<Operation *>) -> SmallVector<mlir::InnerTileAlignment> {
+    if (!isa<linalg::UnPackOp, linalg::PackOp>(op)) {
+      return {};
+    }
+    auto tileSizesAttr = dyn_cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        getLoweringConfig(op).getTilingLevelAttr(
+            static_cast<unsigned>(tilingLevel)));
+    SizesAndScalableFlags sizesAndScalableFlags{
+        tileSizesAttr.getSizes(), tileSizesAttr.getScalableFlags()};
+    if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op.getOperation())) {
+      return setAlignmentHints(
+          unpackOp.getInnerDimsPos(), unpackOp.getMixedTiles(),
+          cast<ShapedType>(unpackOp.getDest().getType()).getRank(),
+          sizesAndScalableFlags);
+    }
+    if (auto packOp = dyn_cast<linalg::PackOp>(op.getOperation())) {
+      return setAlignmentHints(
+          packOp.getInnerDimsPos(), packOp.getMixedTiles(),
+          cast<ShapedType>(packOp.getSource().getType()).getRank(),
+          sizesAndScalableFlags);
+    }
+    return {};
+  };
+}
 
 void fuseProducersOfSlices(RewriterBase &rewriter,
                            std::queue<Operation *> &worklist,
@@ -54,7 +119,9 @@ void fuseProducersOfSlices(RewriterBase &rewriter,
     // values produced by operations that implement the `TilingInterface`.
     // Add these operations to the worklist.
     std::optional<scf::SCFFuseProducerOfSliceResult> fusedResult =
-        scf::tileAndFuseProducerOfSlice(rewriter, candidateSlice, loops);
+        scf::tileAndFuseProducerOfSlice(
+            rewriter, candidateSlice, loops,
+            options.tilingOptions.innerTileAlignmentFn);
     if (!fusedResult) {
       continue;
     }
@@ -109,10 +176,11 @@ struct ConsumerFusionQueueEntry {
 };
 } // namespace
 
-FailureOr<std::queue<Operation *>>
-fuseConsumersIntoForall(RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
-                        MutableArrayRef<LoopLikeOpInterface> loops,
-                        std::function<bool(Operation *)> filterFn) {
+FailureOr<std::queue<Operation *>> fuseConsumersIntoForall(
+    RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
+    MutableArrayRef<LoopLikeOpInterface> loops,
+    std::function<bool(Operation *)> filterFn,
+    const scf::InnerTileAlignmentFnTy &innerTileAlignmentFn) {
   // Collect the candidate slices which can be potential consumers that can be
   // fused. Keep them in a vector reverse-sorted by dominance: the candidate
   // dominating others comes last (so it can be cheaply popped from the vector).
@@ -213,7 +281,8 @@ fuseConsumersIntoForall(RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
     ConsumerFusionQueueEntry entry = candidates.pop_back_val();
 
     FailureOr<scf::SCFFuseConsumerOfSliceResult> fusedResult =
-        mlir::scf::tileAndFuseConsumer(rewriter, entry.fusableUser, loops);
+        mlir::scf::tileAndFuseConsumer(rewriter, entry.fusableUser, loops,
+                                       innerTileAlignmentFn);
     if (failed(fusedResult)) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.cpp
@@ -8,9 +8,9 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
-#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/Interfaces/TilingInterface.h"
 
@@ -30,66 +31,23 @@
 
 namespace mlir::iree_compiler {
 
-// Helper method that checks the tile sizes and scalable flags passed against
-// the inner tiles of pack/unpack operations and sets the corresponding inner
-// tile alignment hints on tile sizes corresponding to scalable inner tiles.
-static SmallVector<mlir::InnerTileAlignment>
-setAlignmentHints(ArrayRef<int64_t> innerDimsPos, ArrayRef<OpFoldResult> innerTiles,
-             int64_t rank, SizesAndScalableFlags sizesAndFlags) {
-  SmallVector<mlir::InnerTileAlignment> alignments(
-      rank, mlir::InnerTileAlignment::Unknown);
-  for (auto [pos, innerTile, tile, scalable] :
-       llvm::zip_equal(innerDimsPos, innerTiles, sizesAndFlags.first,
-                       sizesAndFlags.second)) {
-    // TODO: implement and check vscale ranges to decide if static tile
-    // sizes are multiples of scalable inner tile sizes.
-    if (!scalable) {
-      continue;
-    }
-    auto innerTileVal = dyn_cast<Value>(innerTile);
-    std::optional<int64_t> innerTileCst =
-        vector::getConstantVscaleMultiplier(innerTileVal);
-    // If we have a static or a non-scalable dynamic inner tile size, skip.
-    if (!innerTileCst) {
-      continue;
-    }
-    auto kind = mlir::InnerTileAlignment::Unknown;
-    if (tile == *innerTileCst) {
-      kind = mlir::InnerTileAlignment::Equal;
-    } else if (tile % *innerTileCst == 0) {
-      kind = mlir::InnerTileAlignment::Multiple;
-    }
-    alignments[pos] = kind;
-  }
-  return alignments;
-}
-
 scf::InnerTileAlignmentFnTy
 makeInnerTileAlignmentFn(IREE::CPU::TilingLevel tilingLevel) {
   return [tilingLevel](
              TilingInterface op, ArrayRef<OpFoldResult>,
              ArrayRef<Operation *>) -> SmallVector<mlir::InnerTileAlignment> {
-    if (!isa<linalg::UnPackOp, linalg::PackOp>(op)) {
+    // Tile-size selection already recorded this op's per-dimension inner-tile
+    // alignments per tiling level. We simply forward those along.
+    auto hint =
+        IREE::CPU::InnerTileAlignmentsAttr::getFromOp(op.getOperation());
+    if (!hint) {
       return {};
     }
-    auto tileSizesAttr = dyn_cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
-        getLoweringConfig(op).getTilingLevelAttr(
-            static_cast<unsigned>(tilingLevel)));
-    SizesAndScalableFlags sizesAndScalableFlags{
-        tileSizesAttr.getSizes(), tileSizesAttr.getScalableFlags()};
-    if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op.getOperation())) {
-      return setAlignmentHints(
-          unpackOp.getInnerDimsPos(), unpackOp.getMixedTiles(),
-          cast<ShapedType>(unpackOp.getDest().getType()).getRank(),
-          sizesAndScalableFlags);
-    }
-    if (auto packOp = dyn_cast<linalg::PackOp>(op.getOperation())) {
-      return setAlignmentHints(
-          packOp.getInnerDimsPos(), packOp.getMixedTiles(),
-          cast<ShapedType>(packOp.getSource().getType()).getRank(),
-          sizesAndScalableFlags);
-    }
-    return {};
+    auto alignments = hint.getAlignments().getAs<DenseI64ArrayAttr>(
+        IREE::CPU::getTilingLevelName(tilingLevel));
+    return alignments
+               ? mlir::convertInnerTileAlignments(alignments.asArrayRef())
+               : SmallVector<mlir::InnerTileAlignment>{};
   };
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_TILEANDFUSEUTILS_H_
 #define IREE_COMPILER_CODEGEN_COMMON_TILEANDFUSEUTILS_H_
 
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
@@ -31,15 +32,25 @@ void fuseProducersOfSlices(RewriterBase &rewriter,
 void collectTiledAndFusedOps(Operation *rootOp,
                              llvm::SmallDenseSet<Operation *> &result);
 
+/// Returns an inner tile alignment control function that asserts
+/// `Multiple` at the distribution level, `Equal` at the
+/// vector level at each scalable (dynamic) inner tile of a tiled/fused
+/// linalg.pack/linalg.unpack op, computed in that op's own iteration domain;
+/// every other op gets no hint. IREE's KernelDispatch guarantees this
+/// relationship on scalable dims, so the assertion holds. The SCF driver
+/// invokes the function per op, so it threads correctly.
+scf::InnerTileAlignmentFnTy
+makeInnerTileAlignmentFn(IREE::CPU::TilingLevel tilingLevel);
+
 /// Fuse all consumers of the given `tiledOps` into the surrounding `scf.forall`
 /// unless specified otherwise by `filterFn`. Returns a list of new
 /// `tensor.extract_slice` ops with new fusion opportunities.
 FailureOr<std::queue<Operation *>> fuseConsumersIntoForall(
     RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
     MutableArrayRef<LoopLikeOpInterface> loops,
-    std::function<bool(Operation *)> filterFn = [](Operation *) {
-      return true;
-    });
+    std::function<bool(Operation *)> filterFn =
+        [](Operation *) { return true; },
+    const scf::InnerTileAlignmentFnTy &innerTileAlignmentFn = nullptr);
 
 /// Apply a tile and fuse transformation to all payload ops and store both the
 /// tiled operation as well as the created tile loops.

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_TILEANDFUSEUTILS_H_
 #define IREE_COMPILER_CODEGEN_COMMON_TILEANDFUSEUTILS_H_
 
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
@@ -31,15 +32,22 @@ void fuseProducersOfSlices(RewriterBase &rewriter,
 void collectTiledAndFusedOps(Operation *rootOp,
                              llvm::SmallDenseSet<Operation *> &result);
 
+/// Returns an inner tile alignment control function that asserts
+/// `Multiple` or `Equal` for scalable inner tiles of a tiled/fused
+/// linalg.pack/linalg.unpack op, computed in that op's own iteration domain;
+/// every other op gets no hint. The kind of the hint is decided by checking the inner tile
+scf::InnerTileAlignmentFnTy
+makeInnerTileAlignmentFn(IREE::CPU::TilingLevel tilingLevel);
+
 /// Fuse all consumers of the given `tiledOps` into the surrounding `scf.forall`
 /// unless specified otherwise by `filterFn`. Returns a list of new
 /// `tensor.extract_slice` ops with new fusion opportunities.
 FailureOr<std::queue<Operation *>> fuseConsumersIntoForall(
     RewriterBase &rewriter, ArrayRef<Operation *> tiledOps,
     MutableArrayRef<LoopLikeOpInterface> loops,
-    std::function<bool(Operation *)> filterFn = [](Operation *) {
-      return true;
-    });
+    std::function<bool(Operation *)> filterFn =
+        [](Operation *) { return true; },
+    const scf::InnerTileAlignmentFnTy &innerTileAlignmentFn = nullptr);
 
 /// Apply a tile and fuse transformation to all payload ops and store both the
 /// tiled operation as well as the created tile loops.

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndFuseUtils.h
@@ -32,10 +32,9 @@ void fuseProducersOfSlices(RewriterBase &rewriter,
 void collectTiledAndFusedOps(Operation *rootOp,
                              llvm::SmallDenseSet<Operation *> &result);
 
-/// Returns an inner tile alignment control function that asserts
-/// `Multiple` or `Equal` for scalable inner tiles of a tiled/fused
-/// linalg.pack/linalg.unpack op, computed in that op's own iteration domain;
-/// every other op gets no hint. The kind of the hint is decided by checking the inner tile
+/// Returns an inner tile alignment control function for scalable tiling at
+/// `tilingLevel`. It forwards the per-dimension `InnerTileAlignment` hints that
+/// tile-size selection set on `linalg.pack`/`linalg.unpack` ops.
 scf::InnerTileAlignmentFnTy
 makeInnerTileAlignmentFn(IREE::CPU::TilingLevel tilingLevel);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuseProducerConsumer.cpp
@@ -187,9 +187,15 @@ static FailureOr<Operation *> tileRootAndFuseProducerConsumer(
   tileSizes.resize(numLoops, 0);
   tileScalableFlags.resize(numLoops, false);
 
+  // Get the caller-asserted alignment function of a tiled/fused
+  // linalg.pack/unpack op's inner tiles to the loop tile sizes.
+  scf::InnerTileAlignmentFnTy innerTileAlignmentFn =
+      makeInnerTileAlignmentFn(tilingLevel);
+
   scf::SCFTilingOptions tilingOptions;
   setSCFTileSizes(tilingOptions, rootOp, std::move(tileSizes),
                   std::move(tileScalableFlags));
+  tilingOptions.setInnerTileAlignmentFn(innerTileAlignmentFn);
 
   // onlyFuseProducerInputOperands implies reduction tiling.
   if (!onlyFuseProducerInputOperands) {
@@ -262,7 +268,8 @@ static FailureOr<Operation *> tileRootAndFuseProducerConsumer(
             [&tiledAndFusedOps, &unfusableOps](Operation *op) {
               return tiledAndFusedOps.contains(op) &&
                      !unfusableOps.contains(op);
-            });
+            },
+            innerTileAlignmentFn);
 
     if (failed(newFusionOpportunities)) {
       LDBG() << "failed to fuse consumers, skip";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuseProducerConsumer.cpp
@@ -187,8 +187,9 @@ static FailureOr<Operation *> tileRootAndFuseProducerConsumer(
   tileSizes.resize(numLoops, 0);
   tileScalableFlags.resize(numLoops, false);
 
-  // Get the caller-asserted alignment function of a tiled/fused
-  // linalg.pack/unpack op's inner tiles to the loop tile sizes.
+  // Lets a scalable pack/unpack's tiled outer dims fold to a static single
+  // inner tile, using the alignment hints tile-size selection recorded on the
+  // op.
   scf::InnerTileAlignmentFnTy innerTileAlignmentFn =
       makeInnerTileAlignmentFn(tilingLevel);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile_and_fuse_producer_consumer_anchoring_root_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile_and_fuse_producer_consumer_anchoring_root_op.mlir
@@ -416,3 +416,103 @@ func.func @infusible_pack(%arg0 : tensor<30xf32>) -> tensor<5x6xf32> {
 // CHECK:           linalg.generic
 // CHECK:         scf.forall.in_parallel
 // CHECK:         linalg.pack
+
+// -----
+
+// Scalable linalg.pack with an elementwise-add producer.
+// This test exercises the inner tile alignment hint `Equal` being passed.
+
+#config = #iree_cpu.lowering_config<distribution = [64, 64], vector_common_parallel = [[8], 1]>
+#config1 = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @scalable_pack_with_producer(%arg0: tensor<384x512xf32>, %arg1: tensor<384x512xf32>) -> tensor<?x512x?x1xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %0 = tensor.empty() : tensor<384x512xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<384x512xf32>, tensor<384x512xf32>) outs(%0 : tensor<384x512xf32>) attrs = {lowering_config = #config} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %3 = arith.addf %in, %in_0 : f32
+    linalg.yield %3 : f32
+  } -> tensor<384x512xf32>
+  %mouter = affine.apply affine_map<()[s0] -> (384 ceildiv s0)>()[%c8_vscale]
+  %2 = tensor.empty(%mouter, %c8_vscale) : tensor<?x512x?x1xf32>
+  %pack = linalg.pack %1 padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [%c8_vscale, 1] into %2 {lowering_config = #config1} : tensor<384x512xf32> -> tensor<?x512x?x1xf32>
+  return %pack : tensor<?x512x?x1xf32>
+}
+// CHECK-LABEL: func.func @scalable_pack_with_producer
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}} : index
+// CHECK:         scf.forall {{.*}} = (0, 0) to (384, 512) step (%[[C8VS]], 1)
+// CHECK:           %[[GEN:.+]] = linalg.generic
+// CHECK:           linalg.pack %[[GEN]]
+// CHECK-SAME:        inner_tiles = [%[[C8VS]], 1]
+// CHECK-SAME:        -> tensor<1x1x?x1xf32>
+// CHECK:           scf.forall.in_parallel
+
+// -----
+
+// Scalable linalg.unpack fused as the producer of an elementwise-add consumer.
+// This test exercises the inner tile alignment hint `Equal` being passed.
+
+#config = #iree_cpu.lowering_config<vector_common_parallel = [7, [8]]>
+#config1 = #iree_cpu.lowering_config<distribution = [84, 64], vector_common_parallel = [7, [8]]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @scalable_unpack_with_consumer(%arg0: tensor<12x?x7x?xf32>, %arg1: tensor<80x320xf32>) -> tensor<80x320xf32> {
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %0 = tensor.empty() : tensor<80x320xf32>
+  %unpack = linalg.unpack %arg0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %0 {lowering_config = #config} : tensor<12x?x7x?xf32> -> tensor<80x320xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1, %unpack : tensor<80x320xf32>, tensor<80x320xf32>) outs(%0 : tensor<80x320xf32>) attrs = {lowering_config = #config1} {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %2 = arith.addf %in, %in_0 : f32
+    linalg.yield %2 : f32
+  } -> tensor<80x320xf32>
+  return %1 : tensor<80x320xf32>
+}
+// CHECK-LABEL: func.func @scalable_unpack_with_consumer
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}} : index
+// CHECK:         scf.forall {{.*}} = (0, 0) to (80, 320) step (7, %[[C8VS]])
+// CHECK:           %[[UNPACK:.+]] = linalg.unpack
+// CHECK-SAME:        inner_tiles = [7, %[[C8VS]]]
+// CHECK-SAME:        tensor<1x1x7x?xf32> -> tensor<?x?xf32>
+// CHECK:           linalg.generic
+// CHECK-SAME:        ins(%{{.*}}, %[[UNPACK]]
+// CHECK:           scf.forall.in_parallel
+
+// -----
+
+// Scalable linalg.mmt4d (N0 = 8*vscale) with a linalg.unpack consumer fused into
+// the mmt4d's tiling. This test exercises the inner tile alignment hint `Equal` being passed.
+
+#config = #iree_cpu.lowering_config<distribution = [5, 8, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 7, [8], 0]>
+#config1 = #iree_cpu.lowering_config<vector_common_parallel = [7, [8]]>
+func.func @scalable_mmt4d_with_unpack_consumer(%lhs: tensor<55x512x7x1xf32>, %rhs: tensor<?x512x?x1xf32>) -> tensor<385x?xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %nouter = tensor.dim %rhs, %c0 : tensor<?x512x?x1xf32>
+  %acc = tensor.empty(%nouter, %c8_vscale) : tensor<55x?x7x?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%acc : tensor<55x?x7x?xf32>) -> tensor<55x?x7x?xf32>
+  %mmt4d = linalg.mmt4d {lowering_config = #config} ins(%lhs, %rhs : tensor<55x512x7x1xf32>, tensor<?x512x?x1xf32>) outs(%fill : tensor<55x?x7x?xf32>) -> tensor<55x?x7x?xf32>
+  %n = arith.muli %nouter, %c8_vscale : index
+  %out = tensor.empty(%n) : tensor<385x?xf32>
+  %unpack = linalg.unpack %mmt4d outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %out {lowering_config = #config1} : tensor<55x?x7x?xf32> -> tensor<385x?xf32>
+  return %unpack : tensor<385x?xf32>
+}
+// CHECK-LABEL: func.func @scalable_mmt4d_with_unpack_consumer
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}} : index
+// CHECK:         scf.forall {{.*}} step (1, 1, %[[C8VS]])
+// CHECK:           %[[FILL:.+]] = linalg.fill
+// CHECK:           %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:        outs(%[[FILL]]
+// CHECK:           linalg.unpack %[[MMT4D]]
+// CHECK-SAME:        inner_tiles = [7, %[[C8VS]]]
+// CHECK-SAME:        tensor<1x1x7x?xf32> -> tensor<7x?xf32>
+// CHECK:           scf.forall.in_parallel

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile_and_fuse_producer_consumer_anchoring_root_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile_and_fuse_producer_consumer_anchoring_root_op.mlir
@@ -420,7 +420,7 @@ func.func @infusible_pack(%arg0 : tensor<30xf32>) -> tensor<5x6xf32> {
 // -----
 
 // Scalable linalg.pack with an elementwise-add producer.
-// This test exercises the inner tile alignment hint `Equal` being passed.
+// The `Equal` hint folds the scalable inner tile's outer dim to a static 1.
 
 #config = #iree_cpu.lowering_config<distribution = [64, 64], vector_common_parallel = [[8], 1]>
 #config1 = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
@@ -438,7 +438,10 @@ func.func @scalable_pack_with_producer(%arg0: tensor<384x512xf32>, %arg1: tensor
   } -> tensor<384x512xf32>
   %mouter = affine.apply affine_map<()[s0] -> (384 ceildiv s0)>()[%c8_vscale]
   %2 = tensor.empty(%mouter, %c8_vscale) : tensor<?x512x?x1xf32>
-  %pack = linalg.pack %1 padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [%c8_vscale, 1] into %2 {lowering_config = #config1} : tensor<384x512xf32> -> tensor<?x512x?x1xf32>
+  %pack = linalg.pack %1 padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1]
+    inner_tiles = [%c8_vscale, 1] into %2
+    {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Equal, Unknown]>,
+    lowering_config = #config1} : tensor<384x512xf32> -> tensor<?x512x?x1xf32>
   return %pack : tensor<?x512x?x1xf32>
 }
 // CHECK-LABEL: func.func @scalable_pack_with_producer
@@ -454,7 +457,7 @@ func.func @scalable_pack_with_producer(%arg0: tensor<384x512xf32>, %arg1: tensor
 // -----
 
 // Scalable linalg.unpack fused as the producer of an elementwise-add consumer.
-// This test exercises the inner tile alignment hint `Equal` being passed.
+// The `Equal` hint folds the scalable inner tile's outer dim to a static 1.
 
 #config = #iree_cpu.lowering_config<vector_common_parallel = [7, [8]]>
 #config1 = #iree_cpu.lowering_config<distribution = [84, 64], vector_common_parallel = [7, [8]]>
@@ -464,7 +467,10 @@ func.func @scalable_unpack_with_consumer(%arg0: tensor<12x?x7x?xf32>, %arg1: ten
   %vscale = vector.vscale
   %c8_vscale = arith.muli %vscale, %c8 : index
   %0 = tensor.empty() : tensor<80x320xf32>
-  %unpack = linalg.unpack %arg0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %0 {lowering_config = #config} : tensor<12x?x7x?xf32> -> tensor<80x320xf32>
+  %unpack = linalg.unpack %arg0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1]
+    inner_tiles = [7, %c8_vscale] into %0
+    {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>,
+    lowering_config = #config} : tensor<12x?x7x?xf32> -> tensor<80x320xf32>
   %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1, %unpack : tensor<80x320xf32>, tensor<80x320xf32>) outs(%0 : tensor<80x320xf32>) attrs = {lowering_config = #config1} {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %2 = arith.addf %in, %in_0 : f32
@@ -486,7 +492,7 @@ func.func @scalable_unpack_with_consumer(%arg0: tensor<12x?x7x?xf32>, %arg1: ten
 // -----
 
 // Scalable linalg.mmt4d (N0 = 8*vscale) with a linalg.unpack consumer fused into
-// the mmt4d's tiling. This test exercises the inner tile alignment hint `Equal` being passed.
+// the mmt4d's tiling. The `Equal` hint folds the scalable inner tile's outer dim to a static 1.
 
 #config = #iree_cpu.lowering_config<distribution = [5, 8, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 7, [8], 0]>
 #config1 = #iree_cpu.lowering_config<vector_common_parallel = [7, [8]]>
@@ -502,7 +508,7 @@ func.func @scalable_mmt4d_with_unpack_consumer(%lhs: tensor<55x512x7x1xf32>, %rh
   %mmt4d = linalg.mmt4d {lowering_config = #config} ins(%lhs, %rhs : tensor<55x512x7x1xf32>, tensor<?x512x?x1xf32>) outs(%fill : tensor<55x?x7x?xf32>) -> tensor<55x?x7x?xf32>
   %n = arith.muli %nouter, %c8_vscale : index
   %out = tensor.empty(%n) : tensor<385x?xf32>
-  %unpack = linalg.unpack %mmt4d outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %out {lowering_config = #config1} : tensor<55x?x7x?xf32> -> tensor<385x?xf32>
+  %unpack = linalg.unpack %mmt4d outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %out {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>, lowering_config = #config1} : tensor<55x?x7x?xf32> -> tensor<385x?xf32>
   return %unpack : tensor<385x?xf32>
 }
 // CHECK-LABEL: func.func @scalable_mmt4d_with_unpack_consumer
@@ -515,4 +521,64 @@ func.func @scalable_mmt4d_with_unpack_consumer(%lhs: tensor<55x512x7x1xf32>, %rh
 // CHECK:           linalg.unpack %[[MMT4D]]
 // CHECK-SAME:        inner_tiles = [7, %[[C8VS]]]
 // CHECK-SAME:        tensor<1x1x7x?xf32> -> tensor<7x?xf32>
+// CHECK:           scf.forall.in_parallel
+
+// -----
+
+// Scalable linalg.mmt4d (M0 = N0 = 8*vscale) with fused generic, unpack and pack
+// consumers. Each scalable inner tile dim is expected to fold to a static 1.
+
+#config = #iree_cpu.lowering_config<distribution = [5, 7, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, [8], [8], 0]>
+#config1 = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, [8], [8]]>
+#config2 = #iree_cpu.lowering_config<vector_common_parallel = [[8], [8]]>
+#config3 = #iree_cpu.lowering_config<vector_common_parallel = [[8], 1]>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @scalable_mmt4d_generic_unpack_pack(%lhs: tensor<5x512x?x1xf32>, %rhs: tensor<7x512x?x1xf32>) -> tensor<?x?x?x1xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c5 = arith.constant 5 : index
+  %c7 = arith.constant 7 : index
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %acc = tensor.empty(%c8_vscale, %c8_vscale) : tensor<5x7x?x?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%acc : tensor<5x7x?x?xf32>) -> tensor<5x7x?x?xf32>
+  %mmt4d = linalg.mmt4d {lowering_config = #config}
+    ins(%lhs, %rhs : tensor<5x512x?x1xf32>, tensor<7x512x?x1xf32>)
+    outs(%fill : tensor<5x7x?x?xf32>) -> tensor<5x7x?x?xf32>
+  %genout = tensor.empty(%c8_vscale, %c8_vscale) : tensor<5x7x?x?xf32>
+  %gen = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%mmt4d : tensor<5x7x?x?xf32>) outs(%genout : tensor<5x7x?x?xf32>)
+    attrs = {lowering_config = #config1} {
+  ^bb0(%in: f32, %out: f32):
+    %v = arith.maximumf %in, %cst : f32
+    linalg.yield %v : f32
+  } -> tensor<5x7x?x?xf32>
+  %m = arith.muli %c5, %c8_vscale : index
+  %n = arith.muli %c7, %c8_vscale : index
+  %uout = tensor.empty(%m, %n) : tensor<?x?xf32>
+  %unpack = linalg.unpack %gen outer_dims_perm = [0, 1] inner_dims_pos = [0, 1]
+    inner_tiles = [%c8_vscale, %c8_vscale] into %uout
+    {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Equal, Equal]>,
+    lowering_config = #config2} : tensor<5x7x?x?xf32> -> tensor<?x?xf32>
+  %mouter = affine.apply affine_map<()[s0, s1] -> (s0 ceildiv s1)>()[%m, %c8_vscale]
+  %pout = tensor.empty(%mouter, %n, %c8_vscale) : tensor<?x?x?x1xf32>
+  %pack = linalg.pack %unpack padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1]
+    inner_tiles = [%c8_vscale, 1] into %pout
+    {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Equal, Multiple]>,
+    lowering_config = #config3} : tensor<?x?xf32> -> tensor<?x?x?x1xf32>
+  return %pack : tensor<?x?x?x1xf32>
+}
+// CHECK-LABEL: func.func @scalable_mmt4d_generic_unpack_pack
+// CHECK:         %[[VSCALE:.+]] = vector.vscale
+// CHECK:         %[[C8VS:.+]] = arith.muli %[[VSCALE]], %{{.+}} : index
+// CHECK:         scf.forall {{.*}} step (1, 1, %[[C8VS]], %[[C8VS]])
+// CHECK:           %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK:           %[[GEN:.+]] = linalg.generic
+// CHECK-SAME:        ins(%[[MMT4D]]
+// CHECK:           %[[UNPACK:.+]] = linalg.unpack %[[GEN]]
+// CHECK-SAME:        inner_tiles = [%[[C8VS]], %[[C8VS]]]
+// CHECK-SAME:        tensor<1x1x?x?xf32> -> tensor<?x?xf32>
+// CHECK:           linalg.pack %[[UNPACK]]
+// CHECK-SAME:        inner_tiles = [%[[C8VS]], 1]
+// CHECK-SAME:        tensor<?x?xf32> -> tensor<1x?x?x1xf32>
 // CHECK:           scf.forall.in_parallel

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile_and_fuse_producer_consumer_anchoring_root_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/tile_and_fuse_producer_consumer_anchoring_root_op.mlir
@@ -425,20 +425,21 @@ func.func @infusible_pack(%arg0 : tensor<30xf32>) -> tensor<5x6xf32> {
 #config = #iree_cpu.lowering_config<distribution = [64, 64], vector_common_parallel = [[8], 1]>
 #config1 = #iree_cpu.lowering_config<vector_common_parallel = [1, 1]>
 #map = affine_map<(d0, d1) -> (d0, d1)>
-func.func @scalable_pack_with_producer(%arg0: tensor<384x512xf32>, %arg1: tensor<384x512xf32>) -> tensor<?x512x?x1xf32> {
+func.func @scalable_pack_with_producer(%arg0: tensor<384x512xf32>, %arg1: tensor<384x512xf32>, %arg2 : tensor<384x512xf32>) -> tensor<?x512x?x1xf32> {
   %cst = arith.constant 0.000000e+00 : f32
   %c8 = arith.constant 8 : index
   %vscale = vector.vscale
   %c8_vscale = arith.muli %vscale, %c8 : index
-  %0 = tensor.empty() : tensor<384x512xf32>
-  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<384x512xf32>, tensor<384x512xf32>) outs(%0 : tensor<384x512xf32>) attrs = {lowering_config = #config} {
+  %generic = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg1 : tensor<384x512xf32>, tensor<384x512xf32>)
+    outs(%arg2 : tensor<384x512xf32>) attrs = {lowering_config = #config} {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %3 = arith.addf %in, %in_0 : f32
     linalg.yield %3 : f32
   } -> tensor<384x512xf32>
   %mouter = affine.apply affine_map<()[s0] -> (384 ceildiv s0)>()[%c8_vscale]
   %2 = tensor.empty(%mouter, %c8_vscale) : tensor<?x512x?x1xf32>
-  %pack = linalg.pack %1 padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1]
+  %pack = linalg.pack %generic padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1]
     inner_tiles = [%c8_vscale, 1] into %2
     {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Equal, Unknown]>,
     lowering_config = #config1} : tensor<384x512xf32> -> tensor<?x512x?x1xf32>
@@ -451,6 +452,7 @@ func.func @scalable_pack_with_producer(%arg0: tensor<384x512xf32>, %arg1: tensor
 // CHECK:           %[[GEN:.+]] = linalg.generic
 // CHECK:           linalg.pack %[[GEN]]
 // CHECK-SAME:        inner_tiles = [%[[C8VS]], 1]
+// The outermost dimension has to equal 1 to confirm the Equal hint is taken into account.
 // CHECK-SAME:        -> tensor<1x1x?x1xf32>
 // CHECK:           scf.forall.in_parallel
 
@@ -471,12 +473,14 @@ func.func @scalable_unpack_with_consumer(%arg0: tensor<12x?x7x?xf32>, %arg1: ten
     inner_tiles = [7, %c8_vscale] into %0
     {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>,
     lowering_config = #config} : tensor<12x?x7x?xf32> -> tensor<80x320xf32>
-  %1 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1, %unpack : tensor<80x320xf32>, tensor<80x320xf32>) outs(%0 : tensor<80x320xf32>) attrs = {lowering_config = #config1} {
+  %generic = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+    ins(%arg1, %unpack : tensor<80x320xf32>, tensor<80x320xf32>)
+    outs(%0 : tensor<80x320xf32>) attrs = {lowering_config = #config1} {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %2 = arith.addf %in, %in_0 : f32
     linalg.yield %2 : f32
   } -> tensor<80x320xf32>
-  return %1 : tensor<80x320xf32>
+  return %generic : tensor<80x320xf32>
 }
 // CHECK-LABEL: func.func @scalable_unpack_with_consumer
 // CHECK:         %[[VSCALE:.+]] = vector.vscale
@@ -484,6 +488,7 @@ func.func @scalable_unpack_with_consumer(%arg0: tensor<12x?x7x?xf32>, %arg1: ten
 // CHECK:         scf.forall {{.*}} = (0, 0) to (80, 320) step (7, %[[C8VS]])
 // CHECK:           %[[UNPACK:.+]] = linalg.unpack
 // CHECK-SAME:        inner_tiles = [7, %[[C8VS]]]
+// The outermost dimensions have to equal 1 to confirm the Equal hint is taken into account.
 // CHECK-SAME:        tensor<1x1x7x?xf32> -> tensor<?x?xf32>
 // CHECK:           linalg.generic
 // CHECK-SAME:        ins(%{{.*}}, %[[UNPACK]]
@@ -520,6 +525,7 @@ func.func @scalable_mmt4d_with_unpack_consumer(%lhs: tensor<55x512x7x1xf32>, %rh
 // CHECK-SAME:        outs(%[[FILL]]
 // CHECK:           linalg.unpack %[[MMT4D]]
 // CHECK-SAME:        inner_tiles = [7, %[[C8VS]]]
+// The outermost dimensions have to equal 1 to confirm the Equal hint is taken into account.
 // CHECK-SAME:        tensor<1x1x7x?xf32> -> tensor<7x?xf32>
 // CHECK:           scf.forall.in_parallel
 
@@ -560,8 +566,8 @@ func.func @scalable_mmt4d_generic_unpack_pack(%lhs: tensor<5x512x?x1xf32>, %rhs:
     inner_tiles = [%c8_vscale, %c8_vscale] into %uout
     {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Equal, Equal]>,
     lowering_config = #config2} : tensor<5x7x?x?xf32> -> tensor<?x?xf32>
-  %mouter = affine.apply affine_map<()[s0, s1] -> (s0 ceildiv s1)>()[%m, %c8_vscale]
-  %pout = tensor.empty(%mouter, %n, %c8_vscale) : tensor<?x?x?x1xf32>
+  %m_outer = affine.apply affine_map<()[s0, s1] -> (s0 ceildiv s1)>()[%m, %c8_vscale]
+  %pout = tensor.empty(%m_outer, %n, %c8_vscale) : tensor<?x?x?x1xf32>
   %pack = linalg.pack %unpack padding_value(%cst : f32) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1]
     inner_tiles = [%c8_vscale, 1] into %pout
     {inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Equal, Multiple]>,
@@ -580,5 +586,6 @@ func.func @scalable_mmt4d_generic_unpack_pack(%lhs: tensor<5x512x?x1xf32>, %rhs:
 // CHECK-SAME:        tensor<1x1x?x?xf32> -> tensor<?x?xf32>
 // CHECK:           linalg.pack %[[UNPACK]]
 // CHECK-SAME:        inner_tiles = [%[[C8VS]], 1]
+// The outermost dimension has to equal 1 to confirm the Equal hint is taken into account.
 // CHECK-SAME:        tensor<?x?xf32> -> tensor<1x?x?x1xf32>
 // CHECK:           scf.forall.in_parallel


### PR DESCRIPTION
Introduces a helper function that will generate the inner tile alignment hint control function introduced in https://github.com/llvm/llvm-project/pull/204007. 

The control function is passed to the SCF tiling driver and is invoked per-op before tiling/fusion. It merely forwards the inner tile alignment hints set during tile size selection, added in the stack of https://github.com/iree-org/iree/pull/24806.

Also utilizes this in the `TileAndFuseProducerConsumer` pass.

Assisted-by: Claude Code