### PR TITLE
[LIT] Migrate compiler lit config to the internal shell

### DIFF
--- a/compiler/lit.cfg.py
+++ b/compiler/lit.cfg.py
@@ -17,9 +17,7 @@ import lit.formats
 
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
-config.test_format = lit.formats.ShTest(
-    execute_external=True, force_execute_external=True
-)
+config.test_format = lit.formats.ShTest()
 
 # Forward all IREE environment variables, as well as some passthroughs.
 # Note: env vars are case-insensitive on Windows, so check matches carefully.


### PR DESCRIPTION
Part of #24607, following #24794 and #24810.

Same change as the last two: drops execute_external / force_execute_external from compiler/lit.cfg.py. No RUN lines needed touching.

Ran all 1104 lit tests under compiler/ before and after the change: 1019 passed / 85 failed both times, same failing tests. The 85 fail identically on unmodified main too, so they're unrelated to this PR.

Assisted-by: Claude Code