### PR TITLE
[Stream] Keep the parameter-file offset invariant when folding a resource subview

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -2814,11 +2814,6 @@ struct FoldAsyncParameterReadTargetSubview
     Value newTargetEnd;
     if (auto subviewOp = dyn_cast_or_null<IREE::Stream::ResourceSubviewOp>(
             newTargetResource.getDefiningOp())) {
-      newSourceOffset = rewriter.createOrFold<mlir::arith::AddIOp>(
-          subviewOp.getLoc(), newSourceOffset,
-          rewriter.createOrFold<mlir::arith::IndexCastOp>(
-              subviewOp.getLoc(), rewriter.getI64Type(),
-              subviewOp.getSourceOffset()));
       newTargetResource = subviewOp.getSource();
       newTargetSize = subviewOp.getSourceSize();
       newTargetOffset = rewriter.createOrFold<mlir::arith::AddIOp>(
@@ -2892,11 +2887,6 @@ struct FoldAsyncParameterWriteSourceSubview
           subviewOp.getLoc(), subviewOp.getSourceOffset(), newSourceOffset);
       newSourceEnd = rewriter.createOrFold<mlir::arith::AddIOp>(
           subviewOp.getLoc(), newSourceOffset, op.getSourceLength());
-      newTargetOffset = rewriter.createOrFold<mlir::arith::AddIOp>(
-          subviewOp.getLoc(), newTargetOffset,
-          rewriter.createOrFold<mlir::arith::IndexCastOp>(
-              subviewOp.getLoc(), rewriter.getI64Type(),
-              subviewOp.getSourceOffset()));
       needsUpdate = true;
     }
     rewriter.restoreInsertionPoint(ip);
@@ -2966,15 +2956,11 @@ struct FoldAsyncParameterGatherTargetSubview
     auto ip = rewriter.saveInsertionPoint();
     rewriter.setInsertionPoint(op);
 
-    // Adjust all source_offsets (I64) by adding index_cast(subview_offset).
-    SmallVector<Value> newSourceOffsets;
-    auto subviewOffsetI64 = rewriter.createOrFold<mlir::arith::IndexCastOp>(
-        subviewOp.getLoc(), rewriter.getI64Type(), subviewOp.getSourceOffset());
-    for (auto sourceOffset : op.getSourceOffsets()) {
-      auto newOffset = rewriter.createOrFold<mlir::arith::AddIOp>(
-          subviewOp.getLoc(), sourceOffset, subviewOffsetI64);
-      newSourceOffsets.push_back(newOffset);
-    }
+    // The parameter-file source_offsets live in an address space independent
+    // of the target resource, so folding a resource subview must not change
+    // them (only the target resource offsets shift).
+    SmallVector<Value> newSourceOffsets(op.getSourceOffsets().begin(),
+                                        op.getSourceOffsets().end());
 
     // Adjust all target_offsets (index) by adding subview_offset.
     SmallVector<Value> newTargetOffsets;
@@ -3077,15 +3063,11 @@ struct FoldAsyncParameterScatterSourceSubview
       newSourceEnds.push_back(newEnd);
     }
 
-    // Adjust all target_offsets (I64) by adding index_cast(subview_offset).
-    SmallVector<Value> newTargetOffsets;
-    auto subviewOffsetI64 = rewriter.createOrFold<mlir::arith::IndexCastOp>(
-        subviewOp.getLoc(), rewriter.getI64Type(), subviewOp.getSourceOffset());
-    for (auto targetOffset : op.getTargetOffsets()) {
-      auto newOffset = rewriter.createOrFold<mlir::arith::AddIOp>(
-          subviewOp.getLoc(), targetOffset, subviewOffsetI64);
-      newTargetOffsets.push_back(newOffset);
-    }
+    // The parameter-file target_offsets live in an address space independent
+    // of the source resource, so folding a resource subview must not change
+    // them (only the source resource offsets shift).
+    SmallVector<Value> newTargetOffsets(op.getTargetOffsets().begin(),
+                                        op.getTargetOffsets().end());
 
     rewriter.restoreInsertionPoint(ip);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_parameter_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_parameter_folding.mlir
@@ -24,13 +24,11 @@ util.func private @FoldAsyncParameterReadTargetSubview(%target: !stream.resource
   %transfer_length = arith.constant 200 : index
   // CHECK-DAG: %[[RESOURCE_END:.+]] = arith.constant 300 : index
   %subview_size = arith.constant 300 : index
-  // CHECK-DAG: %[[OFFSET_I64:.+]] = arith.index_cast %[[OFFSET]] : index to i64
-  // CHECK-DAG: %[[FOLDED_PARAM_OFFSET:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_OFFSET:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_OFFSET]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_END:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_END]]
   // CHECK-NOT: stream.resource.subview
   %subview = stream.resource.subview %target[%offset] : !stream.resource<transient>{%target_size} -> !stream.resource<transient>{%subview_size}
-  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY]][%[[FOLDED_PARAM_OFFSET]]] -> %[[TARGET]][%[[FOLDED_RESOURCE_OFFSET]] to %[[FOLDED_RESOURCE_END]] for %[[TRANSFER_LENGTH]]] : !stream.resource<transient>{%[[TARGET_SIZE]]} => !stream.timepoint
+  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY]][%[[PARAM_OFFSET]]] -> %[[TARGET]][%[[FOLDED_RESOURCE_OFFSET]] to %[[FOLDED_RESOURCE_END]] for %[[TRANSFER_LENGTH]]] : !stream.resource<transient>{%[[TARGET_SIZE]]} => !stream.timepoint
   %result, %result_ready = stream.async.parameter.read %scope::%key[%param_offset] -> %subview[%resource_offset to %resource_end for %transfer_length] : !stream.resource<transient>{%subview_size} => !stream.timepoint
   // CHECK: %[[RESULT_SYNC:.+]] = stream.timepoint.await %[[RESULT_READY]] => %[[RESULT]] : !stream.resource<transient>{%[[TARGET_SIZE]]}
   %result_sync = stream.timepoint.await %result_ready => %result : !stream.resource<transient>{%target_size}
@@ -52,13 +50,11 @@ util.func private @FoldAsyncParameterWriteSourceSubview(%source: !stream.resourc
   %transfer_length = arith.constant 200 : index
   // CHECK-DAG: %[[RESOURCE_END:.+]] = arith.constant 300 : index
   %subview_size = arith.constant 300 : index
-  // CHECK-DAG: %[[OFFSET_I64:.+]] = arith.index_cast %[[OFFSET]] : index to i64
-  // CHECK-DAG: %[[FOLDED_PARAM_OFFSET:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_OFFSET:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_OFFSET]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_END:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_END]]
   // CHECK-NOT: stream.resource.subview
   %subview = stream.resource.subview %source[%offset] : !stream.resource<transient>{%source_size} -> !stream.resource<transient>{%subview_size}
-  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.write %[[SOURCE]][%[[FOLDED_RESOURCE_OFFSET]] to %[[FOLDED_RESOURCE_END]] for %[[TRANSFER_LENGTH]]] -> %[[SCOPE]]::%[[KEY]][%[[FOLDED_PARAM_OFFSET]]] : !stream.resource<transient>{%[[SOURCE_SIZE]]} => !stream.timepoint
+  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.write %[[SOURCE]][%[[FOLDED_RESOURCE_OFFSET]] to %[[FOLDED_RESOURCE_END]] for %[[TRANSFER_LENGTH]]] -> %[[SCOPE]]::%[[KEY]][%[[PARAM_OFFSET]]] : !stream.resource<transient>{%[[SOURCE_SIZE]]} => !stream.timepoint
   %result, %result_ready = stream.async.parameter.write %subview[%resource_offset to %resource_end for %transfer_length] -> %scope::%key[%param_offset] : !stream.resource<transient>{%subview_size} => !stream.timepoint
   // CHECK: %[[RESULT_SYNC:.+]] = stream.timepoint.await %[[RESULT_READY]] => %[[RESULT]] : !stream.resource<transient>{%[[SOURCE_SIZE]]}
   %result_sync = stream.timepoint.await %result_ready => %result : !stream.resource<transient>{%source_size}
@@ -88,9 +84,6 @@ util.func private @FoldAsyncParameterGatherTargetSubview(%target: !stream.resour
   // CHECK-DAG: %[[TRANSFER_LENGTH1:.+]] = arith.constant 201 : index
   %transfer_length1 = arith.constant 201 : index
   %subview_size = arith.constant 300 : index
-  // CHECK-DAG: %[[OFFSET_I64:.+]] = arith.index_cast %[[OFFSET]] : index to i64
-  // CHECK-DAG: %[[FOLDED_PARAM_OFFSET0:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET0]]
-  // CHECK-DAG: %[[FOLDED_PARAM_OFFSET1:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET1]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_OFFSET0:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_OFFSET0]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_OFFSET1:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_OFFSET1]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_END0:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_END0]]
@@ -98,8 +91,8 @@ util.func private @FoldAsyncParameterGatherTargetSubview(%target: !stream.resour
   // CHECK-NOT: stream.resource.subview
   %subview = stream.resource.subview %target[%offset] : !stream.resource<transient>{%target_size} -> !stream.resource<transient>{%subview_size}
   // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.gather {
-  // CHECK-NEXT: %[[SCOPE]]::%[[KEY0]][%[[FOLDED_PARAM_OFFSET0]]] -> %[[TARGET]][%[[FOLDED_RESOURCE_OFFSET0]] to %[[FOLDED_RESOURCE_END0]] for %[[TRANSFER_LENGTH0]]] : !stream.resource<transient>{%[[TARGET_SIZE]]},
-  // CHECK-NEXT: %[[SCOPE]]::%[[KEY1]][%[[FOLDED_PARAM_OFFSET1]]] -> %[[TARGET]][%[[FOLDED_RESOURCE_OFFSET1]] to %[[FOLDED_RESOURCE_END1]] for %[[TRANSFER_LENGTH1]]] : !stream.resource<transient>{%[[TARGET_SIZE]]}
+  // CHECK-NEXT: %[[SCOPE]]::%[[KEY0]][%[[PARAM_OFFSET0]]] -> %[[TARGET]][%[[FOLDED_RESOURCE_OFFSET0]] to %[[FOLDED_RESOURCE_END0]] for %[[TRANSFER_LENGTH0]]] : !stream.resource<transient>{%[[TARGET_SIZE]]},
+  // CHECK-NEXT: %[[SCOPE]]::%[[KEY1]][%[[PARAM_OFFSET1]]] -> %[[TARGET]][%[[FOLDED_RESOURCE_OFFSET1]] to %[[FOLDED_RESOURCE_END1]] for %[[TRANSFER_LENGTH1]]] : !stream.resource<transient>{%[[TARGET_SIZE]]}
   // CHECK-NEXT: } : !stream.resource<transient> => !stream.timepoint
   %result, %result_ready = stream.async.parameter.gather {
     %scope::%key0[%param_offset0] -> %subview[%resource_offset0 to %resource_end0 for %transfer_length0] : !stream.resource<transient>{%subview_size},
@@ -133,9 +126,6 @@ util.func private @FoldAsyncParameterScatterSourceSubview(%source: !stream.resou
   // CHECK-DAG: %[[TRANSFER_LENGTH1:.+]] = arith.constant 201 : index
   %transfer_length1 = arith.constant 201 : index
   %subview_size = arith.constant 300 : index
-  // CHECK-DAG: %[[OFFSET_I64:.+]] = arith.index_cast %[[OFFSET]] : index to i64
-  // CHECK-DAG: %[[FOLDED_PARAM_OFFSET0:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET0]]
-  // CHECK-DAG: %[[FOLDED_PARAM_OFFSET1:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET1]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_OFFSET0:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_OFFSET0]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_OFFSET1:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_OFFSET1]]
   // CHECK-DAG: %[[FOLDED_RESOURCE_END0:.+]] = arith.addi %[[OFFSET]], %[[RESOURCE_END0]]
@@ -143,8 +133,8 @@ util.func private @FoldAsyncParameterScatterSourceSubview(%source: !stream.resou
   // CHECK-NOT: stream.resource.subview
   %subview = stream.resource.subview %source[%offset] : !stream.resource<transient>{%source_size} -> !stream.resource<transient>{%subview_size}
   // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.scatter {
-  // CHECK-NEXT: %[[SOURCE]][%[[FOLDED_RESOURCE_OFFSET0]] to %[[FOLDED_RESOURCE_END0]] for %[[TRANSFER_LENGTH0]]] : !stream.resource<transient>{%[[SOURCE_SIZE]]} -> %[[SCOPE]]::%[[KEY0]][%[[FOLDED_PARAM_OFFSET0]]],
-  // CHECK-NEXT: %[[SOURCE]][%[[FOLDED_RESOURCE_OFFSET1]] to %[[FOLDED_RESOURCE_END1]] for %[[TRANSFER_LENGTH1]]] : !stream.resource<transient>{%[[SOURCE_SIZE]]} -> %[[SCOPE]]::%[[KEY1]][%[[FOLDED_PARAM_OFFSET1]]]
+  // CHECK-NEXT: %[[SOURCE]][%[[FOLDED_RESOURCE_OFFSET0]] to %[[FOLDED_RESOURCE_END0]] for %[[TRANSFER_LENGTH0]]] : !stream.resource<transient>{%[[SOURCE_SIZE]]} -> %[[SCOPE]]::%[[KEY0]][%[[PARAM_OFFSET0]]],
+  // CHECK-NEXT: %[[SOURCE]][%[[FOLDED_RESOURCE_OFFSET1]] to %[[FOLDED_RESOURCE_END1]] for %[[TRANSFER_LENGTH1]]] : !stream.resource<transient>{%[[SOURCE_SIZE]]} -> %[[SCOPE]]::%[[KEY1]][%[[PARAM_OFFSET1]]]
   // CHECK-NEXT: } : !stream.resource<transient> => !stream.timepoint
   %result, %result_ready = stream.async.parameter.scatter {
     %subview[%resource_offset0 to %resource_end0 for %transfer_length0] : !stream.resource<transient>{%subview_size} -> %scope::%key0[%param_offset0],
@@ -445,21 +435,17 @@ util.func private @FoldAsyncParameterReadTargetSubviewMultipleReads(%base: !stre
   // Subview used by multiple different reads. Both reads can independently fold.
   // CHECK-NOT: stream.resource.subview
   // First read's arithmetic.
-  // CHECK-DAG: %[[OFFSET1_I64:.+]] = arith.index_cast %[[SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM_OFFSET1:.+]] = arith.addi %[[PARAM_OFFSET1]], %[[OFFSET1_I64]]
   // CHECK-DAG: %[[ADJUSTED_READ1_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[READ1_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_READ1_END:.+]] = arith.addi %[[ADJUSTED_READ1_OFFSET]], %[[READ1_LENGTH]]
   // First read operation.
-  // CHECK: %[[RESULT1:.+]], %[[RESULT1_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY1]][%[[ADJUSTED_PARAM_OFFSET1]]] -> %[[BASE]][%[[ADJUSTED_READ1_OFFSET]] to %[[ADJUSTED_READ1_END]] for %[[READ1_LENGTH]]]
+  // CHECK: %[[RESULT1:.+]], %[[RESULT1_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY1]][%[[PARAM_OFFSET1]]] -> %[[BASE]][%[[ADJUSTED_READ1_OFFSET]] to %[[ADJUSTED_READ1_END]] for %[[READ1_LENGTH]]]
   %subview = stream.resource.subview %base[%subview_offset] : !stream.resource<transient>{%base_size} -> !stream.resource<transient>{%subview_size}
   %result1, %result1_ready = stream.async.parameter.read %scope::%key1[%param_offset1] -> %subview[%read1_offset to %read1_end for %read1_length] : !stream.resource<transient>{%subview_size} => !stream.timepoint
   // Second read's arithmetic.
-  // CHECK-DAG: %[[OFFSET2_I64:.+]] = arith.index_cast %[[SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM_OFFSET2:.+]] = arith.addi %[[PARAM_OFFSET2]], %[[OFFSET2_I64]]
   // CHECK-DAG: %[[ADJUSTED_READ2_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[READ2_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_READ2_END:.+]] = arith.addi %[[ADJUSTED_READ2_OFFSET]], %[[READ2_LENGTH]]
   // Second read operation.
-  // CHECK: %[[RESULT2:.+]], %[[RESULT2_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY2]][%[[ADJUSTED_PARAM_OFFSET2]]] -> %[[BASE]][%[[ADJUSTED_READ2_OFFSET]] to %[[ADJUSTED_READ2_END]] for %[[READ2_LENGTH]]]
+  // CHECK: %[[RESULT2:.+]], %[[RESULT2_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY2]][%[[PARAM_OFFSET2]]] -> %[[BASE]][%[[ADJUSTED_READ2_OFFSET]] to %[[ADJUSTED_READ2_END]] for %[[READ2_LENGTH]]]
   %result2, %result2_ready = stream.async.parameter.read %scope::%key2[%param_offset2] -> %subview[%read2_offset to %read2_end for %read2_length] : !stream.resource<transient>{%subview_size} => !stream.timepoint
   // CHECK: %[[RESULT1_SYNC:.+]] = stream.timepoint.await %[[RESULT1_READY]] => %[[RESULT1]]
   %result1_sync = stream.timepoint.await %result1_ready => %result1 : !stream.resource<transient>{%base_size}
@@ -477,21 +463,17 @@ util.func private @FoldAsyncParameterWriteSourceSubviewMultipleWrites(%base: !st
   // Subview used by multiple different writes. Both writes can independently fold.
   // CHECK-NOT: stream.resource.subview
   // First write's arithmetic.
-  // CHECK-DAG: %[[OFFSET1_I64:.+]] = arith.index_cast %[[SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM_OFFSET1:.+]] = arith.addi %[[PARAM_OFFSET1]], %[[OFFSET1_I64]]
   // CHECK-DAG: %[[ADJUSTED_WRITE1_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[WRITE1_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_WRITE1_END:.+]] = arith.addi %[[ADJUSTED_WRITE1_OFFSET]], %[[WRITE1_LENGTH]]
   // First write operation.
-  // CHECK: %[[RESULT1:.+]], %[[RESULT1_READY:.+]] = stream.async.parameter.write %[[BASE]][%[[ADJUSTED_WRITE1_OFFSET]] to %[[ADJUSTED_WRITE1_END]] for %[[WRITE1_LENGTH]]] -> %[[SCOPE]]::%[[KEY1]][%[[ADJUSTED_PARAM_OFFSET1]]]
+  // CHECK: %[[RESULT1:.+]], %[[RESULT1_READY:.+]] = stream.async.parameter.write %[[BASE]][%[[ADJUSTED_WRITE1_OFFSET]] to %[[ADJUSTED_WRITE1_END]] for %[[WRITE1_LENGTH]]] -> %[[SCOPE]]::%[[KEY1]][%[[PARAM_OFFSET1]]]
   %subview = stream.resource.subview %base[%subview_offset] : !stream.resource<transient>{%base_size} -> !stream.resource<transient>{%subview_size}
   %result1, %result1_ready = stream.async.parameter.write %subview[%write1_offset to %write1_end for %write1_length] -> %scope::%key1[%param_offset1] : !stream.resource<transient>{%subview_size} => !stream.timepoint
   // Second write's arithmetic.
-  // CHECK-DAG: %[[OFFSET2_I64:.+]] = arith.index_cast %[[SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM_OFFSET2:.+]] = arith.addi %[[PARAM_OFFSET2]], %[[OFFSET2_I64]]
   // CHECK-DAG: %[[ADJUSTED_WRITE2_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[WRITE2_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_WRITE2_END:.+]] = arith.addi %[[ADJUSTED_WRITE2_OFFSET]], %[[WRITE2_LENGTH]]
   // Second write operation.
-  // CHECK: %[[RESULT2:.+]], %[[RESULT2_READY:.+]] = stream.async.parameter.write %[[BASE]][%[[ADJUSTED_WRITE2_OFFSET]] to %[[ADJUSTED_WRITE2_END]] for %[[WRITE2_LENGTH]]] -> %[[SCOPE]]::%[[KEY2]][%[[ADJUSTED_PARAM_OFFSET2]]]
+  // CHECK: %[[RESULT2:.+]], %[[RESULT2_READY:.+]] = stream.async.parameter.write %[[BASE]][%[[ADJUSTED_WRITE2_OFFSET]] to %[[ADJUSTED_WRITE2_END]] for %[[WRITE2_LENGTH]]] -> %[[SCOPE]]::%[[KEY2]][%[[PARAM_OFFSET2]]]
   %result2, %result2_ready = stream.async.parameter.write %subview[%write2_offset to %write2_end for %write2_length] -> %scope::%key2[%param_offset2] : !stream.resource<transient>{%subview_size} => !stream.timepoint
   // CHECK: %[[RESULT1_SYNC:.+]] = stream.timepoint.await %[[RESULT1_READY]] => %[[RESULT1]]
   %result1_sync = stream.timepoint.await %result1_ready => %result1 : !stream.resource<transient>{%base_size}
@@ -509,15 +491,13 @@ util.func private @FoldAsyncParameterReadTargetNestedSubviews(%base: !stream.res
   // Nested subviews: subview2 = subview(subview1).
   // Both subviews should be completely folded away.
   // CHECK-DAG: %[[COMBINED_OFFSET12:.+]] = arith.addi %[[OFFSET1]], %[[OFFSET2]]
-  // CHECK-DAG: %[[COMBINED_OFFSET12_I64:.+]] = arith.index_cast %[[COMBINED_OFFSET12]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM_OFFSET:.+]] = arith.addi %[[PARAM_OFFSET]], %[[COMBINED_OFFSET12_I64]]
   // CHECK-DAG: %[[ADJUSTED_READ_OFFSET:.+]] = arith.addi %[[COMBINED_OFFSET12]], %[[READ_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_READ_END:.+]] = arith.addi %[[ADJUSTED_READ_OFFSET]], %[[READ_LENGTH]]
   // CHECK-NOT: stream.resource.subview
   %subview1 = stream.resource.subview %base[%offset1] : !stream.resource<transient>{%base_size} -> !stream.resource<transient>{%subview1_size}
   %subview2 = stream.resource.subview %subview1[%offset2] : !stream.resource<transient>{%subview1_size} -> !stream.resource<transient>{%subview2_size}
   // Both subviews fold completely away.
-  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY]][%[[ADJUSTED_PARAM_OFFSET]]] -> %[[BASE]][%[[ADJUSTED_READ_OFFSET]] to %[[ADJUSTED_READ_END]] for %[[READ_LENGTH]]]
+  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY]][%[[PARAM_OFFSET]]] -> %[[BASE]][%[[ADJUSTED_READ_OFFSET]] to %[[ADJUSTED_READ_END]] for %[[READ_LENGTH]]]
   %result, %result_ready = stream.async.parameter.read %scope::%key[%param_offset] -> %subview2[%read_offset to %read_end for %read_length] : !stream.resource<transient>{%subview2_size} => !stream.timepoint
   // CHECK: %[[RESULT_SYNC:.+]] = stream.timepoint.await %[[RESULT_READY]] => %[[RESULT]] : !stream.resource<transient>{%[[SUBVIEW1_SIZE]]}
   %result_sync = stream.timepoint.await %result_ready => %result : !stream.resource<transient>{%subview1_size}
@@ -533,25 +513,21 @@ util.func private @FoldAsyncParameterGatherTargetSubviewMultipleGathers(%base: !
   // Subview used by multiple different gather operations. Both gathers can independently fold.
   // CHECK-NOT: stream.resource.subview
   // First gather's arithmetic.
-  // CHECK-DAG: %[[OFFSET1_I64:.+]] = arith.index_cast %[[SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM_OFFSET1:.+]] = arith.addi %[[PARAM_OFFSET1]], %[[OFFSET1_I64]]
   // CHECK-DAG: %[[ADJUSTED_GATHER1_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[GATHER1_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_GATHER1_END:.+]] = arith.addi %[[ADJUSTED_GATHER1_OFFSET]], %[[GATHER1_LENGTH]]
   // First gather operation.
   // CHECK: %[[RESULT1:.+]], %[[RESULT1_READY:.+]] = stream.async.parameter.gather {
-  // CHECK-NEXT: %[[SCOPE]]::%[[KEY1]][%[[ADJUSTED_PARAM_OFFSET1]]] -> %[[BASE]][%[[ADJUSTED_GATHER1_OFFSET]] to %[[ADJUSTED_GATHER1_END]] for %[[GATHER1_LENGTH]]]
+  // CHECK-NEXT: %[[SCOPE]]::%[[KEY1]][%[[PARAM_OFFSET1]]] -> %[[BASE]][%[[ADJUSTED_GATHER1_OFFSET]] to %[[ADJUSTED_GATHER1_END]] for %[[GATHER1_LENGTH]]]
   %subview = stream.resource.subview %base[%subview_offset] : !stream.resource<transient>{%base_size} -> !stream.resource<transient>{%subview_size}
   %result1, %result1_ready = stream.async.parameter.gather {
     %scope::%key1[%param_offset1] -> %subview[%gather1_offset to %gather1_end for %gather1_length] : !stream.resource<transient>{%subview_size}
   } : !stream.resource<transient> => !stream.timepoint
   // Second gather's arithmetic.
-  // CHECK-DAG: %[[OFFSET2_I64:.+]] = arith.index_cast %[[SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM_OFFSET2:.+]] = arith.addi %[[PARAM_OFFSET2]], %[[OFFSET2_I64]]
   // CHECK-DAG: %[[ADJUSTED_GATHER2_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[GATHER2_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_GATHER2_END:.+]] = arith.addi %[[ADJUSTED_GATHER2_OFFSET]], %[[GATHER2_LENGTH]]
   // Second gather operation.
   // CHECK: %[[RESULT2:.+]], %[[RESULT2_READY:.+]] = stream.async.parameter.gather {
-  // CHECK-NEXT: %[[SCOPE]]::%[[KEY2]][%[[ADJUSTED_PARAM_OFFSET2]]] -> %[[BASE]][%[[ADJUSTED_GATHER2_OFFSET]] to %[[ADJUSTED_GATHER2_END]] for %[[GATHER2_LENGTH]]]
+  // CHECK-NEXT: %[[SCOPE]]::%[[KEY2]][%[[PARAM_OFFSET2]]] -> %[[BASE]][%[[ADJUSTED_GATHER2_OFFSET]] to %[[ADJUSTED_GATHER2_END]] for %[[GATHER2_LENGTH]]]
   %result2, %result2_ready = stream.async.parameter.gather {
     %scope::%key2[%param_offset2] -> %subview[%gather2_offset to %gather2_end for %gather2_length] : !stream.resource<transient>{%subview_size}
   } : !stream.resource<transient> => !stream.timepoint
@@ -588,10 +564,6 @@ util.func private @FoldAsyncParameterScatterSourceSubviewVariadicEntries(%base: 
   %source_length3 = arith.constant 100 : index
   %subview_size = arith.constant 800 : index
   // Single scatter with 3 variadic entries using same subview should fold.
-  // CHECK-DAG: %[[OFFSET_I64:.+]] = arith.index_cast %[[OFFSET]] : index to i64
-  // CHECK-DAG: %[[FOLDED_PARAM1:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET1]]
-  // CHECK-DAG: %[[FOLDED_PARAM2:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET2]]
-  // CHECK-DAG: %[[FOLDED_PARAM3:.+]] = arith.addi %[[OFFSET_I64]], %[[PARAM_OFFSET3]]
   // CHECK-DAG: %[[FOLDED_SOURCE1:.+]] = arith.addi %[[OFFSET]], %[[SOURCE_OFFSET1]]
   // CHECK-DAG: %[[FOLDED_SOURCE2:.+]] = arith.addi %[[OFFSET]], %[[SOURCE_OFFSET2]]
   // CHECK-DAG: %[[FOLDED_SOURCE3:.+]] = arith.addi %[[OFFSET]], %[[SOURCE_OFFSET3]]
@@ -599,9 +571,9 @@ util.func private @FoldAsyncParameterScatterSourceSubviewVariadicEntries(%base: 
   %subview = stream.resource.subview %base[%offset] : !stream.resource<transient>{%base_size} -> !stream.resource<transient>{%subview_size}
   // All 3 entries should have folded offsets.
   // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.scatter {
-  // CHECK-NEXT: %[[BASE]][%[[FOLDED_SOURCE1]]{{.+}} -> %[[SCOPE]]::%[[KEY1]][%[[FOLDED_PARAM1]]]
-  // CHECK-NEXT: %[[BASE]][%[[FOLDED_SOURCE2]]{{.+}} -> %[[SCOPE]]::%[[KEY2]][%[[FOLDED_PARAM2]]]
-  // CHECK-NEXT: %[[BASE]][%[[FOLDED_SOURCE3]]{{.+}} -> %[[SCOPE]]::%[[KEY3]][%[[FOLDED_PARAM3]]]
+  // CHECK-NEXT: %[[BASE]][%[[FOLDED_SOURCE1]]{{.+}} -> %[[SCOPE]]::%[[KEY1]][%[[PARAM_OFFSET1]]]
+  // CHECK-NEXT: %[[BASE]][%[[FOLDED_SOURCE2]]{{.+}} -> %[[SCOPE]]::%[[KEY2]][%[[PARAM_OFFSET2]]]
+  // CHECK-NEXT: %[[BASE]][%[[FOLDED_SOURCE3]]{{.+}} -> %[[SCOPE]]::%[[KEY3]][%[[PARAM_OFFSET3]]]
   %result, %result_ready = stream.async.parameter.scatter {
     %subview[%source_offset1 to %source_end1 for %source_length1] : !stream.resource<transient>{%subview_size} -> %scope::%key1[%param_offset1],
     %subview[%source_offset2 to %source_end2 for %source_length2] : !stream.resource<transient>{%subview_size} -> %scope::%key2[%param_offset2],
@@ -619,13 +591,11 @@ util.func private @FoldAsyncParameterScatterSourceSubviewVariadicEntries(%base: 
 // CHECK-SAME: (%[[TARGET:.+]]: !stream.resource<transient>, %[[TARGET_SIZE:.+]]: index, %[[PARAM_OFFSET:[a-zA-Z0-9]+]]: i64, %[[ALIGNMENT_OFFSET:[a-zA-Z0-9]+]]: index, %[[SUBVIEW_SIZE:[a-zA-Z0-9]+]]: index, %[[READ_OFFSET:[a-zA-Z0-9]+]]: index, %[[READ_END:[a-zA-Z0-9]+]]: index, %[[READ_LENGTH:[a-zA-Z0-9]+]]: index, %[[SCOPE:.+]]: !util.buffer, %[[KEY:.+]]: !util.buffer)
 util.func private @FoldAsyncParameterReadTargetAlignmentOffsets(%target: !stream.resource<transient>, %target_size: index, %param_offset: i64, %alignment_offset: index, %subview_size: index, %read_offset: index, %read_end: index, %read_length: index, %scope: !util.buffer, %key: !util.buffer) -> !stream.resource<transient> {
   // Test with common alignment values (4KB, 16KB, 8KB).
-  // CHECK-DAG: %[[OFFSET_I64:.+]] = arith.index_cast %[[ALIGNMENT_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM:.+]] = arith.addi %[[PARAM_OFFSET]], %[[OFFSET_I64]]
   // CHECK-DAG: %[[ADJUSTED_READ_OFFSET:.+]] = arith.addi %[[ALIGNMENT_OFFSET]], %[[READ_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_READ_END:.+]] = arith.addi %[[ADJUSTED_READ_OFFSET]], %[[READ_LENGTH]]
   // CHECK-NOT: stream.resource.subview
   %subview = stream.resource.subview %target[%alignment_offset] : !stream.resource<transient>{%target_size} -> !stream.resource<transient>{%subview_size}
-  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY]][%[[ADJUSTED_PARAM]]] -> %[[TARGET]][%[[ADJUSTED_READ_OFFSET]] to %[[ADJUSTED_READ_END]]
+  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY]][%[[PARAM_OFFSET]]] -> %[[TARGET]][%[[ADJUSTED_READ_OFFSET]] to %[[ADJUSTED_READ_END]]
   %result, %result_ready = stream.async.parameter.read %scope::%key[%param_offset] -> %subview[%read_offset to %read_end for %read_length] : !stream.resource<transient>{%subview_size} => !stream.timepoint
   // CHECK: %[[RESULT_SYNC:.+]] = stream.timepoint.await %[[RESULT_READY]] => %[[RESULT]]
   %result_sync = stream.timepoint.await %result_ready => %result : !stream.resource<transient>{%target_size}
@@ -641,20 +611,17 @@ util.func private @FoldAsyncParameterGatherTargetSubviewMultipleEntries(%base: !
   // Single gather with multiple entries all using same subview target should fold.
   // All entries should have their parameter offsets and target offsets adjusted.
   // First entry's arithmetic.
-  // CHECK-DAG: %[[OFFSET_I64:.+]] = arith.index_cast %[[SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM1:.+]] = arith.addi %[[PARAM_OFFSET1]], %[[OFFSET_I64]]
   // CHECK-DAG: %[[ADJUSTED_GATHER1_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[GATHER1_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_GATHER1_END:.+]] = arith.addi %[[ADJUSTED_GATHER1_OFFSET]], %[[GATHER1_LENGTH]]
   // Second entry's arithmetic.
-  // CHECK-DAG: %[[ADJUSTED_PARAM2:.+]] = arith.addi %[[PARAM_OFFSET2]], %[[OFFSET_I64]]
   // CHECK-DAG: %[[ADJUSTED_GATHER2_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[GATHER2_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_GATHER2_END:.+]] = arith.addi %[[ADJUSTED_GATHER2_OFFSET]], %[[GATHER2_LENGTH]]
   // CHECK-NOT: stream.resource.subview
   %subview = stream.resource.subview %base[%subview_offset] : !stream.resource<transient>{%base_size} -> !stream.resource<transient>{%subview_size}
   // Both entries should fold to use base resource with adjusted offsets.
   // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.gather {
-  // CHECK-NEXT: %[[SCOPE]]::%[[KEY1]][%[[ADJUSTED_PARAM1]]] -> %[[BASE]][%[[ADJUSTED_GATHER1_OFFSET]] to %[[ADJUSTED_GATHER1_END]] for %[[GATHER1_LENGTH]]] : !stream.resource<transient>{%[[BASE_SIZE]]}
-  // CHECK-NEXT: %[[SCOPE]]::%[[KEY2]][%[[ADJUSTED_PARAM2]]] -> %[[BASE]][%[[ADJUSTED_GATHER2_OFFSET]] to %[[ADJUSTED_GATHER2_END]] for %[[GATHER2_LENGTH]]] : !stream.resource<transient>{%[[BASE_SIZE]]}
+  // CHECK-NEXT: %[[SCOPE]]::%[[KEY1]][%[[PARAM_OFFSET1]]] -> %[[BASE]][%[[ADJUSTED_GATHER1_OFFSET]] to %[[ADJUSTED_GATHER1_END]] for %[[GATHER1_LENGTH]]] : !stream.resource<transient>{%[[BASE_SIZE]]}
+  // CHECK-NEXT: %[[SCOPE]]::%[[KEY2]][%[[PARAM_OFFSET2]]] -> %[[BASE]][%[[ADJUSTED_GATHER2_OFFSET]] to %[[ADJUSTED_GATHER2_END]] for %[[GATHER2_LENGTH]]] : !stream.resource<transient>{%[[BASE_SIZE]]}
   %result, %result_ready = stream.async.parameter.gather {
     %scope::%key1[%param_offset1] -> %subview[%gather1_offset to %gather1_end for %gather1_length] : !stream.resource<transient>{%subview_size},
     %scope::%key2[%param_offset2] -> %subview[%gather2_offset to %gather2_end for %gather2_length] : !stream.resource<transient>{%subview_size}
@@ -675,8 +642,6 @@ util.func private @FoldAsyncParameterReadAwaitThenSubviewThenRead(%target: !stre
   // CHECK: %[[READ1_RESULT:.+]], %[[READ1_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY1]][%[[PARAM_OFFSET1]]] -> %[[TARGET]]
   %read1_result, %read1_ready = stream.async.parameter.read %scope::%key1[%param_offset1] -> %target[%subview_offset to %read_end for %read_length] : !stream.resource<transient>{%target_size} => !stream.timepoint
   // Arithmetic for second read is hoisted after first read but before await.
-  // CHECK-DAG: %[[OFFSET_I64:.+]] = arith.index_cast %[[SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[ADJUSTED_PARAM:.+]] = arith.addi %[[PARAM_OFFSET2]], %[[OFFSET_I64]]
   // CHECK-DAG: %[[ADJUSTED_READ_OFFSET:.+]] = arith.addi %[[SUBVIEW_OFFSET]], %[[READ_OFFSET]]
   // CHECK-DAG: %[[ADJUSTED_READ_END:.+]] = arith.addi %[[ADJUSTED_READ_OFFSET]], %[[READ_LENGTH]]
   // CHECK: %[[AWAITED:.+]] = stream.timepoint.await %[[READ1_READY]] => %[[READ1_RESULT]]
@@ -684,7 +649,7 @@ util.func private @FoldAsyncParameterReadAwaitThenSubviewThenRead(%target: !stre
   // CHECK-NOT: stream.resource.subview
   %subview = stream.resource.subview %awaited[%subview_offset] : !stream.resource<transient>{%target_size} -> !stream.resource<transient>{%subview_size}
   // Subview should fold into second read.
-  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY2]][%[[ADJUSTED_PARAM]]] -> %[[AWAITED]][%[[ADJUSTED_READ_OFFSET]] to %[[ADJUSTED_READ_END]]
+  // CHECK: %[[RESULT:.+]], %[[RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY2]][%[[PARAM_OFFSET2]]] -> %[[AWAITED]][%[[ADJUSTED_READ_OFFSET]] to %[[ADJUSTED_READ_END]]
   %result, %result_ready = stream.async.parameter.read %scope::%key2[%param_offset2] -> %subview[%read_offset to %read_end for %read_length] : !stream.resource<transient>{%subview_size} => !stream.timepoint
   // CHECK: %[[RESULT_SYNC:.+]] = stream.timepoint.await %[[RESULT_READY]] => %[[RESULT]]
   %result_sync = stream.timepoint.await %result_ready => %result : !stream.resource<transient>{%target_size}
@@ -725,8 +690,6 @@ util.func private @MultipleAsyncParameterFoldsInFunction(%target: !stream.resour
   // CHECK: %[[LOADED:.+]], %[[LOADED_READY:.+]] = stream.async.parameter.load %[[SCOPE]]::%[[KEY1]][%[[LOAD_ADJUSTED_OFFSET]]] : !stream.resource<constant>{%[[LOAD_SUBVIEW_SIZE]]} => !stream.timepoint
   %loaded, %loaded_ready = stream.async.parameter.load %scope::%key1[%load_param_offset] : !stream.resource<constant>{%load_size} => !stream.timepoint
   // Second fold arithmetic appears after load operation.
-  // CHECK-DAG: %[[READ_OFFSET_I64:.+]] = arith.index_cast %[[READ_SUBVIEW_OFFSET]] : index to i64
-  // CHECK-DAG: %[[READ_ADJUSTED_PARAM:.+]] = arith.addi %[[READ_PARAM_OFFSET]], %[[READ_OFFSET_I64]]
   // CHECK-DAG: %[[READ_ADJUSTED_OFFSET:.+]] = arith.addi %[[READ_SUBVIEW_OFFSET]], %[[READ_OFFSET]]
   // CHECK-DAG: %[[READ_ADJUSTED_END:.+]] = arith.addi %[[READ_ADJUSTED_OFFSET]], %[[READ_LENGTH]]
   // CHECK-NOT: stream.resource.subview %[[LOADED]]
@@ -734,7 +697,7 @@ util.func private @MultipleAsyncParameterFoldsInFunction(%target: !stream.resour
   // Second fold: read target subview (independent of first).
   // CHECK-NOT: stream.resource.subview %[[TARGET]]
   %read_subview = stream.resource.subview %target[%read_subview_offset] : !stream.resource<transient>{%target_size} -> !stream.resource<transient>{%read_subview_size}
-  // CHECK: %[[READ_RESULT:.+]], %[[READ_RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY2]][%[[READ_ADJUSTED_PARAM]]] -> %[[TARGET]][%[[READ_ADJUSTED_OFFSET]] to %[[READ_ADJUSTED_END]]
+  // CHECK: %[[READ_RESULT:.+]], %[[READ_RESULT_READY:.+]] = stream.async.parameter.read %[[SCOPE]]::%[[KEY2]][%[[READ_PARAM_OFFSET]]] -> %[[TARGET]][%[[READ_ADJUSTED_OFFSET]] to %[[READ_ADJUSTED_END]]
   %read_result, %read_result_ready = stream.async.parameter.read %scope::%key2[%read_param_offset] -> %read_subview[%read_offset to %read_end for %read_length] : !stream.resource<transient>{%read_subview_size} => !stream.timepoint
   // CHECK-DAG: %[[READ_RESULT_SYNC:.+]] = stream.timepoint.await %[[READ_RESULT_READY]] => %[[READ_RESULT]]
   %read_result_sync = stream.timepoint.await %read_result_ready => %read_result : !stream.resource<transient>{%target_size}


### PR DESCRIPTION
## Summary

The four `stream.async.parameter.*` subview-fusion canonicalizations (read,
write, gather, scatter) fold a consumer/producer `stream.resource.subview`
into the transfer op. Each of them wrongly added the subview's byte offset to
the **parameter-archive file offset** in addition to the resource offset.

The parameter-file offset and the resource offset live in **independent
address spaces**. From the op definition of `stream.async.parameter.read`:

> Reads data from a parameter archive file ... at the specified byte offset
> into an existing target resource. Unlike `load` which allocates a new
> resource, `read` writes into a caller-provided allocation.

So a `stream.resource.subview` on the target/source resource shifts only the
**resource-side** offset; the **file** offset (`source_offset` for
read/gather, `target_offset` for write/scatter) must stay invariant under the
subview.

Concretely, for a read with subview offset `svOff`: the original op reads
`file[source_offset, +len)` into `subview[target_offset, ...]` =
`base[svOff + target_offset, ...]`. The correct fold keeps the file
`source_offset` and adds `svOff` to the resource `target_offset`. The buggy
fold instead added `svOff` to the file `source_offset`, i.e. it read the
**wrong bytes** out of the archive (a silent miscompile).

## The fix (`StreamOpFolders.cpp`)

Remove only the file-offset pollution in each of the four folds; the
resource-side offset/size/end adjustments are unchanged:

- `FoldAsyncParameterReadTargetSubview` — stop adding the subview offset to
  `source_offset` (the file offset).
- `FoldAsyncParameterWriteSourceSubview` — stop adding the subview offset to
  `target_offset` (the file offset).
- `FoldAsyncParameterGatherTargetSubview` — keep the per-entry
  `source_offsets` (file offsets) as-is.
- `FoldAsyncParameterScatterSourceSubview` — keep the per-entry
  `target_offsets` (file offsets) as-is.

The now-unused `index_cast`/`subviewOffsetI64` locals that only fed the file
add are dropped.

### Why the sibling `load` fold is correct and untouched

`FoldAsyncParameterLoadResultSubview` legitimately *does* add the subview
offset to the file offset, and is intentionally left alone: `load` allocates
a fresh, 1:1 image of the file region, so there the resource index equals the
file index and the subview offset applies to both.

## Tests

`async_parameter_folding.mlir` encoded the buggy arithmetic: each affected
test checked a folded file offset `= arith.addi index_cast(subview_offset),
param_offset` and referenced it in the folded op's file-offset position.
After the fix the file offset is the raw parameter offset (no `addi`), and the
`index_cast` that fed only the file add is dead and DCE'd. The relevant
CHECK-DAG lines were updated accordingly and the folded op's file-offset
operand now references the raw parameter offset. 13 tests exercise these four
folds (the 4 primary tests plus the multiple-op / nested-subview / variadic /
alignment / await-then-subview / multi-fold variants) and were corrected; the
`parameter.load` and `async.slice` tests keep their (correct) arithmetic.

## Caveat

IREE doesn't build on my dev box, so the fold logic is verified by the op
semantics + the contrast with the correct `load` fold, and I updated the
FileCheck lines by hand without running `lit`. Happy to adjust if CI flags
anything.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
