### PR TITLE
[DispatchCreation] Register enum literals for parsing data-tiling hint op types

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -68,6 +68,16 @@ static llvm::cl::list<mlir::iree_compiler::IREE::Encoding::EncodingOpType>
         llvm::cl::desc("Op families eligible for data-tiling annotation. "
                        "Defaults to {matmul, scaled_matmul}, add convolution "
                        "to enable experimental data tiling support."),
+        llvm::cl::values(
+            clEnumValN(
+                mlir::iree_compiler::IREE::Encoding::EncodingOpType::matmul,
+                "matmul", "Matmul-like operations."),
+            clEnumValN(mlir::iree_compiler::IREE::Encoding::EncodingOpType::
+                           scaled_matmul,
+                       "scaled_matmul", "Scaled matmul-like operations."),
+            clEnumValN(
+                mlir::iree_compiler::IREE::Encoding::EncodingOpType::conv,
+                "convolution", "Convolutions.")),
         llvm::cl::list_init<
             mlir::iree_compiler::IREE::Encoding::EncodingOpType>(
             {mlir::iree_compiler::IREE::Encoding::EncodingOpType::matmul,


### PR DESCRIPTION
The CLI option that lists op families eligible for data-tiling annotation takes `EncodingOpType` enum values, but no `cl::values` were registered for it. Hence, passing a keyword such as `convolution` on the command line to `--iree-dispatch-creation-experimental-set-data-tiling-ops` failed to parse. Register the literals (`matmul`, `scaled_matmul`, `convolution`) so the option is actually usable from `iree-compile`.