### PR TITLE
[Bindings] Reject unranked tensors in native ABI signatures

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -46,6 +46,20 @@ static Type mapToABIType(Type type) {
   return type;
 }
 
+// Verifies that |funcOp| does not contain unsupported unranked tensors.
+static LogicalResult verifyABISignature(FunctionOpInterface funcOp) {
+  auto hasUnrankedTensor = [](TypeRange types) {
+    return llvm::any_of(types, llvm::IsaPred<UnrankedTensorType>);
+  };
+  if (hasUnrankedTensor(funcOp.getArgumentTypes()) ||
+      hasUnrankedTensor(funcOp.getResultTypes())) {
+    return funcOp.emitError()
+           << "unranked tensor types are not supported in native ABI "
+              "function signatures";
+  }
+  return success();
+}
+
 // Returns true if the given |attr| is a known ABI attribute that is only used
 // by this pass.
 static bool isABIAttr(NamedAttribute attr) {
@@ -829,10 +843,17 @@ public:
       // Ignore functions already marked as having their ABI goo handled.
       if (funcOp->hasAttr("iree.abi.stub")) {
         continue;
-      } else if (funcOp.isExternal()) {
+      }
+      if (!funcOp.isExternal() && !funcOp.isPublic()) {
+        continue;
+      }
+      if (failed(verifyABISignature(funcOp))) {
+        return signalPassFailure();
+      }
+      if (funcOp.isExternal()) {
         // Imported function.
         importOps.push_back(funcOp);
-      } else if (funcOp.isPublic()) {
+      } else {
         // Exported function.
         exportOps.push_back(funcOp);
       }

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/wrap_entry_points.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-abi-wrap-entry-points{invocation-model=sync})' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-abi-wrap-entry-points{invocation-model=sync})' --split-input-file --verify-diagnostics %s | FileCheck %s
 
 // Tests basic dynamic tensor I/O marshaling.
 
@@ -337,3 +337,38 @@ util.func public @transientsBufferView(%arg0: tensor<4xf32>, %storage: !hal.buff
   %0 = arith.addf %arg0, %arg0 : tensor<4xf32>
   util.return %0 : tensor<4xf32>
 }
+
+// -----
+
+// Tests that unranked tensor arguments in native ABI signatures are rejected.
+
+// expected-error@below {{unranked tensor types are not supported in native ABI function signatures}}
+util.func public @unrankedTensorArgument(%arg0: tensor<*xf32>) {
+  util.return
+}
+
+// -----
+
+// Tests that unranked tensor results in native ABI signatures are rejected.
+
+// expected-error@below {{unranked tensor types are not supported in native ABI function signatures}}
+util.func public @unrankedTensorResult(%arg0: tensor<1xf32>) -> tensor<*xf32> {
+  %0 = tensor.cast %arg0 : tensor<1xf32> to tensor<*xf32>
+  util.return %0 : tensor<*xf32>
+}
+
+// -----
+
+// Tests that unranked tensor arguments in external native ABI signatures are
+// rejected.
+
+// expected-error@below {{unranked tensor types are not supported in native ABI function signatures}}
+util.func private @externalUnrankedTensorArgument(tensor<*xf32>)
+
+// -----
+
+// Tests that unranked tensor results in external native ABI signatures are
+// rejected.
+
+// expected-error@below {{unranked tensor types are not supported in native ABI function signatures}}
+util.func private @externalUnrankedTensorResult(tensor<1xf32>) -> tensor<*xf32>


### PR DESCRIPTION
The native ABI wrapper assumes tensor types are ranked when building marshaling ops. An unranked tensor in a function signature hits an assertion when its rank is queried.

Check import and export signatures up front and report an error for unranked tensor arguments or results. Add separate regression coverage for arguments and results on imports and exports.
    
Fixes #24846
