### PR TITLE
[LIT] Migrate tests lit config to the internal shell

### DIFF
--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -17,9 +17,7 @@ import lit.formats
 
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
-config.test_format = lit.formats.ShTest(
-    execute_external=True, force_execute_external=True
-)
+config.test_format = lit.formats.ShTest()
 
 # Forward all IREE environment variables, as well as some passthroughs.
 # Note: env vars are case-insensitive on Windows, so check matches carefully.


### PR DESCRIPTION
Part of #24607, following #24794.

Moves `tests/lit.cfg.py` to the internal shell.

No RUN lines need changes here. None of the 27 lit tests under `tests/`
use subshells or anything else the internal shell rejects, and all 27 pass
the same as before.

Verified on macOS/arm64 only.

Assisted by: Claude Code