### PR TITLE
[CUDA] Preserve executable export names independently from PTX symbols

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -657,6 +657,7 @@ public:
 
       auto kernelNameRef =
           builder.createString(sanitizeSymbolName(exportOp.getName()));
+      auto exportNameRef = builder.createString(exportOp.getName());
 
       iree_hal_cuda_BlockDims_t blockDims = {0};
       if (auto workgroupSizeAttr = exportOp.getWorkgroupSize()) {
@@ -700,6 +701,7 @@ public:
       iree_hal_cuda_ExportDef_binding_flags_add(builder, bindingFlagsRef);
       iree_hal_cuda_ExportDef_debug_info_add(builder,
                                              exportDebugInfos[ordinal]);
+      iree_hal_cuda_ExportDef_export_name_add(builder, exportNameRef);
       exportRefs[ordinal] = iree_hal_cuda_ExportDef_end(builder);
     }
     auto exportsRef = builder.createOffsetVecDestructive(exportRefs);

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -293,10 +293,15 @@ iree_status_t iree_hal_cuda_native_executable_create(
   for (iree_host_size_t i = 0; i < export_count; ++i) {
     iree_hal_cuda_ExportDef_table_t export_def =
         iree_hal_cuda_ExportDef_vec_at(exports_vec, i);
+    flatbuffers_string_t export_name =
+        iree_hal_cuda_ExportDef_export_name_get(export_def);
+    if (!export_name) {
+      // Binaries produced before export_name was added used kernel_name for
+      // both PTX lookup and IREE executable export lookup.
+      export_name = iree_hal_cuda_ExportDef_kernel_name_get(export_def);
+    }
     if (IREE_UNLIKELY(!iree_host_size_checked_add(
-            total_export_name_length,
-            flatbuffers_string_len(
-                iree_hal_cuda_ExportDef_kernel_name_get(export_def)),
+            total_export_name_length, flatbuffers_string_len(export_name),
             &total_export_name_length))) {
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "export name storage size overflow");
@@ -431,14 +436,23 @@ iree_status_t iree_hal_cuda_native_executable_create(
           "cuFuncSetAttribute");
       if (!iree_status_is_ok(status)) break;
 
+      // Preserve the original executable export identity separately from the
+      // sanitized PTX symbol used for cuModuleGetFunction. Binaries produced
+      // before export_name was added use kernel_name for both.
+      flatbuffers_string_t export_name =
+          iree_hal_cuda_ExportDef_export_name_get(export_def);
+      if (!export_name) {
+        export_name = kernel_name;
+      }
+
       // Package required parameters for kernel launches for each entry point.
       iree_hal_cuda_kernel_params_t* kernel_info = &executable->exports[i];
-      const iree_host_size_t kernel_name_length =
-          flatbuffers_string_len(kernel_name);
+      const iree_host_size_t export_name_length =
+          flatbuffers_string_len(export_name);
       kernel_info->name =
-          iree_make_string_view(export_name_ptr, kernel_name_length);
-      memcpy(export_name_ptr, kernel_name, kernel_name_length);
-      export_name_ptr += kernel_name_length;
+          iree_make_string_view(export_name_ptr, export_name_length);
+      memcpy(export_name_ptr, export_name, export_name_length);
+      export_name_ptr += export_name_length;
       kernel_info->function = function;
       const iree_hal_cuda_BlockDims_t* block_dims =
           iree_hal_cuda_ExportDef_block_dims_get(export_def);

--- a/runtime/src/iree/schemas/cuda_executable_def.fbs
+++ b/runtime/src/iree/schemas/cuda_executable_def.fbs
@@ -48,6 +48,10 @@ table ExportDef {
 
   // Optional debug information related to the export.
   debug_info:iree.hal.debug.ExportDef;
+
+  // Original IREE executable export name used for runtime lookup. When absent,
+  // runtimes fall back to kernel_name for compatibility with older binaries.
+  export_name:string;
 }
 
 // A library containing one or more exported functions.


### PR DESCRIPTION
## Motivation

While testing [Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) end-to-end with IREE, I found a CUDA executable lookup failure.

## Summary

CUDA executable serialization sanitizes kernel names for PTX, but previously used that same sanitized name as the IREE executable export identity.

This breaks modules whose generated dispatch names contain characters that are not valid PTX symbols, such as `$`. Turbine-exported modules can contain names such as `forward$async_dispatch_*`: compilation succeeds, but CUDA executable creation fails at runtime.

This change stores the original IREE export name separately from the sanitized PTX kernel symbol:

- `kernel_name` remains the sanitized symbol used by `cuModuleGetFunction`.
- `export_name` preserves the original name used by `hal.executable.lookup.function`.

`export_name` is an appended optional FlatBuffer field. Updated runtimes fall back to `kernel_name` when loading older VMFBs that do not contain it.


## Minimal reproduction

A standalone IREE module with a public function containing `$` reproduces the failure:

```mlir
func.func @qwen$prefill(%input: tensor<4xf32>) -> tensor<4xf32> {
  %output = tensor.empty() : tensor<4xf32>
  %result = linalg.generic {
      indexing_maps = [
        affine_map<(d0) -> (d0)>,
        affine_map<(d0) -> (d0)>
      ],
      iterator_types = ["parallel"]
    }
    ins(%input : tensor<4xf32>) outs(%output : tensor<4xf32>) {
      ^bb0(%in: f32, %out: f32):
        %scaled = arith.mulf %in, %in : f32
        linalg.yield %scaled : f32
    } -> tensor<4xf32>
  return %result : tensor<4xf32>
}
```

```
iree-compile repro.mlir \
  --iree-hal-target-backends=cuda \
  --iree-cuda-target=sm_120 \
  --iree-cuda-target-features=+ptx87 \
  -o repro.vmfb

iree-run-module \
  --module=repro.vmfb \
  --device=cuda \
  --function='qwen$prefill' \
  --input=4xf32=1
```

## Error
```
NOT_FOUND; function 'qwen$prefill' not found in executable
```
Changing only the public symbol to `@qwen_prefill` succeeds and produces the expected result.

## Testing

Built `iree-compile` and `iree-run-module`, then ran the repro on CUDA SM120 with PTX 8.7. 
After this change it succeeds:

```text
EXEC @qwen$prefill
result[0]: hal.buffer_view
4xf32=1 1 1 1
```
