### PR TITLE
[Codegen] Keep bounded dynamic dims for masked vectorization in TileLargeTensors

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -1178,6 +1178,11 @@ def TileLargeTensorsPass :
     Option<"maxVectorSize", "max-vector-size", "int64_t",
            /*default=*/"64",
            "Maximum static size to tile to (i.e. all remaining ops will be smaller)">,
+    Option<"allowMaskedDynamicDims", "allow-masked-dynamic-dims", "bool",
+           /*default=*/"false",
+           "Leave dynamic parallel dims untiled when a static upper bound can "
+           "be proven for them, deferring partial-tile remainders to "
+           "downstream masked vectorization instead of tiling them to 1.">,
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
@@ -5,9 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
@@ -41,6 +43,25 @@ int64_t getLargestFactorLessThan(int64_t val, int64_t upperBound) {
   return 1;
 }
 
+/// Tries to compute a provable static upper bound for loop dim |dim| of
+/// |linalgOp| through the operand dims mapped to it. This mirrors the vector
+/// size inference in GenericVectorization (inferSizesFromIR) so that both
+/// stages agree on which dynamic dims masked vectorization can handle.
+static std::optional<int64_t>
+getProvenLoopDimUpperBound(linalg::LinalgOp linalgOp, unsigned dim) {
+  SmallVector<std::pair<Value, unsigned>> operandDimPairs;
+  linalgOp.mapIterationSpaceDimToAllOperandDims(dim, operandDimPairs);
+  for (auto [operand, operandDim] : operandDimPairs) {
+    FailureOr<DimBoundSize> bound =
+        computeDimUpperBound(operand, operandDim, /*vscaleRange=*/std::nullopt,
+                             RoundUpVscaleMultiple::No);
+    if (succeeded(bound) && !bound->scalable) {
+      return bound->baseSize;
+    }
+  }
+  return std::nullopt;
+}
+
 /// Helper to tile and greedily fuse the given operation. This does not yield
 /// any fused operation and only replaces the tiling root. Because this pass is
 /// primarily concerned with managing large vector sizes, we only handle linalg
@@ -51,33 +72,46 @@ int64_t getLargestFactorLessThan(int64_t val, int64_t upperBound) {
 /// verification steps will throw an error if distribution does not occur.
 static void tileToMaxVectorSize(RewriterBase &rewriter,
                                 TilingInterface tilingInterfaceOp,
-                                ArrayRef<int64_t> bounds,
-                                int64_t maxVectorSize) {
+                                ArrayRef<int64_t> bounds, int64_t maxVectorSize,
+                                bool allowMaskedDynamicDims) {
   assert(maxVectorSize >= 1 && "maximum vector size must be at least 1");
   SmallVector<int64_t> staticTileSizes(bounds);
   SmallVector<utils::IteratorType> iteratorTypes =
       tilingInterfaceOp.getLoopIteratorTypes();
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(tilingInterfaceOp.getOperation());
+  // Provable static upper bounds of dynamic parallel dims. With
+  // |allowMaskedDynamicDims|, bounded dims stay untiled (tile size 0, "no
+  // tiling" like reduction dims) so masked vectorization handles the partial
+  // tile remainders downstream.
+  SmallVector<std::optional<int64_t>> dynamicDimUBs(staticTileSizes.size());
 
   // Collect the total statically known parallel iterations of the linalg op.
   // We expect this to be the minimum required vector size for the op
   // because outputs should reflect the full parallel iteration space.
   int64_t staticNumTrips = 1;
-  for (auto [size, type] : llvm::zip_equal(staticTileSizes, iteratorTypes)) {
+  for (int64_t i = 0, e = staticTileSizes.size(); i < e; ++i) {
+    int64_t &size = staticTileSizes[i];
     // Skip tiling of reduction iterators.
-    if (type == utils::IteratorType::reduction) {
+    if (iteratorTypes[i] == utils::IteratorType::reduction) {
       size = 0;
       continue;
     }
-    if (ShapedType::isDynamic(size)) {
-      // Tile all dynamic dims to 1 as well to enable new vectorization
-      // opportunities. This also ensures all entries in staticTileSizes are
-      // static.
-      // TODO: This may want to be a pass option in case strategies like
-      // masked vectorization are employed for dynamic shapes.
-      size = 1;
-    } else {
+    if (!ShapedType::isDynamic(size)) {
       staticNumTrips *= size;
+      continue;
     }
+    if (allowMaskedDynamicDims && linalgOp) {
+      dynamicDimUBs[i] = getProvenLoopDimUpperBound(linalgOp, i);
+    }
+    if (dynamicDimUBs[i]) {
+      size = 0;
+      staticNumTrips *= *dynamicDimUBs[i];
+      continue;
+    }
+    // Tile dynamic dims without a proven bound to 1 to enable new
+    // vectorization opportunities. This also keeps all tiled entries in
+    // staticTileSizes static.
+    size = 1;
   }
 
   int64_t expectedMinVectorSize = staticNumTrips;
@@ -92,9 +126,16 @@ static void tileToMaxVectorSize(RewriterBase &rewriter,
     // that can be meaningfully vectorized is the inner most which is not always
     // true. Considering this is fallback logic, this is fine.
     if (expectedMinVectorSize > maxVectorSize) {
-      // These two quantities are always divisible. Also staticTileSizes[i] is
-      // always static since we set all dynamic entries to 1.
-      expectedMinVectorSize /= staticTileSizes[i];
+      // Dims kept dynamic for masked vectorization contribute their proven
+      // upper bound instead of a tile size.
+      int64_t dimSize = staticTileSizes[i];
+      if (dimSize == 0) {
+        if (!dynamicDimUBs[i]) {
+          continue; // Zero-trip dim; nothing useful to shrink.
+        }
+        dimSize = *dynamicDimUBs[i];
+      }
+      expectedMinVectorSize /= dimSize;
       staticTileSizes[i] = 1;
     }
   }
@@ -104,14 +145,29 @@ static void tileToMaxVectorSize(RewriterBase &rewriter,
 
   // For the inner most loop, pick the largest static integer factor that is
   // less than the maximum vector size. This might not be a great approximation
-  // and we may opt for a smaller default in the future.
+  // and we may opt for a smaller default in the future. For a dynamic dim kept
+  // for masked vectorization, tile to a factor of its proven bound instead;
+  // the remaining partial tile is masked downstream.
   if (expectedMinVectorSize > maxVectorSize) {
+    int64_t dimSize =
+        dynamicDimUBs[lastParallelDim].value_or(expectedMinVectorSize);
     staticTileSizes[lastParallelDim] =
-        getLargestFactorLessThan(expectedMinVectorSize, maxVectorSize);
+        getLargestFactorLessThan(dimSize, maxVectorSize);
   }
 
-  // Check if nothing to do.
-  if (staticTileSizes == bounds) {
+  // Check if nothing to do. Dims kept dynamic for masked vectorization carry
+  // tile size 0 ("no tiling") and count as unchanged for this comparison.
+  bool nothingToDo = true;
+  for (int64_t i = 0, e = staticTileSizes.size(); i < e; ++i) {
+    int64_t effective = (staticTileSizes[i] == 0 && dynamicDimUBs[i])
+                            ? bounds[i]
+                            : staticTileSizes[i];
+    if (effective != bounds[i]) {
+      nothingToDo = false;
+      break;
+    }
+  }
+  if (nothingToDo) {
     return;
   }
 
@@ -163,7 +219,7 @@ static void tileToMaxVectorSize(RewriterBase &rewriter,
 /// tiled or lowered by this point and this is a fallback to avoid large vector
 /// sizes.
 static void processRegion(RewriterBase &rewriter, Region *region,
-                          int64_t maxVectorSize) {
+                          int64_t maxVectorSize, bool allowMaskedDynamicDims) {
   // Process the region blocks in reverse.
   for (Block &block : llvm::reverse(region->getBlocks())) {
     // Save a reversed list of operations within the block. Ops will be
@@ -195,7 +251,7 @@ static void processRegion(RewriterBase &rewriter, Region *region,
         }
         SmallVector<int64_t> bounds = linalgOp.getStaticLoopRanges();
         tileToMaxVectorSize(rewriter, cast<TilingInterface>(&*linalgOp), bounds,
-                            maxVectorSize);
+                            maxVectorSize, allowMaskedDynamicDims);
         continue;
       }
 
@@ -207,13 +263,14 @@ static void processRegion(RewriterBase &rewriter, Region *region,
       if (auto mapStoreOp = dyn_cast<IREE::LinalgExt::MapStoreOp>(op)) {
         ArrayRef<int64_t> bounds = mapStoreOp.getInputType().getShape();
         tileToMaxVectorSize(rewriter, mapStoreOp, bounds,
-                            std::max<int64_t>(maxVectorSize / 4, 1));
+                            std::max<int64_t>(maxVectorSize / 4, 1),
+                            allowMaskedDynamicDims);
         continue;
       }
 
       // Else recursively process all nested operations.
       for (auto &region : op->getRegions()) {
-        processRegion(rewriter, &region, maxVectorSize);
+        processRegion(rewriter, &region, maxVectorSize, allowMaskedDynamicDims);
       }
     }
   }
@@ -224,7 +281,7 @@ void TileLargeTensorsPass::runOnOperation() {
 
   IRRewriter rewriter(funcOp->getContext());
   for (auto &region : funcOp->getRegions()) {
-    processRegion(rewriter, &region, maxVectorSize);
+    processRegion(rewriter, &region, maxVectorSize, allowMaskedDynamicDims);
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_large_tensors.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_large_tensors.mlir
@@ -1,6 +1,9 @@
 // RUN: iree-opt %s --split-input-file --mlir-print-local-scope \
 // RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-tile-large-tensors, canonicalize, cse))" | \
 // RUN:   FileCheck %s
+// RUN: iree-opt %s --split-input-file --mlir-print-local-scope \
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-tile-large-tensors{allow-masked-dynamic-dims=true}, canonicalize, cse))" | \
+// RUN:   FileCheck %s --check-prefix=MASKED
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 func.func @simple_generic(%3: tensor<64x256xf32>, %4: tensor<64x256xf32>, %5: tensor<64x256xf32>) -> tensor<64x256xf32> {
@@ -196,3 +199,94 @@ func.func @skip_empty_parallel_loops(%arg0: tensor<f32>, %arg1: tensor<f32>, %ar
 
 // CHECK-LABEL: func.func @skip_empty_parallel_loops
 //   CHECK-NOT:   scf.for
+
+// -----
+
+// With allow-masked-dynamic-dims, a dynamic parallel dim with a provable
+// static upper bound within the vector size limit is left untiled; the
+// partial tile is handled by masked vectorization downstream.
+func.func @masked_bound_kept_dynamic(%arg0: tensor<196x32xf32>, %arg1: tensor<196xf32>) -> tensor<196xf32> {
+  %0 = scf.forall (%arg2) = (0) to (196) step (16) shared_outs(%arg3 = %arg1) -> (tensor<196xf32>) {
+    %1 = affine.min affine_map<(d0) -> (-d0 + 196, 16)>(%arg2)
+    %extracted_slice = tensor.extract_slice %arg0[%arg2, 0] [%1, 32] [1, 1] : tensor<196x32xf32> to tensor<?x32xf32>
+    %extracted_slice_0 = tensor.extract_slice %arg3[%arg2] [%1] [1] : tensor<196xf32> to tensor<?xf32>
+    %2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d0)>],
+      iterator_types = ["parallel", "reduction"]}
+    ins(%extracted_slice : tensor<?x32xf32>)
+    outs(%extracted_slice_0 : tensor<?xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %3 = arith.addf %out, %in : f32
+      linalg.yield %3 : f32
+    } -> tensor<?xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %2 into %arg3[%arg2] [%1] [1] : tensor<?xf32> into tensor<196xf32>
+    }
+  }
+  return %0 : tensor<196xf32>
+}
+
+// Without the option (CHECK), the dynamic dim is tiled to 1.
+//       CHECK-LABEL: func.func @masked_bound_kept_dynamic
+//             CHECK:   scf.for %{{.+}} = %c0 to %{{.+}} step %c1
+// With the option (MASKED), the op is left alone.
+//  MASKED-LABEL: func.func @masked_bound_kept_dynamic
+//    MASKED-NOT:   scf.for %
+//        MASKED:   linalg.generic
+//   MASKED-SAME:   ins(%{{.*}} : tensor<?x32xf32>)
+
+// -----
+
+// A dynamic parallel dim whose proven upper bound exceeds the vector size
+// limit is tiled to the largest factor of the bound within the limit (here
+// 100 -> 50, the largest factor of 100 <= 64).
+func.func @masked_large_bound_tiled(%arg0: tensor<4096xf32>, %arg1: tensor<4096xf32>) -> tensor<4096xf32> {
+  %0 = scf.forall (%arg2) = (0) to (4096) step (100) shared_outs(%arg3 = %arg1) -> (tensor<4096xf32>) {
+    %1 = affine.min affine_map<(d0) -> (-d0 + 4096, 100)>(%arg2)
+    %extracted_slice = tensor.extract_slice %arg0[%arg2] [%1] [1] : tensor<4096xf32> to tensor<?xf32>
+    %extracted_slice_0 = tensor.extract_slice %arg3[%arg2] [%1] [1] : tensor<4096xf32> to tensor<?xf32>
+    %2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+    ins(%extracted_slice : tensor<?xf32>)
+    outs(%extracted_slice_0 : tensor<?xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<?xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %2 into %arg3[%arg2] [%1] [1] : tensor<?xf32> into tensor<4096xf32>
+    }
+  }
+  return %0 : tensor<4096xf32>
+}
+
+//  MASKED-LABEL: func.func @masked_large_bound_tiled
+//        MASKED:   scf.for %{{.+}} = %c0 to %{{.+}} step %c50
+
+// -----
+
+// A dynamic parallel dim without a provable upper bound keeps the legacy
+// tile-to-1 behavior with or without the option.
+func.func @masked_unbounded_tiled_to_one(%arg0: tensor<?x32xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1) -> (d0, d1)>,
+      affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+  ins(%arg0 : tensor<?x32xf32>)
+  outs(%arg1 : tensor<?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = arith.addf %out, %in : f32
+    linalg.yield %1 : f32
+  } -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+//       CHECK-LABEL: func.func @masked_unbounded_tiled_to_one
+//             CHECK:   scf.for %{{.+}} = %c0 to %{{.+}} step %c1
+//  MASKED-LABEL: func.func @masked_unbounded_tiled_to_one
+//        MASKED:   scf.for %{{.+}} = %c0 to %{{.+}} step %c1

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -564,7 +564,14 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(
       createCombineResultLayoutTransformationPass(combineLayoutOptions));
   funcPassManager.addPass(createGPUGreedilyDistributeToThreadsPass());
-  funcPassManager.addPass(createTileLargeTensorsPass());
+  {
+    TileLargeTensorsPassOptions options;
+    // This pipeline always vectorizes with masking (Step 6), so leave bounded
+    // dynamic parallel dims for masked vectorization instead of tiling them
+    // down to scalars.
+    options.allowMaskedDynamicDims = true;
+    funcPassManager.addPass(createTileLargeTensorsPass(options));
+  }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());


### PR DESCRIPTION
TileLargeTensors unconditionally tiled dynamic parallel dims to 1. For partial tiles (e.g. matmul-like ops whose N dim does not divide the chosen workgroup tile), this serialized the spatial dims and left only the reduction dim vectorizable, producing scalar loads feeding a scalar FMA chain -- e.g. the dispatch in #23210 did 512 scalar 4B loads plus a per-element reloaded RHS vector per K-chunk per thread.

This adds an allow-masked-dynamic-dims pass option (off by default). When enabled, dynamic parallel dims with a provable static upper bound (computed with the same value-bounds analysis used by vector size inference downstream) are left untiled so masked vectorization can handle the partial remainders; dims exceeding the vector size budget are tiled to a factor of their bound instead; dims without a provable bound keep the legacy tile-to-1 behavior. The LLVMGPU TileAndFuse pipeline enables the option since it always vectorizes with masking.

For the 8x1024x14x14 f32 matmul-like op from #23210, the dispatch now lowers to 16-wide masked vector loads feeding a 32-deep vector.contract per K chunk (single wide RHS load and masked store), with the K-loop iter_args hoisted to vectors. 

Part of #23210.

The measurement was collected and analyzed with AI-assisted tooling.