### PR TITLE
[Runtime][Python] Fix multiple f64 return values

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -348,6 +348,13 @@ iree_py_test(
 
 iree_py_test(
   NAME
+    py_module_test
+  SRCS
+    "tests/py_module_test.py"
+)
+
+iree_py_test(
+  NAME
     system_setup_test
   SRCS
     "tests/system_setup_test.py"

--- a/runtime/bindings/python/py_module.cc
+++ b/runtime/bindings/python/py_module.cc
@@ -430,6 +430,7 @@ class PyModuleInterface {
         case IREE_VM_CCONV_TYPE_F64: {
           double result = py::cast<double>(value);
           memcpy(packed_results, &result, sizeof(result));
+          packed_results += sizeof(result);
           break;
         }
         case IREE_VM_CCONV_TYPE_REF: {

--- a/runtime/bindings/python/tests/py_module_test.py
+++ b/runtime/bindings/python/tests/py_module_test.py
@@ -163,15 +163,11 @@ class PyModuleInterfaceTest(unittest.TestCase):
         args = rt.VmVariantList(2)
         args.push_float(2.0)
         args.push_float(4.0)
-        # TODO: Python doesn't have 32bit floats, so we are populating f64 args.
-        # These are coming back as zeros, and I expected something to be
-        # doing a conversion? The same is being done with i64 above but is
-        # working there.
         context.invoke(m.lookup_function("do_it_f32"), args, results)
         context.invoke(m.lookup_function("do_it_f64"), args, results)
 
         print(values)
-        self.assertEqual(repr(values), "[(42, 43), (42, 43), (0.0, 0.0), (2.0, 4.0)]")
+        self.assertEqual(repr(values), "[(42, 43), (42, 43), (2.0, 4.0), (2.0, 4.0)]")
 
         # Make sure no circular refs and that everything frees.
         context = None


### PR DESCRIPTION
Advance the packed result buffer after writing each f64 result. Without this, consecutive f64 results overwrite the same slot and subsequent result slots are never written.

The existing `PyModuleInterfaceTest.testPrimitiveResults` test covers multiple f64 return values and now passes.

Fixes #22386