### PR TITLE
Instate initial technical steering committee

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Google LLC
 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. for its Fraunhofer Institute for Material Flow and Logistics (IML)
 Nod, Inc.
 Advanced Micro Devices, Inc.
+RooflineAI GmbH

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,32 @@ To get started with contributing, please take a look at the
 *   [GitHub issues](https://github.com/iree-org/iree/issues): Feature requests,
     bugs, and other work tracking
 *   [IREE Discord server](https://discord.gg/wEWh6Z9nMU): Daily development
-    discussions with the core team and collaborators
+    discussions with maintainers, contributors, and collaborators
 *   [iree-technical-discussion email list](https://lists.lfaidata.foundation/g/iree-technical-discussion):
     General and low-priority discussion
+
+## Project governance
+
+IREE is a sandbox-stage project of the
+[LF AI & Data Foundation](https://lfaidata.foundation/). Technical
+oversight of the project is the responsibility of its Technical
+Steering Committee (TSC), as set out in the
+[IREE Technical Charter](https://github.com/lfai/foundation/blob/main/technical%20project%20charters/IREE%20Technical%20Charter%20Final%205-14-2024.docx.pdf).
+
+As provided for in section 2.b of the charter, the voting members of
+the TSC are:
+
+*   Maximilian Bartel (@maxbartel), RooflineAI — Chairperson
+*   Tobias Fuchs (@devtbi), RooflineAI
+*   Artem Gindinson (@AGindinson), RooflineAI
+*   Stella Laurenzo (@stellaraccident), AMD
+*   Christopher McGirr (@chrsmcgrr), RooflineAI
+*   Stefan Schuermans (@schuermans-roofline), RooflineAI
+*   Jelle Schuhmacher (@jschuhmacher), RooflineAI
+*   Ben Vanik (@benvanik), AMD
+
+See [MAINTAINERS.md](MAINTAINERS.md) for how the TSC operates. TSC
+meetings are open to everyone.
 
 ## Community guidelines
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,12 @@
+# IREE Project Governance
+
+IREE is a sandbox-stage project of the
+[LF AI & Data Foundation](https://lfaidata.foundation/). Technical
+governance is exercised by the project's Technical Steering Committee
+(TSC), as provided for in the
+[IREE Technical Charter](https://github.com/lfai/foundation/blob/main/technical%20project%20charters/IREE%20Technical%20Charter%20Final%205-14-2024.docx.pdf).
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for current TSC membership and
+the contribution policies the TSC maintains, and
+[MAINTAINERS.md](MAINTAINERS.md) for how the TSC operates and for
+component maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -45,9 +45,11 @@ the charter.
 
 ## Overall
 
-Questions of project direction or components without a listed
-maintainer are escalated to the
-[Technical Steering Committee](#technical-steering-committee).
+Escalate questions about project direction and questions about components
+without a listed maintainer to the [Technical Steering
+Committee](#technical-steering-committee). Post to the [IREE-TSC mailing
+list](mailto:iree-TSC@lists.lfaidata.foundation) (preferred), or contact one of
+the TSC members individually.
 
 ## Compiler Maintainers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,10 +15,39 @@ This file is kept in the `iree` core repository but can refer to other
 affiliated repositories at need. This is meant to help "direct traffic" and
 individual projects should be authoritative about their status.
 
+## Technical Steering Committee
+
+The Technical Steering Committee (TSC) is responsible for the overall
+technical direction and health of the project, as set out in the
+[IREE Technical Charter](https://github.com/lfai/foundation/blob/main/technical%20project%20charters/IREE%20Technical%20Charter%20Final%205-14-2024.docx.pdf),
+and represents the project to the LF AI & Data Foundation's Technical
+Advisory Council (TAC).
+
+The current TSC voting members are listed in
+[CONTRIBUTING.md](CONTRIBUTING.md), as provided for in section 2.b of
+the charter.
+
+### Operation
+
+* The TSC decides by lazy consensus where possible. When a formal vote
+  is needed, each voting member has one vote and voting follows the
+  rules in section 3 of the Technical Charter: majority of those
+  present at a quorate meeting, or majority of all voting members for
+  electronic votes. License exceptions and charter amendments require
+  a two-thirds vote of the entire TSC (charter sections 7.c and 8.a).
+* The chairperson is elected by the TSC voting members and serves as
+  the project's representative to the LF AI & Data TAC.
+* Changes to TSC membership (additions, removals, emeritus status) are
+  decided by TSC vote.
+* The TSC meets monthly. Meetings are open to the public and announced
+  on the [iree-technical-discussion mailing list](https://lists.lfaidata.foundation/g/iree-technical-discussion)
+  and Discord.
+
 ## Overall
 
-Stella Laurenzo (@stellaraccident) is the maintainer of last resort for
-uncovered components, questions of project direction, etc.
+Questions of project direction or components without a listed
+maintainer are escalated to the
+[Technical Steering Committee](#technical-steering-committee).
 
 ## Compiler Maintainers
 

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -21,6 +21,19 @@ We'd love to accept your patches and contributions to this project.
 This project follows the
 [LF Projects code of conduct](https://lfprojects.org/policies/code-of-conduct/).
 
+### :octicons-organization-16: Project governance
+
+IREE is a sandbox-stage project of the
+[LF AI & Data Foundation](https://lfaidata.foundation/). Technical
+oversight of the project is the responsibility of its Technical
+Steering Committee (TSC), as set out in the
+[IREE Technical Charter](https://github.com/lfai/foundation/blob/main/technical%20project%20charters/IREE%20Technical%20Charter%20Final%205-14-2024.docx.pdf).
+The voting members of the TSC are listed in
+[CONTRIBUTING.md](https://github.com/iree-org/iree/blob/main/CONTRIBUTING.md);
+see
+[MAINTAINERS.md](https://github.com/iree-org/iree/blob/main/MAINTAINERS.md)
+for how the TSC operates. TSC meetings are open to everyone.
+
 ### :octicons-law-16: Developer Certificate of Origin
 
 Contributors must certify that they wrote or otherwise have the right to submit
@@ -146,7 +159,8 @@ lets maintainers opt in to PR reviews modifying certain paths.
 
 The
 [`MAINTAINERS.md` file](https://github.com/iree-org/iree/blob/main/MAINTAINERS.md)
-documents official maintainers for project components.
+documents the Technical Steering Committee (TSC) and official maintainers for
+project components.
 
 ## :octicons-code-16: Coding policies
 
@@ -283,7 +297,7 @@ Access to repositories is divided into tiers following the
 | ---- | ----------- | --------- |
 Triage | **New project members should typically start here**<br>:material-check: Can be [assigned issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)<br>:material-check: Can apply labels to issues / PRs<br>:material-check: Can run workflows [without approval](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) | <ul><li>[iree-triage](https://github.com/orgs/iree-org/teams/iree-triage)<br>(access to most repositories)</li></ul>
 Write | **Established contributors can request this access**<br>:material-check: Can [merge approved pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request)<br>:material-check: Can create branches<br>:material-check: Can [re-run workflows](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/re-running-workflows-and-jobs) | <ul><li>[iree-write](https://github.com/orgs/iree-org/teams/iree-write)<br>(access to most repositories)</li><li>[iree-turbine-write](https://github.com/orgs/iree-org/teams/iree-turbine-write)<br>(access to <a href="https://github.com/iree-org/iree-turbine">iree-turbine</a>)</li><li>[iree-fusilli-write](https://github.com/orgs/iree-org/teams/iree-fusilli-write)<br>(access to <a href="https://github.com/iree-org/fusilli">fusilli</a>)</li></ul>
-Maintain/Admin | :material-check: Can [edit repository settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features)<br>:material-check: Can push to [protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) | Added case-by-case
+Maintain/Admin | :material-check: Can [edit repository settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features)<br>:material-check: Can push to [protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) | Added case-by-case by the TSC
 
 All access tiers first require joining the
 [iree-org GitHub organization](https://github.com/iree-org/). To request

--- a/docs/website/docs/developers/general/release-management.md
+++ b/docs/website/docs/developers/general/release-management.md
@@ -49,7 +49,8 @@ in scope:
     If you maintain a project that you would like to connect with this release
     process, please reach out on one of our
     [communication channels](../../index.md#communication-channels). The current
-    project list is driven by the priorities of the core project maintainers and
+    project list is driven by the priorities of the project's maintainers and
+    TSC, and
     we would be happy to adapt the process to include other projects too.
 
 The dependency graph looks like this:

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -182,7 +182,9 @@ using various languages.
 
 IREE is a [sandbox-stage project](https://lfaidata.foundation/projects/iree/)
 of [LF AI & Data Foundation](https://lfaidata.foundation/) made possible thanks
-to a growing community of developers.
+to a growing community of developers. The project is governed by a Technical
+Steering Committee — see
+[GOVERNANCE.md](https://github.com/iree-org/iree/blob/main/GOVERNANCE.md).
 
 See how IREE is used:
 
@@ -202,7 +204,7 @@ See how IREE is used:
   bugs, and other work tracking
 * :fontawesome-brands-discord:
   [IREE Discord server](https://discord.gg/wEWh6Z9nMU): Daily development
-  discussions with the core team and collaborators
+  discussions with maintainers, contributors, and collaborators
 * :fontawesome-solid-bullhorn: (New) [iree-announce email list](https://lists.lfaidata.foundation/g/iree-announce):
   Announcements
 * :fontawesome-solid-envelope: (New) [iree-technical-discussion email list](https://lists.lfaidata.foundation/g/iree-technical-discussion):


### PR DESCRIPTION
After the recent changes in the IREE community new contributors took over the steering of the project.

This change instantiates the "Technical Steering Committee" as described in LF AI & Data Foundation [IREE charter](https://github.com/lfai/foundation/blob/main/technical%20project%20charters/IREE%20Technical%20Charter%20Final%205-14-2024.docx.pdf) to make it transparent for users, contributors and maintainers on how the project is run, whom to ask for advice and who can help moderate issues.

If anyone thinks this change or list should be changed please reach out. The PR will be kept open for a few days and will get merged if there are no blocking issues.