### PR TITLE
[Security] Fix rwdata global bounds checks: F64 access length and offset overflow

### DIFF
--- a/runtime/src/iree/vm/bytecode/dispatch.c
+++ b/runtime/src/iree/vm/bytecode/dispatch.c
@@ -16,6 +16,16 @@
 #include "iree/vm/bytecode/module_impl.h"
 #include "iree/vm/ops.h"
 
+// Returns true if [byte_offset, byte_offset + access_length) lies entirely
+// within a buffer of |data_length| bytes. Performs no addition so it cannot
+// overflow, regardless of the width of iree_host_size_t.
+static inline bool iree_vm_bytecode_rwdata_range_ok(
+    uint32_t byte_offset, iree_host_size_t access_length,
+    iree_host_size_t data_length) {
+  return access_length <= data_length &&
+         (iree_host_size_t)byte_offset <= data_length - access_length;
+}
+
 //===----------------------------------------------------------------------===//
 // Ref register debug checking
 //===----------------------------------------------------------------------===//
@@ -1205,11 +1215,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
       IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
       IREE_VM_ISA_DISPATCH_DECODE_RESULT_I32(value);
       const uint32_t byte_offset = (uint32_t)byte_offset_i32;
-      if (IREE_UNLIKELY(byte_offset + 4 >
-                        module_state->rwdata_storage.data_length)) {
+      if (IREE_UNLIKELY(!iree_vm_bytecode_rwdata_range_ok(
+              byte_offset, 4, module_state->rwdata_storage.data_length))) {
         return iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
-            "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
+            "global byte_offset out of range: %u (rwdata=%" PRIhsz ")",
             byte_offset, module_state->rwdata_storage.data_length);
       }
       const int32_t global_value =
@@ -1221,11 +1231,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
       IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
       IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(value);
       const uint32_t byte_offset = (uint32_t)byte_offset_i32;
-      if (IREE_UNLIKELY(byte_offset + 4 >
-                        module_state->rwdata_storage.data_length)) {
+      if (IREE_UNLIKELY(!iree_vm_bytecode_rwdata_range_ok(
+              byte_offset, 4, module_state->rwdata_storage.data_length))) {
         return iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
-            "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
+            "global byte_offset out of range: %u (rwdata=%" PRIhsz ")",
             byte_offset, module_state->rwdata_storage.data_length);
       }
       vm_global_store_i32(module_state->rwdata_storage.data, byte_offset,
@@ -1253,11 +1263,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
       IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
       IREE_VM_ISA_DISPATCH_DECODE_RESULT_I64(value);
       const uint32_t byte_offset = (uint32_t)byte_offset_i32;
-      if (IREE_UNLIKELY(byte_offset + 8 >
-                        module_state->rwdata_storage.data_length)) {
+      if (IREE_UNLIKELY(!iree_vm_bytecode_rwdata_range_ok(
+              byte_offset, 8, module_state->rwdata_storage.data_length))) {
         return iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
-            "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
+            "global byte_offset out of range: %u (rwdata=%" PRIhsz ")",
             byte_offset, module_state->rwdata_storage.data_length);
       }
       const int64_t global_value =
@@ -1269,11 +1279,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
       IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
       IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I64(value);
       const uint32_t byte_offset = (uint32_t)byte_offset_i32;
-      if (IREE_UNLIKELY(byte_offset + 8 >
-                        module_state->rwdata_storage.data_length)) {
+      if (IREE_UNLIKELY(!iree_vm_bytecode_rwdata_range_ok(
+              byte_offset, 8, module_state->rwdata_storage.data_length))) {
         return iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
-            "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
+            "global byte_offset out of range: %u (rwdata=%" PRIhsz ")",
             byte_offset, module_state->rwdata_storage.data_length);
       }
       vm_global_store_i64(module_state->rwdata_storage.data, byte_offset,
@@ -2411,11 +2421,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
         IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
         IREE_VM_ISA_DISPATCH_DECODE_RESULT_F32(value);
         const uint32_t byte_offset = (uint32_t)byte_offset_i32;
-        if (IREE_UNLIKELY(byte_offset + 4 >
-                          module_state->rwdata_storage.data_length)) {
+        if (IREE_UNLIKELY(!iree_vm_bytecode_rwdata_range_ok(
+                byte_offset, 4, module_state->rwdata_storage.data_length))) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
-              "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
+              "global byte_offset out of range: %u (rwdata=%" PRIhsz ")",
               byte_offset, module_state->rwdata_storage.data_length);
         }
         const float global_value =
@@ -2427,11 +2437,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
         IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
         IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F32(value);
         const uint32_t byte_offset = (uint32_t)byte_offset_i32;
-        if (IREE_UNLIKELY(byte_offset + 4 >
-                          module_state->rwdata_storage.data_length)) {
+        if (IREE_UNLIKELY(!iree_vm_bytecode_rwdata_range_ok(
+                byte_offset, 4, module_state->rwdata_storage.data_length))) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
-              "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
+              "global byte_offset out of range: %u (rwdata=%" PRIhsz ")",
               byte_offset, module_state->rwdata_storage.data_length);
         }
         vm_global_store_f32(module_state->rwdata_storage.data, byte_offset,
@@ -2702,11 +2712,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
         IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
         IREE_VM_ISA_DISPATCH_DECODE_RESULT_F64(value);
         const uint32_t byte_offset = (uint32_t)byte_offset_i32;
-        if (IREE_UNLIKELY(byte_offset + 4 >
-                          module_state->rwdata_storage.data_length)) {
+        if (IREE_UNLIKELY(!iree_vm_bytecode_rwdata_range_ok(
+                byte_offset, 8, module_state->rwdata_storage.data_length))) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
-              "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
+              "global byte_offset out of range: %u (rwdata=%" PRIhsz ")",
               byte_offset, module_state->rwdata_storage.data_length);
         }
         const double global_value =
@@ -2718,11 +2728,11 @@ static iree_status_t iree_vm_bytecode_dispatch(
         IREE_VM_ISA_DISPATCH_DECODE_OPERAND_I32(byte_offset_i32);
         IREE_VM_ISA_DISPATCH_DECODE_OPERAND_F64(value);
         const uint32_t byte_offset = (uint32_t)byte_offset_i32;
-        if (IREE_UNLIKELY(byte_offset + 4 >
-                          module_state->rwdata_storage.data_length)) {
+        if (IREE_UNLIKELY(!iree_vm_bytecode_rwdata_range_ok(
+                byte_offset, 8, module_state->rwdata_storage.data_length))) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
-              "global byte_offset out of range: %d (rwdata=%" PRIhsz ")",
+              "global byte_offset out of range: %u (rwdata=%" PRIhsz ")",
               byte_offset, module_state->rwdata_storage.data_length);
         }
         vm_global_store_f64(module_state->rwdata_storage.data, byte_offset,

--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -668,11 +668,15 @@ iree_status_t iree_vm_bytecode_function_verify(
                                 verify_state->function_descriptors));       \
   }
 #define IREE_VM_ISA_VERIFY_RWDATA_OFFSET(name, access_length)               \
-  if (IREE_UNLIKELY(((name) + (access_length)) >                            \
-                    verify_state->rwdata_storage_size)) {                   \
+  /* Compare without adding so the check cannot overflow. */                \
+  if (IREE_UNLIKELY((iree_host_size_t)(access_length) >                     \
+                        verify_state->rwdata_storage_size ||                \
+                    (iree_host_size_t)(name) >                              \
+                        verify_state->rwdata_storage_size -                 \
+                            (iree_host_size_t)(access_length))) {           \
     return iree_make_status(                                                \
         IREE_STATUS_OUT_OF_RANGE,                                           \
-        "global byte_offset out of range: %d (rwdata=%" PRIhsz ")", (name), \
+        "global byte_offset out of range: %u (rwdata=%" PRIhsz ")", (name), \
         verify_state->rwdata_storage_size);                                 \
   }
 #define IREE_VM_ISA_VERIFY_GLOBAL_REF_ORDINAL(name)                        \
@@ -1960,13 +1964,13 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
 
     IREE_VM_ISA_VERIFY_OP(EXT_F64, GlobalLoadF64, {
       IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
-      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 4);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 8);
       IREE_VM_ISA_DECODE_RESULT_F64(value);
     });
 
     IREE_VM_ISA_VERIFY_OP(EXT_F64, GlobalStoreF64, {
       IREE_VM_ISA_DECODE_GLOBAL_ATTR(byte_offset);
-      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 4);
+      IREE_VM_ISA_VERIFY_RWDATA_OFFSET(byte_offset, 8);
       IREE_VM_ISA_DECODE_OPERAND_F64(value);
     });
 


### PR DESCRIPTION
## Summary

Two problems in the rwdata global bounds checks, both reachable from a `.vmfb` that passes verification.

`IREE_VM_ISA_VERIFY_RWDATA_OFFSET` in `verifier.c:670-677` computes `(name) + (access_length)` where `name` is a `uint32_t` decoded from the module. The addition happens in 32-bit, so `byte_offset = 0xFFFFFFFC` with an access length of 4 sums to 0 and passes against any `rwdata_storage_size`, including 0. The same unchecked add is used at all eight runtime checks for the indirect global ops in `dispatch.c`.

Separately, the F64 globals are verified with an access length of 4 while the op reads and writes 8 bytes. `verifier.c:1963` and `:1969` pass 4; the I64 globals at `:1061` and `:1067` correctly pass 8 for the same 8-byte access. The runtime checks for `GlobalLoadIndirectF64` and `GlobalStoreIndirectF64` at `dispatch.c:2705` and `:2721` have the same wrong length. An F64 global in the last 4 bytes of rwdata therefore verifies and then writes past the end.

`config.h:336-341` says bytecode verification "should be left on in all cases where untrusted inputs can be provided", so these are bypasses of that control rather than general untrusted-input concerns.

## Fix

Replaced the additive comparisons with subtraction so they cannot overflow on either 32-bit or 64-bit hosts, corrected the four F64 access lengths from 4 to 8, and routed the eight runtime checks through one shared helper so the pattern is not repeated per op.

The `IREE_ASSERT` checks on the direct ops are left alone since the verifier is the guard for those.

## Testing

Built with assertions on and ran the VM suite: 19/19 pass, no regressions. Also checked the new comparison against the old across the boundary cases. No offset that previously passed is now rejected. The only inputs whose behaviour changes are those that wrapped, plus F64 accesses in the final 4 bytes of rwdata, which were out of bounds and silently allowed.
