### PR TITLE
[LLVMCPU] Set distribution-level inner-tile alignment hints for pack

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3292,6 +3292,19 @@ getScalableInnerTileAlignment(int64_t loopTile, bool loopScalable,
   return mlir::InnerTileAlignment::Unknown;
 }
 
+/// Returns the `InnerTileAlignment` of a static distribution tile relative to a
+/// scalable inner tile whose largest runtime size is `maxInnerTile`
+/// (base * vscaleMax). A distribution tile that is a whole multiple of the
+/// largest inner tile is a whole multiple of the inner tile for any vscale, so
+/// it is reported as `Multiple`.
+static mlir::InnerTileAlignment
+getDistributionInnerTileAlignment(int64_t distTile, int64_t maxInnerTile) {
+  if (distTile <= 0 || maxInnerTile <= 0 || distTile % maxInnerTile != 0) {
+    return mlir::InnerTileAlignment::Unknown;
+  }
+  return mlir::InnerTileAlignment::Multiple;
+}
+
 /// Transforms tiling sizes from the unpacked domain to the packed domain
 /// for a `PackOp` by undoing the scaling for inner dimensions and applying
 /// outer dimension permutations.
@@ -3851,15 +3864,17 @@ template <typename PackUnpackType>
 static void captureInnerTileAlignment(
     PackUnpackType op, const SizesAndScalableFlags &scalableTilesFlags,
     IREE::CPU::TilingLevel level, ArrayRef<int64_t> tileSizes,
-    ArrayRef<bool> scalableFlags,
+    ArrayRef<bool> scalableFlags, int64_t vscaleMax,
     SmallVectorImpl<std::pair<IREE::CPU::TilingLevel, SmallVector<int64_t>>>
         &perLevel) {
   static_assert(
       std::is_same_v<PackUnpackType, linalg::PackOp> ||
           std::is_same_v<PackUnpackType, linalg::UnPackOp>,
       "Inner tile alignment hints can only be captured for pack/unpack ops!");
-  // TODO(egebeysel): wire in distribution tile size alignment logic.
-  if (level == IREE::CPU::TilingLevel::DistributionTiles) {
+  bool isDistribution = level == IREE::CPU::TilingLevel::DistributionTiles;
+  // Distribution-level hints for pack ops are captured separately; for now only
+  // unpack ops get a distribution hint.
+  if (isDistribution && std::is_same_v<PackUnpackType, linalg::PackOp>) {
     return;
   }
   int64_t rank = std::is_same_v<PackUnpackType, linalg::PackOp>
@@ -3874,8 +3889,16 @@ static void captureInnerTileAlignment(
     if (!scalableTilesFlags.second[i] || pos >= tileSizes.size()) {
       continue;
     }
-    mlir::InnerTileAlignment kind = getScalableInnerTileAlignment(
-        tileSizes[pos], scalableFlags[pos], scalableTilesFlags.first[i]);
+    int64_t innerBase = scalableTilesFlags.first[i];
+    // At the distribution level the loop tile is static but has been aligned to
+    // the largest inner tile (base * vscaleMax), so classify against that;
+    // other levels compare the scalable loop tile against the base directly.
+    mlir::InnerTileAlignment kind =
+        isDistribution
+            ? getDistributionInnerTileAlignment(tileSizes[pos],
+                                                innerBase * vscaleMax)
+            : getScalableInnerTileAlignment(tileSizes[pos], scalableFlags[pos],
+                                            innerBase);
     alignments[pos] = llvm::to_underlying(kind);
     if (kind != mlir::InnerTileAlignment::Unknown) {
       any = true;
@@ -3894,6 +3917,8 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
   }
   std::sort(tilingLevels.begin(), tilingLevels.end());
 
+  int64_t vscaleMax =
+      getVscaleMax(IREE::HAL::ExecutableTargetAttr::lookup(rootOperation));
   for (auto op : computeOps) {
     SmallVector<utils::IteratorType> iterTypes =
         cast<TilingInterface>(op).getLoopIteratorTypes();
@@ -3936,7 +3961,7 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
                 getScalableTileSizesAndFlags(packOp.getMixedTiles())) {
           captureInnerTileAlignment<linalg::PackOp>(
               packOp, *packScalableTilesFlags, level, tileSizes, scalableFlags,
-              perLevelAlignments);
+              vscaleMax, perLevelAlignments);
         }
         // `MultiLoweringConfigGenerator` propagates tiling on the
         // unpacked dimensions, while for a pack operation, `LoweringConfig`
@@ -3961,7 +3986,7 @@ void MultiLoweringConfigGenerator::setNewTilingConfigs() {
                 getScalableTileSizesAndFlags(unpackOp.getMixedTiles())) {
           captureInnerTileAlignment<linalg::UnPackOp>(
               unpackOp, *unpackScalableTilesFlags, level, tileSizes,
-              scalableFlags, perLevelAlignments);
+              scalableFlags, vscaleMax, perLevelAlignments);
         }
       }
       // Append tiling info.
@@ -4266,6 +4291,8 @@ static void annotateScalablePackConsumerOfUnpack(linalg::PackOp packOp) {
     return;
   }
 
+  int64_t vscaleMax =
+      getVscaleMax(IREE::HAL::ExecutableTargetAttr::lookup(packOp));
   SmallVector<std::pair<IREE::CPU::TilingLevel, SmallVector<int64_t>>> perLevel;
   for (int levelIdx = 0;
        levelIdx < llvm::to_underlying(IREE::CPU::TilingLevel::MaxNumTileLevels);
@@ -4283,7 +4310,7 @@ static void annotateScalablePackConsumerOfUnpack(linalg::PackOp packOp) {
     }
     captureInnerTileAlignment<linalg::PackOp>(
         packOp, *packScalableTilesFlags, level, levelAttr.getSizes(),
-        levelAttr.getScalableFlags(), perLevel);
+        levelAttr.getScalableFlags(), vscaleMax, perLevel);
   }
 
   if (!perLevel.empty()) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3872,11 +3872,6 @@ static void captureInnerTileAlignment(
           std::is_same_v<PackUnpackType, linalg::UnPackOp>,
       "Inner tile alignment hints can only be captured for pack/unpack ops!");
   bool isDistribution = level == IREE::CPU::TilingLevel::DistributionTiles;
-  // Distribution-level hints for pack ops are captured separately; for now only
-  // unpack ops get a distribution hint.
-  if (isDistribution && std::is_same_v<PackUnpackType, linalg::PackOp>) {
-    return;
-  }
   int64_t rank = std::is_same_v<PackUnpackType, linalg::PackOp>
                      ? op.getSourceRank()
                      : op.getDestRank();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -189,7 +189,7 @@ func.func @unpack(%arg0 : tensor<128x10x?x8x?xf32>) -> tensor<128x80x320xf32> at
 //       CHECK: func.func @unpack
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
-//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Unknown, Equal]>
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Unknown, Multiple], vector_common_parallel = [Unknown, Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -211,7 +211,7 @@ func.func @unpack_outer_dynamic(%arg0 : tensor<?x?x32x?xi32>, %dim0 : index, %di
 //       CHECK: func.func @unpack_outer_dynamic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
-//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Multiple], vector_common_parallel = [Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -232,7 +232,7 @@ func.func @unpack_transposed(%arg0 : tensor<?x?x32x?xf32>, %dim0 : index, %dim1 
 //       CHECK: func.func @unpack_transposed
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
-//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Equal, Unknown]>
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Multiple, Unknown], vector_common_parallel = [Equal, Unknown]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -279,7 +279,7 @@ func.func @unpack_with_generic(%arg0 : tensor<128x10x?x8x?xf32>, %arg1 : tensor<
 //       CHECK: func.func @unpack_with_generic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
-//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Unknown, Equal]>
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Unknown, Multiple], vector_common_parallel = [Unknown, Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG_UNPACK]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       lowering_config = #[[CONFIG_GENERIC]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -303,7 +303,7 @@ func.func @pack(%arg0: tensor<20x48xf32>) -> tensor<2x?x16x?xf32> attributes {ha
 //      CHECK: func.func @pack(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pack
-// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Multiple], vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -334,7 +334,7 @@ func.func @elem_pack(%arg0: tensor<128x384xf32>) -> tensor<16x?x8x?xf32> attribu
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG1]]
 //      CHECK:   linalg.pack
-// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Multiple], vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG2]]
 
 // -----
@@ -413,7 +413,7 @@ func.func @transpose_pack(%arg0: tensor<30522x768xf32>) -> tensor<?x96x?x8xf32> 
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG1]]
 //      CHECK:   linalg.pack
-// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Multiple], vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG2]]
 
 // -----
@@ -452,7 +452,7 @@ func.func @reduction_pack(%arg0: tensor<384x1024x32xf32>, %arg1: tensor<384x1024
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG2]]
 //      CHECK:   linalg.pack
-// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Multiple], vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG3]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_v_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_v_lowering_strategy.mlir
@@ -121,7 +121,7 @@ func.func @pack(%arg0: tensor<20x48xf32>) -> tensor<2x?x16x?xf32> attributes {ha
 //      CHECK: func.func @pack(
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.pack
-// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Multiple], vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -152,7 +152,7 @@ func.func @elem_pack(%arg0: tensor<128x384xf32>) -> tensor<16x?x8x?xf32> attribu
 //      CHECK:   linalg.generic
 // CHECK-SAME:       lowering_config = #[[CONFIG1]]
 //      CHECK:   linalg.pack
-// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+// CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Multiple], vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:       lowering_config = #[[CONFIG2]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_v_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_riscv_v_lowering_strategy.mlir
@@ -77,7 +77,7 @@ func.func @unpack(%arg0 : tensor<128x10x?x8x?xf32>) -> tensor<128x80x320xf32> at
 //       CHECK: func.func @unpack
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
-//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Unknown, Equal]>
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Unknown, Multiple], vector_common_parallel = [Unknown, Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----
@@ -99,7 +99,7 @@ func.func @unpack_outer_dynamic(%arg0 : tensor<?x?x32x?xf32>, %dim0 : index, %di
 //       CHECK: func.func @unpack_outer_dynamic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   linalg.unpack
-//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
+//  CHECK-SAME:       inner_tile_alignments = #iree_cpu.inner_tile_alignments<distribution = [Unknown, Multiple], vector_common_parallel = [Unknown, Equal]>
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]
 
 // -----


### PR DESCRIPTION
Extends distribution inner-tile alignment hints to pack ops. A scalable pack's
distribution tile is now aligned to base * vscaleMax, so it is a whole multiple
of the runtime inner tile and gets a `distribution` hint of `Multiple`. This
covers both a pack tiled directly and a pack that consumes an unpack
(`annotateScalablePackConsumerOfUnpack`), which derives its distribution hint
from the unpack's distribution tiles: a match only yields `Multiple` when the
distribution tile is a whole multiple of the pack's largest inner tile, so a
pack whose scalable inner tile differs from its unpack producer's gets no hint.

Packs whose scalable dim is not distributed (e.g. a reduction/broadcast pack)
and mmt4d-fused packs (which distribute on outer dims) are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>