### PR TITLE
[CUDA] Fix missing CUDA kernel sanitization in runtime

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -550,13 +550,35 @@ static iree_status_t iree_hal_cuda_native_executable_export_parameters(
                           "parameter reflection not implemented");
 }
 
+// PTX identifiers only allow [a-zA-Z0-9_]; the compiler sanitizes kernel names
+// by replacing every other character with '_' (matching sanitizeSymbolName in
+// compiler/src/iree/compiler/Utils/StringUtils.cpp). The runtime lookup
+// receives the original unsanitized name, so we sanitize it here before
+// comparing against the stored (already-sanitized) kernel names.
+// TODO(upstream): remove once the compiler stores both the original and PTX
+// names in the flatbuffer so the runtime can do an unsanitized lookup.
+static bool iree_hal_cuda_name_matches_sanitized(iree_string_view_t stored,
+                                                 iree_string_view_t name) {
+  if (stored.size != name.size) return false;
+  for (iree_host_size_t i = 0; i < name.size; ++i) {
+    char c = name.data[i];
+    if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+          (c >= '0' && c <= '9') || c == '_')) {
+      c = '_';
+    }
+    if (stored.data[i] != c) return false;
+  }
+  return true;
+}
+
 static iree_status_t iree_hal_cuda_native_executable_lookup_export_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
     iree_hal_executable_function_t* out_export_ordinal) {
   iree_hal_cuda_native_executable_t* executable =
       iree_hal_cuda_native_executable_cast(base_executable);
   for (iree_host_size_t i = 0; i < executable->export_count; ++i) {
-    if (iree_string_view_equal(executable->exports[i].name, name)) {
+    if (iree_hal_cuda_name_matches_sanitized(executable->exports[i].name,
+                                             name)) {
       *out_export_ordinal =
           iree_hal_executable_function_from_index((uint32_t)i);
       return iree_ok_status();


### PR DESCRIPTION
This PR fixes a divergence between the CUDA compiler plugin and the CUDA HAL driver in how export names are stored and looked up. As shown in #24653 the compiler plugin sanitizes the kernel names to match PTX restrictions, while the runtime does a direct string equality check. This PR corrects that divergence by adding a small utility function to perform the same sanitization runtime-side. However, this means there are two different codepaths performing sanitization that may become desynced. Another idea I had was to add some metadata to the flatbuffer mapping export names to kernel names, but I have not yet looked too deep into how that would work.

As this is my first PR here, I would appreciate some guidance on how to proceed. I fully intend to add tests for this bug but would like to know whether this solution is good enough or if the IREE developers would prefer a different solution.