### PR TITLE
[LLVMCPU] infer inner-tile alignment hints for mixed scalability

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3252,18 +3252,20 @@ setRootConfigImpl(mlir::FunctionOpInterface entryPointFn, Operation *op,
 }
 
 /// Returns the `InnerTileAlignment` implied by a loop tile size relative to a
-/// scalable pack/unpack inner tile whose vscale multiplier is `innerBase`.
-static mlir::InnerTileAlignment
-getScalableInnerTileAlignment(int64_t loopTile, bool loopScalable,
-                              int64_t innerBase) {
-  if (innerBase <= 0 || loopTile <= 0 || !loopScalable) {
+/// pack/unpack inner tile size.
+static mlir::InnerTileAlignment getInnerTileAlignment(int64_t loopTile,
+                                                      bool loopScalable,
+                                                      int64_t innerTile,
+                                                      bool innerScalable) {
+  if (innerTile <= 0 || loopTile <= 0) {
     return mlir::InnerTileAlignment::Unknown;
   }
-  if (loopTile == innerBase) {
-    return mlir::InnerTileAlignment::Equal;
-  }
-  if (loopTile % innerBase == 0) {
-    return mlir::InnerTileAlignment::Multiple;
+  if (loopScalable) {
+    if (innerScalable && loopTile == innerTile) {
+      return mlir::InnerTileAlignment::Equal;
+    }
+    return loopTile % innerTile == 0 ? mlir::InnerTileAlignment::Multiple
+                                     : mlir::InnerTileAlignment::Unknown;
   }
   return mlir::InnerTileAlignment::Unknown;
 }
@@ -3830,13 +3832,19 @@ static void captureInnerTileAlignment(
       rank, llvm::to_underlying(mlir::InnerTileAlignment::Unknown));
   bool any = false;
   for (auto [i, pos] : llvm::enumerate(op.getInnerDimsPos())) {
-    // Only scalable inner tiles need a hint; static ones are resolved by static
-    // shape inference downstream.
-    if (!scalableTilesFlags.second[i] || pos >= tileSizes.size()) {
+    if (pos >= tileSizes.size() || pos >= scalableFlags.size()) {
       continue;
     }
-    mlir::InnerTileAlignment kind = getScalableInnerTileAlignment(
-        tileSizes[pos], scalableFlags[pos], scalableTilesFlags.first[i]);
+    bool innerScalable = scalableTilesFlags.second[i];
+    bool loopScalable = scalableFlags[pos];
+    // Two static sizes are related by static shape inference downstream, which
+    // needs no hint.
+    if (!innerScalable && !loopScalable) {
+      continue;
+    }
+    mlir::InnerTileAlignment kind =
+        getInnerTileAlignment(tileSizes[pos], loopScalable,
+                              scalableTilesFlags.first[i], innerScalable);
     alignments[pos] = llvm::to_underlying(kind);
     if (kind != mlir::InnerTileAlignment::Unknown) {
       any = true;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -512,7 +512,7 @@ func.func @mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tens
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map2 = affine_map<()[s0] -> (77 ceildiv s0)>
-func.func @negative_hint_mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16>, %arg1: tensor<?x4096x?x1xf16>) -> tensor<?x640x16x?xf16> attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+func.func @mmt4d_generic_unpack_pack_mixed_static_scalable_inner_tiles(%arg0: tensor<5x4096x16x1xf16>, %arg1: tensor<?x4096x?x1xf16>) -> tensor<?x640x16x?xf16> attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
   %cst = arith.constant 0.000000e+00 : f16
   %cst_0 = arith.constant 0.000000e+00 : f32
 
@@ -539,7 +539,7 @@ func.func @negative_hint_mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16
 // CHECK-DAG:   #[[$CONFIG0:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [1, 1, 16, [16]]>
 // CHECK-DAG:   #[[$CONFIG1:.+]] = #iree_cpu.lowering_config<distribution = [1, 1, 0, 0, 0, 0], vector_common_parallel = [1, 1, 0, 16, [16], 0], vector_reduction = [0, 0, 1, 0, 0, 1]>
 // CHECK-DAG:   #[[$CONFIG2:.+]] = #iree_cpu.lowering_config<vector_common_parallel = [16, [16]]>
-// CHECK-LABEL: func.func @negative_hint_mmt4d_generic_unpack_pack(
+// CHECK-LABEL: func.func @mmt4d_generic_unpack_pack_mixed_static_scalable_inner_tiles(
 // CHECK:         linalg.fill
 // CHECK-SAME:      {lowering_config = #[[$CONFIG0]]}
 // CHECK:         linalg.mmt4d
@@ -550,10 +550,10 @@ func.func @negative_hint_mmt4d_generic_unpack_pack(%arg0: tensor<5x4096x16x1xf16
 // CHECK:         linalg.unpack
 // CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Equal]>
 // CHECK-SAME:      lowering_config = #[[$CONFIG2]]
-// The consumer pack has no lowering config nor carries an inner tile alignment,
-// since the unpack and pack inner dimensions are not aligned.
+// The consumer pack's inner dims are transposed: only the static inner tile
+// divides its scalable loop tile. The pack gets no lowering config.
 // CHECK:         linalg.pack
-// CHECK-NOT:      inner_tile_alignments
+// CHECK-SAME:      inner_tile_alignments = #iree_cpu.inner_tile_alignments<vector_common_parallel = [Unknown, Multiple]>
 // CHECK-NOT:       lowering_config
 
 // -----


### PR DESCRIPTION
An inner-tile alignment hint was only captured when the pack/unpack inner tile itself was scalable, on the assumption that a static inner tile is resolved by static shape inference downstream. That only holds when the loop tile is static too. A static inner tile under a scalable loop tile also needs a hint.

Assisted-by: Claude Code