### PR TITLE
[Vulkan] Mark vkGetMemoryHostPointerPropertiesEXT as optional

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/util/libvulkan_tables.h
+++ b/runtime/src/iree/hal/drivers/vulkan/util/libvulkan_tables.h
@@ -160,7 +160,7 @@ IREE_HAL_VULKAN_DEVICE_PFN(VkResult, vkAllocateMemory,
                                 VkDeviceMemory* pMemory),
                            ARGS(device, pAllocateInfo, pAllocator, pMemory))
 
-IREE_HAL_VULKAN_DEVICE_PFN(
+IREE_HAL_VULKAN_DEVICE_OPTIONAL_PFN(
     VkResult, vkGetMemoryHostPointerPropertiesEXT,
     DECL(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
          const void* pHostPointer,


### PR DESCRIPTION
`vkGetMemoryHostPointerPropertiesEXT` only available if `VK_EXT_external_memory_host` is available & enabled.
If the extension is not available and the function is marked as required, `Vulkan device symbol 'vkGetMemoryHostPointerPropertiesEXT' not found` is thrown, see #24717.

Call-sites are guarded by `iree_hal_vulkan_allocator_supports_host_allocation_import`.