### PR TITLE
[ci] [windows] Route choco installs through cluster-local Nexus mirror

### DIFF
--- a/.github/workflows/ci_windows_x64_msvc.yml
+++ b/.github/workflows/ci_windows_x64_msvc.yml
@@ -45,17 +45,23 @@ jobs:
           python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
       # TODO(#18813): Fix to actually use either ccache or sccache.
       #               No need to install both, and neither is currently used.
+      # Route choco through the cluster-local Nexus proxy group (choco-group) to
+      # avoid sporadic 503s / rate limiting from the public community.chocolatey.org
+      # feed. See https://github.com/iree-org/iree/issues/24826
       - name: "Installing requirements"
-        run: choco install ccache --yes
+        run: |
+          choco source disable -n=chocolatey
+          choco source add -n=internal -s http://nexus-service.nexus-ns.svc.cluster.local:8081/repository/choco-group/ --priority=1
+          choco install ccache --yes --no-progress
       - name: "Configuring MSVC"
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: "Installing IREE requirements"
         run: |
-          choco install sccache
-          choco install cmake
+          choco install sccache --no-progress -y
+          choco install cmake --no-progress -y
           # ninja pinned due to a bug in the 1.13.0 release:
           # https://github.com/ninja-build/ninja/issues/2616
-          choco install ninja --version 1.12.1
+          choco install ninja --version 1.12.1 --no-progress -y
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv
       - name: "Building IREE"


### PR DESCRIPTION
## Summary
Windows CI (`ci_windows_x64_msvc`) sporadically fails at the tool-install steps because `choco install` hits the public `community.chocolatey.org` feed, which intermittently returns `503 (Service Unavailable)` (rate limiting / transient outages). See #24826.

This routes choco through the cluster-local Nexus proxy group (`choco-group`) via its Kubernetes service FQDN, mirroring the approach already used in [ROCm/TheRock](https://github.com/ROCm/TheRock/commit/dd781140d887e35b6e3c84cc059e4c0f8d37068a). The proxy only mirrors package *metadata*; binaries still download from the upstream mirror named in the cached nuspec, which is enough to avoid the community-feed 503s.

## Change
In `.github/workflows/ci_windows_x64_msvc.yml`, before installing packages:
```yaml
choco source disable -n=chocolatey
choco source add -n=internal -s http://nexus-service.nexus-ns.svc.cluster.local:8081/repository/choco-group/ --priority=1
```

## Verification
Dispatched on a test branch on an `azure-windows-scale` runner (run [32531536526](https://github.com/iree-org/iree/actions/runs/32531536526)). Both choco steps completed with `success`, fetching every package through the mirror with no 503s:
```
Disabled chocolatey
Added internal - http://nexus-service.nexus-ns.svc.cluster.local:8081/repository/choco-group/ (Priority 1)
Downloading package from source 'http://nexus-service.nexus-ns.svc.cluster.local:8081/repository/choco-group/'
Chocolatey installed 1/1 packages.   # ccache
Chocolatey installed 1/1 packages.   # sccache
Chocolatey installed 0/1 packages.   # cmake already present on image (no-op, step still succeeded)
Chocolatey installed 1/1 packages.   # ninja 1.12.1
```
This also confirms the `azure-windows-scale` runners are in the same cluster and can resolve the Nexus service FQDN. The build step itself was cancelled after the install steps passed, since only the choco behavior was under test.

Closes #24826

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>