### PR TITLE
Integrate LLVM to llvm/llvm-project@4641f4879e47

### DIFF
--- a/compiler/plugins/target/LLVMCPU/internal/WindowsLinkerTool.cpp
+++ b/compiler/plugins/target/LLVMCPU/internal/WindowsLinkerTool.cpp
@@ -179,7 +179,7 @@ public:
         "/out:" + artifacts.libraryFile.path,
     };
 
-    if (targetOptions.target.optimizerOptLevel.getSpeedupLevel() >= 2) {
+    if (targetOptions.target.optimizerOptLevel >= llvm::OptimizationLevel::O2) {
       // https://docs.microsoft.com/en-us/cpp/build/reference/opt-optimizations?view=vs-2019
       // Enable all the fancy optimizations.
       flags.push_back("/opt:ref,icf,lbr");
@@ -233,7 +233,7 @@ public:
     // We need to link against different libraries based on our configuration
     // matrix (dynamic/static and debug/release).
     int libIndex = 0;
-    if (targetOptions.target.optimizerOptLevel.getSpeedupLevel() == 0) {
+    if (targetOptions.target.optimizerOptLevel == llvm::OptimizationLevel::O0) {
       libIndex += 0; // debug
     } else {
       libIndex += 2; // release

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -827,10 +827,14 @@ struct RewriteFuncOpABI : OpRewritePattern<LLVM::LLVMFuncOp> {
         return cast<DictionaryAttr>(attr);
       });
     }
+    std::optional<uint64_t> functionEntryCount;
+    if (auto attr = funcOp.getFunctionEntryCountAttr()) {
+      functionEntryCount = attr.getEntryCount();
+    }
     LLVM::LLVMFuncOp::create(
         rewriter, funcOp.getLoc(), funcOp.getName(), expectedType.value(),
         funcOp.getLinkage(), funcOp.getDsoLocal(), funcOp.getCConv(),
-        /*comdat=*/nullptr, attrs, argAttrs, funcOp.getFunctionEntryCount());
+        /*comdat=*/nullptr, attrs, argAttrs, functionEntryCount);
     rewriter.eraseOp(funcOp);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -11,8 +11,9 @@
 
 namespace mlir::iree_compiler {
 
-// Bridge type for MLIR pass/pipeline options, which cannot store
-// llvm::OptimizationLevel directly because it is a final class.
+// Bridge type for MLIR pass/pipeline options.
+// TODO: llvm::OptimizationLevel is an enum; this bridge type could be 
+// potentially removed.
 enum class CodegenPipelineOptLevel {
   O0 = 0,
   O1 = 1,

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -12,7 +12,7 @@
 namespace mlir::iree_compiler {
 
 // Bridge type for MLIR pass/pipeline options.
-// TODO: llvm::OptimizationLevel is an enum; this bridge type could be 
+// TODO: llvm::OptimizationLevel is an enum; this bridge type could be
 // potentially removed.
 enum class CodegenPipelineOptLevel {
   O0 = 0,

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -265,7 +265,7 @@ struct SchedulingOptions {
 };
 
 struct DispatchCreationOptions {
-  llvm::OptimizationLevel optLevel;
+  llvm::OptimizationLevel optLevel = llvm::OptimizationLevel::O2;
 
   bool enableAggressiveFusion = false;
   bool enableFuseMultiUse = true;

--- a/compiler/src/iree/compiler/Utils/OptionUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.cpp
@@ -231,13 +231,13 @@ void llvm::cl::parser<llvm::OptimizationLevel>::printOptionDiff(
   std::string Str;
   {
     llvm::raw_string_ostream SS(Str);
-    SS << V.getSpeedupLevel();
+    SS << static_cast<unsigned>(V);
   }
   outs() << "= " << Str;
   outs().indent(2) << " (default: ";
   if (Default.hasValue()) {
     auto defaultVal = Default.getValue();
-    outs() << defaultVal.getSpeedupLevel();
+    outs() << static_cast<unsigned>(defaultVal);
   } else {
     outs() << "*no default*";
   }

--- a/compiler/src/iree/compiler/Utils/OptionUtils.h
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.h
@@ -19,7 +19,7 @@
 namespace llvm {
 inline raw_ostream &operator<<(raw_ostream &os,
                                const llvm::OptimizationLevel &opt) {
-  return os << 'O' << opt.getSpeedupLevel();
+  return os << 'O' << static_cast<unsigned>(opt);
 }
 } // namespace llvm
 
@@ -35,7 +35,7 @@ struct opt_initializer {
                   const Ty &val)
       : parentName(parentName), init(val), optLevel(opt) {}
   void apply(const llvm::OptimizationLevel inLevel, Ty &val) const {
-    if (inLevel.getSpeedupLevel() >= optLevel.getSpeedupLevel()) {
+    if (inLevel >= optLevel) {
       val = init;
     }
   }
@@ -162,7 +162,7 @@ public:
                                                       inits.end());
     llvm::sort(initsSorted, [](opt_initializer<T> &lhs,
                                opt_initializer<T> &rhs) {
-      return lhs.optLevel.getSpeedupLevel() < rhs.optLevel.getSpeedupLevel();
+      return lhs.optLevel < rhs.optLevel;
     });
 
     llvm::cl::desc &desc = filterDescription(Ms...);

--- a/compiler/src/iree/compiler/Utils/OptionUtils.h
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.h
@@ -160,10 +160,10 @@ public:
            std::initializer_list<opt_initializer<T>> inits, Mods... Ms) {
     llvm::SmallVector<opt_initializer<T>> initsSorted(inits.begin(),
                                                       inits.end());
-    llvm::sort(initsSorted, [](opt_initializer<T> &lhs,
-                               opt_initializer<T> &rhs) {
-      return lhs.optLevel < rhs.optLevel;
-    });
+    llvm::sort(initsSorted,
+               [](opt_initializer<T> &lhs, opt_initializer<T> &rhs) {
+                 return lhs.optLevel < rhs.optLevel;
+               });
 
     llvm::cl::desc &desc = filterDescription(Ms...);
     auto descStr = std::make_unique<std::string>(desc.Desc);


### PR DESCRIPTION
Integrates LLVM from abbcebe652841d to 4641f4879e47

IREE changes:
- Adapted to llvm/llvm-project#209424, which changed `llvm::OptimizationLevel` from a class to an enum.
  - Changed `DispatchCreationOptions` in compiler/src/iree/compiler/Pipelines/Options.h so that `optLevel` is explicitly initialized to `llvm::OptimizationLevel::O2`. This was the default value of the old `llvm::OptimizationLevel` class. 
  - As a side note `CodegenPipelineOptLevel` in ‎compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h was intended as a bridge from the old llvm class. Now, that enum seems to duplicate the new llvm enum, but I did not remove it.
- Adapted to llvm/llvm-project#204707, which changed LLVM::FunctionEntryCountAttr while LLVMFuncOp::build in llvm-project/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp still expects `std::optional<uint64_t>`

The integrate caused the following failing tests, that got addressed with the cherry-picked changes below
```
  The following tests FAILED:
        1750 - iree/tests/e2e/matmul/e2e_matmul_cpu_dt_uk_f16_f16_llvm-cpu_local-task_avx2 (SEGFAULT) cpu_features=avx2 driver=local-task iree/tests/e2e/matmul noriscv nowasm
        1756 - iree/tests/e2e/matmul/e2e_matmul_cpu_dt_uk_bf16_bf16_llvm-cpu_local-task_avx2 (SEGFAULT) cpu_features=avx2 driver=local-task iree/tests/e2e/matmul noriscv nowasm
        1812 - iree/tests/e2e/matmul/e2e_matmul_cpu_experimental_dt_uk_f16_f16_llvm-cpu_local-task_avx2 (SEGFAULT) cpu_features=avx2 driver=local-task iree/tests/e2e/matmul noriscv nowasm
        1818 - iree/tests/e2e/matmul/e2e_matmul_cpu_experimental_dt_uk_bf16_bf16_llvm-cpu_local-task_avx2 (SEGFAULT) cpu_features=avx2 driver=local-task iree/tests/e2e/matmul noriscv nowasm
``` 
Additional LLVM fixups:
- Cherry-picked https://github.com/llvm/llvm-project/pull/210303
- Cherry-picked https://github.com/llvm/llvm-project/pull/209345


