### PR TITLE
[LLVMCPU] `vlen` attribute for DataTiledMMAAttr for RISCV + FP16 port

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -99,6 +99,7 @@ iree_lit_test_suite(
             "materialize_encoding_into_nop.mlir",
             "materialize_encoding_into_padding.mlir",
             "materialize_encoding_riscv.mlir",
+            "materialize_encoding_riscv_inner_tiled.mlir",
             "materialize_encoding_vmvx.mlir",
             "materialize_encoding_x86_64.mlir",
             "materialize_smt_constraint_assignments.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -94,6 +94,7 @@ iree_lit_test_suite(
     "materialize_encoding_into_nop.mlir"
     "materialize_encoding_into_padding.mlir"
     "materialize_encoding_riscv.mlir"
+    "materialize_encoding_riscv_inner_tiled.mlir"
     "materialize_encoding_vmvx.mlir"
     "materialize_encoding_x86_64.mlir"
     "materialize_smt_constraint_assignments.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv_inner_tiled.mlir
@@ -1,0 +1,113 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-materialize-device-encoding))" --split-input-file %s | FileCheck %s
+
+// -----
+
+// Materialization of data-tiled f16 matmul encodings to iree_codegen.inner_tiled
+// on RISC-V V with Zvfh.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f16_zvl128b(%arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf16> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfh,+zvl128b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f16
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf16, #acc>
+  %3 = linalg.fill ins(%cst : f16) outs(%2 : tensor<?x?xf16, #acc>) -> tensor<?x?xf16, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf16, #lhs>, tensor<?x?xf16, #rhs>)
+      outs(%3 : tensor<?x?xf16, #acc>) -> tensor<?x?xf16, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf16, #acc> -> tensor<?x?xf16>{%d0, %d1}
+  return %5 : tensor<?x?xf16>
+}
+// CHECK-LABEL: func @matmul_f16_zvl128b(
+//       CHECK:   %[[PACK_LHS:.+]] = linalg.pack {{.*}}inner_tiles = [14, 1]
+//  CHECK-SAME:       -> tensor<?x?x14x1xf16>
+//       CHECK:   %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK_LHS]] {{\[}}[0], [1], [2], [3, 4]{{\]}}
+//  CHECK-SAME:       tensor<?x?x14x1xf16> into tensor<?x?x14x1x1xf16>
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [16, 1]
+//  CHECK-SAME:       -> tensor<?x?x16x1xf16>
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled ins(%[[EXPANDED]], %[[PACK_RHS]])
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16, intrinsics_m = 14, vlen = 128>
+//  CHECK-SAME:       tensor<?x?x14x1x1xf16>, tensor<?x?x16x1xf16> into tensor<?x?x14x1x16xf16>
+//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[INNER]] {{\[}}[0], [1], [2], [3, 4]{{\]}}
+//  CHECK-SAME:       tensor<?x?x14x1x16xf16> into tensor<?x?x14x16xf16>
+//       CHECK:   linalg.unpack %[[COLLAPSED]]
+
+// -----
+
+// The operand sizes scale with the target's vector length.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f16_zvl512b(%arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf16> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfh,+zvl512b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f16
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf16, #acc>
+  %3 = linalg.fill ins(%cst : f16) outs(%2 : tensor<?x?xf16, #acc>) -> tensor<?x?xf16, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf16, #lhs>, tensor<?x?xf16, #rhs>)
+      outs(%3 : tensor<?x?xf16, #acc>) -> tensor<?x?xf16, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf16, #acc> -> tensor<?x?xf16>{%d0, %d1}
+  return %5 : tensor<?x?xf16>
+}
+// CHECK-LABEL: func @matmul_f16_zvl512b(
+//       CHECK:   %[[PACK_LHS:.+]] = linalg.pack {{.*}}inner_tiles = [14, 1]
+//  CHECK-SAME:       -> tensor<?x?x14x1xf16>
+//       CHECK:   %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK_LHS]] {{\[}}[0], [1], [2], [3, 4]{{\]}}
+//  CHECK-SAME:       tensor<?x?x14x1xf16> into tensor<?x?x14x1x1xf16>
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [64, 1]
+//  CHECK-SAME:       -> tensor<?x?x64x1xf16>
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled ins(%[[EXPANDED]], %[[PACK_RHS]])
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16, intrinsics_m = 14, vlen = 512>
+//  CHECK-SAME:       tensor<?x?x14x1x1xf16>, tensor<?x?x64x1xf16> into tensor<?x?x14x1x64xf16>
+//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[INNER]] {{\[}}[0], [1], [2], [3, 4]{{\]}}
+//  CHECK-SAME:       tensor<?x?x14x1x64xf16> into tensor<?x?x14x64xf16>
+//       CHECK:   linalg.unpack %[[COLLAPSED]]
+
+// -----
+
+// Without Zvfh, selection falls back to the generic-scalar layout.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f16], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f16_no_zvfh(%arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf16> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvl256b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f16
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf16, #acc>
+  %3 = linalg.fill ins(%cst : f16) outs(%2 : tensor<?x?xf16, #acc>) -> tensor<?x?xf16, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf16, #lhs>, tensor<?x?xf16, #rhs>)
+      outs(%3 : tensor<?x?xf16, #acc>) -> tensor<?x?xf16, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf16, #acc> -> tensor<?x?xf16>{%d0, %d1}
+  return %5 : tensor<?x?xf16>
+}
+// CHECK-LABEL: func @matmul_f16_no_zvfh(
+//       CHECK:   iree_codegen.inner_tiled
+//  CHECK-SAME:       intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16
+//   CHECK-NOT:       vlen

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -437,7 +437,7 @@ InnerTileAlignmentsAttr InnerTileAlignmentsAttr::getFromOp(Operation *op) {
 // declares its shape here, including scalable ones, which declare their base
 // sizes.
 std::optional<std::tuple<int64_t, int64_t, int64_t>>
-getIntrinsicMNKShape(MMAIntrinsic intrinsic) {
+getIntrinsicMNKShape(MMAIntrinsic intrinsic, int64_t vlen) {
   using Tuple = std::tuple<int64_t, int64_t, int64_t>;
   switch (intrinsic) {
   case MMAIntrinsic::None:
@@ -505,10 +505,16 @@ constexpr uint32_t kMMAIntrinsicGenericBudgetMask = 0x00FF;
 constexpr uint32_t kMMAIntrinsicISAX86Avx2 = 0x1200;
 constexpr uint32_t kMMAIntrinsicISAX86Avx512 = 0x1300;
 constexpr uint32_t kMMAIntrinsicISAArmSve = 0x2200;
+constexpr uint32_t kMMAIntrinsicISARiscvV = 0x3100;
 
 bool isGenericScalar(MMAIntrinsic intr) {
   return (static_cast<uint32_t>(intr) & kMMAIntrinsicISAMask) ==
          kMMAIntrinsicISAGeneric;
+}
+
+bool isVlenParameterized(MMAIntrinsic intr) {
+  return (static_cast<uint32_t>(intr) & kMMAIntrinsicISAMask) ==
+         kMMAIntrinsicISARiscvV;
 }
 
 int64_t getGenericScalarRegisterBudget(MMAIntrinsic intr) {
@@ -516,7 +522,7 @@ int64_t getGenericScalarRegisterBudget(MMAIntrinsic intr) {
   return static_cast<uint32_t>(intr) & kMMAIntrinsicGenericBudgetMask;
 }
 
-int64_t getRegisterSpaceBytes(MMAIntrinsic intrinsic) {
+int64_t getRegisterSpaceBytes(MMAIntrinsic intrinsic, int64_t vlen) {
   // Total architectural vector register file size, in bytes. The inner-tiled
   // cost model uses this as the capacity for the union of the ACC, LHS and
   // RHS tiles. For scalable ISAs we treat the vector length as its minimum
@@ -532,6 +538,8 @@ int64_t getRegisterSpaceBytes(MMAIntrinsic intrinsic) {
     return 32 * 64;
   case kMMAIntrinsicISAArmSve: // 32 Z × (VL treated as 128 bits).
     return 32 * 16;
+  case kMMAIntrinsicISARiscvV: // 32 v × vlen bits.
+    return 32 * (vlen / 8);
   default:
     // Plausible default, but override it on each arch you care for.
     return 16 * 32;
@@ -561,17 +569,20 @@ static Codegen::TileSwizzle fixupSwizzle(Codegen::TileSwizzle swizzle) {
 /// Returns the hand-rolled TileSwizzle for the intrinsics whose tiles are not
 /// row-major, or nullopt for every other intrinsic.
 static std::optional<Codegen::TileSwizzle>
-getNonRowMajorIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma, int operandIdx) {
+getNonRowMajorIntrinsicSwizzle(IREE::CPU::MMAIntrinsic intrinsic,
+                               int operandIdx) {
   using TileSwizzle = Codegen::TileSwizzle;
   using Dim = TileSwizzle::Dim;
 
   // SVE has scalable dims that the row-major path can't express. The natural
-  // orientation is 1×4VL×1: 4VL lives on RHS dim 0 (N) and ACC dim 0 (the
-  // convention is `(N, M)` here). The transposed orientation 4VL×1×1 mirrors
-  // that: 4VL on LHS dim 0 (M) and ACC dim 0 (now `(M, N)`).
-  if (mma == MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32 ||
-      mma == MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32) {
-    bool transposed = (mma == MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32);
+  // orientation is 1×4VL×1: 4VL lives on
+  // RHS dim 0 (N) and ACC dim 0 (the convention is `(N, M)` here). The
+  // transposed orientation 4VL×1×1 mirrors that: 4VL on LHS dim 0 (M) and
+  // ACC dim 0 (now `(M, N)`).
+  if (intrinsic == MMAIntrinsic::MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32 ||
+      intrinsic == MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32) {
+    bool transposed =
+        intrinsic == MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32;
     TileSwizzle swizzle;
     swizzle.expandShape().resize(2);
     int operandWith4VL = transposed ? 0 : 1;
@@ -591,7 +602,7 @@ getNonRowMajorIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma, int operandIdx) {
   // are ordered (rlo, chi, rhi, clo) with r = 4*rhi + rlo, c = 4*chi + clo.
   // As a TileSwizzle: split M into [rhi(4), rlo(4)] and N into [chi(4),
   // clo(4)] (expanded dims 0..3), then permute to (rlo, chi, rhi, clo).
-  if (mma == MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16 &&
+  if (intrinsic == MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16 &&
       operandIdx == 2) {
     TileSwizzle swizzle;
     swizzle.expandShape().resize(2);
@@ -604,11 +615,12 @@ getNonRowMajorIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma, int operandIdx) {
   return std::nullopt;
 }
 
-Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
+Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::DataTiledMMAAttr mma,
                                          int operandIdx) {
   using TileSwizzle = Codegen::TileSwizzle;
+  MMAIntrinsic intrinsic = mma.getIntrinsic();
   if (std::optional<TileSwizzle> swizzle =
-          getNonRowMajorIntrinsicSwizzle(mma, operandIdx)) {
+          getNonRowMajorIntrinsicSwizzle(intrinsic, operandIdx)) {
     return *swizzle;
   }
 
@@ -622,7 +634,7 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
   // If you're trying to add support for a new intrinsic that doesn't have a
   // row-major tile layout, its swizzle belongs in
   // `getNonRowMajorIntrinsicSwizzle`.
-  auto maybeMnkTuple = getIntrinsicMNKShape(mma);
+  auto maybeMnkTuple = getIntrinsicMNKShape(intrinsic, mma.getVlen());
   if (!maybeMnkTuple) {
     assert(false && "intrinsic does not declare an MNK shape.");
     return TileSwizzle();
@@ -658,7 +670,7 @@ Codegen::TileSwizzle getIntrinsicSwizzle(IREE::CPU::MMAIntrinsic mma,
 Codegen::TileSwizzle getSwizzle(IREE::CPU::DataTiledMMAAttr mma,
                                 int operandIdx) {
   using TileSwizzle = Codegen::TileSwizzle;
-  TileSwizzle swizzle = getIntrinsicSwizzle(mma.getIntrinsic(), operandIdx);
+  TileSwizzle swizzle = getIntrinsicSwizzle(mma, operandIdx);
   TileSwizzle::Dim intrinsicsM =
       TileSwizzle::Dim::crossIntrinsic(mma.getIntrinsicsM());
   TileSwizzle::Dim intrinsicsN =
@@ -775,6 +787,32 @@ getABCElementTypes(MLIRContext *context, IREE::CPU::DataTiledMMAAttr attr) {
 //===----------------------------------------------------------------------===//
 // DataTiledMMA Attributes
 //===----------------------------------------------------------------------===//
+
+LogicalResult DataTiledMMAAttr::verify(
+    function_ref<InFlightDiagnostic()> emitError, MMAIntrinsic intrinsic,
+    int64_t intrinsics_m, int64_t intrinsics_n, int64_t intrinsics_k,
+    Type lhs_type, Type rhs_type, Type acc_type, int64_t vlen) {
+  if (isVlenParameterized(intrinsic)) {
+    // 128 is the V extension's architectural minimum VLEN.
+    if (vlen < 128 || (vlen & (vlen - 1)) != 0) {
+      return emitError() << "intrinsic " << stringifyMMAIntrinsic(intrinsic)
+                         << " is VLEN-parameterized and requires `vlen` to be "
+                            "a power of two >= 128; got "
+                         << vlen;
+    }
+    // A well-formed VLEN is not enough: the intrinsic must also have a tile
+    // shape at this VLEN, or there is no layout to materialize.
+    if (!getIntrinsicMNKShape(intrinsic, vlen)) {
+      return emitError() << "intrinsic " << stringifyMMAIntrinsic(intrinsic)
+                         << " has no tile shape for vlen = " << vlen;
+    }
+  } else if (vlen != 0) {
+    return emitError() << "`vlen` is only meaningful for VLEN-parameterized "
+                          "intrinsics; got vlen = "
+                       << vlen;
+  }
+  return success();
+}
 
 int64_t DataTiledMMAAttr::getExpectedNumInputs() const { return 2; }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -485,6 +485,14 @@ getIntrinsicMNKShape(MMAIntrinsic intrinsic, int64_t vlen) {
     return Tuple{1, 4, 1};
   case MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32:
     return Tuple{4, 1, 1};
+  // VLs = vlen / 8 lanes, one LMUL=2 register group at 16-bit elements.
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16: {
+    int64_t vl = vlen / 8;
+    bool transposed =
+        intrinsic == MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16;
+    return transposed ? Tuple{vl, 1, 1} : Tuple{1, vl, 1};
+  }
   default:
     if (isGenericScalar(intrinsic)) {
       return Tuple{1, 1, 1};
@@ -538,7 +546,7 @@ int64_t getRegisterSpaceBytes(MMAIntrinsic intrinsic, int64_t vlen) {
     return 32 * 64;
   case kMMAIntrinsicISAArmSve: // 32 Z × (VL treated as 128 bits).
     return 32 * 16;
-  case kMMAIntrinsicISARiscvV: // 32 v × vlen bits.
+  case kMMAIntrinsicISARiscvV: // 32 v × vlen B.
     return 32 * (vlen / 8);
   default:
     // Plausible default, but override it on each arch you care for.
@@ -735,6 +743,8 @@ std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
     return {f16, f16, f32};
   case MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16:
   case MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16:
     return {f16, f16, f16};
   case MMAIntrinsic::MMA_X86_AVX512BF16_1x16x2_F32_BF16:
   case MMAIntrinsic::MMA_X86_AVX512BF16_16x1x2_F32_BF16:
@@ -793,12 +803,14 @@ LogicalResult DataTiledMMAAttr::verify(
     int64_t intrinsics_m, int64_t intrinsics_n, int64_t intrinsics_k,
     Type lhs_type, Type rhs_type, Type acc_type, int64_t vlen) {
   if (isVlenParameterized(intrinsic)) {
-    // 128 is the V extension's architectural minimum VLEN.
-    if (vlen < 128 || (vlen & (vlen - 1)) != 0) {
-      return emitError() << "intrinsic " << stringifyMMAIntrinsic(intrinsic)
-                         << " is VLEN-parameterized and requires `vlen` to be "
-                            "a power of two >= 128; got "
-                         << vlen;
+    // 128 is the V extension's architectural minimum, and 65536 is the maximum
+    // VLEN.
+    if (vlen < 128 || vlen > 65536 || (vlen & (vlen - 1)) != 0) {
+      return emitError()
+             << "intrinsic " << stringifyMMAIntrinsic(intrinsic)
+             << " is VLEN-parameterized and requires a power of two "
+                "128 <= vlen <= 65536; got "
+             << vlen;
     }
     // A well-formed VLEN is not enough: the intrinsic must also have a tile
     // shape at this VLEN, or there is no layout to materialize.

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -127,7 +127,14 @@ def IREECPU_DataTiledMMAAttr
           DefaultValuedParameter<
               "::mlir::Type", "::mlir::Type()",
               "ACC element type, used only by type-polymorphic intrinsics "
-              "such as MMA_GENERIC_SCALAR_1x1x1.">:$acc_type);
+              "such as MMA_GENERIC_SCALAR_1x1x1.">:$acc_type,
+          DefaultValuedParameter<
+              "int64_t", "0",
+              "Vector register length in bits, for intrinsics whose tile "
+              "shape and register budget are a function of an "
+              "implementation-defined vector length (RISC-V V).">:$vlen);
+
+  let genVerifyDecl = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -83,6 +83,8 @@ class IREECPU_I32EnumAttr<string name, string summary,
 //     - 1 is NEON.
 //     - 2 is SVE/SVE2.
 //     - 3 is SME/SME2.
+//   - For RISC-V:
+//     - 1 is V (RVV).
 // * C denotes the element type of the A-matrix (LHS):
 //   * 0 = float64 (IEEE754 half precision).
 //   * 1 = float32 (IEEE754 half precision).
@@ -172,6 +174,16 @@ def MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32
 def MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32
     : I32EnumAttrCase<"MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32", 0x2211>;
 
+// RISC-V V `vfmacc.vf` (f16, f16): a 1x8VLsx1 matmul tile, or 8VLsx1x1 in the
+// M<->N-swapped orientation. `8VLs` is 8 f16 elements per 64-bit vector-length
+// unit, i.e. one LMUL=2 register group, and s stands for static. The LHS is a
+// scalar broadcast out of an FP register (`.vf` variant), not a vector operand.
+// Requires Zvfh for native half-precision arithmetic.
+def MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16
+    : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16", 0x3120>;
+def MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16
+    : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16", 0x3121>;
+
 // Architecture-agnostic, type-polymorphic generic-scalar fallback. Tile
 // shape is 1×1×1, lowering is a single `vector.contract` over the
 // unrolled (`intrinsics_m`, `intrinsics_n`, `intrinsics_k`) tile. Unlike
@@ -219,6 +231,10 @@ def IREECPU_MMAIntrinsic
 
            // Arm SVE
            MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32, MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32,
+
+           // RISC-V V
+           MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16,
+           MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16,
 
            // Architecture-agnostic generic-scalar fallback (type-polymorphic).
            MMA_GENERIC_SCALAR_1x1x1_REG8, MMA_GENERIC_SCALAR_1x1x1_REG16]>;

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h
@@ -63,8 +63,9 @@ SmallVector<int> getTilingLevelsAsInts();
 /// Returns the corresponding key string for `level`.
 StringRef getTilingLevelName(TilingLevel level);
 
-// Returns the TileSwizzle for the given intrinsic and operand index.
-Codegen::TileSwizzle getIntrinsicSwizzle(MMAIntrinsic mma, int operandIdx);
+// Returns the TileSwizzle for the given MMA attr's intrinsic and operand
+// index, i.e. the layout of a single intrinsic without any unrolling.
+Codegen::TileSwizzle getIntrinsicSwizzle(DataTiledMMAAttr mma, int operandIdx);
 
 // Returns the TileSwizzle for the given MMA attr and operand index.
 Codegen::TileSwizzle getSwizzle(DataTiledMMAAttr mma, int operandIdx);
@@ -75,11 +76,18 @@ Codegen::TileSwizzle getSwizzle(DataTiledMMAAttr mma, int operandIdx);
 // treated as its 128-bit minimum — a deliberate simplification that produces
 // good-enough `intrinsics_m`/`intrinsics_n` choices without leaking
 // scalability into the cost model.
-// Values: AVX/AVX2 = 16 × 32 B, AVX-512 = 32 × 64 B, SVE/SVE2 = 32 × 16 B.
-int64_t getRegisterSpaceBytes(MMAIntrinsic intrinsic);
+// `vlen` is the target's vector register length in bits, if the ISA does not
+// specify a single one.
+// Values: AVX/AVX2 = 16 × 32 B, AVX-512 = 32 × 64 B, SVE/SVE2 = 32 × 16 B,
+// RISC-V V = 32 × (vlen/8) B.
+int64_t getRegisterSpaceBytes(MMAIntrinsic intrinsic, int64_t vlen);
 
 // True if `intr` is one of the `MMA_GENERIC_SCALAR_1x1x1_REG*` cases.
 bool isGenericScalar(MMAIntrinsic intr);
+
+// Returns if `intr` is parameterized by vector length. Currently, this is the
+// RISC-V family of intrinsics.
+bool isVlenParameterized(MMAIntrinsic intr);
 
 // For an `MMA_GENERIC_SCALAR_1x1x1_REG*` intrinsic, returns the register
 // budget encoded in the enum case (8 or 16). Asserts otherwise.
@@ -96,7 +104,7 @@ std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
 // Returns how many M/N/K elements one invocation of `intrinsic` computes.
 // Scalable intrinsics declare their base sizes.
 std::optional<std::tuple<int64_t, int64_t, int64_t>>
-getIntrinsicMNKShape(MMAIntrinsic intrinsic);
+getIntrinsicMNKShape(MMAIntrinsic intrinsic, int64_t vlen);
 
 // Idempotently attaches the bitcode for ukernel `name` as
 // `hal.executable.objects` on `op`, looking it up first in any

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/invalid.mlir
@@ -142,3 +142,10 @@ func.func @cpu_inner_tiled_sve_rhs_n_must_be_dynamic(
 // An empty hint (no tiling levels) is meaningless and is rejected.
 // expected-error@+1 {{expected at least one tiling level}}
 #invalid_inner_tile_alignment_empty = #iree_cpu.inner_tile_alignments<>
+
+// -----
+
+// `vlen` is only accepted on VLEN-parameterized intrinsics (RISC-V V).
+// expected-error@+1 {{`vlen` is only meaningful for VLEN-parameterized intrinsics}}
+#invalid_vlen_on_non_parameterized_intrinsic = #iree_cpu.data_tiled_mma_layout<
+    intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, vlen = 512>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/invalid.mlir
@@ -149,3 +149,17 @@ func.func @cpu_inner_tiled_sve_rhs_n_must_be_dynamic(
 // expected-error@+1 {{`vlen` is only meaningful for VLEN-parameterized intrinsics}}
 #invalid_vlen_on_non_parameterized_intrinsic = #iree_cpu.data_tiled_mma_layout<
     intrinsic = MMA_X86_AVX512_1x16x1_F32_F32, vlen = 512>
+
+// -----
+
+// A VLEN-parameterized intrinsic requires a `vlen`.
+// expected-error@+1 {{is VLEN-parameterized and requires a power of two 128 <= vlen <= 65536}}
+#invalid_vlen_missing = #iree_cpu.data_tiled_mma_layout<
+    intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16>
+
+// -----
+
+// RVV VLEN is a power of two, at least the V extension's 128-bit minimum.
+// expected-error@+1 {{is VLEN-parameterized and requires a power of two 128 <= vlen <= 65536}}
+#invalid_vlen_not_pow2 = #iree_cpu.data_tiled_mma_layout<
+    intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16, vlen = 384>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
@@ -280,3 +280,50 @@ func.func @cpu_inner_tiled_tensor_arm_sve_fmla_f32(
 //       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32>
 //  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16 at vlen = 256, intrinsics 1x1x1
+func.func @cpu_riscv_v_vfmacc_f16(
+    %lhs: vector<1x1x1xf16>, %rhs: vector<1x1x32xf16>, %acc: vector<1x1x32xf16>)
+    -> vector<1x1x32xf16> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x1xf16>, vector<1x1x32xf16> into vector<1x1x32xf16>
+  return %0 : vector<1x1x32xf16>
+}
+// CHECK-LABEL: func @cpu_riscv_v_vfmacc_f16
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16, vlen = 256>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16 at vlen = 512, intrinsics 1x1x1
+func.func @cpu_riscv_v_vfmacc_f16_swapped(
+    %lhs: vector<1x1x64xf16>, %rhs: vector<1x1x1xf16>, %acc: vector<1x1x64xf16>)
+    -> vector<1x1x64xf16> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16, vlen = 512>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x64xf16>, vector<1x1x1xf16> into vector<1x1x64xf16>
+  return %0 : vector<1x1x64xf16>
+}
+// CHECK-LABEL: func @cpu_riscv_v_vfmacc_f16_swapped
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16, vlen = 512>

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -432,6 +432,9 @@ getMmaIntrinsicRequiredFeatures(IREE::CPU::MMAIntrinsic intr) {
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16:
     return {"+avx512vnni"};
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16:
+    return {"+v", "+zvfh"};
   default:
     return {};
   }
@@ -552,6 +555,24 @@ static bool isMmaIntrinsicArrayValid(DictionaryAttr config,
 /// when no real MMA covers the requested element types.
 ///
 /// There must be no early-return path that omits the trailing
+/// Appends the intrinsics from `candidates` whose required target features are
+/// all present in `config` to `out`.
+static void
+checkIntrinsicRequiredFeatures(DictionaryAttr config,
+                               ArrayRef<IREE::CPU::MMAIntrinsic> candidates,
+                               SmallVectorImpl<IREE::CPU::MMAIntrinsic> &out) {
+  for (IREE::CPU::MMAIntrinsic intr : candidates) {
+    SmallVector<StringRef> required = getMmaIntrinsicRequiredFeatures(intr);
+    if (required.empty()) {
+      continue;
+    }
+    if (llvm::all_of(required,
+                     [&](StringRef f) { return hasFeature(config, f); })) {
+      out.push_back(intr);
+    }
+  }
+}
+
 /// generic-scalar push — `out` is asserted to be non-empty / well-formed at
 /// the bottom and downstream callers rely on always seeing at least the
 /// generic fallback. Place the generic at the end (rather than the front)
@@ -592,16 +613,14 @@ getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
         MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8,
         MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16,
     };
-    for (MMAIntrinsic intr : kAllX86) {
-      SmallVector<StringRef> required = getMmaIntrinsicRequiredFeatures(intr);
-      if (required.empty()) {
-        continue;
-      }
-      if (llvm::all_of(required,
-                       [&](StringRef f) { return hasFeature(config, f); })) {
-        out.push_back(intr);
-      }
-    }
+    checkIntrinsicRequiredFeatures(config, kAllX86, out);
+  }
+  if (isRISCV64(config)) {
+    static const MMAIntrinsic kAllRiscvV[] = {
+        MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16,
+        MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16,
+    };
+    checkIntrinsicRequiredFeatures(config, kAllRiscvV, out);
   }
   out.push_back(pickGenericScalarMMAForTarget(config));
   assert(isMmaIntrinsicArrayValid(config, out) &&
@@ -1708,6 +1727,10 @@ private:
       return info;
     }
     info = std::move(maybeEncodingInfo.value());
+    // TODO(egebeysel): this does not work. The tile shape comes from an
+    // intrinsic and is static, so marking a dim scalable makes the packed
+    // extent dynamic while the inner tile type keeps its literal size, and the
+    // `expand_shape` onto the inner tile is then rejected.
     FailureOr<IREE::Codegen::ScalableTileFlags> scalableFlags =
         getScalableTileFlags(cDims, encoding, config);
     if (succeeded(scalableFlags)) {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -72,6 +72,53 @@ namespace {
 // Utilities.
 //===----------------------------------------------------------------------===//
 
+// RISC-V has vector register length extensions: zvl128b, zvl256b etc.
+// If these extension are specified in target cpu feature,
+// they can be used to determine VLEN. This function assumes that
+// 'v' feature is present
+static size_t getRISCVVVlenFromCPUFeatures(DictionaryAttr config) {
+  // If +zvl* feature is not explicitly specified,
+  // fallback to +zvl128b, as spec specifies minimum VLEN
+  // of 128b for the V extension: https://rb.gy/p8rbzv
+  size_t vlen;
+  if (hasFeature(config, "+zvl65536b")) {
+    vlen = 65536;
+  } else if (hasFeature(config, "+zvl32768b")) {
+    vlen = 32768;
+  } else if (hasFeature(config, "+zvl16384b")) {
+    vlen = 16384;
+  } else if (hasFeature(config, "+zvl8192b")) {
+    vlen = 8192;
+  } else if (hasFeature(config, "+zvl4096b")) {
+    vlen = 4096;
+  } else if (hasFeature(config, "+zvl2048b")) {
+    vlen = 2048;
+  } else if (hasFeature(config, "+zvl1024b")) {
+    vlen = 1024;
+  } else if (hasFeature(config, "+zvl512b")) {
+    vlen = 512;
+  } else if (hasFeature(config, "+zvl256b")) {
+    vlen = 256;
+  } else {
+    vlen = 128;
+  }
+  return vlen;
+}
+
+/// Returns the vector register length in bits to use for VLEN-parameterized
+/// ISAs, or 0 if the target has none. Also 0 under scalable vectorization,
+/// where the tile layout comes from scalable tile flags rather than a resolved
+/// VLEN.
+static int64_t getVlenBitsForConfig(DictionaryAttr config) {
+  if (!config || isScalableVectorizationEnabled()) {
+    return 0;
+  }
+  if (isRISCV64(config) && hasFeature(config, "+v")) {
+    return static_cast<int64_t>(getRISCVVVlenFromCPUFeatures(config));
+  }
+  return 0;
+}
+
 /// Determines which tile dimensions should be scalable for a given target.
 /// For AArch64 SVE/SVE2 and RISC-V with the V extension (when not using static
 /// vectors), the N dimension is made scalable to take advantage of scalable
@@ -430,10 +477,13 @@ pickGenericScalarMMAForTarget(DictionaryAttr config) {
 /// type-polymorphic, so it satisfies (4) vacuously. We skip the
 /// `DataTiledMMAAttr`-based extraction for it (passing null element types
 /// to the attr would invalidate the resulting vector types).
-static bool isMmaIntrinsicArrayValid(MLIRContext *ctx,
+static bool isMmaIntrinsicArrayValid(DictionaryAttr config,
                                      ArrayRef<IREE::CPU::MMAIntrinsic> arr) {
   using IREE::CPU::DataTiledMMAAttr;
   using IREE::CPU::MMAIntrinsic;
+
+  MLIRContext *ctx = config.getContext();
+  int64_t vlen = getVlenBitsForConfig(config);
 
   // Conventions (1) and (2): order, strict increase, swap-pair structure.
   if (!arr.empty() && (static_cast<uint32_t>(arr[0]) & 1) != 0) {
@@ -454,7 +504,7 @@ static bool isMmaIntrinsicArrayValid(MLIRContext *ctx,
   // `ui8` LHS visibly swaps with its sibling's `ui8` RHS. Read directly
   // from `getABCElementTypes`; `getUndistributedTileTypes` would strip it.
   auto getShapeAndTypes = [&](MMAIntrinsic intr) {
-    auto mnk = IREE::CPU::getIntrinsicMNKShape(intr);
+    auto mnk = IREE::CPU::getIntrinsicMNKShape(intr, vlen);
     assert(mnk && "intrinsic does not declare an MNK shape");
     auto [m, n, k] = *mnk;
     auto [lhs, rhs, acc] = IREE::CPU::getABCElementTypes(ctx, intr);
@@ -554,7 +604,7 @@ getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
     }
   }
   out.push_back(pickGenericScalarMMAForTarget(config));
-  assert(isMmaIntrinsicArrayValid(config.getContext(), out) &&
+  assert(isMmaIntrinsicArrayValid(config, out) &&
          "getMmaIntrinsicsForTargetConfig must return a list satisfying the "
          "conventions in IREECPUEnums.td (strictly increasing, paired "
          "natural/swapped entries, etc.)");
@@ -578,7 +628,7 @@ struct IntrinsicInfo {
 /// generic-scalar branch of `chooseUnrolling` doesn't read them.
 static std::optional<IntrinsicInfo>
 getIntrinsicInfo(MLIRContext *ctx, ArrayRef<Type> elementTypes,
-                 IREE::CPU::MMAIntrinsic intr) {
+                 IREE::CPU::MMAIntrinsic intr, int64_t vlen) {
   if (IREE::CPU::isGenericScalar(intr)) {
     if (elementTypes.size() != 3 || !elementTypes[0] || !elementTypes[1] ||
         !elementTypes[2]) {
@@ -599,7 +649,7 @@ getIntrinsicInfo(MLIRContext *ctx, ArrayRef<Type> elementTypes,
       accTy != elementTypes[2]) {
     return std::nullopt;
   }
-  auto mnk = IREE::CPU::getIntrinsicMNKShape(intr);
+  auto mnk = IREE::CPU::getIntrinsicMNKShape(intr, vlen);
   if (!mnk) {
     return std::nullopt;
   }
@@ -634,6 +684,7 @@ static IREE::CPU::MMAIntrinsic
 chooseIntrinsic(MLIRContext *ctx, ArrayRef<Type> elementTypes,
                 DictionaryAttr config,
                 const IREE::Encoding::BxMxNxKxKb &matmulSizes) {
+  int64_t vlen = getVlenBitsForConfig(config);
   auto usefulSize = [](int64_t matmulSize, int64_t intrinsicSize) -> int64_t {
     return ShapedType::isDynamic(matmulSize)
                ? intrinsicSize
@@ -643,7 +694,7 @@ chooseIntrinsic(MLIRContext *ctx, ArrayRef<Type> elementTypes,
   std::pair<int64_t, int64_t> bestScore = {-1, -1};
   for (IREE::CPU::MMAIntrinsic intr : getMmaIntrinsicsForTargetConfig(config)) {
     std::optional<IntrinsicInfo> info =
-        getIntrinsicInfo(ctx, elementTypes, intr);
+        getIntrinsicInfo(ctx, elementTypes, intr, vlen);
     if (!info) {
       continue;
     }
@@ -697,9 +748,10 @@ static int64_t unrollCap(int64_t matmulSize, int64_t intrinsicSize,
 // tiling outright.
 static std::optional<std::tuple<int64_t, int64_t, int64_t>>
 chooseUnrolling(MLIRContext *ctx, ArrayRef<Type> elementTypes,
-                IREE::CPU::MMAIntrinsic intr,
+                IREE::CPU::MMAIntrinsic intr, int64_t vlen,
                 const IREE::Encoding::BxMxNxKxKb &matmulSizes) {
-  std::optional<IntrinsicInfo> info = getIntrinsicInfo(ctx, elementTypes, intr);
+  std::optional<IntrinsicInfo> info =
+      getIntrinsicInfo(ctx, elementTypes, intr, vlen);
   if (!info) {
     return std::nullopt;
   }
@@ -728,7 +780,7 @@ chooseUnrolling(MLIRContext *ctx, ArrayRef<Type> elementTypes,
     budget = IREE::CPU::getGenericScalarRegisterBudget(intr);
     accUnit = lhsUnit = rhsUnit = 1;
   } else {
-    budget = IREE::CPU::getRegisterSpaceBytes(intr) * 8;
+    budget = IREE::CPU::getRegisterSpaceBytes(intr, vlen) * 8;
     accUnit = info->accBits;
     lhsUnit = info->lhsBits;
     rhsUnit = info->rhsBits;
@@ -783,13 +835,14 @@ chooseCpuInnerTiledMmaForEncoding(MLIRContext *ctx,
   if (failed(matmulSizes)) {
     return {};
   }
+  int64_t vlen = getVlenBitsForConfig(config);
   IREE::CPU::MMAIntrinsic intr =
       chooseIntrinsic(ctx, elementTypes, config, *matmulSizes);
   if (intr == IREE::CPU::MMAIntrinsic::None) {
     return {};
   }
   std::optional<std::tuple<int64_t, int64_t, int64_t>> unroll =
-      chooseUnrolling(ctx, elementTypes, intr, *matmulSizes);
+      chooseUnrolling(ctx, elementTypes, intr, vlen, *matmulSizes);
   if (!unroll) {
     return {};
   }
@@ -803,9 +856,9 @@ chooseCpuInnerTiledMmaForEncoding(MLIRContext *ctx,
     rhsType = elementTypes[1];
     accType = elementTypes[2];
   }
-  return IREE::CPU::DataTiledMMAAttr::get(ctx, intr, intrinsicsM, intrinsicsN,
-                                          intrinsicsK, lhsType, rhsType,
-                                          accType);
+  return IREE::CPU::DataTiledMMAAttr::get(
+      ctx, intr, intrinsicsM, intrinsicsN, intrinsicsK, lhsType, rhsType,
+      accType, IREE::CPU::isVlenParameterized(intr) ? vlen : 0);
 }
 
 /// Lowers a contraction under a `CPUEncodingResolverAttr` with
@@ -1116,38 +1169,6 @@ enumerateMatmulTileRiscv32(DictionaryAttr config) {
   }
   // Fallback - no architecture-optimized tile size for this case.
   return {};
-}
-// RISC-V has vector register length extensions: zvl128b, zvl256b etc.
-// If these extension are specified in target cpu feature,
-// they can be used to determine VLEN. This function assumes that
-// 'v' feature is present
-size_t getRISCVVVlenFromCPUFeatures(DictionaryAttr config) {
-  // If +zvl* feature is not explicitly specified,
-  // fallback to +zvl128b, as spec specifies minimum VLEN
-  // of 128b for the V extension: https://rb.gy/p8rbzv
-  size_t vlen;
-  if (hasFeature(config, "+zvl65536b")) {
-    vlen = 65536;
-  } else if (hasFeature(config, "+zvl32768b")) {
-    vlen = 32768;
-  } else if (hasFeature(config, "+zvl16384b")) {
-    vlen = 16384;
-  } else if (hasFeature(config, "+zvl8192b")) {
-    vlen = 8192;
-  } else if (hasFeature(config, "+zvl4096b")) {
-    vlen = 4096;
-  } else if (hasFeature(config, "+zvl2048b")) {
-    vlen = 2048;
-  } else if (hasFeature(config, "+zvl1024b")) {
-    vlen = 1024;
-  } else if (hasFeature(config, "+zvl512b")) {
-    vlen = 512;
-  } else if (hasFeature(config, "+zvl256b")) {
-    vlen = 256;
-  } else {
-    vlen = 128;
-  }
-  return vlen;
 }
 // Enumerate tile sizes to choose from on riscv64.
 // For narrow-{M,N} cases, this only enumerates on narrow M. The narrow-N cases


### PR DESCRIPTION
For RISC-V, the vector length per SIMD register is not fixed and is configurable. Therefore, the tile shape of an intrinsic and the total SIMD register bit budget is also parameterized by the vector length. In order for all of these vector length configurations to share a single intrinsic and not duplicate it per-configurable-vlen, we add a `vlen` parameter to the `DataTiledMMAAttr`, which in combination with the intrinsic itself gives the exact shape information, as well as the register budget. These are derived from the `+zvl*b` flags.

Furthermore, add materialization for data-tiled f16 matmul encodings to `iree_codegen.inner_tiled` on RISC-V V targets with Zvfh, as the first consumer of the `vlen` attribute parameter. Lowering to LLVM intrinsics is not included.

Towards https://github.com/iree-org/iree/issues/24311

Assisted-by: Claude Code