### PR TITLE
[Runtime] Fix ctype calls for signed char inputs

### DIFF
--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -182,14 +182,14 @@ iree_string_view_trim(iree_string_view_t value) {
   iree_host_size_t start = 0;
   iree_host_size_t end = value.size - 1;
   while (value.size > 0 && start <= end) {
-    if (isspace(value.data[start])) {
+    if (isspace((unsigned char)value.data[start])) {
       start++;
     } else {
       break;
     }
   }
   while (end > start) {
-    if (isspace(value.data[end])) {
+    if (isspace((unsigned char)value.data[end])) {
       --end;
     } else {
       break;

--- a/runtime/src/iree/hal/string_util.c
+++ b/runtime/src/iree/hal/string_util.c
@@ -676,7 +676,8 @@ IREE_API_EXPORT iree_status_t iree_hal_parse_buffer_elements(
   iree_host_size_t token_start = IREE_STRING_VIEW_NPOS;
   while (src_i < data_str.size) {
     char c = data_str.data[src_i++];
-    bool is_separator = isspace(c) || c == ',' || c == '[' || c == ']';
+    bool is_separator =
+        isspace((unsigned char)c) || c == ',' || c == '[' || c == ']';
     if (token_start == IREE_STRING_VIEW_NPOS) {
       if (!is_separator) {
         token_start = src_i - 1;

--- a/runtime/src/iree/tokenizer/regex/internal/lexer.c
+++ b/runtime/src/iree/tokenizer/regex/internal/lexer.c
@@ -1008,7 +1008,7 @@ static bool iree_tokenizer_regex_lexer_parse_quantifier(
   // Parse min - require at least one digit.
   uint32_t min = 0;
   bool has_min_digit = false;
-  while (isdigit(iree_tokenizer_regex_lexer_peek_char(lexer))) {
+  while (isdigit((unsigned char)iree_tokenizer_regex_lexer_peek_char(lexer))) {
     has_min_digit = true;
     min = min * 10 + (iree_tokenizer_regex_lexer_peek_char(lexer) - '0');
     if (min >= UINT16_MAX) {
@@ -1046,7 +1046,8 @@ static bool iree_tokenizer_regex_lexer_parse_quantifier(
     } else {
       // {n,m}
       max = 0;
-      while (isdigit(iree_tokenizer_regex_lexer_peek_char(lexer))) {
+      while (
+          isdigit((unsigned char)iree_tokenizer_regex_lexer_peek_char(lexer))) {
         max = max * 10 + (iree_tokenizer_regex_lexer_peek_char(lexer) - '0');
         if (max >= UINT16_MAX) {
           // UINT16_MAX (65535) is reserved as the "unbounded" marker.


### PR DESCRIPTION
Fix `ctype` calls to cast `char` values to `unsigned char` before passing them to `isspace`/ `isdigit`. 

This is needed for the bare-metal RISC-V CI in #24844. That build uses GCC + newlib, where passing a plain `char` to these functions triggers `-Wchar-subscripts`. Since warnings are treated as errors, the build fails without these casts.

Using `unsigned char` is also the correct way to call `ctype` functions on character data, since plain `char` can be negative on some platforms.

Assisted-by: Claude Code
