### PR TITLE
[Vulkan] Align memory type tie-breaking with pool selection heuristics

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -28,6 +28,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_library(
     name = "headers",
     hdrs = [
+        "allocator.h",
         "api.h",
         "command_buffer.h",
         "debug_utils.h",
@@ -43,6 +44,21 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/vulkan/util:libvulkan",
+        "@vulkan_headers",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "allocator_test",
+    srcs = ["allocator_test.cc"],
+    group = "iree-hal-drivers-vulkan-tests",
+    deps = [
+        ":headers",
+        ":vulkan",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
         "@vulkan_headers",
     ],
 )

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
   NAME
     headers
   HDRS
+    "allocator.h"
     "api.h"
     "command_buffer.h"
     "debug_utils.h"
@@ -41,6 +42,23 @@ iree_cc_library(
     iree::hal
     iree::hal::drivers::vulkan::util::libvulkan
   PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    allocator_test
+  SRCS
+    "allocator_test.cc"
+  DEPS
+    ::headers
+    ::vulkan
+    Vulkan::Headers
+    iree::base
+    iree::hal
+    iree::testing::gtest
+    iree::testing::gtest_main
+  GROUP
+    "iree-hal-drivers-vulkan-tests"
 )
 
 iree_cc_test(

--- a/runtime/src/iree/hal/drivers/vulkan/allocator.c
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.c
@@ -437,6 +437,27 @@ static int32_t iree_hal_vulkan_allocator_memory_type_priority(
   return priority;
 }
 
+uint32_t iree_hal_vulkan_allocator_select_default_device_memory_type(
+    const VkPhysicalDeviceMemoryProperties* memory_properties) {
+  uint32_t best_index = UINT32_MAX;
+  int32_t best_priority = INT32_MIN;
+  for (uint32_t i = 0; i < memory_properties->memoryTypeCount; ++i) {
+    const iree_hal_memory_type_t memory_type =
+        iree_hal_vulkan_memory_type_from_vk(
+            memory_properties->memoryTypes[i].propertyFlags);
+    if (!iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE)) {
+      continue;
+    }
+    const int32_t priority =
+        iree_hal_vulkan_allocator_memory_type_priority(memory_type);
+    if (priority > best_priority) {
+      best_priority = priority;
+      best_index = i;
+    }
+  }
+  return best_index;
+}
+
 // Heap queries feed first-match consumers such as the caching allocator. Prefer
 // private device-local memory for common dispatches, then UMA/BAR memory, then
 // host-local staging/readback classes.
@@ -678,8 +699,9 @@ static iree_status_t iree_hal_vulkan_allocator_initialize_default_pools(
       &allocator->memory_properties2.memoryProperties;
   uint32_t selected_indices[3] = {0};
   iree_host_size_t selected_count = 0;
-  uint32_t best_device_index = UINT32_MAX;
-  int32_t best_device_priority = INT32_MIN;
+  const uint32_t best_device_index =
+      iree_hal_vulkan_allocator_select_default_device_memory_type(
+          memory_properties);
   uint32_t best_host_write_index = UINT32_MAX;
   int32_t best_host_write_priority = INT32_MIN;
   uint32_t best_host_cached_index = UINT32_MAX;
@@ -688,14 +710,6 @@ static iree_status_t iree_hal_vulkan_allocator_initialize_default_pools(
     const iree_hal_memory_type_t memory_type =
         iree_hal_vulkan_memory_type_from_vk(
             memory_properties->memoryTypes[i].propertyFlags);
-    if (iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE)) {
-      const int32_t priority =
-          iree_hal_vulkan_allocator_memory_type_priority(memory_type);
-      if (priority > best_device_priority) {
-        best_device_priority = priority;
-        best_device_index = i;
-      }
-    }
     if (iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)) {
       const int32_t priority =
           iree_hal_vulkan_allocator_host_write_memory_priority(memory_type);
@@ -887,29 +901,18 @@ static int iree_hal_vulkan_allocator_score_memory_type(
   return score;
 }
 
-static bool iree_hal_vulkan_allocator_resolve_memory_placement(
-    const iree_hal_vulkan_allocator_t* allocator,
+bool iree_hal_vulkan_allocator_select_memory_type(
+    const VkPhysicalDeviceMemoryProperties* memory_properties,
     uint32_t allowed_memory_type_bits, iree_hal_buffer_params_t* params,
-    iree_hal_vulkan_allocator_memory_placement_t* out_placement) {
-  memset(out_placement, 0, sizeof(*out_placement));
-  if (!iree_hal_vulkan_allocator_normalize_queue_affinity(allocator, params)) {
-    return false;
-  }
-  if (!iree_device_size_is_valid_alignment(params->min_alignment)) {
-    return false;
-  }
-
+    uint32_t* out_memory_type_index) {
   const iree_hal_memory_type_t required_type =
       params->type & ~IREE_HAL_MEMORY_TYPE_OPTIMAL;
-  const VkPhysicalDeviceMemoryProperties* memory_properties =
-      &allocator->memory_properties2.memoryProperties;
 
   bool found = false;
   int best_score = 0;
   int32_t best_priority = INT32_MIN;
+  uint32_t best_index = 0;
   iree_hal_buffer_params_t best_params = *params;
-  iree_hal_vulkan_allocator_memory_placement_t best_placement;
-  memset(&best_placement, 0, sizeof(best_placement));
 
   for (uint32_t i = 0; i < memory_properties->memoryTypeCount; ++i) {
     if (!iree_all_bits_set(allowed_memory_type_bits, 1u << i)) continue;
@@ -942,19 +945,47 @@ static bool iree_hal_vulkan_allocator_resolve_memory_placement(
       found = true;
       best_score = score;
       best_priority = priority;
+      best_index = i;
       best_params = candidate_params;
       best_params.type = memory_type;
-      best_placement = (iree_hal_vulkan_allocator_memory_placement_t){
-          .memory_type_index = i,
-          .memory_property_flags = vk_memory_type->propertyFlags,
-          .memory_type = memory_type,
-      };
     }
   }
 
   if (!found) return false;
   *params = best_params;
-  *out_placement = best_placement;
+  *out_memory_type_index = best_index;
+  return true;
+}
+
+static bool iree_hal_vulkan_allocator_resolve_memory_placement(
+    const iree_hal_vulkan_allocator_t* allocator,
+    uint32_t allowed_memory_type_bits, iree_hal_buffer_params_t* params,
+    iree_hal_vulkan_allocator_memory_placement_t* out_placement) {
+  memset(out_placement, 0, sizeof(*out_placement));
+  if (!iree_hal_vulkan_allocator_normalize_queue_affinity(allocator, params)) {
+    return false;
+  }
+  if (!iree_device_size_is_valid_alignment(params->min_alignment)) {
+    return false;
+  }
+
+  const VkPhysicalDeviceMemoryProperties* memory_properties =
+      &allocator->memory_properties2.memoryProperties;
+  uint32_t memory_type_index = 0;
+  if (!iree_hal_vulkan_allocator_select_memory_type(
+          memory_properties, allowed_memory_type_bits, params,
+          &memory_type_index)) {
+    return false;
+  }
+
+  // select_memory_type rewrote params->type to the full flag set of the
+  // winning memory type.
+  *out_placement = (iree_hal_vulkan_allocator_memory_placement_t){
+      .memory_type_index = memory_type_index,
+      .memory_property_flags =
+          memory_properties->memoryTypes[memory_type_index].propertyFlags,
+      .memory_type = params->type,
+  };
   return true;
 }
 

--- a/runtime/src/iree/hal/drivers/vulkan/allocator.c
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.c
@@ -906,6 +906,7 @@ static bool iree_hal_vulkan_allocator_resolve_memory_placement(
 
   bool found = false;
   int best_score = 0;
+  int32_t best_priority = INT32_MIN;
   iree_hal_buffer_params_t best_params = *params;
   iree_hal_vulkan_allocator_memory_placement_t best_placement;
   memset(&best_placement, 0, sizeof(best_placement));
@@ -930,9 +931,17 @@ static bool iree_hal_vulkan_allocator_resolve_memory_placement(
 
     const int score = iree_hal_vulkan_allocator_score_memory_type(
         &candidate_params, memory_type);
-    if (!found || score > best_score) {
+    // Ties must be broken with the same heuristic used to select the default
+    // pool memory types: the resolved placement type is later matched against
+    // pool capabilities and a divergent winner may name a memory type that has
+    // no backing pool.
+    const int32_t priority =
+        iree_hal_vulkan_allocator_memory_type_priority(memory_type);
+    if (!found || score > best_score ||
+        (score == best_score && priority > best_priority)) {
       found = true;
       best_score = score;
+      best_priority = priority;
       best_params = candidate_params;
       best_params.type = memory_type;
       best_placement = (iree_hal_vulkan_allocator_memory_placement_t){

--- a/runtime/src/iree/hal/drivers/vulkan/allocator.h
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.h
@@ -101,6 +101,33 @@ iree_status_t iree_hal_vulkan_allocator_select_queue_alloca_plan(
     iree_hal_buffer_params_t* params, iree_device_size_t* allocation_size,
     iree_hal_vulkan_queue_alloca_plan_t* out_plan);
 
+// Selects the Vulkan memory type index that best satisfies |params|.
+//
+// Only memory types present in |allowed_memory_type_bits| (as populated by
+// VkMemoryRequirements::memoryTypeBits) are considered. On success |params| is
+// updated to parameters compatible with the selection: unsupported optional
+// mapping usage is stripped and the memory type is rewritten to the full flag
+// set the winning memory type provides. Returns false when no memory type
+// satisfies the parameters.
+//
+// Score ties are broken with the same priority heuristic used to choose the
+// default pool memory types so resolved placements always name a memory type
+// that has a backing pool. Exposed for testing; production code allocates
+// through the iree_hal_allocator_t interface instead.
+bool iree_hal_vulkan_allocator_select_memory_type(
+    const VkPhysicalDeviceMemoryProperties* memory_properties,
+    uint32_t allowed_memory_type_bits, iree_hal_buffer_params_t* params,
+    uint32_t* out_memory_type_index);
+
+// Returns the memory type index the default device pool is created from or
+// UINT32_MAX when the device reports no compatible memory type.
+//
+// Exposed for testing: device-optimal allocations resolved by
+// iree_hal_vulkan_allocator_select_memory_type must agree with this selection
+// or default-pool queue allocations cannot be satisfied.
+uint32_t iree_hal_vulkan_allocator_select_default_device_memory_type(
+    const VkPhysicalDeviceMemoryProperties* memory_properties);
+
 // Allocates a sparse buffer and returns queue-owned binds for queue_alloca.
 //
 // The returned buffer owns its VkBuffer and VkDeviceMemory blocks but the

--- a/runtime/src/iree/hal/drivers/vulkan/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator_test.cc
@@ -1,0 +1,141 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/vulkan/allocator.h"
+
+#include <cstdint>
+#include <cstring>
+#include <initializer_list>
+
+#include "iree/testing/gtest.h"
+
+namespace iree::hal::vulkan {
+namespace {
+
+VkPhysicalDeviceMemoryProperties MakeMemoryProperties(
+    std::initializer_list<VkMemoryPropertyFlags> type_flags) {
+  VkPhysicalDeviceMemoryProperties memory_properties;
+  std::memset(&memory_properties, 0, sizeof(memory_properties));
+  memory_properties.memoryHeapCount = 1;
+  memory_properties.memoryHeaps[0].size = 1ull << 30;
+  memory_properties.memoryHeaps[0].flags = VK_MEMORY_HEAP_DEVICE_LOCAL_BIT;
+  uint32_t type_count = 0;
+  for (VkMemoryPropertyFlags flags : type_flags) {
+    memory_properties.memoryTypes[type_count].propertyFlags = flags;
+    memory_properties.memoryTypes[type_count].heapIndex = 0;
+    ++type_count;
+  }
+  memory_properties.memoryTypeCount = type_count;
+  return memory_properties;
+}
+
+// Device-optimal dispatch parameters as produced for transient dispatch
+// buffers: no mapping usage requested.
+iree_hal_buffer_params_t MakeDeviceLocalDispatchParams() {
+  iree_hal_buffer_params_t params;
+  std::memset(&params, 0, sizeof(params));
+  params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL_FOR_DEVICE;
+  params.usage =
+      IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE;
+  return params;
+}
+
+// Regression test for https://github.com/iree-org/iree/issues/24788.
+//
+// Mirrors the PowerVR memory layout from the issue: two device-local
+// host-visible memory types (#3 and #4) that differ only in host
+// cached/coherent flags. Without mapping usage both receive the same
+// allocation-time score while default pool creation prefers #4, so a
+// first-wins tie-break resolved placements to #3 and default-pool queue
+// allocations failed with "no Vulkan queue allocation pool can satisfy
+// allocation".
+TEST(VulkanAllocatorMemoryTypeSelectionTest,
+     TieBrokenConsistentlyWithDefaultDevicePool) {
+  const VkPhysicalDeviceMemoryProperties memory_properties =
+      MakeMemoryProperties({
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+              VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+              VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+              VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+      });
+
+  iree_hal_buffer_params_t params = MakeDeviceLocalDispatchParams();
+  uint32_t memory_type_index = 0;
+  ASSERT_TRUE(iree_hal_vulkan_allocator_select_memory_type(
+      &memory_properties, /*allowed_memory_type_bits=*/UINT32_MAX, &params,
+      &memory_type_index));
+  EXPECT_EQ(memory_type_index, 4u);
+  EXPECT_EQ(memory_type_index,
+            iree_hal_vulkan_allocator_select_default_device_memory_type(
+                &memory_properties));
+  // The resolved params must carry the full flag set of the winning type so
+  // pool capability matching sees consistent flags.
+  EXPECT_TRUE(iree_all_bits_set(
+      params.type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                       IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                       IREE_HAL_MEMORY_TYPE_HOST_CACHED |
+                       IREE_HAL_MEMORY_TYPE_HOST_COHERENT));
+}
+
+// Same tied memory types in the opposite enumeration order: the winner must
+// follow the pool priority heuristic, not the enumeration order.
+TEST(VulkanAllocatorMemoryTypeSelectionTest,
+     TieBreakIndependentOfEnumerationOrder) {
+  const VkPhysicalDeviceMemoryProperties memory_properties =
+      MakeMemoryProperties({
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+              VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+              VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+              VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
+      });
+
+  iree_hal_buffer_params_t params = MakeDeviceLocalDispatchParams();
+  uint32_t memory_type_index = 0;
+  ASSERT_TRUE(iree_hal_vulkan_allocator_select_memory_type(
+      &memory_properties, /*allowed_memory_type_bits=*/UINT32_MAX, &params,
+      &memory_type_index));
+  EXPECT_EQ(memory_type_index, 0u);
+  EXPECT_EQ(memory_type_index,
+            iree_hal_vulkan_allocator_select_default_device_memory_type(
+                &memory_properties));
+}
+
+// A strictly better score must still win regardless of pool priority: when
+// mapping is requested the host-visible types outscore the device-only types
+// and the coherent+cached type outscores the cached-only type.
+TEST(VulkanAllocatorMemoryTypeSelectionTest, StrictScoreStillWins) {
+  const VkPhysicalDeviceMemoryProperties memory_properties =
+      MakeMemoryProperties({
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+              VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+              VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+              VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+      });
+
+  iree_hal_buffer_params_t params = MakeDeviceLocalDispatchParams();
+  params.usage |= IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED;
+  uint32_t memory_type_index = 0;
+  ASSERT_TRUE(iree_hal_vulkan_allocator_select_memory_type(
+      &memory_properties, /*allowed_memory_type_bits=*/UINT32_MAX, &params,
+      &memory_type_index));
+  EXPECT_EQ(memory_type_index, 2u);
+}
+
+}  // namespace
+}  // namespace iree::hal::vulkan


### PR DESCRIPTION
Fixes #24788.

## Problem

On PowerVR, queue allocations failed with `no Vulkan queue allocation pool can satisfy allocation of 3240 bytes`. Two memory type selection heuristics disagree:

Allocating a buffer picks a memory type by score; building the default pools picks one by priority. When two memory types tie on score (which happens when no mapping is requested and they differ only in cached/coherent flags), the allocator picked the first one, but the pool was built for the other one so no pool matched and allocation failed on PowerVR.

## Fix

The fix breaks score ties using the same priority function the pools use, so both always pick the same type

## Testing

Tested with a new unit test that recreates the PowerVR memory layout (fails before the fix, passes after), plus the existing Vulkan CTS on Lavapipe.

It is requested to test by someone with PowerVR GPU.