### PR TITLE
[Codegen] Verify compute ops after workgroup distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -8,8 +8,10 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -185,27 +187,59 @@ static bool areAllStaticLoopBounds(scf::ForallOp forallOp) {
   return true;
 }
 
-/// Returns true if it is allowed to leave the `op` outside distribution loops,
-/// i.e., scf.forall loops. The consumer fusion could fail even the `op`
-/// implements TilingInterface. E.g., linalg.pack op can only be fused as a
-/// consumer in perfect tiling scenario.
-static bool isAllowedToFailOnCunsumerFusion(Operation *op) {
-  return isa<linalg::PackOp>(op);
+/// Returns true if it is allowed to leave the `op` outside the distribution
+/// loop. Consumer fusion can fail even when the `op` implements
+/// TilingInterface. E.g., a linalg.pack that consumes the distributed result
+/// can only be fused as a consumer in the perfect tiling case. A boundary
+/// linalg.unpack with one dispatch store user that consumes the distributed
+/// result may remain outside so
+/// CombineResultLayoutTransformationPass can fold it into the store. Producers
+/// used exclusively inside the distribution loop may remain outside until a
+/// later tiling level fuses them.
+static bool isAllowedOutsideDistribution(Operation *op,
+                                         scf::ForallOp forallOp) {
+  if (auto packOp = dyn_cast<linalg::PackOp>(op)) {
+    if (packOp.getSource().getDefiningOp() == forallOp.getOperation()) {
+      return true;
+    }
+  }
+  if (op->use_empty()) {
+    return false;
+  }
+  if (auto unpackOp = dyn_cast<linalg::UnPackOp>(op)) {
+    if (unpackOp.getSource().getDefiningOp() == forallOp.getOperation() &&
+        unpackOp->hasOneUse() &&
+        isa<IREE::TensorExt::DispatchTensorStoreOp>(*unpackOp->user_begin())) {
+      return true;
+    }
+  }
+  return llvm::all_of(op->getUsers(), [&](Operation *user) {
+    return forallOp->isProperAncestor(user);
+  });
 }
 
-/// Returns true if all the compute ops are within scf.forall distribution
-/// loops, except the ops that are allowed to stay outside.
-static bool verifyComputeOpsAfterDistribution(FunctionOpInterface funcOp) {
+/// Verifies that all the compute ops are within scf.forall distribution loops,
+/// except the ops that are allowed to stay outside.
+static LogicalResult
+verifyComputeOpsAfterDistribution(FunctionOpInterface funcOp,
+                                  scf::ForallOp forallOp) {
   WalkResult res = funcOp.walk<WalkOrder::PreOrder>([&](Operation *op) {
-    if (isa<scf::ForallOp>(op) || !isComputeOp(op)) {
-      return WalkResult::skip();
+    if (auto nestedForallOp = dyn_cast<scf::ForallOp>(op)) {
+      if (forallOpHasMappingType<IREE::Codegen::WorkgroupMappingAttr>(
+              nestedForallOp)) {
+        return WalkResult::skip();
+      }
     }
-    if (!isAllowedToFailOnCunsumerFusion(op)) {
+    if (!isComputeOp(op)) {
+      return WalkResult::advance();
+    }
+    if (!isAllowedOutsideDistribution(op, forallOp)) {
+      op->emitOpError("compute op remains outside workgroup distribution");
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
   });
-  return !res.wasInterrupted();
+  return res.wasInterrupted() ? failure() : success();
 }
 
 //===---------------------------------------------------------------------===//
@@ -373,14 +407,10 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
             tilingLoops, [&tiledAndFusedOps](Operation *op) {
               return tiledAndFusedOps.contains(op);
             });
-    if (failed(newFusionOpportunities)) {
-      // Continue the work if the failure is allowed.
-      if (!verifyComputeOpsAfterDistribution(funcOp)) {
-        tileAndFuseResult->tiledAndFusedOps.front()->emitOpError(
-            "failed to fuse consumers");
-        return signalPassFailure();
-      }
-    } else {
+    // Continue on failure so cleanup can remove the original, now-unused root
+    // op before verifying which compute ops remain outside the distribution
+    // loop.
+    if (succeeded(newFusionOpportunities)) {
       // Because we restrict to at most a single tilable consumer for yielding
       // a replacement, no new fusion opportunities will yield a replacement,
       // meaning there is no need to run consumer fusion again afterwards.
@@ -418,6 +448,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
     populateFoldExtractSliceOfBroadcastPattern(patterns);
     linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
     tensor::populateFoldTensorEmptyPatterns(patterns);
+    tensor::DimOp::getCanonicalizationPatterns(patterns, context);
     context->getOrLoadDialect<tensor::TensorDialect>()
         ->getCanonicalizationPatterns(patterns);
     context->getOrLoadDialect<IREE::LinalgExt::IREELinalgExtDialect>()
@@ -428,6 +459,22 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
       funcOp.emitOpError("tiling canonicalization failed");
       return signalPassFailure();
     }
+  }
+
+  // Cleanup may replace the distribution loop or fold it away when it has a
+  // single iteration, so do not use the pre-cleanup LoopLikeOpInterface here.
+  scf::ForallOp distributionLoop;
+  funcOp.walk<WalkOrder::PreOrder>([&](scf::ForallOp forallOp) {
+    if (!forallOpHasMappingType<IREE::Codegen::WorkgroupMappingAttr>(
+            forallOp)) {
+      return WalkResult::advance();
+    }
+    distributionLoop = forallOp;
+    return WalkResult::interrupt();
+  });
+  if (distributionLoop &&
+      failed(verifyComputeOpsAfterDistribution(funcOp, distributionLoop))) {
+    return signalPassFailure();
   }
 
   return;

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -133,6 +133,7 @@ iree_lit_test_suite(
             "strip_compilation_info.mlir",
             "test_partitionable_loops_interface.mlir",
             "tile_and_distribute_workgroups_using_forall.mlir",
+            "tile_and_distribute_workgroups_using_forall_invalid.mlir",
             "tile_large_tensors.mlir",
             "transform_buffer_opt.mlir",
             "transform_collapse_forall_dest.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -128,6 +128,7 @@ iree_lit_test_suite(
     "strip_compilation_info.mlir"
     "test_partitionable_loops_interface.mlir"
     "tile_and_distribute_workgroups_using_forall.mlir"
+    "tile_and_distribute_workgroups_using_forall_invalid.mlir"
     "tile_large_tensors.mlir"
     "transform_buffer_opt.mlir"
     "transform_collapse_forall_dest.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall_invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall_invalid.mlir
@@ -1,0 +1,336 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-tile-and-distribute-to-workgroups-using-forall-op, cse))" --split-input-file --verify-diagnostics %s
+
+// Verify that a compute consumer left outside the distribution loop causes the
+// pass to fail. The pack cannot be fused because the tiling is not perfect, but
+// only the pack itself is allowed to remain outside the loop.
+
+#config = #iree_cpu.lowering_config<distribution = [1, 16]>
+func.func @unfused_compute_consumer(%arg0 : tensor<30xf32>) -> tensor<5x6xf32> {
+  %empty = tensor.empty() : tensor<30xf32>
+  %producer = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<30xf32>) outs(%empty : tensor<30xf32>)
+      attrs = {lowering_config = #config} {
+    ^bb0(%in : f32, %out : f32):
+      %doubled = arith.addf %in, %in : f32
+      linalg.yield %doubled : f32
+  } -> tensor<30xf32>
+  %packed_empty = tensor.empty() : tensor<5x6xf32>
+  %pack = linalg.pack %producer outer_dims_perm = [0]
+      inner_dims_pos = [0] inner_tiles = [6] into %packed_empty
+      : tensor<30xf32> -> tensor<5x6xf32>
+  %consumer_empty = tensor.empty() : tensor<5x6xf32>
+  // expected-error @below {{compute op remains outside workgroup distribution}}
+  %consumer = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%pack : tensor<5x6xf32>) outs(%consumer_empty : tensor<5x6xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %doubled = arith.addf %in, %in : f32
+      linalg.yield %doubled : f32
+  } -> tensor<5x6xf32>
+  return %consumer : tensor<5x6xf32>
+}
+
+// -----
+
+// A pack that does not consume the distributed result is unrelated computation
+// and must not be covered by the boundary pack exception.
+
+#config = #iree_cpu.lowering_config<distribution = [16]>
+func.func @disconnected_pack(
+    %arg0 : tensor<30xf32>, %arg1 : tensor<32xf32>)
+    -> (tensor<5x6xf32>, tensor<32xf32>) {
+  %packed_empty = tensor.empty() : tensor<5x6xf32>
+  // expected-error @below {{compute op remains outside workgroup distribution}}
+  %packed = linalg.pack %arg0 outer_dims_perm = [0]
+      inner_dims_pos = [0] inner_tiles = [6] into %packed_empty
+      : tensor<30xf32> -> tensor<5x6xf32>
+  %distributed_empty = tensor.empty() : tensor<32xf32>
+  %distributed = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg1 : tensor<32xf32>) outs(%distributed_empty : tensor<32xf32>)
+      attrs = {lowering_config = #config} {
+    ^bb0(%in : f32, %out : f32):
+      %doubled = arith.addf %in, %in : f32
+      linalg.yield %doubled : f32
+  } -> tensor<32xf32>
+  return %packed, %distributed : tensor<5x6xf32>, tensor<32xf32>
+}
+
+// -----
+
+// Verify all compute ops after distribution, even when consumer fusion
+// succeeds. The configured op is distributed, while the disconnected compute
+// op must not remain outside the distribution loop.
+
+#config = #iree_cpu.lowering_config<distribution = [16]>
+func.func @disconnected_compute_ops(
+    %arg0 : tensor<32xf32>, %arg1 : tensor<32xf32>)
+    -> (tensor<32xf32>, tensor<32xf32>) {
+  %unfused_empty = tensor.empty() : tensor<32xf32>
+  // expected-error @below {{compute op remains outside workgroup distribution}}
+  %unfused = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<32xf32>) outs(%unfused_empty : tensor<32xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %doubled = arith.addf %in, %in : f32
+      linalg.yield %doubled : f32
+  } -> tensor<32xf32>
+  %distributed_empty = tensor.empty() : tensor<32xf32>
+  %distributed = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg1 : tensor<32xf32>) outs(%distributed_empty : tensor<32xf32>)
+      attrs = {lowering_config = #config} {
+    ^bb0(%in : f32, %out : f32):
+      %doubled = arith.addf %in, %in : f32
+      linalg.yield %doubled : f32
+  } -> tensor<32xf32>
+  return %unfused, %distributed : tensor<32xf32>, tensor<32xf32>
+}
+
+// -----
+
+// A producer needed exclusively by the distribution loop may remain outside
+// until a later tiling level fuses it. Distribution only tiles the second
+// dimension, which is absent from the producer's iteration space. The
+// preceding thread-mapped forall must not be mistaken for the distribution
+// loop.
+
+#producer_config = #iree_cpu.lowering_config<distribution = [0, 16]>
+func.func @producer_consumed_by_distribution(
+    %arg0 : tensor<8xf32>, %arg1 : tensor<8x32xf32>)
+    -> tensor<8x32xf32> {
+  %c7 = arith.constant 7 : index
+  %thread_result = scf.forall (%thread) in (8)
+      shared_outs(%thread_out = %arg0) -> tensor<8xf32> {
+    %reverse = arith.subi %c7, %thread : index
+    %slice = tensor.extract_slice %arg0[%reverse] [1] [1]
+        : tensor<8xf32> to tensor<1xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %slice into %thread_out[%thread] [1] [1]
+          : tensor<1xf32> into tensor<8xf32>
+    }
+  } {mapping = [#gpu.thread<x>]}
+  %producer_empty = tensor.empty() : tensor<8xf32>
+  %producer = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%thread_result : tensor<8xf32>)
+      outs(%producer_empty : tensor<8xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %doubled = arith.addf %in, %in : f32
+      linalg.yield %doubled : f32
+  } -> tensor<8xf32>
+  %distributed_empty = tensor.empty() : tensor<8x32xf32>
+  %distributed = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0)>,
+                       affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%producer, %arg1 : tensor<8xf32>, tensor<8x32xf32>)
+      outs(%distributed_empty : tensor<8x32xf32>)
+      attrs = {lowering_config = #producer_config} {
+    ^bb0(%lhs : f32, %rhs : f32, %out : f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      linalg.yield %sum : f32
+  } -> tensor<8x32xf32>
+  return %distributed : tensor<8x32xf32>
+}
+
+// -----
+
+// A pack needed exclusively by the distribution loop is also a producer and
+// may remain outside until a later tiling level fuses it.
+
+#pack_producer_config = #iree_cpu.lowering_config<distribution = [0, 0, 16]>
+func.func @pack_producer_consumed_by_distribution(
+    %arg0 : tensor<8xf32>, %arg1 : tensor<2x4x32xf32>)
+    -> tensor<2x4x32xf32> {
+  %packed_empty = tensor.empty() : tensor<2x4xf32>
+  %packed = linalg.pack %arg0 outer_dims_perm = [0]
+      inner_dims_pos = [0] inner_tiles = [4] into %packed_empty
+      : tensor<8xf32> -> tensor<2x4xf32>
+  %distributed_empty = tensor.empty() : tensor<2x4x32xf32>
+  %distributed = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%packed, %arg1 : tensor<2x4xf32>, tensor<2x4x32xf32>)
+      outs(%distributed_empty : tensor<2x4x32xf32>)
+      attrs = {lowering_config = #pack_producer_config} {
+    ^bb0(%lhs : f32, %rhs : f32, %out : f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      linalg.yield %sum : f32
+  } -> tensor<2x4x32xf32>
+  return %distributed : tensor<2x4x32xf32>
+}
+
+// -----
+
+// Shape-only users can keep the original compute op alive after its tiled
+// replacement is created. Canonicalize those users before verifying so the
+// original op and its producer are not mistaken for unfused computation.
+
+#dynamic_config = #iree_cpu.lowering_config<distribution = [16]>
+func.func @shape_only_users_after_distribution(%arg0 : tensor<?xf32>)
+    -> (tensor<?xf32>, index) {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.0 : f32
+  %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+  %empty = tensor.empty(%dim) : tensor<?xf32>
+  %filled = linalg.fill ins(%cst : f32) outs(%empty : tensor<?xf32>)
+      -> tensor<?xf32>
+  %root = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<?xf32>) outs(%filled : tensor<?xf32>)
+      attrs = {lowering_config = #dynamic_config} {
+    ^bb0(%in : f32, %out : f32):
+      %sum = arith.addf %in, %out : f32
+      linalg.yield %sum : f32
+  } -> tensor<?xf32>
+  %result_dim = tensor.dim %root, %c0 : tensor<?xf32>
+  return %root, %result_dim : tensor<?xf32>, index
+}
+
+// -----
+
+// Verify compute ops inside a non-workgroup forall instead of skipping the
+// whole loop.
+
+#thread_test_config = #iree_cpu.lowering_config<distribution = [16]>
+func.func @compute_in_thread_forall(
+    %arg0 : tensor<32xf32>, %arg1 : tensor<32xf32>)
+    -> (tensor<32xf32>, tensor<32xf32>) {
+  %c16 = arith.constant 16 : index
+  %thread_empty = tensor.empty() : tensor<32xf32>
+  %thread_result = scf.forall (%thread) in (2)
+      shared_outs(%thread_out = %thread_empty) -> tensor<32xf32> {
+    %offset = arith.muli %thread, %c16 : index
+    %slice = tensor.extract_slice %arg0[%offset] [16] [1]
+        : tensor<32xf32> to tensor<16xf32>
+    %compute_empty = tensor.empty() : tensor<16xf32>
+    // expected-error @below {{compute op remains outside workgroup distribution}}
+    %compute = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>,
+                         affine_map<(d0) -> (d0)>],
+        iterator_types = ["parallel"]}
+        ins(%slice : tensor<16xf32>) outs(%compute_empty : tensor<16xf32>) {
+      ^bb0(%in : f32, %out : f32):
+        %doubled = arith.addf %in, %in : f32
+        linalg.yield %doubled : f32
+    } -> tensor<16xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %compute into %thread_out[%offset] [16] [1]
+          : tensor<16xf32> into tensor<32xf32>
+    }
+  } {mapping = [#gpu.thread<x>]}
+  %distributed_empty = tensor.empty() : tensor<32xf32>
+  %distributed = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg1 : tensor<32xf32>) outs(%distributed_empty : tensor<32xf32>)
+      attrs = {lowering_config = #thread_test_config} {
+    ^bb0(%in : f32, %out : f32):
+      %doubled = arith.addf %in, %in : f32
+      linalg.yield %doubled : f32
+  } -> tensor<32xf32>
+  return %thread_result, %distributed : tensor<32xf32>, tensor<32xf32>
+}
+
+// -----
+
+// An unpack of the distributed result may remain outside the workgroup loop
+// when it only converts the result back to the layout expected by the dispatch
+// output boundary.
+
+#boundary_unpack_config = #iree_cpu.lowering_config<distribution = [2, 2, 0, 0, 0, 0]>
+func.func @boundary_unpack_of_distributed_result(
+    %lhs : tensor<4x2x?x?xf32>, %rhs : tensor<3x2x?x?xf32>,
+    %init : tensor<4x3x?x?xf32>, %tile0 : index, %tile1 : index,
+    %output : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x12xf32>>) {
+  %root = linalg.mmt4d {lowering_config = #boundary_unpack_config}
+      ins(%lhs, %rhs : tensor<4x2x?x?xf32>, tensor<3x2x?x?xf32>)
+      outs(%init : tensor<4x3x?x?xf32>) -> tensor<4x3x?x?xf32>
+  %unpacked_empty = tensor.empty() : tensor<16x12xf32>
+  %unpacked = linalg.unpack %root outer_dims_perm = [0, 1]
+      inner_dims_pos = [0, 1] inner_tiles = [%tile0, %tile1]
+      into %unpacked_empty
+      : tensor<4x3x?x?xf32> -> tensor<16x12xf32>
+  iree_tensor_ext.dispatch.tensor.store %unpacked, %output,
+      offsets = [0, 0], sizes = [16, 12], strides = [1, 1]
+      : tensor<16x12xf32> ->
+        !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x12xf32>>
+  return
+}
+
+// -----
+
+// A boundary unpack must have exactly one dispatch store user so
+// CombineResultLayoutTransformationPass can fold it into that store.
+
+#multiple_store_unpack_config = #iree_cpu.lowering_config<distribution = [2, 2, 0, 0, 0, 0]>
+func.func @boundary_unpack_with_multiple_stores(
+    %lhs : tensor<4x2x?x?xf32>, %rhs : tensor<3x2x?x?xf32>,
+    %init : tensor<4x3x?x?xf32>, %tile0 : index, %tile1 : index,
+    %output0 : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x12xf32>>,
+    %output1 : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x12xf32>>) {
+  %root = linalg.mmt4d {lowering_config = #multiple_store_unpack_config}
+      ins(%lhs, %rhs : tensor<4x2x?x?xf32>, tensor<3x2x?x?xf32>)
+      outs(%init : tensor<4x3x?x?xf32>) -> tensor<4x3x?x?xf32>
+  %unpacked_empty = tensor.empty() : tensor<16x12xf32>
+  // expected-error @below {{compute op remains outside workgroup distribution}}
+  %unpacked = linalg.unpack %root outer_dims_perm = [0, 1]
+      inner_dims_pos = [0, 1] inner_tiles = [%tile0, %tile1]
+      into %unpacked_empty
+      : tensor<4x3x?x?xf32> -> tensor<16x12xf32>
+  iree_tensor_ext.dispatch.tensor.store %unpacked, %output0,
+      offsets = [0, 0], sizes = [16, 12], strides = [1, 1]
+      : tensor<16x12xf32> ->
+        !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x12xf32>>
+  iree_tensor_ext.dispatch.tensor.store %unpacked, %output1,
+      offsets = [0, 0], sizes = [16, 12], strides = [1, 1]
+      : tensor<16x12xf32> ->
+        !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x12xf32>>
+  return
+}
+
+// -----
+
+// A boundary unpack is not allowed merely because its only user is a dispatch
+// store. Its source must be the result of the workgroup distribution loop.
+
+#unrelated_unpack_config = #iree_cpu.lowering_config<distribution = [16]>
+func.func @boundary_unpack_not_from_distributed_result(
+    %packed : tensor<4x3x4x4xf32>, %arg0 : tensor<32xf32>,
+    %output : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x12xf32>>)
+    -> tensor<32xf32> {
+  %unpacked_empty = tensor.empty() : tensor<16x12xf32>
+  // expected-error @below {{compute op remains outside workgroup distribution}}
+  %unpacked = linalg.unpack %packed outer_dims_perm = [0, 1]
+      inner_dims_pos = [0, 1] inner_tiles = [4, 4] into %unpacked_empty
+      : tensor<4x3x4x4xf32> -> tensor<16x12xf32>
+  iree_tensor_ext.dispatch.tensor.store %unpacked, %output,
+      offsets = [0, 0], sizes = [16, 12], strides = [1, 1]
+      : tensor<16x12xf32> ->
+        !iree_tensor_ext.dispatch.tensor<writeonly:tensor<16x12xf32>>
+  %distributed_empty = tensor.empty() : tensor<32xf32>
+  %distributed = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      ins(%arg0 : tensor<32xf32>) outs(%distributed_empty : tensor<32xf32>)
+      attrs = {lowering_config = #unrelated_unpack_config} {
+    ^bb0(%in : f32, %out : f32):
+      %doubled = arith.addf %in, %in : f32
+      linalg.yield %doubled : f32
+  } -> tensor<32xf32>
+  return %distributed : tensor<32xf32>
+}


### PR DESCRIPTION
The verifier walked func.func in pre-order and returned skip for it, so the function body was never visited and compute ops left outside the  workgroup loop went undetected.
    
Run the check after cleanup, identify the distribution loop by its WorkgroupMappingAttr, and canonicalize tensor.dim so shape-only users do not keep the original roots alive. Allow ops that legitimately stay outside the loop: producers used only by the loop, packs consuming the distributed result, and boundary unpacks feeding a single dispatch store. Report any other compute op left outside as a failure. Add regression coverage in tile_and_distribute_workgroups_using_forall_invalid.mlir.

Fixes #22684