### PR TITLE
[Build] set CCACHE_SLOPPINESS to enable ccache with PCH

### DIFF
--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -27,6 +27,12 @@ macro(iree_llvm_configure_bundled)
   # Disable LLVM's warnings.
   set(LLVM_ENABLE_WARNINGS OFF)
 
+  # ccache can't cache PCH compilations, so disable LLVM's default PCH under ccache.
+  if(NOT DEFINED CMAKE_DISABLE_PRECOMPILE_HEADERS AND
+     CMAKE_CXX_COMPILER_LAUNCHER MATCHES "ccache")
+    set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
+  endif()
+
   # Stash cmake build type in case LLVM messes with it.
   set(_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
 

--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -27,12 +27,6 @@ macro(iree_llvm_configure_bundled)
   # Disable LLVM's warnings.
   set(LLVM_ENABLE_WARNINGS OFF)
 
-  # ccache can't cache PCH compilations, so disable LLVM's default PCH under ccache.
-  if(NOT DEFINED CMAKE_DISABLE_PRECOMPILE_HEADERS AND
-     CMAKE_CXX_COMPILER_LAUNCHER MATCHES "ccache")
-    set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
-  endif()
-
   # Stash cmake build type in case LLVM messes with it.
   set(_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
 

--- a/build_tools/cmake/setup_ccache.sh
+++ b/build_tools/cmake/setup_ccache.sh
@@ -40,6 +40,11 @@ if (( IREE_READ_REMOTE_CCACHE == 1 || IREE_READ_LOCAL_CCACHE == 1 )); then
   export IREE_USE_CCACHE=1
   export CMAKE_C_COMPILER_LAUNCHER="$(which ccache)"
   export CMAKE_CXX_COMPILER_LAUNCHER="$(which ccache)"
+
+  # LLVM builds with precompiled headers by default when using Clang >= 18.
+  # ccache refuses to cache any compilation that uses a PCH
+  export CCACHE_SLOPPINESS="${CCACHE_SLOPPINESS:+${CCACHE_SLOPPINESS},}pch_defines,time_macros"
+
   ccache --zero-stats
   ccache --show-stats
 else

--- a/docs/website/docs/developers/building/cmake-with-ccache.md
+++ b/docs/website/docs/developers/building/cmake-with-ccache.md
@@ -60,7 +60,8 @@ frequently it currently is updated, I'm finding that `20G` is enough to make the
 Use the CMake
 [COMPILER_LAUNCHER functionality](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_LAUNCHER.html)
 by setting `CMAKE_C_COMPILER_LAUNCHER=ccache` and
-`CMAKE_CXX_COMPILER_LAUNCHER=ccache` in your
+`CMAKE_CXX_COMPILER_LAUNCHER=ccache` in your CMake configure command or in your
+environment.
 
 Notes:
 
@@ -68,6 +69,20 @@ Notes:
   (`cmake -G` flag). When using other generators, another approach is needed,
   based on wrapping the compiler in a script that prepends `ccache`. See this
   [article](https://crascit.com/2016/04/09/using-ccache-with-cmake/).
+
+## `ccache` and precompiled headers
+
+`third_party/llvm-project` builds with precompiled headers by default when
+using Clang 18 or newer. `ccache` will not cache a compilation that uses a
+precompiled header unless it is configured to be sloppy about `#define`
+directives and time macros.
+
+`build_tools/cmake/setup_ccache.sh` sets this for you. If you configure
+`ccache` yourself, set it once as persistent `ccache` configuration:
+
+```shell
+ccache --set-config=sloppiness=pch_defines,time_macros
+```
 
 ## Ensuring that `ccache` is used and monitoring cache hits
 


### PR DESCRIPTION
A recent LLVM bump enables precompiled headers by default; ccache can't cache PCH compilations, reducing the cache hit rate. Set CCACHE_SLOPPINESS to enable ccache with PCH