### PR TITLE
[Stream] Fix wrong merged offset in reverse CoalesceAdjacentFills

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -1859,8 +1859,11 @@ struct CoalesceAdjacentFills : OpRewritePattern<AsyncFillOp> {
           fusedLoc, sourceOp.getTargetLength(), fillOp.getTargetLength());
     } else {
       // Extending source op to fill toward the beginning: [fillOp][sourceOp]
-      newOffset = rewriter.createOrFold<arith::AddIOp>(
-          fusedLoc, fillOp.getTargetOffset(), sourceOp.getTargetOffset());
+      // The fill covers the region immediately before the producer, so the
+      // merged fill starts at the fill's (earlier) offset -- mirror of the
+      // toward-the-end branch above, which uses sourceOp.getTargetOffset().
+      // Adding the two absolute offsets would place the merged fill wrong.
+      newOffset = fillOp.getTargetOffset();
       newEnd = sourceOp.getTargetEnd();
       newLength = rewriter.createOrFold<arith::AddIOp>(
           fusedLoc, fillOp.getTargetLength(), sourceOp.getTargetLength());

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -1859,10 +1859,7 @@ struct CoalesceAdjacentFills : OpRewritePattern<AsyncFillOp> {
           fusedLoc, sourceOp.getTargetLength(), fillOp.getTargetLength());
     } else {
       // Extending source op to fill toward the beginning: [fillOp][sourceOp]
-      // The fill covers the region immediately before the producer, so the
-      // merged fill starts at the fill's (earlier) offset -- mirror of the
-      // toward-the-end branch above, which uses sourceOp.getTargetOffset().
-      // Adding the two absolute offsets would place the merged fill wrong.
+      // The merged fill starts at the fill's (earlier) offset.
       newOffset = fillOp.getTargetOffset();
       newEnd = sourceOp.getTargetEnd();
       newLength = rewriter.createOrFold<arith::AddIOp>(

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
@@ -274,6 +274,26 @@ util.func private @CoalesceAdjacentFills(%arg0: !stream.resource<*>, %arg1: inde
 
 // -----
 
+// Coalesces a fill into the region immediately BEFORE the producer fill
+// (sourceOffset == fillEnd). The merged fill starts at the earlier (fill's)
+// offset; regression for adding the two absolute offsets instead.
+
+// CHECK-LABEL: @CoalesceAdjacentFillsReverse
+util.func private @CoalesceAdjacentFillsReverse(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c20 = arith.constant 20 : index
+  %c0_i8 = arith.constant 0 : i8
+  // Producer fills [10, 20); consumer fills [0, 10) -> merged fill of [0, 20).
+  // CHECK: %[[FILL:.+]] = stream.async.fill %c0_i8, %arg0[%c0 to %c20 for %{{.+}}] : i8 -> %arg0 as !stream.resource<*>{%arg1}
+  %0 = stream.async.fill %c0_i8, %arg0[%c10 to %c20 for %c10] : i8 -> %arg0 as !stream.resource<*>{%arg1}
+  %1 = stream.async.fill %c0_i8, %0[%c0 to %c10 for %c10] : i8 -> %0 as !stream.resource<*>{%arg1}
+  // CHECK: util.return %[[FILL]]
+  util.return %1 : !stream.resource<*>
+}
+
+// -----
+
 // If we can't analyze the resources we can't fold as the update may be required
 // to preserve an in-place update of an external resource.
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
@@ -274,10 +274,6 @@ util.func private @CoalesceAdjacentFills(%arg0: !stream.resource<*>, %arg1: inde
 
 // -----
 
-// Coalesces a fill into the region immediately BEFORE the producer fill
-// (sourceOffset == fillEnd). The merged fill starts at the earlier (fill's)
-// offset; regression for adding the two absolute offsets instead.
-
 // CHECK-LABEL: @CoalesceAdjacentFillsReverse
 util.func private @CoalesceAdjacentFillsReverse(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index


### PR DESCRIPTION
## Problem

`CoalesceAdjacentFills` (canonicalization for `stream.async.fill`) merges two spatially-adjacent, same-value fills into one. It has two symmetric branches. In the branch where the consumer fill covers the region **immediately before** the producer's region (`sourceOp.getTargetOffset() == fillOp.getTargetEnd()`), the merged start offset is computed as

```cpp
newOffset = rewriter.createOrFold<arith::AddIOp>(
    fusedLoc, fillOp.getTargetOffset(), sourceOp.getTargetOffset());
```

Both are **absolute** byte offsets into the same target resource, so adding them is meaningless. The merged fill should start at the earlier (the fill's) offset — exactly mirroring the toward-the-end branch, which uses `sourceOp.getTargetOffset()` with no addition.

### Example

Producer fills `[10, 20)`, consumer fills `[0, 10)` (same value). Correct merge = `[0, 20)` (offset 0, end 20, length 20). The current code produces `offset = 0 + 10 = 10`, giving a fill `offset=10, end=20, length=20` — internally inconsistent (`end - offset = 10 ≠ length = 20`) and semantically wrong: the `[0, 10)` bytes are dropped (or, under an `[offset, offset+length)` lowering, it writes `[10, 30)` and overruns). `AsyncFillOp::verify` only checks value sizes, not `end == offset + length`, so this passes verification — a silent miscompile.

## Fix

Use `newOffset = fillOp.getTargetOffset();` (the earlier region's offset); `newEnd`/`newLength` are already correct.

## Testing

IREE doesn't build on my dev box, so I verified the offset arithmetic against the fill semantics with a standalone sweep (1,400 `(fillOffset, fillLength, sourceLength)` combinations): the current offset mismatches the correct filled byte range in **100%** of the reverse-adjacency cases, and `fillOp.getTargetOffset()` matches in **100%**. Added a FileCheck regression test (`@CoalesceAdjacentFillsReverse`) for the reverse-adjacency branch (the existing `@CoalesceAdjacentFills` test only exercises the toward-the-end branch). I couldn't run the lit suite here — happy to adjust the CHECK if CI flags it.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
