### PR TITLE
[StableHLO] Clamp gather start indices on the torch_index_select path

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/GatherToTorchIndexSelect.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/GatherToTorchIndexSelect.cpp
@@ -8,6 +8,7 @@
 
 #include "compiler/plugins/input/StableHLO/Conversion/Preprocessing/Passes.h"
 #include "compiler/plugins/input/StableHLO/Conversion/Preprocessing/Rewriters.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -106,11 +107,69 @@ struct GatherIsTorchIndexSelectPattern final
       return rewriter.notifyMatchFailure(gather, "collapsed_slice_dims != [0]");
     }
 
+    // `gather` clamps every start index into `[0, operand_dim - slice_size]`
+    // (https://openxla.org/stablehlo/spec#gather); `slice_sizes[0]` is 1 here,
+    // so the bound is `operand.dim(0) - 1`. `torch_index_select` promises no
+    // such thing -- it lowers to a bare `tensor.extract` -- so the clamp has to
+    // be materialized here, or an out-of-range index reads unrelated memory.
+    auto indexElemTy = dyn_cast<IntegerType>(startIndicesTy.getElementType());
+    if (!indexElemTy) {
+      return rewriter.notifyMatchFailure(gather, "non-integer start_indices");
+    }
+
+    ImplicitLocOpBuilder b(gather.getLoc(), rewriter);
+    auto indexScalarTy = RankedTensorType::get({}, indexElemTy);
+    unsigned indexWidth = indexElemTy.getWidth();
+
+    Value upperBound;
+    if (!operandTy.isDynamicDim(0)) {
+      // `slice_sizes[0]` is 1 and the verifier bounds it by the dimension, so
+      // a well-formed gather always has an element here. Bail rather than let a
+      // negative bound through the unsigned arithmetic below.
+      int64_t maxIndex = operandTy.getDimSize(0) - 1;
+      if (maxIndex < 0) {
+        return rewriter.notifyMatchFailure(gather, "operand dimension 0 empty");
+      }
+      // An index type too narrow to name element `maxIndex` can never reach
+      // past the end, so saturate the bound instead of truncating it into a
+      // nonsensical (possibly negative) value.
+      uint64_t indexTypeMax =
+          (indexElemTy.isUnsigned() ? APInt::getMaxValue(indexWidth)
+                                    : APInt::getSignedMaxValue(indexWidth))
+              .getLimitedValue();
+      APInt bound(indexWidth, std::min<uint64_t>(maxIndex, indexTypeMax));
+      upperBound = mlir::stablehlo::ConstantOp::create(
+          b, DenseElementsAttr::get(indexScalarTy,
+                                    b.getIntegerAttr(indexElemTy, bound)));
+    } else if (indexWidth >= 32) {
+      // `get_dimension_size` yields an i32, so only index types wide enough to
+      // hold one can carry the bound without wrapping.
+      Value dimSize = mlir::stablehlo::GetDimensionSizeOp::create(
+          b, RankedTensorType::get({}, b.getI32Type()), operand,
+          b.getI64IntegerAttr(0));
+      if (dimSize.getType() != indexScalarTy) {
+        dimSize = mlir::stablehlo::ConvertOp::create(b, indexScalarTy, dimSize);
+      }
+      Value one = mlir::stablehlo::ConstantOp::create(
+          b, DenseElementsAttr::get(
+                 indexScalarTy,
+                 b.getIntegerAttr(indexElemTy, APInt(indexWidth, 1))));
+      upperBound =
+          mlir::stablehlo::SubtractOp::create(b, indexScalarTy, dimSize, one);
+    } else {
+      return rewriter.notifyMatchFailure(
+          gather, "start_indices too narrow to bound a dynamic dimension");
+    }
+
+    Value lowerBound = mlir::stablehlo::ConstantOp::create(
+        b, DenseElementsAttr::get(indexScalarTy, b.getZeroAttr(indexElemTy)));
+    Value clampedIndices = mlir::stablehlo::ClampOp::create(
+        b, startIndicesTy, lowerBound, startIndices, upperBound);
+
     auto torchIndexSelect = mlir::stablehlo::TorchIndexSelectOp::create(
-        rewriter, gather.getLoc(),
-        RankedTensorType::get(indexSelectShape, operandTy.getElementType()),
-        operand, gather.getStartIndices(), rewriter.getI64IntegerAttr(0),
-        rewriter.getI64IntegerAttr(0));
+        b, RankedTensorType::get(indexSelectShape, operandTy.getElementType()),
+        operand, clampedIndices, b.getI64IntegerAttr(0),
+        b.getI64IntegerAttr(0));
 
     rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(
         gather, gather.getType(), torchIndexSelect);

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/gather_to_torch_index_select.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/gather_to_torch_index_select.mlir
@@ -3,7 +3,13 @@
 
 // CHECK-LABEL: @gather_to_index_select
 func.func @gather_to_index_select(%arg0 : tensor<5x4xf32>, %arg1 : tensor<1x3x1xi32>) -> tensor<1x3x4xf32> {
-  // CHECK: [[TIS:%.+]] = "stablehlo.torch_index_select"(%arg0, %arg1)
+  // The spec clamps start indices into [0, operand_dim - slice_size], here
+  // [0, 4]. torch_index_select does no bounds checking of its own.
+  // CHECK-DAG: [[HI:%.+]] = stablehlo.constant dense<4> : tensor<i32>
+  // CHECK-DAG: [[LO:%.+]] = stablehlo.constant dense<0> : tensor<i32>
+  // CHECK: [[IDX:%.+]] = stablehlo.clamp [[LO]], %arg1, [[HI]] :
+  // CHECK-SAME: (tensor<i32>, tensor<1x3x1xi32>, tensor<i32>) -> tensor<1x3x1xi32>
+  // CHECK: [[TIS:%.+]] = "stablehlo.torch_index_select"(%arg0, [[IDX]])
   // CHECK-SAME:   batch_dims = 0 : i64,
   // CHECK-SAME:   dim = 0 : i64
   // CHECK-SAME: : (tensor<5x4xf32>, tensor<1x3x1xi32>) -> tensor<1x3x1x4xf32>
@@ -20,6 +26,87 @@ func.func @gather_to_index_select(%arg0 : tensor<5x4xf32>, %arg1 : tensor<1x3x1x
   } : (tensor<5x4xf32>, tensor<1x3x1xi32>) -> tensor<1x3x4xf32>
 
   // CHECK: return [[RES]]
+  func.return %0 : tensor<1x3x4xf32>
+}
+
+// The bound takes the element type of the indices.
+// CHECK-LABEL: @gather_to_index_select_i64
+func.func @gather_to_index_select_i64(%arg0 : tensor<5x4xf32>, %arg1 : tensor<1x3x1xi64>) -> tensor<1x3x4xf32> {
+  // CHECK-DAG: [[HI:%.+]] = stablehlo.constant dense<4> : tensor<i64>
+  // CHECK-DAG: [[LO:%.+]] = stablehlo.constant dense<0> : tensor<i64>
+  // CHECK: [[IDX:%.+]] = stablehlo.clamp [[LO]], %arg1, [[HI]]
+  // CHECK: "stablehlo.torch_index_select"(%arg0, [[IDX]])
+  %0 = "stablehlo.gather"(%arg0, %arg1) {
+    dimension_numbers = #stablehlo.gather<
+      collapsed_slice_dims = [0],
+      index_vector_dim = 2,
+      offset_dims = [2],
+      start_index_map = [0],
+    >,
+    indices_are_sorted = false,
+    slice_sizes = array<i64: 1, 4>
+  } : (tensor<5x4xf32>, tensor<1x3x1xi64>) -> tensor<1x3x4xf32>
+  func.return %0 : tensor<1x3x4xf32>
+}
+
+// An i8 index cannot name element 199, so the bound saturates at the largest
+// i8 rather than wrapping around into a negative one.
+// CHECK-LABEL: @gather_to_index_select_narrow_index
+func.func @gather_to_index_select_narrow_index(%arg0 : tensor<200x4xf32>, %arg1 : tensor<1x3x1xi8>) -> tensor<1x3x4xf32> {
+  // CHECK-DAG: [[HI:%.+]] = stablehlo.constant dense<127> : tensor<i8>
+  // CHECK-DAG: [[LO:%.+]] = stablehlo.constant dense<0> : tensor<i8>
+  // CHECK: [[IDX:%.+]] = stablehlo.clamp [[LO]], %arg1, [[HI]]
+  // CHECK: "stablehlo.torch_index_select"(%arg0, [[IDX]])
+  %0 = "stablehlo.gather"(%arg0, %arg1) {
+    dimension_numbers = #stablehlo.gather<
+      collapsed_slice_dims = [0],
+      index_vector_dim = 2,
+      offset_dims = [2],
+      start_index_map = [0],
+    >,
+    indices_are_sorted = false,
+    slice_sizes = array<i64: 1, 4>
+  } : (tensor<200x4xf32>, tensor<1x3x1xi8>) -> tensor<1x3x4xf32>
+  func.return %0 : tensor<1x3x4xf32>
+}
+
+// A dynamic gathered dimension takes its bound from the operand at runtime.
+// CHECK-LABEL: @gather_to_index_select_dynamic
+func.func @gather_to_index_select_dynamic(%arg0 : tensor<?x4xf32>, %arg1 : tensor<1x3x1xi32>) -> tensor<1x3x4xf32> {
+  // CHECK-DAG: [[ONE:%.+]] = stablehlo.constant dense<1> : tensor<i32>
+  // CHECK-DAG: [[LO:%.+]] = stablehlo.constant dense<0> : tensor<i32>
+  // CHECK: [[SIZE:%.+]] = stablehlo.get_dimension_size %arg0, dim = 0 : (tensor<?x4xf32>) -> tensor<i32>
+  // CHECK: [[HI:%.+]] = stablehlo.subtract [[SIZE]], [[ONE]] : tensor<i32>
+  // CHECK: [[IDX:%.+]] = stablehlo.clamp [[LO]], %arg1, [[HI]]
+  // CHECK: "stablehlo.torch_index_select"(%arg0, [[IDX]])
+  %0 = "stablehlo.gather"(%arg0, %arg1) {
+    dimension_numbers = #stablehlo.gather<
+      collapsed_slice_dims = [0],
+      index_vector_dim = 2,
+      offset_dims = [2],
+      start_index_map = [0],
+    >,
+    indices_are_sorted = false,
+    slice_sizes = array<i64: 1, 4>
+  } : (tensor<?x4xf32>, tensor<1x3x1xi32>) -> tensor<1x3x4xf32>
+  func.return %0 : tensor<1x3x4xf32>
+}
+
+// An index type narrower than the i32 get_dimension_size returns cannot hold
+// the bound, so leave the gather for the general lowering.
+// CHECK-LABEL: @gather_no_lowering_dynamic_narrow_index
+func.func @gather_no_lowering_dynamic_narrow_index(%arg0 : tensor<?x4xf32>, %arg1 : tensor<1x3x1xi8>) -> tensor<1x3x4xf32> {
+  // CHECK: "stablehlo.gather"
+  %0 = "stablehlo.gather"(%arg0, %arg1) {
+    dimension_numbers = #stablehlo.gather<
+      collapsed_slice_dims = [0],
+      index_vector_dim = 2,
+      offset_dims = [2],
+      start_index_map = [0],
+    >,
+    indices_are_sorted = false,
+    slice_sizes = array<i64: 1, 4>
+  } : (tensor<?x4xf32>, tensor<1x3x1xi8>) -> tensor<1x3x4xf32>
   func.return %0 : tensor<1x3x4xf32>
 }
 

--- a/tests/e2e/stablehlo_ops/gather.mlir
+++ b/tests/e2e/stablehlo_ops/gather.mlir
@@ -167,3 +167,43 @@ func.func @reordered_start_index() {
      [ 9, 10, 11]]]> : tensor<2x2x3xi32>) : tensor<2x2x3xi32>
   return
 }
+
+// Out-of-range start indices are clamped into [0, operand_dim - slice_size],
+// not read out of bounds. This shape takes the torch_index_select lowering.
+func.func @out_of_bounds_indices_are_clamped() {
+  %operand = util.unfoldable_constant dense<[10, 20, 30]> : tensor<3xi32>
+  %start_indices = util.unfoldable_constant dense<[
+    [-5], [0], [2], [100]]> : tensor<4x1xi32>
+  %result = "stablehlo.gather"(%operand, %start_indices) {
+    dimension_numbers = #stablehlo.gather<
+      collapsed_slice_dims = [0],
+      index_vector_dim = 1,
+      offset_dims = [],
+      start_index_map = [0]
+    >,
+    indices_are_sorted = false,
+    slice_sizes = array<i64: 1>
+  } : (tensor<3xi32>, tensor<4x1xi32>) -> tensor<4xi32>
+  check.expect_eq_const(%result, dense<[10, 10, 30, 30]> : tensor<4xi32>) : tensor<4xi32>
+  return
+}
+
+// Same, with the gathered dimension dynamic: the clamp bound comes from
+// stablehlo.get_dimension_size instead of a constant.
+func.func @out_of_bounds_indices_are_clamped_dynamic() {
+  %operand = flow.tensor.dynamic_constant dense<[10, 20, 30]> : tensor<3xi32> -> tensor<?xi32>
+  %start_indices = util.unfoldable_constant dense<[
+    [-5], [0], [2], [100]]> : tensor<4x1xi32>
+  %result = "stablehlo.gather"(%operand, %start_indices) {
+    dimension_numbers = #stablehlo.gather<
+      collapsed_slice_dims = [0],
+      index_vector_dim = 1,
+      offset_dims = [],
+      start_index_map = [0]
+    >,
+    indices_are_sorted = false,
+    slice_sizes = array<i64: 1>
+  } : (tensor<?xi32>, tensor<4x1xi32>) -> tensor<4xi32>
+  check.expect_eq_const(%result, dense<[10, 10, 30, 30]> : tensor<4xi32>) : tensor<4xi32>
+  return
+}


### PR DESCRIPTION
`stablehlo.gather` clamps every start index into
`[0, operand_dim - slice_size]`. `GatherIsTorchIndexSelectPattern` dropped that clamp: `stablehlo.torch_index_select` indexes the operand directly and lowers to a bare `tensor.extract`, so an out-of-range index read whatever happened to sit at that offset. The general gather lowering does emit the clamp, so the two routes for the same op disagreed.

Given `[10, 20, 30]` and indices `[-5, 0, 2, 100]`, IREE returned `0 10 30 0` -- with the out-of-range values varying run to run -- where the spec asks for `10 10 30 30`.

Clamp the indices into range before handing them to torch_index_select. `slice_sizes[0]` is 1 on this path, so the bound is `operand.dim(0) - 1`: a constant when that dimension is static, `get_dimension_size` minus one when it is not. An index type too narrow to name an out-of-bounds element saturates the bound at its own maximum instead of truncating it into a negative one. A dynamic dimension paired with an index type narrower than the i32 `get_dimension_size` returns has nowhere to put the bound, so that combination falls back to the general lowering, which clamps correctly already.

Fixes #24881.