### PR TITLE
[LLVMCPU] set inner-tile alignment hints on scalable unpack ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -57,8 +57,10 @@
 #include "mlir/Interfaces/TilingInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include <cstdint>
 #include <numeric>
 #include <optional>
+#include <type_traits>
 
 #define DEBUG_TYPE "kernel-dispatch"
 
@@ -3804,30 +3806,37 @@ void MultiLoweringConfigGenerator::splitCommonInnerVectorTiles() {
   }
 }
 
-/// Captures the inner-tile alignment of a scalable `linalg.pack` at tiling
-/// `level` from its (unpacked-domain) loop tile sizes.
-static void capturePackInnerTileAlignment(
-    linalg::PackOp packOp, const SizesAndScalableFlags &packScalableTilesFlags,
+/// Captures the inner-tile alignment of a scalable `linalg.pack/unpack` at
+/// tiling `level` from its (unpacked-domain) loop tile sizes.
+template <typename PackUnpackType>
+static void captureInnerTileAlignment(
+    PackUnpackType op, const SizesAndScalableFlags &scalableTilesFlags,
     IREE::CPU::TilingLevel level, ArrayRef<int64_t> tileSizes,
     ArrayRef<bool> scalableFlags,
     SmallVectorImpl<std::pair<IREE::CPU::TilingLevel, SmallVector<int64_t>>>
         &perLevel) {
+  static_assert(
+      std::is_same_v<PackUnpackType, linalg::PackOp> ||
+          std::is_same_v<PackUnpackType, linalg::UnPackOp>,
+      "Inner tile alignment hints can only be captured for pack/unpack ops!");
   // TODO(egebeysel): wire in distribution tile size alignment logic.
   if (level == IREE::CPU::TilingLevel::DistributionTiles) {
     return;
   }
+  int64_t rank = std::is_same_v<PackUnpackType, linalg::PackOp>
+                     ? op.getSourceRank()
+                     : op.getDestRank();
   SmallVector<int64_t> alignments(
-      packOp.getSourceRank(),
-      llvm::to_underlying(mlir::InnerTileAlignment::Unknown));
+      rank, llvm::to_underlying(mlir::InnerTileAlignment::Unknown));
   bool any = false;
-  for (auto [i, pos] : llvm::enumerate(packOp.getInnerDimsPos())) {
+  for (auto [i, pos] : llvm::enumerate(op.getInnerDimsPos())) {
     // Only scalable inner tiles need a hint; static ones are resolved by static
     // shape inference downstream.
-    if (!packScalableTilesFlags.second[i] || pos >= tileSizes.size()) {
+    if (!scalableTilesFlags.second[i] || pos >= tileSizes.size()) {
       continue;
     }
     mlir::InnerTileAlignment kind = getScalableInnerTileAlignment(
-        tileSizes[pos], scalableFlags[pos], packScalableTilesFlags.first[i]);
+        tileSizes[pos], scalableFlags[pos], scalableTilesFlags.first[i]);
     alignments[pos] = llvm::to_underlying(kind);
     if (kind != mlir::InnerTileAlignment::Unknown) {
       any = true;
@@ -3886,9 +3895,9 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
         // unpacked domain.
         if (auto packScalableTilesFlags =
                 getScalableTileSizesAndFlags(packOp.getMixedTiles())) {
-          capturePackInnerTileAlignment(packOp, *packScalableTilesFlags, level,
-                                        tileSizes, scalableFlags,
-                                        perLevelAlignments);
+          captureInnerTileAlignment<linalg::PackOp>(
+              packOp, *packScalableTilesFlags, level, tileSizes, scalableFlags,
+              perLevelAlignments);
         }
         // `MultiLoweringConfigGenerator` propagates tiling on the
         // unpacked dimensions, while for a pack operation, `LoweringConfig`
@@ -3896,19 +3905,26 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
         // `undoScaleAndPermutateTilingForPackOp` to translate the tiling
         // information from the unpacked to the packed dimensions.
         undoScaleAndPermutateTilingForPackOp(packOp, tileSizes, scalableFlags);
-      } else if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op);
-                 unpackOp &&
-                 level == IREE::CPU::TilingLevel::VectorCommonParallelTiles &&
-                 unpackOp.getSource().getDefiningOp<linalg::LinalgOp>()) {
-        // The `IterationDimTracker` ties an unpack's destination loops only to
-        // the *outer* dims of its packed source operand, so `tileSizes`
-        // holds the source's outer tiling for consumer unpack operations. Map
-        // these onto the destination unpacked domain by scaling and permuting
-        // with the inner tile sizes.
-        undoScaleAndPermutateTilingForUnpackOp(unpackOp, tileSizes,
-                                               scalableFlags);
+      } else if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op)) {
+        if (level == IREE::CPU::TilingLevel::VectorCommonParallelTiles &&
+            unpackOp.getSource().getDefiningOp<linalg::LinalgOp>()) {
+          // The `IterationDimTracker` ties an unpack's destination loops only
+          // to the *outer* dims of its packed source operand, so `tileSizes`
+          // holds the source's outer tiling for consumer unpack operations. Map
+          // these onto the destination unpacked domain by scaling and permuting
+          // with the inner tile sizes.
+          undoScaleAndPermutateTilingForUnpackOp(unpackOp, tileSizes,
+                                                 scalableFlags);
+        }
+        // Capture this level's alignment for the unpack's scalable inner tiles
+        // after converting them to the unpacked domain.
+        if (auto unpackScalableTilesFlags =
+                getScalableTileSizesAndFlags(unpackOp.getMixedTiles())) {
+          captureInnerTileAlignment<linalg::UnPackOp>(
+              unpackOp, *unpackScalableTilesFlags, level, tileSizes,
+              scalableFlags, perLevelAlignments);
+        }
       }
-
       // Append tiling info.
       newTilingInfo.push_back(
           {level, std::move(tileSizes), std::move(scalableFlags)});
@@ -4225,9 +4241,9 @@ static void annotateScalablePackConsumerOfUnpack(linalg::PackOp packOp) {
     if (!levelAttr) {
       continue;
     }
-    capturePackInnerTileAlignment(packOp, *packScalableTilesFlags, level,
-                                  levelAttr.getSizes(),
-                                  levelAttr.getScalableFlags(), perLevel);
+    captureInnerTileAlignment<linalg::PackOp>(
+        packOp, *packScalableTilesFlags, level, levelAttr.getSizes(),
+        levelAttr.getScalableFlags(), perLevel);
   }
 
   if (!perLevel.empty()) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/LLVMCPU/KernelDispatch.h"
 
+#include "iree/compiler/Codegen/Common/TileAndFuseUtils.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenEnums.h"
@@ -3247,6 +3248,23 @@ setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
   return failure();
 }
 
+/// Returns the `InnerTileAlignment` implied by a loop tile size relative to a
+/// scalable pack/unpack inner tile whose vscale multiplier is `innerBase`.
+static mlir::InnerTileAlignment
+getScalableInnerTileAlignment(int64_t loopTile, bool loopScalable,
+                              int64_t innerBase) {
+  if (innerBase <= 0 || loopTile <= 0 || !loopScalable) {
+    return mlir::InnerTileAlignment::Unknown;
+  }
+  if (loopTile == innerBase) {
+    return mlir::InnerTileAlignment::Equal;
+  }
+  if (loopTile % innerBase == 0) {
+    return mlir::InnerTileAlignment::Multiple;
+  }
+  return mlir::InnerTileAlignment::Unknown;
+}
+
 /// Transforms tiling sizes from the unpacked domain to the packed domain
 /// for a `PackOp` by undoing the scaling for inner dimensions and applying
 /// outer dimension permutations.
@@ -3785,6 +3803,40 @@ void MultiLoweringConfigGenerator::splitCommonInnerVectorTiles() {
   }
 }
 
+/// Captures the inner-tile alignment of a scalable `linalg.pack` at tiling
+/// `level` from its (unpacked-domain) loop tile sizes.
+static void capturePackInnerTileAlignment(
+    linalg::PackOp packOp, const SizesAndScalableFlags &packSaf,
+    IREE::CPU::TilingLevel level, ArrayRef<int64_t> tileSizes,
+    ArrayRef<bool> scalableFlags,
+    SmallVectorImpl<std::pair<IREE::CPU::TilingLevel, SmallVector<int64_t>>>
+        &perLevel) {
+  // TODO(egebeysel): wire in distribution tile size alignment logic.
+  if (level == IREE::CPU::TilingLevel::DistributionTiles) {
+    return;
+  }
+  SmallVector<int64_t> alignments(
+      packOp.getSourceRank(),
+      static_cast<int64_t>(mlir::InnerTileAlignment::Unknown));
+  bool any = false;
+  for (auto [i, pos] : llvm::enumerate(packOp.getInnerDimsPos())) {
+    // Only scalable inner tiles need a hint; static ones are resolved by static
+    // shape inference downstream.
+    if (!packSaf.second[i] || pos >= static_cast<int64_t>(tileSizes.size())) {
+      continue;
+    }
+    mlir::InnerTileAlignment kind = getScalableInnerTileAlignment(
+        tileSizes[pos], scalableFlags[pos], packSaf.first[i]);
+    alignments[pos] = static_cast<int64_t>(kind);
+    if (kind != mlir::InnerTileAlignment::Unknown) {
+      any = true;
+    }
+  }
+  if (any) {
+    perLevel.emplace_back(level, std::move(alignments));
+  }
+}
+
 void MultiLoweringConfigGenerator::setNewTilingConfigs() {
   SmallVector<IREE::CPU::TilingLevel> tilingLevels;
   tilingLevels.reserve(globalTileSizes.size());
@@ -3798,6 +3850,17 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
         cast<TilingInterface>(op).getLoopIteratorTypes();
     int numLoops = iterTypes.size();
     SmallVector<IREE::CPU::LoweringConfigLevelInfo> newTilingInfo;
+    // Precompute per-tiling-level inner-tile alignment hints for a scalable
+    // pack from the loop tile sizes chosen here. The pack is captured before
+    // `undoScaleAndPermutateTilingForPackOp` divides its (scalable) loop tile
+    // into the packed domain.
+    auto packOp = dyn_cast<linalg::PackOp>(op);
+    std::optional<SizesAndScalableFlags> packSaf;
+    if (packOp) {
+      packSaf = getScalableTileSizesAndFlags(packOp.getMixedTiles());
+    }
+    SmallVector<std::pair<IREE::CPU::TilingLevel, SmallVector<int64_t>>>
+        perLevelAlignments;
     // Collect new tiling info.
     for (IREE::CPU::TilingLevel level : tilingLevels) {
       SmallVector<int64_t> tileSizes(numLoops, 0);
@@ -3825,7 +3888,14 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
         scalableFlags[pos] = globalScalableTileFlags[level][globalDimIdx];
       }
 
-      if (auto packOp = dyn_cast<linalg::PackOp>(op)) {
+      // Capture this level's alignment for the pack's scalable inner tiles from
+      // the loop tile sizes while they are still in the unpacked domain.
+      if (packOp && packSaf) {
+        capturePackInnerTileAlignment(packOp, *packSaf, level, tileSizes,
+                                      scalableFlags, perLevelAlignments);
+      }
+
+      if (packOp) {
         // `MultiLoweringConfigGenerator` propagates tiling on the
         // unpacked dimensions, while for a pack operation, `LoweringConfig`
         // defines tiling on the packed inner dimensions. Therefore, use
@@ -3853,6 +3923,9 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
         getNewLoweringConfig(rootOperation->getContext(), newTilingInfo,
                              /*setDistributionConfig=*/op == rootOperation);
     setLoweringConfig(op, config);
+    if (!perLevelAlignments.empty()) {
+      IREE::CPU::InnerTileAlignmentsAttr::setOnOp(op, perLevelAlignments);
+    }
   }
 }
 
@@ -4121,6 +4194,77 @@ lowerUsingDefaultPipeline(mlir::FunctionOpInterface entryPointFn) {
   return setTranslationInfo(entryPointFn, translationInfo);
 }
 
+/// For a `linalg.pack` whose producer is a `linalg.unpack`, no lowering config
+/// is assigned (see `shouldSetLoweringConfig`), so the consumer-tiling pass
+/// cannot derive how the pack's scalable inner tiles relate to its loop tile
+/// sizes. The pack shares its (unpacked) iteration domain with the producer
+/// unpack, which *does* carry a config, so for each tiling level present on the
+/// unpack we compare that level's tile sizes against the pack's scalable inner
+/// tiles (matched by dimension position) and stash the per-level result on the
+/// pack op for `makeInnerTileAlignmentFn` to read back downstream.
+static void annotateScalablePackConsumerOfUnpack(linalg::PackOp packOp) {
+  auto unpackOp = packOp.getSource().getDefiningOp<linalg::UnPackOp>();
+  if (!unpackOp) {
+    return;
+  }
+  auto unpackConfig = getLoweringConfig<IREE::CPU::LoweringConfigAttr>(unpackOp);
+  if (!unpackConfig) {
+    return;
+  }
+  std::optional<SizesAndScalableFlags> packSaf =
+      getScalableTileSizesAndFlags(packOp.getMixedTiles());
+  if (!packSaf) {
+    return;
+  }
+
+  ArrayRef<int64_t> packPos = packOp.getInnerDimsPos();
+  int64_t rank = packOp.getSourceRank();
+
+  SmallVector<std::pair<IREE::CPU::TilingLevel, SmallVector<int64_t>>> perLevel;
+  for (int levelIdx = 0;
+       levelIdx < static_cast<int>(IREE::CPU::TilingLevel::MaxNumTileLevels);
+       ++levelIdx) {
+    auto level = static_cast<IREE::CPU::TilingLevel>(levelIdx);
+    if (!unpackConfig.hasTilingLevel(static_cast<unsigned>(level))) {
+      continue;
+    }
+    auto levelAttr = dyn_cast<IREE::Codegen::LoweringConfigTilingLevelAttr>(
+        unpackConfig.getTilingLevelAttr(static_cast<unsigned>(level)));
+    if (!levelAttr) {
+      continue;
+    }
+    ArrayRef<int64_t> levelSizes = levelAttr.getSizes();
+    ArrayRef<bool> levelScalable = levelAttr.getScalableFlags();
+
+    SmallVector<int64_t> alignments(
+        rank, static_cast<int64_t>(mlir::InnerTileAlignment::Unknown));
+    bool any = false;
+    for (auto [pos, base, scalable] :
+         llvm::zip_equal(packPos, packSaf->first, packSaf->second)) {
+      // Only scalable pack inner tiles need a hint; static ones are resolved by
+      // static shape inference downstream.
+      if (!scalable || pos >= static_cast<int64_t>(levelSizes.size())) {
+        continue;
+      }
+      bool levelTileScalable =
+          pos < static_cast<int64_t>(levelScalable.size()) && levelScalable[pos];
+      mlir::InnerTileAlignment kind = getScalableInnerTileAlignment(
+          levelSizes[pos], levelTileScalable, base);
+      alignments[pos] = static_cast<int64_t>(kind);
+      if (kind != mlir::InnerTileAlignment::Unknown) {
+        any = true;
+      }
+    }
+    if (any) {
+      perLevel.emplace_back(level, std::move(alignments));
+    }
+  }
+
+  if (!perLevel.empty()) {
+    IREE::CPU::InnerTileAlignmentsAttr::setOnOp(packOp, perLevel);
+  }
+}
+
 /// Returns true if the given operation should have a lowering config set.
 ///
 /// This predicate excludes:
@@ -4208,6 +4352,16 @@ setTranslationInfoAndRootConfig(mlir::FunctionOpInterface entryPointFn,
     if (failed(setLoweringConfigForComputeOps(entryPointFn, prunedComputeOps,
                                               rootOperation))) {
       return failure();
+    }
+
+    // Packs fed by an unpack are pruned above and never receive a lowering
+    // config, yet they are still tiled as fused consumers downstream.
+    // Precompute the alignment of their scalable inner tiles relative to the
+    // producer unpack's inner tiles.
+    for (Operation *op : computeOps) {
+      if (auto packOp = dyn_cast<linalg::PackOp>(op)) {
+        annotateScalablePackConsumerOfUnpack(packOp);
+      }
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3837,6 +3837,46 @@ static void capturePackInnerTileAlignment(
   }
 }
 
+/// Captures the inner-tile alignment of a scalable `linalg.unpack` at tiling
+/// `level` from its (unpacked/dest-domain) loop tile sizes (`tileSizes` /
+/// `scalableFlags`), appending a `{level, per-dim alignments}` entry to
+/// `perLevel` when at least one scalable inner tile resolves to a non-`Unknown`
+/// alignment. Unlike the pack, the unpack's loop tile is already in the unpacked
+/// domain and carries the scalable flag, so it compares directly to the inner
+/// tile. `unpackSaf` holds the unpack's inner tiles decoded by
+/// `getScalableTileSizesAndFlags`. The distribution level is skipped for now.
+static void captureUnpackInnerTileAlignment(
+    linalg::UnPackOp unpackOp, const SizesAndScalableFlags &unpackSaf,
+    IREE::CPU::TilingLevel level, ArrayRef<int64_t> tileSizes,
+    ArrayRef<bool> scalableFlags,
+    SmallVectorImpl<std::pair<IREE::CPU::TilingLevel, SmallVector<int64_t>>>
+        &perLevel) {
+  // TODO(egebeysel): wire in distribution tile size alignment logic.
+  if (level == IREE::CPU::TilingLevel::DistributionTiles) {
+    return;
+  }
+  SmallVector<int64_t> alignments(
+      cast<ShapedType>(unpackOp.getDest().getType()).getRank(),
+      static_cast<int64_t>(mlir::InnerTileAlignment::Unknown));
+  bool any = false;
+  for (auto [i, pos] : llvm::enumerate(unpackOp.getInnerDimsPos())) {
+    // Only scalable inner tiles need a hint; static ones are resolved by static
+    // shape inference downstream.
+    if (!unpackSaf.second[i] || pos >= static_cast<int64_t>(tileSizes.size())) {
+      continue;
+    }
+    mlir::InnerTileAlignment kind = getScalableInnerTileAlignment(
+        tileSizes[pos], scalableFlags[pos], unpackSaf.first[i]);
+    alignments[pos] = static_cast<int64_t>(kind);
+    if (kind != mlir::InnerTileAlignment::Unknown) {
+      any = true;
+    }
+  }
+  if (any) {
+    perLevel.emplace_back(level, std::move(alignments));
+  }
+}
+
 void MultiLoweringConfigGenerator::setNewTilingConfigs() {
   SmallVector<IREE::CPU::TilingLevel> tilingLevels;
   tilingLevels.reserve(globalTileSizes.size());
@@ -3850,14 +3890,21 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
         cast<TilingInterface>(op).getLoopIteratorTypes();
     int numLoops = iterTypes.size();
     SmallVector<IREE::CPU::LoweringConfigLevelInfo> newTilingInfo;
-    // Precompute per-tiling-level inner-tile alignment hints for a scalable
-    // pack from the loop tile sizes chosen here. The pack is captured before
-    // `undoScaleAndPermutateTilingForPackOp` divides its (scalable) loop tile
-    // into the packed domain.
+    // Precompute per-tiling-level inner-tile alignment hints for scalable
+    // pack/unpack ops (see capture{Pack,Unpack}InnerTileAlignment) so
+    // `makeInnerTileAlignmentFn` can read them back instead of re-deriving them.
+    // A pack is captured *before* its loop tile is divided into the packed
+    // domain; an unpack *after* its loop tile is scaled up into the unpacked
+    // domain.
     auto packOp = dyn_cast<linalg::PackOp>(op);
+    auto unpackOp = dyn_cast<linalg::UnPackOp>(op);
     std::optional<SizesAndScalableFlags> packSaf;
+    std::optional<SizesAndScalableFlags> unpackSaf;
     if (packOp) {
       packSaf = getScalableTileSizesAndFlags(packOp.getMixedTiles());
+    }
+    if (unpackOp) {
+      unpackSaf = getScalableTileSizesAndFlags(unpackOp.getMixedTiles());
     }
     SmallVector<std::pair<IREE::CPU::TilingLevel, SmallVector<int64_t>>>
         perLevelAlignments;
@@ -3902,8 +3949,7 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
         // `undoScaleAndPermutateTilingForPackOp` to translate the tiling
         // information from the unpacked to the packed dimensions.
         undoScaleAndPermutateTilingForPackOp(packOp, tileSizes, scalableFlags);
-      } else if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op);
-                 unpackOp &&
+      } else if (unpackOp &&
                  level == IREE::CPU::TilingLevel::VectorCommonParallelTiles &&
                  unpackOp.getSource().getDefiningOp<linalg::LinalgOp>()) {
         // The `IterationDimTracker` ties an unpack's destination loops only to
@@ -3913,6 +3959,13 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
         // with the inner tile sizes.
         undoScaleAndPermutateTilingForUnpackOp(unpackOp, tileSizes,
                                                scalableFlags);
+      }
+
+      // Capture this level's alignment for the unpack's scalable inner tiles,
+      // now that the loop tile has been scaled up into the unpacked domain.
+      if (unpackOp && unpackSaf) {
+        captureUnpackInnerTileAlignment(unpackOp, *unpackSaf, level, tileSizes,
+                                        scalableFlags, perLevelAlignments);
       }
 
       // Append tiling info.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -278,6 +278,7 @@ func.func @pack(%arg0: tensor<20x48xf32>) -> tensor<2x?x16x?xf32> attributes {ha
 //      CHECK: func.func @pack(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pack
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -308,6 +309,7 @@ func.func @elem_pack(%arg0: tensor<128x384xf32>) -> tensor<16x?x8x?xf32> attribu
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG1]]
 //      CHECK:   linalg.pack
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG2]]
 
 // -----
@@ -354,6 +356,7 @@ func.func @reduction_broadcast_pack(%arg0: tensor<384x1024xf32>, %arg1: tensor<3
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG3]]
 //      CHECK:   linalg.pack
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_inner_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG4]]
 
 // -----
@@ -385,6 +388,7 @@ func.func @transpose_pack(%arg0: tensor<30522x768xf32>) -> tensor<?x96x?x8xf32> 
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG1]]
 //      CHECK:   linalg.pack
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG2]]
 
 // -----
@@ -423,6 +427,7 @@ func.func @reduction_pack(%arg0: tensor<384x1024x32xf32>, %arg1: tensor<384x1024
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG2]]
 //      CHECK:   linalg.pack
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG3]]
 
 // -----
@@ -430,7 +435,7 @@ func.func @reduction_pack(%arg0: tensor<384x1024x32xf32>, %arg1: tensor<384x1024
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map2 = affine_map<()[s0] -> (10240 ceildiv s0)>
-func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tensor<?x4096x?x1xf16>) -> tensor<5x10240x16x1xf16> attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tensor<?x4096x?x1xf16>) -> tensor<5x?x16x?xf16> attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
   %cst = arith.constant 0.000000e+00 : f16
   %cst_0 = arith.constant 0.000000e+00 : f32
 
@@ -450,9 +455,9 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
   } -> tensor<5x?x16x?xf16>
   %5 = tensor.empty() : tensor<77x10240xf16>
   %unpack = linalg.unpack %4 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, %c16_vscale] into %5 : tensor<5x?x16x?xf16> -> tensor<77x10240xf16>
-  %6 = tensor.empty() : tensor<5x10240x16x1xf16>
-  %pack = linalg.pack %unpack padding_value(%cst : f16) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 1] into %6 : tensor<77x10240xf16> -> tensor<5x10240x16x1xf16>
-  return %pack : tensor<5x10240x16x1xf16>
+  %6 = tensor.empty(%n0, %c16_vscale) : tensor<5x?x16x?xf16>
+  %pack = linalg.pack %unpack padding_value(%cst : f16) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, %c16_vscale] into %6 : tensor<77x10240xf16> -> tensor<5x?x16x?xf16>
+  return %pack : tensor<5x?x16x?xf16>
 }
 // CHECK-DAG:   #[[$CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16, [16]]>
 // CHECK-DAG:   #[[$CONFIG1:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 16, [16], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
@@ -466,8 +471,11 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
 // CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
 // CHECK:         linalg.unpack
 // CHECK-SAME:      {lowering_config = #[[$CONFIG2]]}
+// The consumer pack has no lowering config of its own; it carries the
+// precomputed inner-tile alignment hint instead.
 // CHECK:         linalg.pack
-// CHECK-NOT:      lowering_config
+// CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-NOT:       lowering_config
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -189,6 +189,7 @@ func.func @unpack(%arg0 : tensor<128x10x?x8x?xf32>) -> tensor<128x80x320xf32> at
 //       CHECK: func.func @unpack
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -210,6 +211,28 @@ func.func @unpack_outer_dynamic(%arg0 : tensor<?x?x32x?xi32>, %dim0 : index, %di
 //       CHECK: func.func @unpack_outer_dynamic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+//  CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+
+// Transposed `inner_dims_pos` puts the scalable inner tile on the first (rather
+// than the last) result dimension, so the hint's `Equal` must match that.
+#executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
+func.func @unpack_transposed(%arg0 : tensor<?x?x32x?xf32>, %dim0 : index, %dim1 : index) -> tensor<?x?xf32> attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+  %c8 = arith.constant 8 : index
+  %vscale = vector.vscale
+  %c8_vscale = arith.muli %vscale, %c8 : index
+  %init = tensor.empty(%dim0, %dim1) : tensor<?x?xf32>
+  %unpack = linalg.unpack %arg0 inner_dims_pos = [1, 0] inner_tiles = [32, %c8_vscale] into %init : tensor<?x?x32x?xf32> -> tensor<?x?xf32>
+  return %unpack : tensor<?x?xf32>
+}
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_cpu.lowering_config<distribution = [64, 64], vector_common_parallel = {{\[\[}}8], 32]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DataTiling>
+//       CHECK: func.func @unpack_transposed
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Equal, Unknown]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -227,6 +250,7 @@ func.func @unpack_fully_dynamic(%arg0 : tensor<?x?x?x?xi32>, %m0 : index, %n0 : 
 //       CHECK: func.func @unpack_fully_dynamic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-NOT:        inner_tile_alignments
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -255,6 +279,7 @@ func.func @unpack_with_generic(%arg0 : tensor<128x10x?x8x?xf32>, %arg1 : tensor<
 //       CHECK: func.func @unpack_with_generic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG_UNPACK]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[CONFIG_GENERIC]]
@@ -469,10 +494,12 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
 // CHECK-SAME:      {lowering_config = #[[$CONFIG1]]}
 // CHECK:         linalg.generic
 // CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
+// The producer unpack carries a precomputed inner-tile alignment hint.
 // CHECK:         linalg.unpack
-// CHECK-SAME:      {lowering_config = #[[$CONFIG2]]}
-// The consumer pack has no lowering config of its own; it carries the
-// precomputed inner-tile alignment hint instead.
+// CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:      lowering_config = #[[$CONFIG2]]
+// The consumer pack also carries a precomputed inner-tile alignment hint and
+// has no lowering config of its own.
 // CHECK:         linalg.pack
 // CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-NOT:       lowering_config
@@ -519,8 +546,10 @@ func.func @negative_hint_mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16
 // CHECK-SAME:      {lowering_config = #[[$CONFIG1]]}
 // CHECK:         linalg.generic
 // CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
+// The producer unpack is a plain scalable unpack, so it carries the hint.
 // CHECK:         linalg.unpack
-// CHECK-SAME:      {lowering_config = #[[$CONFIG2]]}
+// CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:      lowering_config = #[[$CONFIG2]]
 // The consumer pack has no lowering config nor carries an inner tile alignment,
 // since the unpack and pack inner dimensions are not aligned.
 // CHECK:         linalg.pack

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -189,6 +189,7 @@ func.func @unpack(%arg0 : tensor<128x10x?x8x?xf32>) -> tensor<128x80x320xf32> at
 //       CHECK: func.func @unpack
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -210,6 +211,7 @@ func.func @unpack_outer_dynamic(%arg0 : tensor<?x?x32x?xi32>, %dim0 : index, %di
 //       CHECK: func.func @unpack_outer_dynamic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -255,6 +257,7 @@ func.func @unpack_with_generic(%arg0 : tensor<128x10x?x8x?xf32>, %arg1 : tensor<
 //       CHECK: func.func @unpack_with_generic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG_UNPACK]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[CONFIG_GENERIC]]
@@ -469,10 +472,12 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
 // CHECK-SAME:      {lowering_config = #[[$CONFIG1]]}
 // CHECK:         linalg.generic
 // CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
+// The producer unpack carries a precomputed inner-tile alignment hint.
 // CHECK:         linalg.unpack
-// CHECK-SAME:      {lowering_config = #[[$CONFIG2]]}
-// The consumer pack has no lowering config of its own; it carries the
-// precomputed inner-tile alignment hint instead.
+// CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:      lowering_config = #[[$CONFIG2]]
+// The consumer pack also carries a precomputed inner-tile alignment hint and
+// has no lowering config of its own.
 // CHECK:         linalg.pack
 // CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-NOT:       lowering_config

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_v_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_v_lowering_strategy.mlir
@@ -118,6 +118,7 @@ func.func @pack(%arg0: tensor<20x48xf32>) -> tensor<2x?x16x?xf32> attributes {ha
 //      CHECK: func.func @pack(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pack
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -148,6 +149,7 @@ func.func @elem_pack(%arg0: tensor<128x384xf32>) -> tensor<16x?x8x?xf32> attribu
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG1]]
 //      CHECK:   linalg.pack
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG2]]
 
 // -----
@@ -155,7 +157,7 @@ func.func @elem_pack(%arg0: tensor<128x384xf32>) -> tensor<16x?x8x?xf32> attribu
 #executable_target_riscv64 = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {cpu_features = "+zvfh,+v", data_layout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "riscv64-unknown-unknown-eabi-elf"}>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map2 = affine_map<()[s0] -> (10240 ceildiv s0)>
-func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x7x1xf16>, %arg1: tensor<?x4096x?x1xf16>) -> tensor<5x10240x7x1xf16> attributes {hal.executable.target = #executable_target_riscv64} {
+func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x7x1xf16>, %arg1: tensor<?x4096x?x1xf16>) -> tensor<5x?x7x?xf16> attributes {hal.executable.target = #executable_target_riscv64} {
   %cst = arith.constant 0.000000e+00 : f16
   %cst_0 = arith.constant 0.000000e+00 : f32
 
@@ -175,9 +177,9 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x7x1xf16>, %arg1: tenso
   } -> tensor<5x?x7x?xf16>
   %5 = tensor.empty() : tensor<33x10240xf16>
   %unpack = linalg.unpack %4 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %5 : tensor<5x?x7x?xf16> -> tensor<33x10240xf16>
-  %6 = tensor.empty() : tensor<5x10240x7x1xf16>
-  %pack = linalg.pack %unpack padding_value(%cst : f16) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, 1] into %6 : tensor<33x10240xf16> -> tensor<5x10240x7x1xf16>
-  return %pack : tensor<5x10240x7x1xf16>
+  %6 = tensor.empty(%n0, %c8_vscale) : tensor<5x?x7x?xf16>
+  %pack = linalg.pack %unpack padding_value(%cst : f16) outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [7, %c8_vscale] into %6 : tensor<33x10240xf16> -> tensor<5x?x7x?xf16>
+  return %pack : tensor<5x?x7x?xf16>
 }
 // CHECK-DAG:   #[[$CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 7, [8]]>
 // CHECK-DAG:   #[[$CONFIG1:.+]] = #iree_cpu.lowering_config<distribution = [5, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 7, [8], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
@@ -191,5 +193,8 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x7x1xf16>, %arg1: tenso
 // CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
 // CHECK:         linalg.unpack
 // CHECK-SAME:      {lowering_config = #[[$CONFIG2]]}
+// The consumer pack has no lowering config of its own; it carries the
+// precomputed inner-tile alignment hint instead.
 // CHECK:         linalg.pack
-// CHECK-NOT:      lowering_config
+// CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-NOT:       lowering_config

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_v_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_v_lowering_strategy.mlir
@@ -76,6 +76,7 @@ func.func @unpack(%arg0 : tensor<128x10x?x8x?xf32>) -> tensor<128x80x320xf32> at
 //       CHECK: func.func @unpack
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -97,6 +98,7 @@ func.func @unpack_outer_dynamic(%arg0 : tensor<?x?x32x?xf32>, %dim0 : index, %di
 //       CHECK: func.func @unpack_outer_dynamic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -191,10 +193,12 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x7x1xf16>, %arg1: tenso
 // CHECK-SAME:      {lowering_config = #[[$CONFIG1]]}
 // CHECK:         linalg.generic
 // CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
+// The producer unpack carries a precomputed inner-tile alignment hint.
 // CHECK:         linalg.unpack
-// CHECK-SAME:      {lowering_config = #[[$CONFIG2]]}
-// The consumer pack has no lowering config of its own; it carries the
-// precomputed inner-tile alignment hint instead.
+// CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:      lowering_config = #[[$CONFIG2]]
+// The consumer pack also carries a precomputed inner-tile alignment hint and
+// has no lowering config of its own.
 // CHECK:         linalg.pack
 // CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-NOT:       lowering_config


### PR DESCRIPTION
Extend setting the inner tile alignment hints to `linalg.unpack` ops. After the loop tile sizes are in the unpacked domain, the inner tile sizes are compared with these to infer aligment hints per-tiling level and the corresponding attribute is set. 

Assisted-by: Claude Code

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>