### PR TITLE
[CI] Decomission amd gpu runners

### DIFF
--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -40,13 +40,6 @@ jobs:
               - X64
 
           # AMD GPU
-          - name: amdgpu_rocm_mi300_gfx942
-            rocm-chip: gfx942
-            backend: rocm
-            iree_test_files: /shark-cache/data/iree-regression-cache
-            sku: mi300
-            target: target_hip
-            runs-on: linux-mi325-1gpu-ossci-iree-org
           - name: amdgpu_rocm_mi308_gfx942
             rocm-chip: gfx942
             backend: rocm

--- a/.github/workflows/pkgci_test_torch.yml
+++ b/.github/workflows/pkgci_test_torch.yml
@@ -51,11 +51,6 @@ jobs:
             runs-on: [Linux, X64, rdna3]
             cache-dir: /home/nod/iree_tests_cache
             extra-flags: ""
-          - name: amdgpu_rocm_mi300_gfx942_O3
-            config-file: torch_ops_gpu_hip_gfx942_O3.json
-            runs-on: linux-mi325-1gpu-ossci-iree-org
-            cache-dir: /shark-cache/data/iree-regression-cache
-            extra-flags: ""
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       LOG_FILE_PATH: /tmp/test_torch_ops_${{ matrix.name }}_logs.json
@@ -127,12 +122,6 @@ jobs:
               - Linux
               - X64
               - threadripper
-          # MI325
-          - name: amdgpu_mi325_gfx942
-            markers: "gfx942 or mi325"
-            cache-dir: /shark-cache/data/iree-regression-cache
-            summary-file: torch_models_amdgpu_mi325_summary.json
-            runs-on: linux-mi325-1gpu-ossci-iree-org
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages


### PR DESCRIPTION
Since we don't have access to the AMDGPU runners, we cannot fix the cache issue. Therefore it is time to sunset them.