### PR TITLE
[LIT] Migrate runtime lit config to the internal shell

### DIFF
--- a/runtime/lit.cfg.py
+++ b/runtime/lit.cfg.py
@@ -17,9 +17,7 @@ import lit.formats
 
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
-config.test_format = lit.formats.ShTest(
-    execute_external=True, force_execute_external=True
-)
+config.test_format = lit.formats.ShTest()
 # Forward all IREE environment variables
 passthrough_env_vars = ["VK_ICD_FILENAMES"]
 config.environment.update(

--- a/runtime/src/iree/base/tooling/BUILD.bazel
+++ b/runtime/src/iree/base/tooling/BUILD.bazel
@@ -42,5 +42,6 @@ iree_lit_test_suite(
     tools = [
         ":flags_demo",
         "@llvm-project//llvm:FileCheck",
+        "@llvm-project//llvm:not",
     ],
 )

--- a/runtime/src/iree/base/tooling/CMakeLists.txt
+++ b/runtime/src/iree/base/tooling/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_lit_test_suite(
   TOOLS
     ::flags_demo
     FileCheck
+    not
   LABELS
     "hostonly"
 )

--- a/runtime/src/iree/base/tooling/flags_test.txt
+++ b/runtime/src/iree/base/tooling/flags_test.txt
@@ -1,4 +1,4 @@
-// RUN: ( flags_demo )  | FileCheck --check-prefix=NO-FLAGS %s
+// RUN: flags_demo  | FileCheck --check-prefix=NO-FLAGS %s
 // NO-FLAGS: FLAG[test_bool] = false
 // NO-FLAGS: FLAG[test_int32] = 123
 // NO-FLAGS: FLAG[test_int64] = 555
@@ -7,7 +7,7 @@
 // NO-FLAGS: FLAG[test_callback] = 0
 // NO-FLAGS: ARG(0) ={{.+}}flags_demo
 
-// RUN: ( flags_demo --help )  | FileCheck --check-prefix=FLAGS-HELP %s
+// RUN: flags_demo --help  | FileCheck --check-prefix=FLAGS-HELP %s
 // FLAGS-HELP: # {{.+}} IREE
 // FLAGS-HELP: # Flags in {{.+}}flags.c
 // FLAGS-HELP: # Displays command line usage information.
@@ -27,71 +27,71 @@
 // FLAGS-HELP: # Callback!
 // FLAGS-HELP: --test_callback=0
 
-// RUN: ( flags_demo --unknown-flag 2>&1 || [[ $? == 1 ]] ) | FileCheck --check-prefix=UNKNOWN-FLAG %s
+// RUN: not flags_demo --unknown-flag 2>&1 | FileCheck --check-prefix=UNKNOWN-FLAG %s
 // UNKNOWN-FLAG: INVALID_ARGUMENT; flag 'unknown-flag' not recognized
 
-// RUN: ( flags_demo --test_bool=true ) | FileCheck --check-prefix=FLAG-BOOL-TRUE %s
+// RUN: flags_demo --test_bool=true | FileCheck --check-prefix=FLAG-BOOL-TRUE %s
 // FLAG-BOOL-TRUE: FLAG[test_bool] = true
-// RUN: ( flags_demo --test_bool=1 ) | FileCheck --check-prefix=FLAG-BOOL-1 %s
+// RUN: flags_demo --test_bool=1 | FileCheck --check-prefix=FLAG-BOOL-1 %s
 // FLAG-BOOL-1: FLAG[test_bool] = true
-// RUN: ( flags_demo --test_bool=true --test_bool=false ) | FileCheck --check-prefix=FLAG-BOOL-OVERRIDE %s
+// RUN: flags_demo --test_bool=true --test_bool=false | FileCheck --check-prefix=FLAG-BOOL-OVERRIDE %s
 // FLAG-BOOL-OVERRIDE: FLAG[test_bool] = false
 
-// RUN: ( flags_demo --test_int32=456 ) | FileCheck --check-prefix=FLAG-INT32 %s
+// RUN: flags_demo --test_int32=456 | FileCheck --check-prefix=FLAG-INT32 %s
 // FLAG-INT32: FLAG[test_int32] = 456
-// RUN: ( flags_demo --test_int32=-2147483648 ) | FileCheck --check-prefix=FLAG-INT32-MIN %s
+// RUN: flags_demo --test_int32=-2147483648 | FileCheck --check-prefix=FLAG-INT32-MIN %s
 // FLAG-INT32-MIN: FLAG[test_int32] = -2147483648
-// RUN: ( flags_demo --test_int32=2147483647 ) | FileCheck --check-prefix=FLAG-INT32-MAX %s
+// RUN: flags_demo --test_int32=2147483647 | FileCheck --check-prefix=FLAG-INT32-MAX %s
 // FLAG-INT32-MAX: FLAG[test_int32] = 2147483647
 
-// RUN: ( flags_demo --test_int64=902834 ) | FileCheck --check-prefix=FLAG-INT64 %s
+// RUN: flags_demo --test_int64=902834 | FileCheck --check-prefix=FLAG-INT64 %s
 // FLAG-INT64: FLAG[test_int64] = 902834
-// RUN: ( flags_demo --test_int64=-9223372036854775808 ) | FileCheck --check-prefix=FLAG-INT64-MIN %s
+// RUN: flags_demo --test_int64=-9223372036854775808 | FileCheck --check-prefix=FLAG-INT64-MIN %s
 // FLAG-INT64-MIN: FLAG[test_int64] = -9223372036854775808
-// RUN: ( flags_demo --test_int64=9223372036854775807 ) | FileCheck --check-prefix=FLAG-INT64-MAX %s
+// RUN: flags_demo --test_int64=9223372036854775807 | FileCheck --check-prefix=FLAG-INT64-MAX %s
 // FLAG-INT64-MAX: FLAG[test_int64] = 9223372036854775807
 
-// RUN: ( flags_demo --test_float=1.1234 ) | FileCheck --check-prefix=FLAG-FLOAT %s
+// RUN: flags_demo --test_float=1.1234 | FileCheck --check-prefix=FLAG-FLOAT %s
 // FLAG-FLOAT: FLAG[test_float] = 1.1234
 
-// RUN: ( flags_demo --test_string= ) | FileCheck --check-prefix=FLAG-STRING-EMPTY %s
+// RUN: flags_demo --test_string= | FileCheck --check-prefix=FLAG-STRING-EMPTY %s
 // FLAG-STRING-EMPTY: FLAG[test_string] =
-// RUN: ( flags_demo --test_string=abc ) | FileCheck --check-prefix=FLAG-STRING-ABC %s
+// RUN: flags_demo --test_string=abc | FileCheck --check-prefix=FLAG-STRING-ABC %s
 // FLAG-STRING-ABC: FLAG[test_string] = abc
-// RUN: ( flags_demo --test_string="with some space" ) | FileCheck --check-prefix=FLAG-STRING-SPACES %s
+// RUN: flags_demo --test_string="with some space" | FileCheck --check-prefix=FLAG-STRING-SPACES %s
 // FLAG-STRING-SPACES: FLAG[test_string] = with some space
 
-// RUN: ( flags_demo --test_callback=1 ) | FileCheck --check-prefix=FLAG-CALLBACK-1 %s
+// RUN: flags_demo --test_callback=1 | FileCheck --check-prefix=FLAG-CALLBACK-1 %s
 // FLAG-CALLBACK-1: FLAG[test_callback] = 1
-// RUN: ( flags_demo --test_callback=4 ) | FileCheck --check-prefix=FLAG-CALLBACK-4 %s
+// RUN: flags_demo --test_callback=4 | FileCheck --check-prefix=FLAG-CALLBACK-4 %s
 // FLAG-CALLBACK-4: FLAG[test_callback] = 4
-// RUN: ( flags_demo --test_callback=FORCE_FAILURE 2>&1 || [[ $? == 1 ]] ) | FileCheck --check-prefix=FLAG-CALLBACK-ERROR %s
+// RUN: not flags_demo --test_callback=FORCE_FAILURE 2>&1 | FileCheck --check-prefix=FLAG-CALLBACK-ERROR %s
 // FLAG-CALLBACK-ERROR: INTERNAL; callbacks can do verification
 
-// RUN: ( flags_demo ) | FileCheck --check-prefix=FLAG-LIST-0 %s
+// RUN: flags_demo | FileCheck --check-prefix=FLAG-LIST-0 %s
 // FLAG-LIST-0: FLAG[test_strings] = 0
-// RUN: ( flags_demo --test_strings=a ) | FileCheck --check-prefix=FLAG-LIST-1 %s
+// RUN: flags_demo --test_strings=a | FileCheck --check-prefix=FLAG-LIST-1 %s
 // FLAG-LIST-1: FLAG[test_strings] = 1: a
-// RUN: ( flags_demo --test_strings=a --test_strings=b ) | FileCheck --check-prefix=FLAG-LIST-2 %s
+// RUN: flags_demo --test_strings=a --test_strings=b | FileCheck --check-prefix=FLAG-LIST-2 %s
 // FLAG-LIST-2: FLAG[test_strings] = 2: a, b
-// RUN: ( flags_demo --test_strings=a --test_strings=b --test_strings=c ) | FileCheck --check-prefix=FLAG-LIST-3 %s
+// RUN: flags_demo --test_strings=a --test_strings=b --test_strings=c | FileCheck --check-prefix=FLAG-LIST-3 %s
 // FLAG-LIST-3: FLAG[test_strings] = 3: a, b, c
-// RUN: ( flags_demo --test_strings=a --test_strings=b --test_strings=c --test_strings=d ) | FileCheck --check-prefix=FLAG-LIST-4 %s
+// RUN: flags_demo --test_strings=a --test_strings=b --test_strings=c --test_strings=d | FileCheck --check-prefix=FLAG-LIST-4 %s
 // FLAG-LIST-4: FLAG[test_strings] = 4: a, b, c, d
-// RUN: ( flags_demo --test_strings=a --test_strings=b --test_strings=c --test_strings=d --test_strings=e ) | FileCheck --check-prefix=FLAG-LIST-5 %s
+// RUN: flags_demo --test_strings=a --test_strings=b --test_strings=c --test_strings=d --test_strings=e | FileCheck --check-prefix=FLAG-LIST-5 %s
 // FLAG-LIST-5: FLAG[test_strings] = 5: a, b, c, d, e
 
-// RUN: ( flags_demo arg1 ) | FileCheck --check-prefix=FLAG-POSITIONAL-1 %s
+// RUN: flags_demo arg1 | FileCheck --check-prefix=FLAG-POSITIONAL-1 %s
 // FLAG-POSITIONAL-1: ARG(1) = arg1
-// RUN: ( flags_demo arg1 arg2 arg3 ) | FileCheck --check-prefix=FLAG-POSITIONAL-3 %s
+// RUN: flags_demo arg1 arg2 arg3 | FileCheck --check-prefix=FLAG-POSITIONAL-3 %s
 // FLAG-POSITIONAL-3: ARG(1) = arg1
 // FLAG-POSITIONAL-3: ARG(2) = arg2
 // FLAG-POSITIONAL-3: ARG(3) = arg3
 
-// RUN: ( flags_demo --test_bool=true --flagfile=not_found.txt 2>&1 || [[ $? == 1 ]] ) | FileCheck --check-prefix=MISSING-FLAGFILE %s
+// RUN: not flags_demo --test_bool=true --flagfile=not_found.txt 2>&1 | FileCheck --check-prefix=MISSING-FLAGFILE %s
 // MISSING-FLAGFILE: NOT_FOUND; failed to open file 'not_found.txt'
 
-// RUN: ( flags_demo --test_bool=true --flagfile=%s ) | FileCheck --check-prefix=FLAGFILE %s
+// RUN: flags_demo --test_bool=true --flagfile=%s | FileCheck --check-prefix=FLAGFILE %s
 # Comments are ignored.
 // FLAGFILE: FLAG[test_bool] = false
 --test_bool=false


### PR DESCRIPTION
Part of #24607.

This switches `runtime/lit.cfg.py` to the internal shell and removes the `execute_external` / `force_execute_external` workaround. It's the first of the seven configs listed in the issue. I'm doing one at a time so the failures stay easy to review.

The internal shell has no subshells, so the `( ... )` wrappers in `flags_test.txt` were read as a command named `(` and the test died with exit 127. Two kinds of RUN lines needed fixing:

- **26 lines** wrapped a single command in `( ... )` before piping to FileCheck. The subshell did nothing there, so I dropped the parentheses.
- **3 lines** used `( cmd 2>&1 || [[ $? == 1 ]] )` to tolerate an expected non-zero exit. Those now use `not`, which is the usual spelling for expected-failure RUN lines and also asserts the command really does fail. `not` is declared in the suite's tools, the same way `tools/test/BUILD.bazel` does it.

Same commands and same FileCheck prefixes, so no coverage is lost.

## Testing


ctest -R "flags_test.txt.test|modules/check/test/(failure|success|unavailable).mlir.test 

All 4 tests pass on the internal shell, matching the baseline before the change. The three modules/check tests are plain pipelines and needed no edits.

One thing I checked: rewriting those lines could have made them stop running while still going green. I broke an expected UNKNOWN-FLAG pattern on purpose, confirmed the test failed, then put it back.

Verified on macOS/arm64 only - relying on CI for Linux and Windows.

Assisted by: Claude Code

