### PR TITLE
Fix arena allocation alignment at the block boundary

### DIFF
--- a/runtime/src/iree/base/internal/arena.c
+++ b/runtime/src/iree/base/internal/arena.c
@@ -204,11 +204,9 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
 
   iree_arena_block_pool_t* block_pool = arena->block_pool;
 
-  // Pad pooled allocations so each subsequent allocation starts aligned. Large
-  // requests skip this as they are serviced directly by the system allocator.
-  iree_host_size_t aligned_length = byte_length;
-  if (byte_length <= block_pool->usable_block_size &&
-      !iree_host_size_checked_align(byte_length, iree_max_align_t,
+  // Pad allocations so each subsequent allocation starts aligned.
+  iree_host_size_t aligned_length = 0;
+  if (!iree_host_size_checked_align(byte_length, iree_max_align_t,
                                     &aligned_length)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "alignment overflow");
   }
@@ -218,11 +216,9 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
     // allocate directly from the system allocator and track it ourselves for
     // freeing during reset.
     IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_arena_allocate_oversize");
-    const iree_host_size_t allocation_header_size =
-        iree_sizeof_struct(iree_arena_oversized_allocation_t);
     iree_host_size_t allocation_size = 0;
-    if (!iree_host_size_checked_add(allocation_header_size, byte_length,
-                                    &allocation_size)) {
+    if (!iree_host_size_checked_add(sizeof(iree_arena_oversized_allocation_t),
+                                    byte_length, &allocation_size)) {
       IREE_TRACE_ZONE_END(z0);
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "oversized allocation size overflow");
@@ -236,7 +232,7 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
     arena->allocation_head = allocation;
     arena->total_allocation_size += allocation_size;
     arena->used_allocation_size += byte_length;
-    *out_ptr = (uint8_t*)allocation + allocation_header_size;
+    *out_ptr = (uint8_t*)allocation + sizeof(iree_arena_oversized_allocation_t);
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
   }

--- a/runtime/src/iree/base/internal/arena.c
+++ b/runtime/src/iree/base/internal/arena.c
@@ -204,14 +204,25 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
 
   iree_arena_block_pool_t* block_pool = arena->block_pool;
 
-  if (byte_length > block_pool->usable_block_size) {
+  // Pad pooled allocations so each subsequent allocation starts aligned. Large
+  // requests skip this as they are serviced directly by the system allocator.
+  iree_host_size_t aligned_length = byte_length;
+  if (byte_length <= block_pool->usable_block_size &&
+      !iree_host_size_checked_align(byte_length, iree_max_align_t,
+                                    &aligned_length)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "alignment overflow");
+  }
+
+  if (aligned_length > block_pool->usable_block_size) {
     // Oversized allocation that can't be handled by the block pool. We'll
     // allocate directly from the system allocator and track it ourselves for
     // freeing during reset.
     IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_arena_allocate_oversize");
+    const iree_host_size_t allocation_header_size =
+        iree_sizeof_struct(iree_arena_oversized_allocation_t);
     iree_host_size_t allocation_size = 0;
-    if (!iree_host_size_checked_add(sizeof(iree_arena_oversized_allocation_t),
-                                    byte_length, &allocation_size)) {
+    if (!iree_host_size_checked_add(allocation_header_size, byte_length,
+                                    &allocation_size)) {
       IREE_TRACE_ZONE_END(z0);
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "oversized allocation size overflow");
@@ -225,17 +236,9 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
     arena->allocation_head = allocation;
     arena->total_allocation_size += allocation_size;
     arena->used_allocation_size += byte_length;
-    *out_ptr = (uint8_t*)allocation + sizeof(iree_arena_oversized_allocation_t);
+    *out_ptr = (uint8_t*)allocation + allocation_header_size;
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
-  }
-
-  // Pad length allocated so that each pointer bump is always ending at an
-  // aligned address and the next allocation will start aligned.
-  iree_host_size_t aligned_length = 0;
-  if (!iree_host_size_checked_align(byte_length, iree_max_align_t,
-                                    &aligned_length)) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "alignment overflow");
   }
 
   // Check to see if the current block (if any) has space - if not, get another.

--- a/runtime/src/iree/base/internal/arena.c
+++ b/runtime/src/iree/base/internal/arena.c
@@ -217,8 +217,9 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
     // freeing during reset.
     IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_arena_allocate_oversize");
     iree_host_size_t allocation_size = 0;
-    if (!iree_host_size_checked_add(sizeof(iree_arena_oversized_allocation_t),
-                                    byte_length, &allocation_size)) {
+    if (!iree_host_size_checked_add(
+            iree_sizeof_struct(iree_arena_oversized_allocation_t), byte_length,
+            &allocation_size)) {
       IREE_TRACE_ZONE_END(z0);
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "oversized allocation size overflow");
@@ -232,7 +233,8 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
     arena->allocation_head = allocation;
     arena->total_allocation_size += allocation_size;
     arena->used_allocation_size += byte_length;
-    *out_ptr = (uint8_t*)allocation + sizeof(iree_arena_oversized_allocation_t);
+    *out_ptr = (uint8_t*)allocation +
+               iree_sizeof_struct(iree_arena_oversized_allocation_t);
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
   }

--- a/runtime/src/iree/base/internal/arena.c
+++ b/runtime/src/iree/base/internal/arena.c
@@ -204,7 +204,14 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
 
   iree_arena_block_pool_t* block_pool = arena->block_pool;
 
-  if (byte_length > block_pool->usable_block_size) {
+  // Pad allocations so each subsequent allocation starts aligned.
+  iree_host_size_t aligned_length = 0;
+  if (!iree_host_size_checked_align(byte_length, iree_max_align_t,
+                                    &aligned_length)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "alignment overflow");
+  }
+
+  if (aligned_length > block_pool->usable_block_size) {
     // Oversized allocation that can't be handled by the block pool. We'll
     // allocate directly from the system allocator and track it ourselves for
     // freeing during reset.
@@ -228,14 +235,6 @@ iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
     *out_ptr = (uint8_t*)allocation + sizeof(iree_arena_oversized_allocation_t);
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
-  }
-
-  // Pad length allocated so that each pointer bump is always ending at an
-  // aligned address and the next allocation will start aligned.
-  iree_host_size_t aligned_length = 0;
-  if (!iree_host_size_checked_align(byte_length, iree_max_align_t,
-                                    &aligned_length)) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE, "alignment overflow");
   }
 
   // Check to see if the current block (if any) has space - if not, get another.

--- a/runtime/src/iree/base/internal/arena.h
+++ b/runtime/src/iree/base/internal/arena.h
@@ -153,7 +153,7 @@ void iree_arena_reset(iree_arena_allocator_t* arena);
 
 // Allocates |byte_length| contiguous bytes from the arena.
 // The returned bytes will have undefined contents and must be initialized by
-// the caller.
+// the caller. The returned pointer is aligned to iree_max_align_t.
 iree_status_t iree_arena_allocate(iree_arena_allocator_t* arena,
                                   iree_host_size_t byte_length, void** out_ptr);
 

--- a/runtime/src/iree/base/internal/arena_test.cc
+++ b/runtime/src/iree/base/internal/arena_test.cc
@@ -158,7 +158,37 @@ TEST(Arena, OversizedAllocation) {
   void* ptr = NULL;
   IREE_ASSERT_OK(iree_arena_allocate(&arena, kBlockSize * 4, &ptr));
   ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr) % iree_max_align_t, 0u);
   memset(ptr, 0xEF, kBlockSize * 4);
+
+  iree_arena_deinitialize(&arena);
+  iree_arena_block_pool_deinitialize(&pool);
+}
+
+TEST(Arena, RoundedSizeUsesOversizedAllocation) {
+  iree_arena_block_pool_t pool;
+  iree_arena_block_pool_initialize(kBlockSize, iree_allocator_system(), &pool);
+  const iree_host_size_t remainder =
+      pool.usable_block_size % iree_max_align_t;
+  if (remainder == 0) {
+    iree_arena_block_pool_deinitialize(&pool);
+    GTEST_SKIP() << "the default block capacity is naturally aligned";
+  }
+  iree_arena_allocator_t arena;
+  iree_arena_initialize(&pool, &arena);
+
+  // A request that fits before rounding may not fit after natural alignment.
+  const iree_host_size_t request_size =
+      pool.usable_block_size - remainder + 1;
+  void* ptr = NULL;
+  IREE_ASSERT_OK(iree_arena_allocate(&arena, request_size, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr) % iree_max_align_t, 0u);
+  EXPECT_EQ(arena.block_head, nullptr);
+  EXPECT_EQ(arena.block_tail, nullptr);
+  EXPECT_EQ(arena.block_bytes_remaining, 0);
+  EXPECT_NE(arena.allocation_head, nullptr);
+  memset(ptr, 0xEF, request_size);
 
   iree_arena_deinitialize(&arena);
   iree_arena_block_pool_deinitialize(&pool);

--- a/runtime/src/iree/base/internal/arena_test.cc
+++ b/runtime/src/iree/base/internal/arena_test.cc
@@ -167,19 +167,15 @@ TEST(Arena, OversizedAllocation) {
 
 TEST(Arena, RoundedSizeUsesOversizedAllocation) {
   iree_arena_block_pool_t pool;
-  iree_arena_block_pool_initialize(kBlockSize, iree_allocator_system(), &pool);
-  const iree_host_size_t remainder =
-      pool.usable_block_size % iree_max_align_t;
-  if (remainder == 0) {
-    iree_arena_block_pool_deinitialize(&pool);
-    GTEST_SKIP() << "the default block capacity is naturally aligned";
-  }
+  iree_arena_block_pool_initialize(kBlockSize + 1, iree_allocator_system(),
+                                   &pool);
+  const iree_host_size_t remainder = pool.usable_block_size % iree_max_align_t;
+  ASSERT_NE(remainder, 0);
   iree_arena_allocator_t arena;
   iree_arena_initialize(&pool, &arena);
 
   // A request that fits before rounding may not fit after natural alignment.
-  const iree_host_size_t request_size =
-      pool.usable_block_size - remainder + 1;
+  const iree_host_size_t request_size = pool.usable_block_size - remainder + 1;
   void* ptr = NULL;
   IREE_ASSERT_OK(iree_arena_allocate(&arena, request_size, &ptr));
   ASSERT_NE(ptr, nullptr);

--- a/runtime/src/iree/base/internal/arena_test.cc
+++ b/runtime/src/iree/base/internal/arena_test.cc
@@ -158,6 +158,7 @@ TEST(Arena, OversizedAllocation) {
   void* ptr = NULL;
   IREE_ASSERT_OK(iree_arena_allocate(&arena, kBlockSize * 4, &ptr));
   ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr) % iree_max_align_t, 0u);
   memset(ptr, 0xEF, kBlockSize * 4);
 
   iree_arena_deinitialize(&arena);

--- a/runtime/src/iree/base/internal/arena_test.cc
+++ b/runtime/src/iree/base/internal/arena_test.cc
@@ -164,6 +164,31 @@ TEST(Arena, OversizedAllocation) {
   iree_arena_block_pool_deinitialize(&pool);
 }
 
+TEST(Arena, RoundedSizeUsesOversizedAllocation) {
+  iree_arena_block_pool_t pool;
+  iree_arena_block_pool_initialize(kBlockSize + 1, iree_allocator_system(),
+                                   &pool);
+  const iree_host_size_t remainder = pool.usable_block_size % iree_max_align_t;
+  ASSERT_NE(remainder, 0);
+  iree_arena_allocator_t arena;
+  iree_arena_initialize(&pool, &arena);
+
+  // A request that fits before rounding may not fit after natural alignment.
+  const iree_host_size_t request_size = pool.usable_block_size - remainder + 1;
+  void* ptr = NULL;
+  IREE_ASSERT_OK(iree_arena_allocate(&arena, request_size, &ptr));
+  ASSERT_NE(ptr, nullptr);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr) % iree_max_align_t, 0u);
+  EXPECT_EQ(arena.block_head, nullptr);
+  EXPECT_EQ(arena.block_tail, nullptr);
+  EXPECT_EQ(arena.block_bytes_remaining, 0);
+  EXPECT_NE(arena.allocation_head, nullptr);
+  memset(ptr, 0xEF, request_size);
+
+  iree_arena_deinitialize(&arena);
+  iree_arena_block_pool_deinitialize(&pool);
+}
+
 TEST(Arena, Reset) {
   iree_arena_block_pool_t pool;
   iree_arena_block_pool_initialize(kBlockSize, iree_allocator_system(), &pool);


### PR DESCRIPTION
This fixes an arena edge case where a request fits in a block before alignment, but no longer fits after rounding. Such requests now use the oversized allocation path, and oversized allocations keep their returned pointers naturally aligned.

Added tests for both boundary cases.

Assisted by: Codex Sol