### PR TITLE
[VM] Fix ref ownership in branch remaps

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Dialect/VM/Analysis/LinearScan/LiveIntervals.h"
 #include "iree/compiler/Dialect/VM/Analysis/LinearScan/RegisterBank.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/IR/Attributes.h"
@@ -58,6 +59,7 @@ LogicalResult RegisterAllocation::annotateIR(IREE::VM::FuncOp funcOp) {
         llvm::DenseMap<unsigned, Register> branchOperandRegs;
         if (auto branchOp = dyn_cast<BranchOpInterface>(&op)) {
           for (unsigned i = 0; i < op.getNumSuccessors(); ++i) {
+            Block *targetBlock = op.getSuccessor(i);
             auto srcDstRegs =
                 registerAllocation.remapSuccessorRegisters(&op, i);
             auto succOperands =
@@ -75,9 +77,18 @@ LogicalResult RegisterAllocation::annotateIR(IREE::VM::FuncOp funcOp) {
             // in this successor's operand list can get MOVE (matches
             // remapSuccessorRegisters logic).
             llvm::DenseMap<Value, unsigned> lastOccurrence;
+            llvm::DenseMap<Value, unsigned> refOccurrenceCounts;
+            llvm::DenseSet<Value> coalescedRefValues;
             for (auto [idx, operand] : llvm::enumerate(succOperands)) {
               if (isa<IREE::VM::RefType>(operand.getType())) {
                 lastOccurrence[operand] = idx;
+                ++refOccurrenceCounts[operand];
+                auto srcReg = registerAllocation.mapToRegister(operand);
+                auto dstReg = registerAllocation.mapToRegister(
+                    targetBlock->getArgument(idx));
+                if (srcReg == dstReg) {
+                  coalescedRefValues.insert(operand);
+                }
               }
             }
 
@@ -91,7 +102,24 @@ LogicalResult RegisterAllocation::annotateIR(IREE::VM::FuncOp funcOp) {
                 bool isLastUse =
                     registerAllocation.liveness_.isLastRealValueUse(
                         operand, &op, globalIdx);
-                if (isLastOccurrence && isLastUse) {
+                auto dstReg = registerAllocation.mapToRegister(
+                    targetBlock->getArgument(localIdx));
+                bool transfersOnTargetEdge =
+                    srcReg != dstReg &&
+                    !llvm::is_contained(
+                        registerAllocation.liveness_.getBlockLiveIns(
+                            targetBlock),
+                        operand);
+                isLastUse |= transfersOnTargetEdge;
+                bool isMovable = false;
+                if (auto moveOp = dyn_cast<IREE::VM::RefMoveInterface>(&op)) {
+                  isMovable = moveOp.isRefOperandMovable(globalIdx);
+                }
+                bool hasCoalescedDuplicate =
+                    refOccurrenceCounts.lookup(operand) > 1 &&
+                    coalescedRefValues.contains(operand);
+                if (isLastOccurrence && isLastUse && isMovable &&
+                    !hasCoalescedDuplicate) {
                   srcReg.setMove(true);
                 }
               }
@@ -791,11 +819,13 @@ RegisterAllocation::remapSuccessorRegisters(Location loc, Block *targetBlock,
 // - MOVE transfers ownership (runtime nulls source after copy)
 // - No MOVE retains (runtime increments refcount of destination)
 //
-// MOVE is set when all three conditions are true:
+// MOVE is set when all four conditions are true:
 // 1. This is the last occurrence of the ref value in this successor's list
 //    (handles same ref appearing multiple times like `^bb(%ref, %ref)`)
-// 2. The ref is not live after this branch (checked via isLastRealValueUse)
+// 2. The ref is not live after this branch globally or on the selected edge
 // 3. The branch op supports MOVE on this operand (RefMoveInterface)
+// 4. The value is not duplicated with one occurrence coalesced with its
+//    destination block argument
 //
 // MOVE on back-edges (loops) is CORRECT:
 // - Ownership transfers to the next iteration's block argument
@@ -818,9 +848,17 @@ RegisterAllocation::remapSuccessorRegisters(Operation *branchOp,
   // Only the last occurrence of a value can get MOVE (for multi-use cases like
   // passing same ref to both branches of cond_br).
   llvm::DenseMap<Value, unsigned> lastOccurrence;
+  llvm::DenseMap<Value, unsigned> refOccurrenceCounts;
+  llvm::DenseSet<Value> coalescedRefValues;
   for (auto [idx, operand] : llvm::enumerate(targetOperands)) {
     if (isa<IREE::VM::RefType>(operand.getType())) {
       lastOccurrence[operand] = idx;
+      ++refOccurrenceCounts[operand];
+      auto srcReg = mapToRegister(operand);
+      auto dstReg = mapToRegister(targetBlock->getArgument(idx));
+      if (srcReg == dstReg) {
+        coalescedRefValues.insert(operand);
+      }
     }
   }
 
@@ -842,6 +880,14 @@ RegisterAllocation::remapSuccessorRegisters(Operation *branchOp,
       bool isLastUse =
           liveness_.isLastRealValueUse(operand, branchOp, globalOperandIndex);
 
+      // A branch may keep a value live on one successor while transferring it
+      // on another. For a non-coalesced remap, MOVE is safe when the original
+      // value is not live-in to this specific target block.
+      bool transfersOnTargetEdge =
+          srcReg != dstReg &&
+          !llvm::is_contained(liveness_.getBlockLiveIns(targetBlock), operand);
+      isLastUse |= transfersOnTargetEdge;
+
       // Check if the branch op supports MOVE on this operand.
       bool isMovable = false;
       if (auto moveOp = dyn_cast<IREE::VM::RefMoveInterface>(branchOp)) {
@@ -852,9 +898,15 @@ RegisterAllocation::remapSuccessorRegisters(Operation *branchOp,
       // 1. This is the last occurrence in this successor's operand list
       // 2. This is the last real use of the value (not live after branch)
       // 3. The branch op supports MOVE on this operand
+      // 4. The value is not duplicated with one occurrence coalesced with its
+      //    destination. A MOVE on another occurrence would clear the
+      //    coalesced register.
       // Note: MOVE is correct even on back-edges. The ref ownership transfers
       // to the destination block arg, which is correct for loop-carried values.
-      if (isLastOccurrence && isLastUse && isMovable) {
+      bool hasCoalescedDuplicate = refOccurrenceCounts.lookup(operand) > 1 &&
+                                   coalescedRefValues.contains(operand);
+      if (isLastOccurrence && isLastUse && isMovable &&
+          !hasCoalescedDuplicate) {
         srcReg.setMove(true);
       }
     }

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/test/register_allocation_refs.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/test/register_allocation_refs.mlir
@@ -216,6 +216,24 @@ vm.module @module_diamond {
     vm.return
   }
 
+  // CHECK-LABEL: @diamond_forward_or_use
+  // A ref can transfer on one edge while remaining live on another. The
+  // non-coalesced forwarding edge must MOVE to avoid retaining a stale source.
+  vm.func @diamond_forward_or_use(%cond : i32, %buf : !vm.buffer) {
+    // CHECK: vm.cond_br
+    // CHECK-SAME: operand_registers = ["i0", "R0"]
+    // CHECK-SAME: remap_registers = {{\[}}{{\[}}"R0->r1"{{\]}}, {{\[}}{{\]}}{{\]}}
+    vm.cond_br %cond, ^forward(%buf : !vm.buffer), ^use_original
+  ^forward(%forwarded : !vm.buffer):
+    vm.call @consume_buffer(%forwarded) : (!vm.buffer) -> ()
+    vm.discard.refs %forwarded : !vm.buffer
+    vm.return
+  ^use_original:
+    vm.call @consume_buffer(%buf) : (!vm.buffer) -> ()
+    vm.discard.refs %buf : !vm.buffer
+    vm.return
+  }
+
   // CHECK-LABEL: @diamond_asymmetric_call
   // Diamond where one path calls with ref, other doesn't use it.
   vm.func @diamond_asymmetric_call(%cond : i32, %buf : !vm.buffer) {
@@ -683,6 +701,7 @@ vm.module @module_mixed {
 vm.module @module_same_target {
 
   vm.import private @consume_buffer(%buf : !vm.buffer)
+  vm.import private @use_two_buffers(%a : !vm.buffer, %b : !vm.buffer)
 
   // CHECK-LABEL: @same_ref_both_edges_same_target
   // cond_br where both edges go to same block with same ref.
@@ -699,6 +718,23 @@ vm.module @module_same_target {
     vm.call @consume_buffer(%b) : (!vm.buffer) -> ()
     // CHECK: vm.discard.refs
     vm.discard.refs %b : !vm.buffer
+    vm.return
+  }
+
+  // CHECK-LABEL: @same_ref_multiple_args_same_target
+  // When one destination coalesces with the source register, another
+  // destination must retain instead of moving and clearing that register.
+  vm.func @same_ref_multiple_args_same_target(%buf : !vm.buffer) {
+    // CHECK: vm.br
+    // CHECK-SAME: operand_registers = ["r0", "r0"]
+    // CHECK-SAME: remap_registers = {{\[}}{{\[}}"r0->r1"{{\]}}{{\]}}
+    vm.br ^merge(%buf, %buf : !vm.buffer, !vm.buffer)
+  ^merge(%a : !vm.buffer, %b : !vm.buffer):
+    // CHECK: vm.call @use_two_buffers
+    // CHECK-SAME: operand_registers = ["R0", "R1"]
+    vm.call @use_two_buffers(%a, %b) : (!vm.buffer, !vm.buffer) -> ()
+    // CHECK: vm.discard.refs
+    vm.discard.refs %a, %b : !vm.buffer, !vm.buffer
     vm.return
   }
 }
@@ -802,8 +838,8 @@ vm.module @module_br_table_refs {
   vm.func @br_table_ref_some_cases(%idx: i32, %ref: !vm.buffer) {
     // CHECK: vm.br_table
     // Ref forwarded to default and case 0, but NOT case 1.
-    // Case 0 gets MOVE since case 1 doesn't use the ref.
-    // CHECK: operand_registers = ["i0", "r0", "R0"]
+    // Each forwarding edge gets MOVE since only one edge executes.
+    // CHECK: operand_registers = ["i0", "R0", "R0"]
     vm.br_table %idx {
       default: ^bb_default(%ref : !vm.buffer),
       0: ^bb0(%ref : !vm.buffer),

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -37,6 +37,7 @@ iree_lit_test_suite(
         "trace_dispatch_tensors.mlir",
         "transients_test.mlir",
         "unused_args.mlir",
+        "vm_ref_branch_ownership.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
     tags = [
@@ -47,6 +48,7 @@ iree_lit_test_suite(
         "//tools:iree-compile",
         "//tools:iree-opt",
         "//tools:iree-run-mlir",
+        "//tools:iree-run-module",
         "@llvm-project//lld",
         "@llvm-project//llvm:FileCheck",
     ],

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -22,12 +22,14 @@ iree_lit_test_suite(
     "trace_dispatch_tensors.mlir"
     "transients_test.mlir"
     "unused_args.mlir"
+    "vm_ref_branch_ownership.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck
     iree-compile
     iree-opt
     iree-run-mlir
+    iree-run-module
   LABELS
     "driver=local-task"
     "hostonly"

--- a/tests/e2e/regression/vm_ref_branch_ownership.mlir
+++ b/tests/e2e/regression/vm_ref_branch_ownership.mlir
@@ -1,0 +1,139 @@
+// RUN: iree-compile %s \
+// RUN:   --iree-hal-target-device=local \
+// RUN:   --iree-hal-local-target-device-backends=llvm-cpu \
+// RUN:   --iree-llvmcpu-target-cpu=generic \
+// RUN:   --iree-hal-indirect-command-buffers=false \
+// RUN:   -o %t.vmfb
+// RUN: iree-run-module \
+// RUN:   --device=local-sync \
+// RUN:   --module=%t.vmfb \
+// RUN:   --function=main \
+// RUN:   --input=7xi32=0 \
+// RUN:   --input=7xi32=0 \
+// RUN:   --input=7xi32=0 \
+// RUN:   --input=i32=0 \
+// RUN:   --input=i32=0 \
+// RUN:   --input=i1=00 \
+// RUN:   --input=i32=2 \
+// RUN:   --expected_output=7xi32=1,1,1,1,1,1,1 \
+// RUN:   --expected_output=7xi32=0,0,0,0,0,0,0 \
+// RUN:   --expected_output=7xi32=1,1,1,1,1,1,1 \
+// RUN:   --expected_output=i32=0 \
+// RUN:   --expected_output=i32=0 \
+// RUN:   --expected_output=i1=00
+// RUN: iree-run-module \
+// RUN:   --device=local-sync \
+// RUN:   --module=%t.vmfb \
+// RUN:   --function=main \
+// RUN:   --input=7xi32=0 \
+// RUN:   --input=7xi32=0 \
+// RUN:   --input=7xi32=0 \
+// RUN:   --input=i32=0 \
+// RUN:   --input=i32=0 \
+// RUN:   --input=i1=01 \
+// RUN:   --input=i32=2 \
+// RUN:   --expected_output=7xi32=1,1,1,1,1,1,1 \
+// RUN:   --expected_output=7xi32=0,0,0,0,0,0,0 \
+// RUN:   --expected_output=7xi32=1,1,1,1,1,1,1 \
+// RUN:   --expected_output=i32=0 \
+// RUN:   --expected_output=i32=0 \
+// RUN:   --expected_output=i1=01
+
+// Regression test for https://github.com/iree-org/iree/issues/24753.
+// With indirect command buffers disabled, both selector paths must execute
+// successfully and preserve every returned value.
+module {
+  func.func public @main(
+      %arg0: tensor<7xi32>, %arg1: tensor<7xi32>, %arg2: tensor<7xi32>,
+      %arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<i1>,
+      %arg6: tensor<i32>)
+      -> (tensor<7xi32>, tensor<7xi32>, tensor<7xi32>, tensor<i32>,
+          tensor<i32>, tensor<i1>) {
+    %false = stablehlo.constant dense<false> : tensor<i1>
+    %c1 = stablehlo.constant dense<1> : tensor<i32>
+    %c0 = stablehlo.constant dense<0> : tensor<i32>
+    %is_zero = stablehlo.compare EQ, %arg6, %c0, SIGNED
+        : (tensor<i32>, tensor<i32>) -> tensor<i1>
+    %case_index = stablehlo.convert %is_zero
+        : (tensor<i1>) -> tensor<i32>
+    %0:4 = "stablehlo.case"(%case_index) ({
+      %is_one = stablehlo.compare EQ, %arg6, %c1, SIGNED
+          : (tensor<i32>, tensor<i32>) -> tensor<i1>
+      %nested_case_index = stablehlo.convert %is_one
+          : (tensor<i1>) -> tensor<i32>
+      %1:4 = "stablehlo.case"(%nested_case_index) ({
+        %splat1_a = stablehlo.broadcast_in_dim %c1, dims = []
+            : (tensor<i32>) -> tensor<7xi32>
+        %result0 = stablehlo.add %arg0, %splat1_a : tensor<7xi32>
+        %splat1_b = stablehlo.broadcast_in_dim %c1, dims = []
+            : (tensor<i32>) -> tensor<7xi32>
+        %result2 = stablehlo.add %arg2, %splat1_b : tensor<7xi32>
+        %not_arg5 = stablehlo.not %arg5 : tensor<i1>
+        %inner_case_index = stablehlo.convert %not_arg5
+            : (tensor<i1>) -> tensor<i32>
+        %result3 = "stablehlo.case"(%inner_case_index) ({
+          %splat0 = stablehlo.broadcast_in_dim %c0, dims = []
+              : (tensor<i32>) -> tensor<7xi32>
+          %positive = stablehlo.compare GT, %result0, %splat0, SIGNED
+              : (tensor<7xi32>, tensor<7xi32>) -> tensor<7xi1>
+          %any_positive = stablehlo.reduce(%positive init: %false)
+              applies stablehlo.or across dimensions = [0]
+              : (tensor<7xi1>, tensor<i1>) -> tensor<i1>
+          %sum_case_index = stablehlo.convert %any_positive
+              : (tensor<i1>) -> tensor<i32>
+          %selected = "stablehlo.case"(%sum_case_index) ({
+            stablehlo.return %arg3 : tensor<i32>
+          }, {
+            %sum = stablehlo.reduce(%arg1 init: %c0)
+                applies stablehlo.add across dimensions = [0]
+                : (tensor<7xi32>, tensor<i32>) -> tensor<i32>
+            stablehlo.return %sum : tensor<i32>
+          }) : (tensor<i32>) -> tensor<i32>
+          stablehlo.return %selected : tensor<i32>
+        }, {
+          stablehlo.return %arg3 : tensor<i32>
+        }) : (tensor<i32>) -> tensor<i32>
+        stablehlo.return %result0, %result2, %result3, %c0
+            : tensor<7xi32>, tensor<7xi32>, tensor<i32>, tensor<i32>
+      }, {
+        stablehlo.return %arg0, %arg2, %arg3, %arg4
+            : tensor<7xi32>, tensor<7xi32>, tensor<i32>, tensor<i32>
+      }) : (tensor<i32>) ->
+          (tensor<7xi32>, tensor<7xi32>, tensor<i32>, tensor<i32>)
+      stablehlo.return %1#0, %1#1, %1#2, %1#3
+          : tensor<7xi32>, tensor<7xi32>, tensor<i32>, tensor<i32>
+    }, {
+      %not_arg5 = stablehlo.not %arg5 : tensor<i1>
+      %inner_case_index = stablehlo.convert %not_arg5
+          : (tensor<i1>) -> tensor<i32>
+      %result3 = "stablehlo.case"(%inner_case_index) ({
+        %splat0 = stablehlo.broadcast_in_dim %c0, dims = []
+            : (tensor<i32>) -> tensor<7xi32>
+        %positive = stablehlo.compare GT, %arg0, %splat0, SIGNED
+            : (tensor<7xi32>, tensor<7xi32>) -> tensor<7xi1>
+        %any_positive = stablehlo.reduce(%positive init: %false)
+            applies stablehlo.or across dimensions = [0]
+            : (tensor<7xi1>, tensor<i1>) -> tensor<i1>
+        %sum_case_index = stablehlo.convert %any_positive
+            : (tensor<i1>) -> tensor<i32>
+        %selected = "stablehlo.case"(%sum_case_index) ({
+          stablehlo.return %arg3 : tensor<i32>
+        }, {
+          %sum = stablehlo.reduce(%arg1 init: %c0)
+              applies stablehlo.add across dimensions = [0]
+              : (tensor<7xi32>, tensor<i32>) -> tensor<i32>
+          stablehlo.return %sum : tensor<i32>
+        }) : (tensor<i32>) -> tensor<i32>
+        stablehlo.return %selected : tensor<i32>
+      }, {
+        stablehlo.return %arg3 : tensor<i32>
+      }) : (tensor<i32>) -> tensor<i32>
+      stablehlo.return %arg0, %arg2, %result3, %arg4
+          : tensor<7xi32>, tensor<7xi32>, tensor<i32>, tensor<i32>
+    }) : (tensor<i32>) ->
+        (tensor<7xi32>, tensor<7xi32>, tensor<i32>, tensor<i32>)
+    return %0#0, %arg1, %0#1, %0#2, %0#3, %arg5
+        : tensor<7xi32>, tensor<7xi32>, tensor<7xi32>, tensor<i32>,
+          tensor<i32>, tensor<i1>
+  }
+}


### PR DESCRIPTION
Branch remaps selected MOVE using `isLastRealValueUse`, whose result accounts for uses across all successors. A use on one successor therefore prevented ownership transfer on another mutually exclusive successor, leaving an extra owning reference on the taken path.

Use target-block liveness to select MOVE independently for each successor. If one occurrence of a repeated operand is coalesced with its destination, prevent the other remaps from using MOVE; otherwise a MOVE would clear the coalesced register.

Add register allocation tests for both cases and an LLVM CPU end-to-end regression that executes both selector paths with indirect command buffers disabled.

Fixes #24753