### PR TITLE
[Flow] Bounds-check constant indices in tensor.load/tensor.store folders

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -663,14 +663,35 @@ void TensorBitCastOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // flow.tensor.load
 //===----------------------------------------------------------------------===//
 
+// Returns true if |index| is a valid in-bounds multidimensional index into a
+// statically shaped |type| (the rank matches and every component is within
+// its dimension). The op verifiers do not range-check constant indices, so a
+// parseable flow.tensor.load/store may index past the constant; folding such
+// an access would read or write out of bounds of the constant's storage.
+static bool isInBoundsIndex(ShapedType type, ArrayRef<uint64_t> index) {
+  if (!type.hasStaticShape())
+    return false;
+  auto shape = type.getShape();
+  if (static_cast<int64_t>(index.size()) != type.getRank())
+    return false;
+  for (int64_t i = 0; i < type.getRank(); ++i) {
+    if (index[i] >= static_cast<uint64_t>(shape[i]))
+      return false;
+  }
+  return true;
+}
+
 OpFoldResult TensorLoadOp::fold(FoldAdaptor operands) {
   if (auto source = dyn_cast_if_present<ElementsAttr>(operands.getSource())) {
     // Load directly from the constant source tensor.
     if (llvm::count(operands.getIndices(), nullptr) == 0) {
-      return source.getValues<Attribute>()[llvm::map_to_vector(
-          operands.getIndices(), [](Attribute value) {
+      auto index =
+          llvm::map_to_vector(operands.getIndices(), [](Attribute value) {
             return cast<IntegerAttr>(value).getValue().getZExtValue();
-          })];
+          });
+      if (!isInBoundsIndex(cast<ShapedType>(source.getType()), index))
+        return {};
+      return source.getValues<Attribute>()[index];
     }
   }
   return {};
@@ -717,11 +738,13 @@ OpFoldResult TensorStoreOp::fold(FoldAdaptor operands) {
       return DenseElementsAttr::get(targetType, {value});
     }
     if (llvm::count(operands.getIndices(), nullptr) == 0) {
-      uint64_t offset = getFlattenedIndex(
-          targetType,
+      auto index =
           llvm::map_to_vector(operands.getIndices(), [](Attribute value) {
             return cast<IntegerAttr>(value).getValue().getZExtValue();
-          }));
+          });
+      if (!isInBoundsIndex(targetType, index))
+        return {};
+      uint64_t offset = getFlattenedIndex(targetType, index);
       SmallVector<Attribute, 16> newContents(target.getValues<Attribute>());
       newContents[offset] = value;
       return DenseElementsAttr::get(targetType, newContents);


### PR DESCRIPTION
## Problem

`TensorLoadOp::fold` and `TensorStoreOp::fold` (`Dialect/Flow/IR/FlowOpFolders.cpp`) constant-fold a load-from / store-into a constant tensor when the indices are all constant, but neither validates the constant index against the tensor bounds:

- `getFlattenedIndex` only `assert`s a static shape and does raw row-major arithmetic — no range check.
- The verifiers (`TensorLoadOp::verify` / `TensorStoreOp::verify`) only check dynamic dims, never constant index values.

So parseable, verifier-clean IR reaches the fold with an out-of-range index:

```mlir
%c = flow.tensor.constant dense<[0,1,2,3]> : tensor<4xi32>
%i = arith.constant 9 : index
%r = flow.tensor.store %v, %c[%i] : tensor<4xi32>   // offset 9 into a 4-elem buffer
```

`TensorStoreOp::fold` then does `newContents[9] = value` — an out-of-bounds `SmallVector` write (assert in asserts builds, heap corruption in release). `TensorLoadOp::fold` does the analogous out-of-bounds read (`source.getValues<Attribute>()[oob-index]`).

## Fix

Add `isInBoundsIndex()` (rank matches and every component `< dim`) and bail out of both folds (`return {}`, i.e. no fold) on any out-of-range or wrong-rank constant index. This mirrors the bounds guard added to the sibling `TensorUpdateOp::fold` in #24680, which did not cover `load`/`store`.

## Testing

Static change (I can't build IREE on my dev box — the LLVM/MLIR link OOMs). The guard is a pure precondition check that only prevents folding an out-of-range constant access; all in-bounds folds are unchanged. Brace balance verified.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
