### PR TITLE
[PreProcessing] Support quantized convolutions in channels-last conversion

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -105,41 +105,38 @@ struct ConvertHwcfToFhwc : OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
   }
 };
 
-/// Transpose the generic form filter layout of `CHWF` or `CFHW` to `FHWC`.
+/// Transpose the generic form filter layout of `CHWF`, `CFHW`, or `HWCF` to
+/// `FHWC`. Also matches convolution-like generics with extra operands (e.g.
+/// quantization zero-points).
 struct ConvertGenericFilterToFhwc : OpRewritePattern<linalg::GenericOp> {
   using Base::Base;
 
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {
     auto linalgOp = cast<linalg::LinalgOp>(op.getOperation());
-    if (!linalgOp || !linalg::isaConvolutionOpInterface(linalgOp)) {
-      return failure();
-    }
-
-    FailureOr<mlir::linalg::ConvolutionDimensions> convolutionDims =
-        mlir::linalg::inferConvolutionDims(linalgOp);
-    if (failed(convolutionDims)) {
+    linalg::ConvolutionDimensions convolutionDims;
+    StringRef errString = getMatchConvolutionMessage(
+        linalg::detail::isConvolutionInterfaceImpl(linalgOp, &convolutionDims));
+    if (!errString.empty()) {
       return failure();
     }
 
     // Require non-empty filter, input and output channel dimensions.
-    if (convolutionDims->outputChannel.empty() ||
-        convolutionDims->inputChannel.empty() ||
-        convolutionDims->filterLoop.empty()) {
+    if (convolutionDims.outputChannel.empty() ||
+        convolutionDims.inputChannel.empty() ||
+        convolutionDims.filterLoop.empty()) {
       return failure();
     }
 
-    OpOperand *input = linalgOp.getDpsInputOperand(0);
-    OpOperand *filter = linalgOp.getDpsInputOperand(1);
-    OpOperand *output = linalgOp.getDpsInitOperand(0);
+    SmallVector<Value> inputs = linalgOp.getDpsInputs();
+    Value inputVal = inputs[0];
+    Value filterVal = inputs[1];
+    Value outputVal = linalgOp.getDpsInits()[0];
 
-    AffineMap inputMap = linalgOp.getMatchingIndexingMap(input);
-    AffineMap filterMap = linalgOp.getMatchingIndexingMap(filter);
-    AffineMap outputMap = linalgOp.getMatchingIndexingMap(output);
-
-    Value inputVal = input->get();
-    Value filterVal = filter->get();
-    Value outputVal = output->get();
+    auto indexingMaps = linalgOp.getIndexingMapsArray();
+    AffineMap inputMap = indexingMaps[0];
+    AffineMap filterMap = indexingMaps[1];
+    AffineMap outputMap = indexingMaps.back();
 
     ArrayRef<int64_t> inputShape =
         cast<ShapedType>(inputVal.getType()).getShape();
@@ -170,34 +167,35 @@ struct ConvertGenericFilterToFhwc : OpRewritePattern<linalg::GenericOp> {
 
     // Don't transpose when the input is in not batch-first layout (e.g., CHWN).
     SmallVector<int64_t> batchInputPos =
-        getDimPositions(convolutionDims->batch, inputMap);
+        getDimPositions(convolutionDims.batch, inputMap);
     if (!batchInputPos.empty() && batchInputPos.front() != 0) {
       return failure();
     }
 
-    // Only transpose when the filter is CHWF or CFHW layout.
+    // Only transpose when the filter is CHWF, CFHW, or HWCF layout.
     SmallVector<int64_t> fFilterPos =
-        getDimPositions(convolutionDims->outputChannel, filterMap);
+        getDimPositions(convolutionDims.outputChannel, filterMap);
     SmallVector<int64_t> cFilterPos =
-        getDimPositions(convolutionDims->inputChannel, filterMap);
+        getDimPositions(convolutionDims.inputChannel, filterMap);
     SmallVector<int64_t> kFilterPos =
-        getDimPositions(convolutionDims->filterLoop, filterMap);
+        getDimPositions(convolutionDims.filterLoop, filterMap);
     int64_t fPos = fFilterPos.back();
     int64_t cPos = cFilterPos.back();
 
     bool isChwf =
         (cPos < kFilterPos.front()) && (fPos == filterShape.size() - 1);
     bool isCfhw = (cPos < fFilterPos.front()) && (fPos < kFilterPos.front());
-    if (!isChwf && !isCfhw) {
+    bool isHwcf = (kFilterPos.back() < cPos) && (cPos < fPos);
+    if (!isChwf && !isCfhw && !isHwcf) {
       return failure();
     }
 
     // Don't transpose if it is a matmul and the input shape is small.
     // TODO(vivian): Solve the fusion of transpose op and remove this check.
     SmallVector<int64_t> imagePos =
-        getDimPositions(convolutionDims->outputImage, outputMap);
+        getDimPositions(convolutionDims.outputImage, outputMap);
     SmallVector<int64_t> batchPos =
-        getDimPositions(convolutionDims->batch, outputMap);
+        getDimPositions(convolutionDims.batch, outputMap);
     SmallVector<int64_t> mPos = imagePos;
     mPos.append(batchPos.begin(), batchPos.end());
 
@@ -246,11 +244,14 @@ struct ConvertGenericFilterToFhwc : OpRewritePattern<linalg::GenericOp> {
     SmallVector<utils::IteratorType> iterators =
         linalgOp.getIteratorTypesArray();
 
-    auto genericOp = linalg::GenericOp::create(
-        rewriter, loc, outputVal.getType(),
-        ValueRange{inputVal, barrierStartOp.getResult()}, outputVal,
-        ArrayRef<AffineMap>{inputMap, transposedFilterMap, outputMap},
-        iterators);
+    SmallVector<Value> newInputs = inputs;
+    newInputs[1] = barrierStartOp.getResult();
+    SmallVector<AffineMap> newMaps = indexingMaps;
+    newMaps[1] = transposedFilterMap;
+
+    auto genericOp =
+        linalg::GenericOp::create(rewriter, loc, outputVal.getType(), newInputs,
+                                  outputVal, newMaps, iterators);
 
     // Reuse the same payload as the original convolution op.
     rewriter.inlineRegionBefore(linalgOp->getRegion(0), genericOp.getRegion(),
@@ -261,10 +262,10 @@ struct ConvertGenericFilterToFhwc : OpRewritePattern<linalg::GenericOp> {
     unsigned numParallelLoop = genericOp.getNumParallelLoops();
     SmallVector<unsigned> interchange =
         llvm::to_vector(llvm::seq<unsigned>(0, numParallelLoop));
-    interchange.append(convolutionDims->filterLoop.begin(),
-                       convolutionDims->filterLoop.end());
-    interchange.append(convolutionDims->inputChannel.begin(),
-                       convolutionDims->inputChannel.end());
+    interchange.append(convolutionDims.filterLoop.begin(),
+                       convolutionDims.filterLoop.end());
+    interchange.append(convolutionDims.inputChannel.begin(),
+                       convolutionDims.inputChannel.end());
 
     FailureOr<linalg::GenericOp> reorderOp =
         linalg::interchangeGenericOp(rewriter, genericOp, interchange);

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
@@ -30,9 +30,9 @@ namespace mlir::iree_compiler::Preprocessing {
 #include "iree/compiler/Preprocessing/Common/Passes.h.inc" // IWYU pragma: export
 
 using ConvBuilderFn = std::function<Value(
-    OpBuilder &b, Location loc, linalg::LinalgOp srcConv, Value input,
-    Value filter, Value output, AffineMap inputMap, AffineMap filterMap,
-    AffineMap outputMap, SmallVector<unsigned> newDimOrder,
+    OpBuilder &b, Location loc, linalg::LinalgOp srcConv, ValueRange inputs,
+    Value output, ArrayRef<AffineMap> inputMaps, AffineMap outputMap,
+    SmallVector<unsigned> newDimOrder,
     SmallVector<utils::IteratorType> newIteratorTypes)>;
 using linalg::detail::MatchConvolutionResult;
 
@@ -41,33 +41,45 @@ using linalg::detail::MatchConvolutionResult;
 // on the map iterators for the new linalg op.
 static Value
 defaultConvBuilderFn(OpBuilder &b, Location loc, linalg::LinalgOp srcConv,
-                     Value input, Value filter, Value output,
-                     AffineMap inputMap, AffineMap filterMap,
-                     AffineMap outputMap, SmallVector<unsigned> newDimOrder,
+                     ValueRange inputs, Value output,
+                     ArrayRef<AffineMap> inputMaps, AffineMap outputMap,
+                     SmallVector<unsigned> newDimOrder,
                      SmallVector<utils::IteratorType> newIteratorTypes) {
-  AffineMap newInputMap = inputMap;
-  AffineMap newFilterMap = filterMap;
+  SmallVector<AffineMap> newInputMaps(inputMaps.begin(), inputMaps.end());
   AffineMap newOutputMap = outputMap;
   if (!newDimOrder.empty()) {
     DenseMap<AffineExpr, AffineExpr> dimMap;
     for (auto [newDim, oldDim] : llvm::enumerate(newDimOrder)) {
       dimMap[b.getAffineDimExpr(oldDim)] = b.getAffineDimExpr(newDim);
     }
-    newInputMap = inputMap.replace(dimMap,
-                                   /*numResultDims=*/newDimOrder.size(),
-                                   /*numResultSymbols=*/0);
-    newFilterMap = filterMap.replace(dimMap,
-                                     /*numResultDims=*/newDimOrder.size(),
-                                     /*numResultSymbols=*/0);
+    for (auto &map : newInputMaps) {
+      map = map.replace(dimMap,
+                        /*numResultDims=*/newDimOrder.size(),
+                        /*numResultSymbols=*/0);
+    }
     newOutputMap = outputMap.replace(dimMap,
                                      /*numResultDims=*/newDimOrder.size(),
                                      /*numResultSymbols=*/0);
+  } else {
+    // Tiling path: the transposed input/filter maps already account for the
+    // new tiled dims, but any other pass-through operand maps (e.g.
+    // quantization zero-points) still have the original dim count. Extend
+    // them to match the new iteration space; their results are
+    // dimension-independent so no remapping is needed.
+    unsigned newNumDims = outputMap.getNumDims();
+    for (auto &map : newInputMaps) {
+      if (map.getNumDims() != newNumDims) {
+        map = AffineMap::get(newNumDims, map.getNumSymbols(), map.getResults(),
+                             map.getContext());
+      }
+    }
   }
   SmallVector<utils::IteratorType> iterators = srcConv.getIteratorTypesArray();
   iterators.append(newIteratorTypes);
-  auto genericConv = linalg::GenericOp::create(
-      b, loc, output.getType(), ValueRange{input, filter}, output,
-      ArrayRef<AffineMap>{newInputMap, newFilterMap, newOutputMap}, iterators);
+  SmallVector<AffineMap> indexingMaps = newInputMaps;
+  indexingMaps.push_back(newOutputMap);
+  auto genericConv = linalg::GenericOp::create(b, loc, output.getType(), inputs,
+                                               output, indexingMaps, iterators);
   IRMapping mapper;
   srcConv->getRegion(0).cloneInto(&genericConv.getRegion(), mapper);
   return genericConv.getResult(0);
@@ -76,14 +88,14 @@ defaultConvBuilderFn(OpBuilder &b, Location loc, linalg::LinalgOp srcConv,
 template <typename sourceNamedConvTy, typename targetNamedConvTy>
 static Value
 namedConvBuilderFn(OpBuilder &b, Location loc, linalg::LinalgOp srcConv,
-                   Value input, Value filter, Value output, AffineMap inputMap,
-                   AffineMap filterMap, AffineMap outputMap,
+                   ValueRange inputs, Value output,
+                   ArrayRef<AffineMap> inputMaps, AffineMap outputMap,
                    SmallVector<unsigned> newDimOrder,
                    SmallVector<utils::IteratorType> newIteratorTypes) {
   sourceNamedConvTy namedConv = cast<sourceNamedConvTy>(srcConv);
-  return targetNamedConvTy::create(
-             b, loc, output.getType(), ValueRange{input, filter}, output,
-             namedConv.getStrides(), namedConv.getDilations())
+  return targetNamedConvTy::create(b, loc, output.getType(), inputs, output,
+                                   namedConv.getStrides(),
+                                   namedConv.getDilations())
       .getResult(0);
 }
 
@@ -355,13 +367,15 @@ transposeConvLikeLinalgOp(PatternRewriter &rewriter, linalg::LinalgOp convOp,
     return failure();
   }
 
-  Value input = convOp->getOperand(0);
-  Value filter = convOp->getOperand(1);
-  Value output = convOp->getOperand(2);
+  SmallVector<Value> inputs = convOp.getDpsInputs();
+  Value input = inputs[0];
+  Value filter = inputs[1];
+  Value output = convOp.getDpsInits()[0];
 
-  auto inputMap = convOp.getIndexingMapsArray()[0];
-  auto filterMap = convOp.getIndexingMapsArray()[1];
-  auto outputMap = convOp.getIndexingMapsArray()[2];
+  auto indexingMaps = convOp.getIndexingMapsArray();
+  auto inputMap = indexingMaps[0];
+  auto filterMap = indexingMaps[1];
+  auto outputMap = indexingMaps.back();
 
   SmallVector<int64_t> inputIndices =
       collectChannelInnerDimsIndices(inputMap, convDims.inputChannel);
@@ -422,13 +436,22 @@ transposeConvLikeLinalgOp(PatternRewriter &rewriter, linalg::LinalgOp convOp,
                             utils::IteratorType::parallel);
   }
 
+  // Update inputs and their maps.
+  SmallVector<Value> newInputs = inputs;
+  newInputs[0] = transposedInput;
+  newInputs[1] = transposedFilter;
+
+  SmallVector<AffineMap> newInputMaps(indexingMaps.begin(),
+                                      indexingMaps.begin() + inputs.size());
+  newInputMaps[0] = transposedInputMap;
+  newInputMaps[1] = transposedFilterMap;
+
   // Invoke the builder function. For named op -> named op conversions, this
   // will construct the target named op, else it constructs a convolution like
   // generic.
-  Value transposedConvResult =
-      convBuilder(rewriter, loc, convOp, transposedInput, transposedFilter,
-                  transposedOutput, transposedInputMap, transposedFilterMap,
-                  transposedOutputMap, newDimOrder, newIteratorTypes);
+  Value transposedConvResult = convBuilder(
+      rewriter, loc, convOp, newInputs, transposedOutput, newInputMaps,
+      transposedOutputMap, newDimOrder, newIteratorTypes);
 
   Value returnToNCHW = transposedConvResult;
   if (outputPack) {

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -130,7 +130,7 @@ util.func public @conv_2d_nhwgc_gchwf(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
-util.func public @conv_2d_nhwc_hwcf_no_transpose(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+util.func public @conv_2d_nhwc_hwcf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>) outs(%arg2 : tensor<1x14x14x16xf32>) {
   ^bb0(%in: f32, %in_0: f32, %out: f32):
     %3 = arith.mulf %in, %in_0 : f32
@@ -140,8 +140,17 @@ util.func public @conv_2d_nhwc_hwcf_no_transpose(%arg0: tensor<1x16x16x4xf32>, %
   util.return %0 : tensor<1x14x14x16xf32>
 }
 
-// CHECK-FHWC-LABEL:  @conv_2d_nhwc_hwcf_no_transpose
-// CHECK-FHWC-NOT:    linalg.transpose
+// CHECK-FHWC: #[[$MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+// CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+
+// CHECK-FHWC-LABEL:  @conv_2d_nhwc_hwcf
+// CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<16x3x3x4xf32>
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<3x3x4x16xf32>) outs(%[[EMPTY]] : tensor<16x3x3x4xf32>)
+// CHECK-FHWC-SAME:   permutation = [3, 0, 1, 2]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
+// CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<1x16x16x4xf32>, tensor<16x3x3x4xf32>)
 
 // -----
 
@@ -250,3 +259,199 @@ util.func public @conv_2d_nhwgc_gcfhw(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
 // CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2],
 // CHECK-FHWC-SAME:   ins({{.*}}, %[[START]] : tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
+
+// -----
+
+// Quantized (multi-operand) NHWC/HWCF convolution generic (e.g. QLinearConv
+// with zero-point operands). Supported under fhwc layout, with the
+// zero-points forwarded untouched; unsupported under hwfc layout.
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @conv_2d_nhwc_hwcf_q(%arg0: tensor<8x16x16x256xi8>, %arg1: tensor<3x3x256x16xi8>, %arg2: tensor<8x14x14x16xi32>) -> tensor<8x14x14x16xi32> {
+  %zp_input = arith.constant 0 : i32
+  %zp_filter = arith.constant 0 : i32
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1, %zp_input, %zp_filter : tensor<8x16x16x256xi8>, tensor<3x3x256x16xi8>, i32, i32) outs(%arg2 : tensor<8x14x14x16xi32>) {
+  ^bb0(%in: i8, %in_0: i8, %zi: i32, %zf: i32, %out: i32):
+    %1 = arith.extsi %in : i8 to i32
+    %2 = arith.subi %1, %zi : i32
+    %3 = arith.extsi %in_0 : i8 to i32
+    %4 = arith.subi %3, %zf : i32
+    %5 = arith.muli %2, %4 : i32
+    %6 = arith.addi %out, %5 : i32
+    linalg.yield %6 : i32
+  } -> tensor<8x14x14x16xi32>
+  util.return %0 : tensor<8x14x14x16xi32>
+}
+
+// CHECK-FHWC: #[[$MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+
+// CHECK-FHWC-LABEL:  @conv_2d_nhwc_hwcf_q
+// CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<16x3x3x256xi8>
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<3x3x256x16xi8>) outs(%[[EMPTY]] : tensor<16x3x3x256xi8>)
+// CHECK-FHWC-SAME:   permutation = [3, 0, 1, 2]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME:   indexing_maps = [#map, #[[$MAP0]], #map2, #map2, #map3],
+// CHECK-FHWC-SAME:   ins(%arg0, %[[START]], %{{.*}}, %{{.*}} : tensor<8x16x16x256xi8>, tensor<16x3x3x256xi8>, i32, i32)
+
+// CHECK-HWFC-LABEL:  @conv_2d_nhwc_hwcf_q
+// CHECK-HWFC-NOT:    linalg.transpose
+
+// -----
+
+// Quantized (multi-operand) CHWF convolution generic.
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d5, d2 + d6, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @conv_2d_nhwc_chwf_q(%arg0: tensor<1x16x16x4xi8>, %arg1: tensor<4x3x3x16xi8>, %arg2: tensor<1x14x14x16xi32>) -> tensor<1x14x14x16xi32> {
+  %zp_input = arith.constant 0 : i32
+  %zp_filter = arith.constant 0 : i32
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1, %zp_input, %zp_filter : tensor<1x16x16x4xi8>, tensor<4x3x3x16xi8>, i32, i32) outs(%arg2 : tensor<1x14x14x16xi32>) {
+  ^bb0(%in: i8, %in_0: i8, %zi: i32, %zf: i32, %out: i32):
+    %1 = arith.extsi %in : i8 to i32
+    %2 = arith.subi %1, %zi : i32
+    %3 = arith.extsi %in_0 : i8 to i32
+    %4 = arith.subi %3, %zf : i32
+    %5 = arith.muli %2, %4 : i32
+    %6 = arith.addi %out, %5 : i32
+    linalg.yield %6 : i32
+  } -> tensor<1x14x14x16xi32>
+  util.return %0 : tensor<1x14x14x16xi32>
+}
+
+// CHECK-FHWC: #[[$MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+// CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+
+// CHECK-FHWC-LABEL:  @conv_2d_nhwc_chwf_q
+// CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<16x3x3x4xi8>
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<4x3x3x16xi8>) outs(%[[EMPTY]] : tensor<16x3x3x4xi8>)
+// CHECK-FHWC-SAME:   permutation = [3, 1, 2, 0]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2, #map2, #map3],
+// CHECK-FHWC-SAME:   ins(%arg0, %[[START]], %{{.*}}, %{{.*}} : tensor<1x16x16x4xi8>, tensor<16x3x3x4xi8>, i32, i32)
+
+// CHECK-HWFC-LABEL:  @conv_2d_nhwc_chwf_q
+// CHECK-HWFC-NOT:    linalg.transpose
+
+// -----
+
+// Quantized (multi-operand) grouped (5D, GCHWF) convolution generic.
+
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1 + d5, d2 + d6, d3, d7)>
+#map5 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d3, d7, d5, d6, d4)>
+#map6 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>
+#map7 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4)>
+util.func public @conv_2d_nhwgc_gchwf_q(%arg0: tensor<2x10x10x7x4xi8>, %arg1: tensor<7x4x3x3x16xi8>, %arg2: tensor<2x8x8x7x16xi32>) -> tensor<2x8x8x7x16xi32> {
+  %zp_input = arith.constant 0 : i32
+  %zp_filter = arith.constant 0 : i32
+  %0 = linalg.generic {indexing_maps = [#map4, #map5, #map6, #map6, #map7], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1, %zp_input, %zp_filter : tensor<2x10x10x7x4xi8>, tensor<7x4x3x3x16xi8>, i32, i32) outs(%arg2 : tensor<2x8x8x7x16xi32>) {
+  ^bb0(%in: i8, %in_0: i8, %zi: i32, %zf: i32, %out: i32):
+    %1 = arith.extsi %in : i8 to i32
+    %2 = arith.subi %1, %zi : i32
+    %3 = arith.extsi %in_0 : i8 to i32
+    %4 = arith.subi %3, %zf : i32
+    %5 = arith.muli %2, %4 : i32
+    %6 = arith.addi %out, %5 : i32
+    linalg.yield %6 : i32
+  } -> tensor<2x8x8x7x16xi32>
+  util.return %0 : tensor<2x8x8x7x16xi32>
+}
+
+// CHECK-FHWC: #[[$MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1 + d5, d2 + d6, d3, d7)>
+// CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d3, d4, d5, d6, d7)>
+
+// CHECK-FHWC-LABEL:  @conv_2d_nhwgc_gchwf_q
+// CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<7x16x3x3x4xi8>
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<7x4x3x3x16xi8>) outs(%[[EMPTY]] : tensor<7x16x3x3x4xi8>)
+// CHECK-FHWC-SAME:   permutation = [0, 4, 2, 3, 1]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2, #map2, #map3],
+// CHECK-FHWC-SAME:   ins(%arg0, %[[START]], %{{.*}}, %{{.*}} : tensor<2x10x10x7x4xi8>, tensor<7x16x3x3x4xi8>, i32, i32)
+
+// CHECK-HWFC-LABEL:  @conv_2d_nhwgc_gchwf_q
+// CHECK-HWFC-NOT:    linalg.transpose
+
+// -----
+
+// Quantized (multi-operand) CFHW convolution generic.
+
+#map8 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d5, d2 + d6, d4)>
+#map9 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d3, d5, d6)>
+#map10 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>
+#map11 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @conv_2d_nhwc_cfhw_q(%arg0: tensor<1x16x16x4xi8>, %arg1: tensor<4x16x3x3xi8>, %arg2: tensor<1x14x14x16xi32>) -> tensor<1x14x14x16xi32> {
+  %zp_input = arith.constant 0 : i32
+  %zp_filter = arith.constant 0 : i32
+  %0 = linalg.generic {indexing_maps = [#map8, #map9, #map10, #map10, #map11], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1, %zp_input, %zp_filter : tensor<1x16x16x4xi8>, tensor<4x16x3x3xi8>, i32, i32) outs(%arg2 : tensor<1x14x14x16xi32>) {
+  ^bb0(%in: i8, %in_0: i8, %zi: i32, %zf: i32, %out: i32):
+    %1 = arith.extsi %in : i8 to i32
+    %2 = arith.subi %1, %zi : i32
+    %3 = arith.extsi %in_0 : i8 to i32
+    %4 = arith.subi %3, %zf : i32
+    %5 = arith.muli %2, %4 : i32
+    %6 = arith.addi %out, %5 : i32
+    linalg.yield %6 : i32
+  } -> tensor<1x14x14x16xi32>
+  util.return %0 : tensor<1x14x14x16xi32>
+}
+
+// CHECK-FHWC: #[[$MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>
+// CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+
+// CHECK-FHWC-LABEL:  @conv_2d_nhwc_cfhw_q
+// CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<16x3x3x4xi8>
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<4x16x3x3xi8>) outs(%[[EMPTY]] : tensor<16x3x3x4xi8>)
+// CHECK-FHWC-SAME:   permutation = [1, 2, 3, 0]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2, #map2, #map3],
+// CHECK-FHWC-SAME:   ins(%arg0, %[[START]], %{{.*}}, %{{.*}} : tensor<1x16x16x4xi8>, tensor<16x3x3x4xi8>, i32, i32)
+
+// CHECK-HWFC-LABEL:  @conv_2d_nhwc_cfhw_q
+// CHECK-HWFC-NOT:    linalg.transpose
+
+// -----
+
+// Quantized (multi-operand) grouped (5D, GCFHW) convolution generic.
+
+#map12 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1 + d5, d2 + d6, d3, d7)>
+#map13 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d3, d7, d4, d5, d6)>
+#map14 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>
+#map15 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4)>
+util.func public @conv_2d_nhwgc_gcfhw_q(%arg0: tensor<2x10x10x7x4xi8>, %arg1: tensor<7x4x16x3x3xi8>, %arg2: tensor<2x8x8x7x16xi32>) -> tensor<2x8x8x7x16xi32> {
+  %zp_input = arith.constant 0 : i32
+  %zp_filter = arith.constant 0 : i32
+  %0 = linalg.generic {indexing_maps = [#map12, #map13, #map14, #map14, #map15], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1, %zp_input, %zp_filter : tensor<2x10x10x7x4xi8>, tensor<7x4x16x3x3xi8>, i32, i32) outs(%arg2 : tensor<2x8x8x7x16xi32>) {
+  ^bb0(%in: i8, %in_0: i8, %zi: i32, %zf: i32, %out: i32):
+    %1 = arith.extsi %in : i8 to i32
+    %2 = arith.subi %1, %zi : i32
+    %3 = arith.extsi %in_0 : i8 to i32
+    %4 = arith.subi %3, %zf : i32
+    %5 = arith.muli %2, %4 : i32
+    %6 = arith.addi %out, %5 : i32
+    linalg.yield %6 : i32
+  } -> tensor<2x8x8x7x16xi32>
+  util.return %0 : tensor<2x8x8x7x16xi32>
+}
+
+// CHECK-FHWC: #[[$MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1 + d5, d2 + d6, d3, d7)>
+// CHECK-FHWC: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d3, d4, d5, d6, d7)>
+
+// CHECK-FHWC-LABEL:  @conv_2d_nhwgc_gcfhw_q
+// CHECK-FHWC:        %[[EMPTY:.*]] = tensor.empty() : tensor<7x16x3x3x4xi8>
+// CHECK-FHWC:        %[[TRANSPOSE:.*]] = linalg.transpose ins({{.*}} : tensor<7x4x16x3x3xi8>) outs(%[[EMPTY]] : tensor<7x16x3x3x4xi8>)
+// CHECK-FHWC-SAME:   permutation = [0, 2, 3, 4, 1]
+// CHECK-FHWC:        %[[START:.*]] = iree_tensor_ext.compute_barrier.start %[[TRANSPOSE]]
+// CHECK-FHWC:        %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME:   indexing_maps = [#[[$MAP0]], #[[$MAP1]], #map2, #map2, #map3],
+// CHECK-FHWC-SAME:   ins(%arg0, %[[START]], %{{.*}}, %{{.*}} : tensor<2x10x10x7x4xi8>, tensor<7x16x3x3x4xi8>, i32, i32)
+
+// CHECK-HWFC-LABEL:  @conv_2d_nhwgc_gcfhw_q
+// CHECK-HWFC-NOT:    linalg.transpose

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_to_channels_last.mlir
@@ -119,6 +119,46 @@ module {
 
 // -----
 
+// Quantized convolution (e.g. lowered from ONNX QLinearConv) carrying extra
+// zero-point scalar operands beyond the usual input/filter/output. The extra
+// operands must be forwarded untouched by both the plain transpose path and
+// the tiled/pack path.
+
+util.func @conv_nchw_fchw_q(%arg0: tensor<8x256x16x16xi8>, %arg1: tensor<16x256x3x3xi8>,
+                            %arg2: tensor<8x16x14x14xi32>) -> tensor<8x16x14x14xi32> {
+  %zp_input = arith.constant 0 : i32
+  %zp_filter = arith.constant 0 : i32
+  %0 = linalg.conv_2d_nchw_fchw_q
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+    ins(%arg0, %arg1, %zp_input, %zp_filter
+        : tensor<8x256x16x16xi8>, tensor<16x256x3x3xi8>, i32, i32)
+    outs(%arg2 : tensor<8x16x14x14xi32>) -> tensor<8x16x14x14xi32>
+  util.return %0 : tensor<8x16x14x14xi32>
+}
+
+// CHECK-LABEL: util.func public @conv_nchw_fchw_q
+
+// CHECK:         %[[IMG:.+]] = linalg.transpose ins(%{{.*}} : tensor<8x256x16x16xi8>)
+// CHECK-SAME:      outs(%{{.*}} : tensor<8x16x16x256xi8>) permutation = [0, 2, 3, 1]
+// CHECK:         %[[FILTER:.+]] = linalg.transpose ins(%{{.*}} : tensor<16x256x3x3xi8>)
+// CHECK-SAME:      outs(%{{.*}} : tensor<3x3x256x16xi8>) permutation = [2, 3, 1, 0]
+// CHECK:         %[[OUT:.+]] = linalg.transpose ins(%{{.*}} : tensor<8x16x14x14xi32>)
+// CHECK-SAME:      outs(%{{.*}} : tensor<8x14x14x16xi32>) permutation = [0, 2, 3, 1]
+
+// CHECK:         linalg.generic
+// CHECK-SAME:      ins(%[[IMG]], %[[FILTER]], %{{.*}}, %{{.*}} : tensor<8x16x16x256xi8>, tensor<3x3x256x16xi8>, i32, i32)
+// CHECK-SAME:      outs(%[[OUT]] : tensor<8x14x14x16xi32>)
+
+// TILE16-LABEL: util.func public @conv_nchw_fchw_q
+// TILE16:      %[[IMG:.+]] = linalg.pack {{.*}} inner_dims_pos = [1] inner_tiles = [16]
+// TILE16-SAME:   tensor<8x256x16x16xi8> -> tensor<8x16x16x16x16xi8>
+// TILE16:      %[[FILTER:.+]] = linalg.pack {{.*}} inner_dims_pos = [1, 0] inner_tiles = [16, 16]
+// TILE16-SAME:   tensor<16x256x3x3xi8> -> tensor<1x16x3x3x16x16xi8>
+// TILE16:      linalg.generic
+// TILE16-SAME:   ins(%[[IMG]], %[[FILTER]], %{{.*}}, %{{.*}} : tensor<8x16x16x16x16xi8>, tensor<1x16x3x3x16x16xi8>, i32, i32)
+
+// -----
+
 // Not a convolution, should not be transposed.
 
 util.func @mmt_no_transpose(%arg0: tensor<2048x1280xf16>, %arg1: tensor<1280x1280xf16>) -> tensor<2048x1280xf32> {


### PR DESCRIPTION
Added Support for quantized convolutions in the convert-conv-to-channel-last conversion pass & support for conversion of conv Filter to channel-last (HWCF -  FHWC)

Added Lit Test Cases for the quatized convolution operations and modified test case IR to support HWCF pattern.


Fixes #24774

Assisted-by : Claude Code 