### PR TITLE
Drop CodegenPipelineOptLevel and use llvm::OptimizationLevel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -752,7 +752,7 @@ static CPUCodegenOptions
 getCPUCodegenOptionsForTextualPipeline(const PipelineOptionsT &options) {
   CPUCodegenOptions cpuOpts = CPUCodegenOptions::FromFlags::get();
   if (options.optLevel.hasValue()) {
-    cpuOpts.setWithOptLevel(mapCodegenPipelineOptLevel(options.optLevel));
+    cpuOpts.setWithOptLevel(options.optLevel);
   }
   return cpuOpts;
 }
@@ -813,16 +813,11 @@ void registerCodegenLLVMCPUPasses() {
 
   struct LLVMCPUConfigurationPipelineOptions final
       : PassPipelineOptions<LLVMCPUConfigurationPipelineOptions> {
-    Option<CodegenPipelineOptLevel> optLevel{
+    Option<llvm::OptimizationLevel> optLevel{
         *this, "opt-level",
         llvm::cl::desc(
             "Optimization level used to derive CPU codegen defaults."),
-        llvm::cl::values(
-            clEnumValN(CodegenPipelineOptLevel::O0, "O0", "Use O0 defaults."),
-            clEnumValN(CodegenPipelineOptLevel::O1, "O1", "Use O1 defaults."),
-            clEnumValN(CodegenPipelineOptLevel::O2, "O2", "Use O2 defaults."),
-            clEnumValN(CodegenPipelineOptLevel::O3, "O3", "Use O3 defaults.")),
-        llvm::cl::init(CodegenPipelineOptLevel::O0)};
+        llvm::cl::init(llvm::OptimizationLevel::O0)};
   };
 
   static PassPipelineRegistration<LLVMCPUConfigurationPipelineOptions>
@@ -856,16 +851,11 @@ void registerCodegenLLVMCPUPasses() {
 
   struct LLVMCPULoweringPipelineOptions
       : PassPipelineOptions<LLVMCPULoweringPipelineOptions> {
-    Option<CodegenPipelineOptLevel> optLevel{
+    Option<llvm::OptimizationLevel> optLevel{
         *this, "opt-level",
         llvm::cl::desc(
             "Optimization level used to derive CPU codegen defaults."),
-        llvm::cl::values(
-            clEnumValN(CodegenPipelineOptLevel::O0, "O0", "Use O0 defaults."),
-            clEnumValN(CodegenPipelineOptLevel::O1, "O1", "Use O1 defaults."),
-            clEnumValN(CodegenPipelineOptLevel::O2, "O2", "Use O2 defaults."),
-            clEnumValN(CodegenPipelineOptLevel::O3, "O3", "Use O3 defaults.")),
-        llvm::cl::init(CodegenPipelineOptLevel::O0)};
+        llvm::cl::init(llvm::OptimizationLevel::O0)};
     Option<bool> enableArmSME{
         *this, "enable-arm-sme",
         llvm::cl::desc("Enable the ArmSME lowering pipeline.")};

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.cpp
@@ -57,22 +57,6 @@ bool CodegenOptions::setTunerAttributes = false;
 bool CodegenOptions::verifyPipelineConstraints = false;
 bool CodegenOptions::emitPipelineConstraints = false;
 
-llvm::OptimizationLevel
-mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel) {
-  switch (optLevel) {
-  case CodegenPipelineOptLevel::O0:
-    return llvm::OptimizationLevel::O0;
-  case CodegenPipelineOptLevel::O1:
-    return llvm::OptimizationLevel::O1;
-  case CodegenPipelineOptLevel::O2:
-    return llvm::OptimizationLevel::O2;
-  case CodegenPipelineOptLevel::O3:
-    return llvm::OptimizationLevel::O3;
-  }
-  assert(false && "unhandled codegen pipeline optimization level");
-  return llvm::OptimizationLevel::O0;
-}
-
 void CodegenOptions::bindOptions(OptionsBinder &binder) {
   static llvm::cl::OptionCategory category("IREE Codegen Options");
 

--- a/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CodegenOptions.h
@@ -11,20 +11,6 @@
 
 namespace mlir::iree_compiler {
 
-// Bridge type for MLIR pass/pipeline options.
-// TODO: llvm::OptimizationLevel is an enum; this bridge type could be
-// potentially removed.
-enum class CodegenPipelineOptLevel {
-  O0 = 0,
-  O1 = 1,
-  O2 = 2,
-  O3 = 3,
-};
-
-// Maps the pass/pipeline bridge enum to llvm::OptimizationLevel.
-llvm::OptimizationLevel
-mapCodegenPipelineOptLevel(CodegenPipelineOptLevel optLevel);
-
 // A base class that defines common codegen options that are shared across
 // different backends (e.g., CPU and GPU). Derived classes can add
 // backend-specific options as needed.


### PR DESCRIPTION
After LLVM integrate in #24713 , the `llvm::OptimizationLevel` is now a enum, so there's no need of `CodegenPipelineOptLevel` and mapping helper function.

this change removes them and fixes #24715 