### PR TITLE
[Preprocessing] Skip convs with extra operands in convert-conv-to-channels-last

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
@@ -355,6 +355,15 @@ transposeConvLikeLinalgOp(PatternRewriter &rewriter, linalg::LinalgOp convOp,
     return failure();
   }
 
+  // The operand indices below, and the builders this hands off to, assume the
+  // op has exactly two inputs (image and filter) and one init (output).
+  // Quantized convolutions such as linalg.conv_2d_nchw_fchw_q carry extra zero
+  // point scalars, so operand 2 is a scalar rather than the output tensor and
+  // the rebuilt op would fail verification.
+  if (convOp.getNumDpsInputs() != 2 || convOp.getNumDpsInits() != 1) {
+    return failure();
+  }
+
   Value input = convOp->getOperand(0);
   Value filter = convOp->getOperand(1);
   Value output = convOp->getOperand(2);

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_to_channels_last.mlir
@@ -167,3 +167,26 @@ util.func @test_unit_dims_pack(%arg0: tensor<10x20x5xf32>) -> tensor<1x1x5x20x10
 // CHECK-SAME:    [0, 1, 2], [3], [4]
 // CHECK-SAME:    tensor<5x20x10xf32> into tensor<1x1x5x20x10xf32>
 // CHECK:       util.return %[[EXPANDED]] : tensor<1x1x5x20x10xf32>
+
+// -----
+
+// Quantized convolutions carry extra zero point scalars that the transpose
+// cannot rebuild, so the pattern has to leave them alone. Operand 2 is the
+// input zero point here, not the output tensor, and rebuilding the op around
+// it produced a linalg.generic that failed verification.
+
+util.func @conv_2d_nchw_fchw_q(%arg0: tensor<1x256x18x18xi8>, %arg1: tensor<128x256x3x3xi8>,
+    %arg2: tensor<1x128x16x16xi32>, %izp: i32, %kzp: i32) -> tensor<1x128x16x16xi32> {
+  %0 = linalg.conv_2d_nchw_fchw_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+    ins(%arg0, %arg1, %izp, %kzp : tensor<1x256x18x18xi8>, tensor<128x256x3x3xi8>, i32, i32)
+    outs(%arg2 : tensor<1x128x16x16xi32>) -> tensor<1x128x16x16xi32>
+  util.return %0 : tensor<1x128x16x16xi32>
+}
+
+// CHECK-LABEL: @conv_2d_nchw_fchw_q
+// CHECK-NOT:     linalg.generic
+// CHECK:         linalg.conv_2d_nchw_fchw_q
+
+// TILE16-LABEL: @conv_2d_nchw_fchw_q
+// TILE16-NOT:     linalg.generic
+// TILE16:         linalg.conv_2d_nchw_fchw_q


### PR DESCRIPTION
Fixes #24774.

`transposeConvLikeLinalgOp` reads the image, filter and output as operands 0, 1 and 2, and the builders it hands off to rebuild the op with exactly two inputs and one init. A quantized convolution such as `linalg.conv_2d_nchw_fchw_q` has `ins(image, filter, input_zp, filter_zp)` and `outs(output)`, so operand 2 is an `i32` zero point rather than the output tensor.

Walking the NCHW case from the issue: the input channel is not innermost, so the early exit for an already correct layout does not fire. The zero point indexing map is `affine_map<(d0, ..., d6) -> ()>`, which has no results, so `collectChannelInnerDimsIndices` returns nothing for it and the pack of the "output" is a no-op that hands the `i32` straight through. `defaultConvBuilderFn` then builds a `linalg.generic` whose result type and init operand are that `i32`, which fails verification with exactly the error in the report:

```
'linalg.generic' op operand #2 must be variadic of shaped of any non-token type values, but got 'i32'
```

The named op pattern `ConvertLinalgConvNchwFchw` is typed on `Conv2DNchwFchwOp` and does not match, but the interface pattern `ConvertLinalgConvOp` matches any `linalg::LinalgOp`, so the quantized op does reach this code.

This bails out when the op does not have the two inputs and one init the rewrite knows how to reconstruct. Supporting channels-last for quantized convolutions would mean threading the extra operands through `ConvBuilderFn`, which is a feature rather than a fix, so it is not attempted here.

`ConvertGenericFilterToFhwc` in `ConvertConvFilterToChannelsLast.cpp` rebuilds the op the same way, with `ValueRange{inputVal, barrier}` and a single init, and inlines the original region into it, so it looks to need the same guard. I left it out to keep this change to the reproducer in the issue. Happy to add it here if you would rather have both in one PR.

Verification: I did not build IREE for this change, so the argument is by reading. The lit test is written to the conventions already in `conv_to_channels_last.mlir` and covers both the default and the `tiling-factor=16` pipelines. I confirmed `linalg.conv_2d_nchw_fchw_q` and its operand order against `LinalgNamedStructuredOps.yaml` at the pinned LLVM commit. The C++ is clang-format clean.

Assisted-by: Claude Code
