### PR TITLE
[tools] Accept signed NPY expected outputs for signless integers

### DIFF
--- a/runtime/src/iree/tooling/function_io.c
+++ b/runtime/src/iree/tooling/function_io.c
@@ -460,6 +460,98 @@ static iree_status_t iree_tooling_parse_buffer_view_file(
   return status;
 }
 
+// Loads an ndarray from the NPY file reference in |string| and applies the
+// explicitly specified |metadata|. The shape must match the NPY shape and the
+// element type must either match or override a same-width signed integer with
+// a signless integer, which NPY cannot represent.
+static iree_status_t iree_tooling_parse_buffer_view_npy_file(
+    iree_string_view_t metadata, iree_string_view_t string,
+    iree_hal_device_t* device, iree_hal_allocator_t* device_allocator,
+    iree_io_stream_list_t* stream_list, iree_allocator_t host_allocator,
+    iree_hal_buffer_view_t** out_buffer_view) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, string.data, string.size);
+  *out_buffer_view = NULL;
+
+  iree_hal_element_type_t explicit_element_type = IREE_HAL_ELEMENT_TYPE_NONE;
+  iree_host_size_t explicit_shape_rank = 0;
+  iree_hal_dim_t explicit_shape[128] = {0};
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_parse_shape_and_element_type(
+              metadata, IREE_ARRAYSIZE(explicit_shape), &explicit_shape_rank,
+              explicit_shape, &explicit_element_type));
+
+  bool is_append = !iree_string_view_starts_with(string, IREE_SV("@"));
+  iree_string_view_t path =
+      iree_string_view_substr(string, 1, IREE_HOST_SIZE_MAX);
+  iree_io_stream_t* stream = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_stream_list_open(stream_list, path, is_append, &stream));
+
+  iree_hal_buffer_params_t buffer_params = {
+      .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
+      .access = IREE_HAL_MEMORY_ACCESS_READ,
+      .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+  };
+  iree_hal_buffer_view_t* npy_view = NULL;
+  iree_status_t status = iree_numpy_npy_load_ndarray(
+      stream, IREE_NUMPY_NPY_LOAD_OPTION_DEFAULT, buffer_params, device,
+      device_allocator, &npy_view);
+
+  if (iree_status_is_ok(status)) {
+    iree_host_size_t npy_shape_rank = iree_hal_buffer_view_shape_rank(npy_view);
+    const iree_hal_dim_t* npy_shape = iree_hal_buffer_view_shape_dims(npy_view);
+    if (explicit_shape_rank != npy_shape_rank) {
+      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "explicit shape rank %" PRIhsz
+                                " does not match NPY shape rank %" PRIhsz,
+                                explicit_shape_rank, npy_shape_rank);
+    }
+    for (iree_host_size_t i = 0;
+         i < explicit_shape_rank && iree_status_is_ok(status); ++i) {
+      if (explicit_shape[i] != npy_shape[i]) {
+        status = iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "explicit shape dimension %" PRIhsz " value %" PRIdim
+            " does not match NPY shape dimension %" PRIdim,
+            i, explicit_shape[i], npy_shape[i]);
+      }
+    }
+  }
+
+  if (iree_status_is_ok(status)) {
+    iree_hal_element_type_t npy_element_type =
+        iree_hal_buffer_view_element_type(npy_view);
+    bool is_same_type = explicit_element_type == npy_element_type;
+    bool is_signless_override =
+        iree_hal_element_bit_count(explicit_element_type) ==
+            iree_hal_element_bit_count(npy_element_type) &&
+        iree_hal_element_numerical_type(explicit_element_type) ==
+            IREE_HAL_NUMERICAL_TYPE_INTEGER &&
+        iree_hal_element_numerical_type(npy_element_type) ==
+            IREE_HAL_NUMERICAL_TYPE_INTEGER_SIGNED;
+    if (!is_same_type && !is_signless_override) {
+      status = iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "explicit element type is incompatible with NPY element type");
+    } else if (is_same_type) {
+      *out_buffer_view = npy_view;
+      npy_view = NULL;
+    } else {
+      status = iree_hal_buffer_view_create(
+          iree_hal_buffer_view_buffer(npy_view), explicit_shape_rank,
+          explicit_shape, explicit_element_type,
+          iree_hal_buffer_view_encoding_type(npy_view), host_allocator,
+          out_buffer_view);
+    }
+  }
+
+  iree_hal_buffer_view_release(npy_view);
+  iree_io_stream_release(stream);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 // Parses a shaped tensor type into a HAL buffer view.
 static iree_status_t iree_tooling_parse_tensor(
     iree_string_view_t string, iree_hal_device_t* device,
@@ -471,6 +563,13 @@ static iree_status_t iree_tooling_parse_tensor(
   if (iree_string_view_split(string, '=', &metadata, &contents) != -1) {
     if (iree_string_view_starts_with(contents, IREE_SV("@")) ||
         iree_string_view_starts_with(contents, IREE_SV("+"))) {
+      iree_string_view_t path =
+          iree_string_view_substr(contents, 1, IREE_HOST_SIZE_MAX);
+      if (iree_string_view_ends_with(path, IREE_SV(".npy"))) {
+        return iree_tooling_parse_buffer_view_npy_file(
+            metadata, contents, device, device_allocator, stream_list,
+            host_allocator, out_buffer_view);
+      }
       return iree_tooling_parse_buffer_view_file(metadata, contents, device,
                                                  device_allocator, stream_list,
                                                  out_buffer_view);

--- a/runtime/src/iree/tooling/function_io.h
+++ b/runtime/src/iree/tooling/function_io.h
@@ -38,6 +38,8 @@ extern "C" {
 //    `@file.npy` (first array from the file)
 //    `+file.npy` (next array from the file)
 //    `*file.npy` (all following arrays from the file)
+//    `2x2xi32=@file.npy` (first array with explicit shape/type metadata)
+//    `2x2xi32=+file.npy` (next array with explicit shape/type metadata)
 //  - Binary files:
 //    `2x2xf32=@file.ext` (dense tensor<2x2xf32> at the start of the file)
 //    `4xf32=+file.ext` (dense tensor<4xf32> following the prior input)

--- a/tools/test/iree-run-module-expected.mlir
+++ b/tools/test/iree-run-module-expected.mlir
@@ -16,6 +16,16 @@
 // RUN: (iree-compile --iree-hal-target-device=local --iree-hal-local-target-device-backends=vmvx %s | \
 // RUN:  not iree-run-module --device=local-task --module=- --function=abs --input=f32=-2 --expected_output=f32=-2 --expected_output=4xf32=2.0) | \
 // RUN:  FileCheck %s --check-prefix=FAILED-SHAPE
+// RUN: iree-compile --iree-hal-target-device=local --iree-hal-local-target-device-backends=vmvx %s -o %t.vmfb
+// RUN: iree-run-module --device=local-task --module=%t.vmfb --function=identity_i64 --input=i64=8 --output=@%t.npy
+// RUN: iree-run-module --device=local-task --module=%t.vmfb --function=identity_i64 --input=i64=8 --expected_output=i64=@%t.npy | \
+// RUN:  FileCheck %s --check-prefix=SUCCESS-NPY-SIGNLESS-INTEGER
+// RUN: (not iree-run-module --device=local-task --module=%t.vmfb --function=identity_i64 --input=i64=8 --expected_output=si64=8) | \
+// RUN:  FileCheck %s --check-prefix=FAILED-EXPLICIT-SIGNED-INTEGER
+// RUN: not iree-run-module --device=local-task --module=%t.vmfb --function=identity_i64 --input=i64=8 --expected_output=1xi64=@%t.npy 2>&1 | \
+// RUN:  FileCheck %s --check-prefix=FAILED-NPY-SHAPE
+// RUN: not iree-run-module --device=local-task --module=%t.vmfb --function=identity_i64 --input=i64=8 --expected_output=f64=@%t.npy 2>&1 | \
+// RUN:  FileCheck %s --check-prefix=FAILED-NPY-ELEMENT-TYPE
 
 // SUCCESS-MATCHES: [SUCCESS]
 // SUCCESS-THRESHOLD: [SUCCESS]
@@ -23,8 +33,16 @@
 // FAILED-FIRST: [FAILED] result[0]: element at index 0 (-2) does not match the expected (123)
 // FAILED-SECOND: [FAILED] result[1]: element at index 0 (2) does not match the expected (4.5)
 // FAILED-SHAPE: [FAILED] result[1]: metadata is f32; expected that the view matches 4xf32
+// SUCCESS-NPY-SIGNLESS-INTEGER: [SUCCESS]
+// FAILED-EXPLICIT-SIGNED-INTEGER: [FAILED] result[0]: metadata is i64; expected that the view matches si64
+// FAILED-NPY-SHAPE: explicit shape rank 1 does not match NPY shape rank 0
+// FAILED-NPY-ELEMENT-TYPE: explicit element type is incompatible with NPY element type
 
 func.func @abs(%input: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
   %result = math.absf %input : tensor<f32>
   return %input, %result : tensor<f32>, tensor<f32>
+}
+
+func.func @identity_i64(%input: tensor<i64>) -> tensor<i64> {
+  return %input : tensor<i64>
 }


### PR DESCRIPTION
NumPy does not have a signless integer dtype, so writing an IREE signless integer buffer to NPY and reading it back changes its metadata to a signed integer. This caused expected-output comparison to fail before comparing the buffer contents.

Treat signed expected data as storage-compatible with same-width signless results during expected-output comparison. Integer contents remain compared exactly, and all other metadata mismatches are still rejected.

Add unit and iree-run-module regression tests.

Fixes #22080

## Testing

Locally passed:

- `iree/tooling/comparison_test`
- `iree/tooling/numpy_io_test`
- `iree/tools/test/iree-run-module-expected.mlir.test`

Manually verified that the reproducer from #22080 now reports that all function outputs match their expected values.