### PR TITLE
Fix TargetRegistry de/serialization and fix FixedPointIteratorPass constructor

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/Internal/BUILD.bazel
@@ -35,6 +35,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Tools:init_passes_and_dialects",
         "//compiler/src/iree/compiler/Tools:version",
         "//compiler/src/iree/compiler/Utils",
+        "@llvm-project//llvm:Passes",
         "@llvm-project//llvm:Remarks",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:TargetParser",

--- a/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     "CompilerDriver.cpp"
     "Diagnostics.cpp"
   DEPS
+    LLVMPasses
     LLVMRemarks
     LLVMSupport
     LLVMTargetParser

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -59,6 +59,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Endian.h"
@@ -1235,6 +1236,9 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
     return false;
   }
 
+  if (llvm::PrintPipelinePasses) {
+    passManager->dump();
+  }
   if (failed(passManager->run(parsedModule))) {
     return false;
   }
@@ -1248,6 +1252,10 @@ bool Invocation::runTextualPassPipeline(const char *textPassPipeline) {
   if (failed(mlir::parsePassPipeline(textPassPipeline, *passManager,
                                      llvm::errs()))) {
     return false;
+  }
+
+  if (llvm::PrintPipelinePasses) {
+    passManager->dump();
   }
   if (failed(passManager->run(parsedModule))) {
     return false;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp
@@ -150,6 +150,15 @@ template class basic_parser<TargetRegistryRef>;
 
 using TargetRegistryRef = llvm::cl::TargetRegistryRef;
 
+void llvm::cl::parser<TargetRegistryRef>::print(
+    raw_ostream &os, const TargetRegistryRef &value) {
+  if (value.isGlobal()) {
+    os << "global";
+  } else {
+    os << "unknown";
+  }
+}
+
 // Return true on error.
 bool llvm::cl::parser<TargetRegistryRef>::parse(Option &O, StringRef ArgName,
                                                 StringRef Arg,
@@ -158,7 +167,8 @@ bool llvm::cl::parser<TargetRegistryRef>::parse(Option &O, StringRef ArgName,
   // of target backends and create a new registry with just that subset but
   // ownership gets tricky.
   if (Arg != "global") {
-    return true;
+    llvm::errs() << "Cannot parse target registery: " << Arg
+                 << ". Defaulting to global.\n";
   }
   Val.value = &mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal();
   return false;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp
@@ -167,7 +167,7 @@ bool llvm::cl::parser<TargetRegistryRef>::parse(Option &O, StringRef ArgName,
   // of target backends and create a new registry with just that subset but
   // ownership gets tricky.
   if (Arg != "global") {
-    llvm::errs() << "Cannot parse target registery: " << Arg
+    llvm::errs() << "Cannot parse target registry: " << Arg
                  << ". Defaulting to global.\n";
   }
   Val.value = &mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal();

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace mlir::iree_compiler::IREE::HAL {
 
@@ -127,13 +128,17 @@ struct TargetRegistryRef {
       : value(&value) {}
   TargetRegistryRef(const mlir::iree_compiler::IREE::HAL::TargetRegistry *value)
       : value(value) {}
-  operator bool() const noexcept {
+  explicit operator bool() const noexcept {
     return value->getRegisteredTargetDevices() !=
                mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal()
                    .getRegisteredTargetDevices() &&
            value->getRegisteredTargetBackends() !=
                mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal()
                    .getRegisteredTargetBackends();
+  }
+  bool isGlobal() const {
+    return value ==
+           &mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal();
   }
   const mlir::iree_compiler::IREE::HAL::TargetRegistry *operator->() const {
     return value;
@@ -152,6 +157,7 @@ public:
   void printOptionDiff(const Option &O, TargetRegistryRef V,
                        const OptVal &Default, size_t GlobalWidth) const;
   void anchor() override;
+  static void print(raw_ostream &os, const TargetRegistryRef &value);
 };
 
 } // namespace llvm::cl

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_legacy_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_legacy_target_devices.mlir
@@ -2,6 +2,8 @@
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx,vmvx-inline})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{target-registry=xyz targetBackends=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{target-registry=global targetBackends=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
 
 // CHECK: module
 // TARGET-0: @module {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -77,7 +77,7 @@ def FixedPointIteratorPass : Pass<"iree-util-fixed-point-iterator", ""> {
   let summary = "Iterates a sub-pipeline to a fixed point.";
   let constructor = [{
     mlir::iree_compiler::IREE::Util::createFixedPointIteratorPass(
-        mlir::OpPassManager("dummy_op"))
+        mlir::OpPassManager())
   }];
 }
 


### PR DESCRIPTION
Fixed reproducer creation: The target registry is serialized as `{target_registry=0}` in the reproducer file (for passes that contain it, e.g. JitGlobalsPass). The deserialization when running a reproducer thus fails, because it expects `{target_registry=global}`.


What changed?
Enabled -print-pipeline-passes
Fix TargetRegistry de/serialization
Fix FixedPointIteratorPass constructor

More detailed explanation of the fixes
- see https://github.com/iree-org/llvm-project/blob/e65959f1684bd2416e8aa2ce684b8c300c381902/mlir/include/mlir/Pass/PassOptions.h#L77-L85
- Making the conversion from TargetRegistryRef to bool explicit,  so that `<<` is no longer overloaded for TargetRegistryDef (otherwise an implicit conversion would be inserted, and simply 0 or 1 printed), leading to the wrong output in the reproducer file
- Add a `parser<TargetRegistryRef>::print` overload that is selected instead, printing either "global" or "unknown"
- Adapting TargetRegistryRef parsing; always select the global registry, but print a warning if an argument different from "global" is provided