### PR TITLE
[Runtime][RISCV] Detect `Zvfbfwma` via hwprobe for the bf16 mmt4d ukernel

### DIFF
--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -406,6 +406,7 @@ struct riscv_hwprobe {
 #define IREE_RISCV_HWPROBE_IMA_V (1 << 2)
 #define IREE_RISCV_HWPROBE_EXT_ZVFH (1 << 30)
 #define IREE_RISCV_HWPROBE_EXT_ZVFHMIN (1ULL << 31)
+#define IREE_RISCV_HWPROBE_EXT_ZVFBFWMA (1ULL << 54)
 
 static struct riscv_hwprobe kv_pairs[] = {
     {IREE_RISCV_HWPROBE_KEY_IMA_EXT_0, 0}};
@@ -429,6 +430,8 @@ static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
                  IREE_RISCV_HWPROBE_EXT_ZVFHMIN);
   IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_ZVFH, hwprobe,
                  IREE_RISCV_HWPROBE_EXT_ZVFH);
+  IREE_COPY_BITS(out_fields[0], IREE_CPU_DATA0_RISCV_64_ZVFBFWMA, hwprobe,
+                 IREE_RISCV_HWPROBE_EXT_ZVFBFWMA);
 }
 
 #else


### PR DESCRIPTION
Without this bit being set the bf16 mmt4d tile functions added in #24695 are unreachable on every board: `iree_uk_mmt4d_p()` falls through to `iree_uk_mmt4d_select_tile_func_generic()` and runs a generic scalar tile.

Define `RISCV_HWPROBE_EXT_ZVFBFWMA` (bit 54, per the kernel uapi asm/hwprobe.h) and copy it alongside the neighbouring `ZVFH/ZVFHMIN` bits. `ZVFBFWMA` is currently the only bf16 extension with a `cpu_data` feature bit, so nothing else is added here.

Verified with iree-cpuinfo built for riscv64 on SpacemiT K3 board.

I was confused and didn't add it to #24695 both because i didn't have access to K3 then, but also because it had an older kernel (pre-[67bec4a](https://github.com/spacemit-com/linux-6.18/commit/67bec4a41806b04b2a92eae3c98c28c146c5e52e)) which didn't surface the Zvfbfwma in the device tree.