### PR TITLE
[LinalgExt] Add affine quantization and dequantization ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -1323,4 +1323,127 @@ FailureOr<SmallVector<Value>> ExpReductionOp::decomposeOperation(OpBuilder &b) {
       [](linalg::GenericOp op) -> Value { return op->getResult(0); });
 }
 
+//===----------------------------------------------------------------------===//
+// QuantizeAffineOp and DequantizeAffineOp
+//===----------------------------------------------------------------------===//
+
+/// Builds the elementwise `linalg.generic` that both quantization ops decompose
+/// into. `bodyBuilder` receives the scalar arguments in operand order.
+template <typename OpTy>
+static SmallVector<Value> buildQuantizationGeneric(
+    OpTy op, OpBuilder &b,
+    function_ref<Value(OpBuilder &, Location, ValueRange)> bodyBuilder) {
+  Location loc = op.getLoc();
+  SmallVector<Value> inputs{op.getInput(), op.getScale()};
+  if (Value zeroPoint = op.getZeroPoint()) {
+    inputs.push_back(zeroPoint);
+  }
+  SmallVector<utils::IteratorType> iteratorTypes(op.getRank(),
+                                                 utils::IteratorType::parallel);
+  auto genericOp = linalg::GenericOp::create(
+      b, loc, op->getResultTypes(), inputs, ValueRange{op.getOutput()},
+      op.getIndexingMapsArray(), iteratorTypes,
+      [&](OpBuilder &nested, Location nestedLoc, ValueRange args) {
+        Value result = bodyBuilder(nested, nestedLoc, args);
+        linalg::YieldOp::create(nested, nestedLoc, result);
+      });
+  return SmallVector<Value>(genericOp->getResults());
+}
+
+FailureOr<SmallVector<Value>>
+DequantizeAffineOp::decomposeOperation(OpBuilder &b) {
+  // The op defines its arithmetic in the element type of the scale, which need
+  // not be the element type of the input or the output.
+  Type computeType = getScaleElementType();
+  Type realType = getOutputType().getElementType();
+  bool inputUnsigned = getInputUnsigned();
+  bool zpUnsigned = getZpUnsigned();
+  bool symmetric = isSymmetric();
+  // Verified to fit in 64 bits, so this is safe to dereference below.
+  IntegerType differenceType =
+      symmetric ? IntegerType() : *getZeroPointDifferenceType();
+
+  return buildQuantizationGeneric(
+      *this, b, [&](OpBuilder &nested, Location loc, ValueRange args) -> Value {
+        Value quantized = args[0];
+        Value scale = args[1];
+        Value real;
+        if (symmetric) {
+          real = convertScalarToDtype(nested, loc, quantized, computeType,
+                                      /*isUnsignedCast=*/inputUnsigned);
+        } else {
+          // `input - zero_point` can leave the range of the storage type,
+          // e.g. -128 - 127 in i8, so both operands are converted to a type
+          // wide enough to hold the difference. That widens the input; a zero
+          // point whose element type is wider is narrowed instead, which is
+          // safe because its values must be representable in the storage type.
+          Value extQuantized =
+              convertScalarToDtype(nested, loc, quantized, differenceType,
+                                   /*isUnsignedCast=*/inputUnsigned);
+          Value extZeroPoint =
+              convertScalarToDtype(nested, loc, args[2], differenceType,
+                                   /*isUnsignedCast=*/zpUnsigned);
+          Value difference =
+              arith::SubIOp::create(nested, loc, extQuantized, extZeroPoint);
+          // The difference is signed even when both operands are unsigned.
+          real = arith::SIToFPOp::create(nested, loc, computeType, difference);
+        }
+        Value dequantized = arith::MulFOp::create(nested, loc, real, scale);
+        return convertScalarToDtype(nested, loc, dequantized, realType,
+                                    /*isUnsignedCast=*/false);
+      });
+}
+
+FailureOr<SmallVector<Value>>
+QuantizeAffineOp::decomposeOperation(OpBuilder &b) {
+  // The op defines its arithmetic in the element type of the scale, which need
+  // not be the element type of the input or the output.
+  Type computeType = getScaleElementType();
+  Type storageType = getOutputType().getElementType();
+  bool storageUnsigned = getStorageUnsigned();
+  bool zpUnsigned = getZpUnsigned();
+  bool symmetric = isSymmetric();
+  int64_t quantMin = getQuantMin();
+  int64_t quantMax = getQuantMax();
+
+  return buildQuantizationGeneric(
+      *this, b, [&](OpBuilder &nested, Location loc, ValueRange args) -> Value {
+        Value real = convertScalarToDtype(nested, loc, args[0], computeType,
+                                          /*isUnsignedCast=*/false);
+        Value scale = args[1];
+        Value scaled = arith::DivFOp::create(nested, loc, real, scale);
+
+        Value rounded = math::RoundEvenOp::create(nested, loc, scaled);
+
+        Value shifted = rounded;
+        if (!symmetric) {
+          Value zeroPoint =
+              convertScalarToDtype(nested, loc, args[2], computeType,
+                                   /*isUnsignedCast=*/zpUnsigned);
+          shifted = arith::AddFOp::create(nested, loc, rounded, zeroPoint);
+        }
+
+        // Clamp before converting: `arith.fptosi` of a value that does not
+        // fit the target integer type is poison, so a large magnitude or an
+        // infinity has to be brought into [quant_min, quant_max] first.
+        //
+        // `maxnumf`/`minnumf` return the other operand when one is NaN, where
+        // `maximumf`/`minimumf` would propagate the NaN into the conversion
+        // and make it poison anyway. A NaN input therefore quantizes to
+        // quant_min, which the frontends leave implementation-defined.
+        Value lowerBound = arith::ConstantOp::create(
+            nested, loc,
+            nested.getFloatAttr(computeType, static_cast<double>(quantMin)));
+        Value upperBound = arith::ConstantOp::create(
+            nested, loc,
+            nested.getFloatAttr(computeType, static_cast<double>(quantMax)));
+        Value clamped =
+            arith::MaxNumFOp::create(nested, loc, shifted, lowerBound);
+        clamped = arith::MinNumFOp::create(nested, loc, clamped, upperBound);
+
+        return convertScalarToDtype(nested, loc, clamped, storageType,
+                                    /*isUnsignedCast=*/storageUnsigned);
+      });
+}
+
 } // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
@@ -43,6 +43,19 @@ class RankedTensorOrScalarType<list<Type> allowedTypes> :
 def AnyRankedTensorOrScalarType :
   RankedTensorOrScalarType<[AnySignlessIntegerOrIndex, AnyFloat]>;
 
+// A ranked shaped value, tensor or memref. Unranked types and vectors are
+// excluded: ops using this derive their iteration space from the rank and
+// lower through `linalg.generic`, which takes neither.
+def AnyRankedShapedType :
+  AnyTypeOf<[AnyRankedTensor, AnyMemRef], "ranked tensor or memref">;
+
+// A ranked shaped value or a scalar. Used for operands that are invariant over
+// some of an op's iteration space, where a rank 0 value and a scalar carry the
+// same information.
+def AnyRankedShapedOrScalarType :
+  AnyTypeOf<[AnyRankedShapedType, AnySignlessIntegerOrIndex, AnyFloat],
+            "ranked tensor or memref, or scalar">;
+
 //===----------------------------------------------------------------------===//
 // Enum definitions
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -29,11 +29,13 @@
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OperationSupport.h"
@@ -2357,6 +2359,324 @@ LogicalResult ExpReductionOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// QuantizeAffineOp and DequantizeAffineOp
+//===----------------------------------------------------------------------===//
+
+/// Verifies that a quantization parameter operand, `scale` or `zero_point`,
+/// agrees with the indexing map it was given. The results of that map name the
+/// iteration dimensions the parameter varies over, so they fix both its rank
+/// and its extents: `()` is per-tensor, `(d0)` is per-channel over `d0`.
+/// `iterationDimToInputDim` gives the input dimension that bounds each
+/// iteration dimension.
+static LogicalResult
+verifyQuantizationParameter(Operation *op, StringRef name, Value qparam,
+                            AffineMap qparamMap, ShapedType inputType,
+                            ArrayRef<int64_t> iterationDimToInputDim) {
+  auto qparamType = dyn_cast<ShapedType>(qparam.getType());
+  if (!qparamType) {
+    if (qparamMap.getNumResults() != 0) {
+      return op->emitOpError("expected scalar ")
+             << name << " to have an indexing map with no results";
+    }
+    return success();
+  }
+  if (qparamType.getRank() != static_cast<int64_t>(qparamMap.getNumResults())) {
+    return op->emitOpError("expected ")
+           << name << " to have rank " << qparamMap.getNumResults()
+           << " to match the number of results of its indexing map, got "
+           << qparamType.getRank();
+  }
+  for (auto [qparamDim, expr] : llvm::enumerate(qparamMap.getResults())) {
+    int64_t valueDim =
+        iterationDimToInputDim[cast<AffineDimExpr>(expr).getPosition()];
+    int64_t valueSize = inputType.getDimSize(valueDim);
+    int64_t qparamSize = qparamType.getDimSize(qparamDim);
+    if (ShapedType::isDynamic(qparamSize) || ShapedType::isDynamic(valueSize)) {
+      continue;
+    }
+    if (qparamSize != valueSize) {
+      return op->emitOpError("expected ")
+             << name << " dimension " << qparamDim << " to have size "
+             << valueSize << " to match dimension " << valueDim
+             << " of the quantized value, got " << qparamSize;
+    }
+  }
+  return success();
+}
+
+/// Verifies the operand structure shared by `quantize_affine` and
+/// `dequantize_affine`, i.e. everything that does not depend on which side of
+/// the op holds the quantized value.
+template <typename OpTy>
+static LogicalResult verifyAffineQuantizationOp(OpTy op) {
+  ShapedType inputType = op.getInputType();
+  ShapedType outputType = op.getOutputType();
+  int64_t rank = inputType.getRank();
+
+  SmallVector<AffineMap> maps = op.getIndexingMapsArray();
+  size_t expectedMaps = op.getZeroPoint() ? 4 : 3;
+  if (maps.size() != expectedMaps) {
+    return op.emitOpError("expected ")
+           << expectedMaps << " indexing maps, one per operand, got "
+           << maps.size();
+  }
+
+  for (auto [index, map] : llvm::enumerate(maps)) {
+    if (static_cast<int64_t>(map.getNumDims()) != rank) {
+      return op.emitOpError("expected indexing map ")
+             << index << " to have " << rank
+             << " dimensions to match the rank of the quantized value, got "
+             << map.getNumDims();
+    }
+    if (map.getNumSymbols() != 0) {
+      return op.emitOpError("expected indexing map ")
+             << index << " to have no symbols";
+    }
+    // Non-projected maps, such as `d1 floordiv 32` for block quantization, are
+    // not supported; blocked quantization is expressed on an expanded shape.
+    if (!map.isProjectedPermutation()) {
+      return op.emitOpError("expected indexing map ")
+             << index << " to be a projected permutation, got "
+             << AffineMapAttr::get(map);
+    }
+  }
+
+  // The op is elementwise over the value, so every value element is read and
+  // written exactly once: the value maps have to be permutations, not merely
+  // projections. A non-identity permutation is a transpose folded into the op.
+  AffineMap inputMap = maps.front();
+  AffineMap outputMap = maps.back();
+  for (auto [name, map] : {std::make_pair("input", inputMap),
+                           std::make_pair("output", outputMap)}) {
+    if (static_cast<int64_t>(map.getNumResults()) != rank) {
+      return op.emitOpError("expected the ")
+             << name << " indexing map to be a permutation with " << rank
+             << " results, got " << AffineMapAttr::get(map);
+    }
+  }
+
+  // The input map names the input dimension each iteration dim reads, which is
+  // what gives the iteration space its extents. The output has to have those
+  // same extents, reordered by its own map.
+  SmallVector<int64_t> iterationDimToInputDim(rank);
+  for (auto [position, expr] : llvm::enumerate(inputMap.getResults())) {
+    iterationDimToInputDim[cast<AffineDimExpr>(expr).getPosition()] = position;
+  }
+  SmallVector<int64_t> expectedOutputShape =
+      llvm::map_to_vector(outputMap.getResults(), [&](AffineExpr expr) {
+        return inputType.getDimSize(
+            iterationDimToInputDim[cast<AffineDimExpr>(expr).getPosition()]);
+      });
+  if (outputType.getShape() != ArrayRef<int64_t>(expectedOutputShape)) {
+    return op.emitOpError("expected input and output to have the same shape up "
+                          "to their indexing maps, got ")
+           << inputType << " and " << outputType;
+  }
+
+  AffineMap scaleMap = maps[1];
+
+  auto scaleType = dyn_cast<FloatType>(op.getScaleElementType());
+  if (!scaleType) {
+    return op.emitOpError(
+               "expected scale to have a floating point element type, got ")
+           << op.getScaleElementType();
+  }
+
+  for (Type type : {inputType.getElementType(), outputType.getElementType()}) {
+    auto floatType = dyn_cast<FloatType>(type);
+    if (floatType && floatType != scaleType &&
+        floatType.getWidth() == scaleType.getWidth()) {
+      return op.emitOpError("cannot mix equal-width floating point types ")
+             << floatType << " and " << scaleType;
+    }
+  }
+
+  if (failed(verifyQuantizationParameter(op, "scale", op.getScale(), scaleMap,
+                                         inputType, iterationDimToInputDim))) {
+    return failure();
+  }
+
+  Value zeroPoint = op.getZeroPoint();
+  if (!zeroPoint) {
+    if (op.getZpUnsigned()) {
+      return op.emitOpError(
+          "zp_unsigned is only allowed when a zero_point operand is present");
+    }
+    return success();
+  }
+  Type zeroPointType = zeroPoint.getType();
+  if (failed(verifyQuantizationParameter(op, "zero_point", zeroPoint, maps[2],
+                                         inputType, iterationDimToInputDim))) {
+    return failure();
+  }
+  if (!getElementTypeOrSelf(zeroPointType).isSignlessInteger()) {
+    return op.emitOpError("expected zero_point to have a signless integer "
+                          "element type, got ")
+           << getElementTypeOrSelf(zeroPointType);
+  }
+  return success();
+}
+
+/// Verifies that the inclusive range `[quantMin, quantMax]` is representable
+/// in `storageType` when interpreted with the given signedness.
+static LogicalResult verifyQuantizationRange(Operation *op, Type storageType,
+                                             int64_t quantMin, int64_t quantMax,
+                                             bool isUnsigned) {
+  if (quantMin > quantMax) {
+    return op->emitOpError("expected quant_min to not exceed quant_max, got [")
+           << quantMin << ", " << quantMax << "]";
+  }
+  auto integerType = dyn_cast<IntegerType>(storageType);
+  // Ranges of 64 bit (and wider) storage types cannot overflow anything we can
+  // express in the attribute, so there is nothing to check.
+  if (!integerType || integerType.getWidth() >= 64) {
+    return success();
+  }
+  unsigned width = integerType.getWidth();
+  int64_t typeMin = isUnsigned ? 0 : llvm::minIntN(width);
+  int64_t typeMax = isUnsigned ? static_cast<int64_t>(llvm::maxUIntN(width))
+                               : llvm::maxIntN(width);
+  if (quantMin < typeMin || quantMax > typeMax) {
+    return op->emitOpError("quantization range [")
+           << quantMin << ", " << quantMax << "] is not representable in "
+           << (isUnsigned ? "unsigned " : "signed ") << storageType;
+  }
+  return success();
+}
+
+LogicalResult QuantizeAffineOp::verify() {
+  if (failed(verifyAffineQuantizationOp(*this))) {
+    return failure();
+  }
+  Type realType = getInputType().getElementType();
+  Type storageType = getOutputType().getElementType();
+  if (!isa<FloatType>(realType)) {
+    return emitOpError("expected input to have a floating point element type, "
+                       "got ")
+           << realType;
+  }
+  if (!storageType.isSignlessInteger()) {
+    return emitOpError("expected output to have a signless integer element "
+                       "type, got ")
+           << storageType;
+  }
+  return verifyQuantizationRange(getOperation(), storageType, getQuantMin(),
+                                 getQuantMax(), getStorageUnsigned());
+}
+
+std::optional<IntegerType> DequantizeAffineOp::getZeroPointDifferenceType() {
+  assert(getZeroPoint() && "expected a zero_point operand");
+  unsigned storageWidth =
+      cast<IntegerType>(getInputType().getElementType()).getWidth();
+  // The zero point is required to be a point on the quantized grid, so a wider
+  // zero point element type carries no extra information and the width depends
+  // only on the storage type: subtracting two storageWidth-bit values needs
+  // storageWidth + 1 bits, rounded up to a power of two and at least a byte.
+  unsigned width = std::max<unsigned>(llvm::PowerOf2Ceil(storageWidth + 1), 8u);
+  if (width > 64) {
+    return std::nullopt;
+  }
+  return IntegerType::get(getContext(), width);
+}
+
+LogicalResult DequantizeAffineOp::verify() {
+  if (failed(verifyAffineQuantizationOp(*this))) {
+    return failure();
+  }
+  Type storageType = getInputType().getElementType();
+  Type realType = getOutputType().getElementType();
+  if (!storageType.isSignlessInteger()) {
+    return emitOpError("expected input to have a signless integer element "
+                       "type, got ")
+           << storageType;
+  }
+  if (!isa<FloatType>(realType)) {
+    return emitOpError("expected output to have a floating point element type, "
+                       "got ")
+           << realType;
+  }
+  if (getZeroPoint()) {
+    if (!getZeroPointDifferenceType()) {
+      return emitOpError("cannot subtract a zero point from a ")
+             << storageType << " value without exceeding 64 bits";
+    }
+    // The zero point is narrowed to the width the storage grid needs, so a
+    // constant that is off the grid would be silently truncated. Reject it
+    // here rather than miscompile it.
+    DenseIntElementsAttr zeroPointAttr;
+    if (matchPattern(getZeroPoint(), m_Constant(&zeroPointAttr))) {
+      unsigned storageWidth = cast<IntegerType>(storageType).getWidth();
+      bool isUnsigned = getInputUnsigned();
+      int64_t lowerBound = isUnsigned ? 0 : llvm::minIntN(storageWidth);
+      int64_t upperBound =
+          isUnsigned ? static_cast<int64_t>(llvm::maxUIntN(storageWidth))
+                     : llvm::maxIntN(storageWidth);
+      for (const APInt &value : zeroPointAttr.getValues<APInt>()) {
+        int64_t zeroPoint =
+            getZpUnsigned() ? value.getZExtValue() : value.getSExtValue();
+        if (zeroPoint < lowerBound || zeroPoint > upperBound) {
+          return emitOpError("zero point ")
+                 << zeroPoint << " is not representable in the storage type "
+                 << storageType << ", whose range is [" << lowerBound << ", "
+                 << upperBound << "]";
+        }
+      }
+    }
+  }
+  std::optional<int64_t> quantMin = getQuantMin();
+  std::optional<int64_t> quantMax = getQuantMax();
+  if (quantMin.has_value() != quantMax.has_value()) {
+    return emitOpError("expected quant_min and quant_max to be specified "
+                       "together");
+  }
+  if (quantMin) {
+    return verifyQuantizationRange(getOperation(), storageType, *quantMin,
+                                   *quantMax, getInputUnsigned());
+  }
+  return success();
+}
+
+// Both ops implement LinalgFusionInterface and IndexingMapOpInterface, which
+// declare overlapping methods. Defining them on the op itself resolves the
+// ambiguity between the two sets of defaults.
+#define DEFINE_AFFINE_QUANTIZATION_OP_METHODS(OP_NAME)                         \
+  SmallVector<AffineMap> OP_NAME::getIndexingMapsArray() {                     \
+    return llvm::to_vector(                                                    \
+        getIndexingMaps().getAsValueRange<AffineMapAttr>());                   \
+  }                                                                            \
+                                                                               \
+  AffineMap OP_NAME::getMatchingIndexingMap(OpOperand *operand) {              \
+    assert(operand->getOwner() == getOperation());                             \
+    return getIndexingMapsArray()[operand->getOperandNumber()];                \
+  }                                                                            \
+                                                                               \
+  SmallVector<AffineMap> OP_NAME::getIndexingMapsForOperands() {               \
+    SmallVector<AffineMap> maps = getIndexingMapsArray();                      \
+    maps.resize(getNumDpsInputs());                                            \
+    return maps;                                                               \
+  }                                                                            \
+                                                                               \
+  SmallVector<AffineMap> OP_NAME::getIndexingMapsForResults() {                \
+    return {getIndexingMapsArray().back()};                                    \
+  }                                                                            \
+                                                                               \
+  SmallVector<int64_t> OP_NAME::getStaticLoopRanges() {                        \
+    return applyPermutationMap<int64_t>(inversePermutation(getInputMap()),     \
+                                        getInputType().getShape());            \
+  }                                                                            \
+                                                                               \
+  LogicalResult OP_NAME::reifyResultShapes(                                    \
+      OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {        \
+    return cast<LinalgExtOp>(getOperation())                                   \
+        .reifyResultShapes(b, reifiedReturnShapes);                            \
+  }
+
+DEFINE_AFFINE_QUANTIZATION_OP_METHODS(QuantizeAffineOp)
+DEFINE_AFFINE_QUANTIZATION_OP_METHODS(DequantizeAffineOp)
+
+#undef DEFINE_AFFINE_QUANTIZATION_OP_METHODS
+
+//===----------------------------------------------------------------------===//
 // Im2colOp
 //===----------------------------------------------------------------------===//
 
@@ -3415,6 +3735,8 @@ DEFINE_OP_GET_EFFECTS(WinogradOutputTransformOp)
 DEFINE_OP_GET_EFFECTS(AttentionOp)
 DEFINE_OP_GET_EFFECTS(OnlineAttentionOp)
 DEFINE_OP_GET_EFFECTS(ExpReductionOp)
+DEFINE_OP_GET_EFFECTS(QuantizeAffineOp)
+DEFINE_OP_GET_EFFECTS(DequantizeAffineOp)
 DEFINE_OP_GET_EFFECTS(Im2colOp)
 DEFINE_OP_GET_EFFECTS(CustomOp)
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h
@@ -22,6 +22,7 @@
 
 // clang-format off
 
+
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtAttrs.h.inc" // IWYU pragma: export
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1666,6 +1666,241 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
 
 } // OpGroupNonStructuredOps
 
+//===----------------------------------------------------------------------===//
+// Affine quantization ops
+//===----------------------------------------------------------------------===//
+
+def OpGroupAffineQuantizationOps : OpDocGroup {
+  let summary = "Affine quantization ops";
+  let description = "";
+}
+
+def IREELinalgExt_QuantizationBoundAttr :
+    TypedSignlessIntegerAttrBase<I64, "int64_t", "quantization bound"> {
+  let convertFromStorage = "$_self.getValue().getSExtValue()";
+}
+
+let opDocGroup = OpGroupAffineQuantizationOps in {
+
+class IREELinalgExt_AffineQuantizationOp<string mnemonic, list<Trait> traits = []>
+    : IREELinalgExt_Op<mnemonic, !listconcat(traits, [
+        DeclareOpInterfaceMethods<LinalgFusionInterface,
+          ["getIndexingMapsForOperands", "getIndexingMapsForResults",
+           "getStaticLoopRanges"]>,
+        DeclareOpInterfaceMethods<IndexingMapOpInterface,
+          ["getMatchingIndexingMap"]>,
+        DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface,
+          ["reifyResultShapes"]>,
+        DeclareOpInterfaceMethods<AggregatedOpInterface,
+          ["decomposeOperation"]>])> {
+  code extraAffineQuantizationOpClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    // Disambiguates the `getIndexingMapsArray` provided by both
+    // LinalgFusionInterface and IndexingMapOpInterface.
+    SmallVector<AffineMap> getIndexingMapsArray();
+
+    // The maps are stored in operand order: input, scale, zero point when
+    // present, then output.
+    AffineMap getInputMap() { return getIndexingMapsArray().front(); }
+    AffineMap getScaleMap() { return getIndexingMapsArray()[1]; }
+    AffineMap getZeroPointMap() {
+      assert(getZeroPoint() && "expected a zero_point operand");
+      return getIndexingMapsArray()[2];
+    }
+    AffineMap getOutputMap() { return getIndexingMapsArray().back(); }
+
+    ShapedType getInputType() {
+      return cast<ShapedType>(getInput().getType());
+    }
+    ShapedType getOutputType() {
+      return cast<ShapedType>(getOutput().getType());
+    }
+    Type getScaleElementType() {
+      return getElementTypeOrSelf(getScale().getType());
+    }
+    int64_t getRank() {
+      return getInputType().getRank();
+    }
+
+    // The op is elementwise, so every loop is parallel. LinalgFusionInterface
+    // derives getNumLoops and getNumParallelLoops from this.
+    SmallVector<utils::IteratorType> getLoopIteratorTypes() {
+      return SmallVector<utils::IteratorType>(getRank(),
+                                              utils::IteratorType::parallel);
+    }
+
+    // No zero point operand, i.e. the zero point is known to be 0.
+    bool isSymmetric() {
+      return !getZeroPoint();
+    }
+
+    // Method to implement for specifying output range for
+    // DestinationStyleOpInterface
+    MutableOperandRange getDpsInitsMutable() {
+      return MutableOperandRange(*this, /*start=*/getZeroPoint() ? 3 : 2,
+                                 /*length=*/1);
+    }
+  }];
+}
+
+def IREELinalgExt_QuantizeAffineOp
+    : IREELinalgExt_AffineQuantizationOp<"quantize_affine"> {
+  let summary = [{Affine (uniform) quantization of a real valued tensor.}];
+  let description = [{
+    Quantizes `input` elementwise, producing an integer `output`:
+
+    ```
+    output[out_map(d)] = clamp(round(input[in_map(d)] / scale[scale_map(d)])
+                                 + extend(zero_point[zp_map(d)]),
+                               quant_min, quant_max)
+    ```
+
+    `round` breaks ties to even, matching ONNX `QuantizeLinear`, the PT2E
+    `quantize_per_tensor` family and StableHLO `uniform_quantize`. The
+    arithmetic is performed in the element type of `scale`, so an f32 scale
+    over an f16 input gives f32 arithmetic. Distinct floating-point formats of
+    the same bit width, such as f16 and bf16, cannot be mixed.
+
+    The `scale` and `zero_point` maps are independent projected permutations
+    whose number of results is the granularity of that parameter:
+
+    - per-tensor:  `affine_map<(d0, d1) -> ()>`
+    - per-channel: `affine_map<(d0, d1) -> (d0)>`
+    - per-block:   `affine_map<(d0, d1, d2) -> (d0, d1)>` over an input whose
+                   blocked dimension has been expanded, e.g. `MxKxi4` reshaped
+                   to `Mx(K/B)xBxi4`.
+
+    `zero_point` is optional; when absent the quantization is symmetric.
+
+    `quant_min`/`quant_max` are the inclusive clamp bounds in the storage value
+    space, following the PT2E `quantize_per_tensor` convention. They are
+    required because the representable range is frequently not the full range
+    of the storage type (narrow-range `[-127, 127]` weights, sub-byte values
+    packed into a wider storage type).
+
+    MLIR integers are signless, so `storage_unsigned` and `zp_unsigned` declare
+    how `output` and `zero_point` are interpreted. Because the signedness lives
+    in those attributes, the integer element types themselves have to be
+    signless: `si8` and `ui8` are rejected in favor of `i8`.
+
+    Example:
+
+    ```mlir
+    %q = iree_linalg_ext.quantize_affine
+        {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                          affine_map<(d0, d1) -> (d0)>,
+                          affine_map<(d0, d1) -> (d0)>,
+                          affine_map<(d0, d1) -> (d0, d1)>],
+         quant_min = -128 : i64, quant_max = 127 : i64}
+        ins(%x, %scale, %zp : tensor<128x64xf32>, tensor<128xf32>, tensor<128xi8>)
+        outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+    ```
+  }];
+
+  let arguments = (ins
+      AnyRankedShapedType:$input,
+      AnyRankedShapedOrScalarType:$scale,
+      Optional<AnyRankedShapedOrScalarType>:$zero_point,
+      AnyRankedShapedType:$output,
+      AffineMapArrayAttr:$indexing_maps,
+      IREELinalgExt_QuantizationBoundAttr:$quant_min,
+      IREELinalgExt_QuantizationBoundAttr:$quant_max,
+      UnitAttr:$storage_unsigned,
+      UnitAttr:$zp_unsigned
+  );
+  let results = (outs Variadic<AnyRankedTensor>:$result);
+
+  let assemblyFormat = [{
+    attr-dict
+    `ins` `(` $input `,` $scale (`,` $zero_point^)? `:`
+              type($input) `,` type($scale) (`,` type($zero_point)^)? `)`
+    `outs` `(` $output `:` type($output) `)`
+    (`->` type($result)^)?
+  }];
+
+  let extraClassDeclaration = extraAffineQuantizationOpClassDeclaration;
+}
+
+def IREELinalgExt_DequantizeAffineOp
+    : IREELinalgExt_AffineQuantizationOp<"dequantize_affine"> {
+  let summary = [{Affine (uniform) dequantization of an integer tensor.}];
+  let description = [{
+    Dequantizes `input` elementwise, producing a real valued `output`:
+
+    ```
+    output[out_map(d)] = (extend(input[in_map(d)])
+                            - extend(zero_point[zp_map(d)]))
+                           * scale[scale_map(d)]
+    ```
+
+    See `iree_linalg_ext.quantize_affine` for the meaning of `indexing_maps` and
+    of the signedness attributes; here `input_unsigned` refers to the quantized
+    operand, which is the input rather than the output.
+
+    As in `quantize_affine`, the multiplication is performed in the element type of
+    `scale`. Distinct floating-point formats of the same bit width cannot be mixed.
+
+    `zero_point` must be a point on the quantized grid: its values must be
+    representable in the element type of `input`, even when its own element
+    type is wider (PT2E emits `i64` zero points for `i8` data).
+
+    It is what makes the subtraction width depend only on the storage
+    type, `PowerOf2Ceil(storage_width + 1)`, so `i8` data subtracts in `i16`
+    whatever the zero point's own element type.
+
+    `quant_min`/`quant_max` optionally describe the inclusive range of the
+    quantized input values. They do not clamp the input or change the
+    dequantization arithmetic. This preserves information that the storage
+    type alone cannot express: an i8 tensor with range `[-8, 7]` uses a
+    four-bit quantization grid, which a consumer can use to pack the values
+    into i4 storage.
+
+    Example:
+
+    ```mlir
+    %dq = iree_linalg_ext.dequantize_affine
+        {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                          affine_map<(d0, d1) -> (d0)>,
+                          affine_map<(d0, d1) -> (d0)>,
+                          affine_map<(d0, d1) -> (d0, d1)>],
+         input_unsigned}
+        ins(%q, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xi32>)
+        outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+    ```
+  }];
+
+  let arguments = (ins
+      AnyRankedShapedType:$input,
+      AnyRankedShapedOrScalarType:$scale,
+      Optional<AnyRankedShapedOrScalarType>:$zero_point,
+      AnyRankedShapedType:$output,
+      AffineMapArrayAttr:$indexing_maps,
+      OptionalAttr<IREELinalgExt_QuantizationBoundAttr>:$quant_min,
+      OptionalAttr<IREELinalgExt_QuantizationBoundAttr>:$quant_max,
+      UnitAttr:$input_unsigned,
+      UnitAttr:$zp_unsigned
+  );
+  let results = (outs Variadic<AnyRankedTensor>:$result);
+
+  let assemblyFormat = [{
+    attr-dict
+    `ins` `(` $input `,` $scale (`,` $zero_point^)? `:`
+              type($input) `,` type($scale) (`,` type($zero_point)^)? `)`
+    `outs` `(` $output `:` type($output) `)`
+    (`->` type($result)^)?
+  }];
+
+  let extraClassDeclaration = extraAffineQuantizationOpClassDeclaration # [{
+    // The integer type in which `input - zero_point` is computed. Requires a
+    // zero point operand. Returns std::nullopt when the difference would need
+    // more than 64 bits, which the verifier rejects, so a caller that has
+    // verified IR can dereference the result.
+    std::optional<IntegerType> getZeroPointDifferenceType();
+
+  }];
+}
+
+} // OpGroupAffineQuantizationOps
+
 
 //===----------------------------------------------------------------------===//
 // Winograd ops

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -2185,3 +2185,448 @@ func.func @map_load_wrong_num_yielded_values(
   } : memref<4xf32> into memref<4xf32>
   return
 }
+
+// -----
+
+func.func @quantize_affine_unranked_input(%input: tensor<*xf32>,
+    %scale: f32, %init: tensor<4xi8>) -> tensor<4xi8> {
+  // expected-error @+1 {{operand #0 must be ranked tensor or memref}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0) -> (d0)>,
+                        affine_map<(d0) -> ()>,
+                        affine_map<(d0) -> (d0)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<*xf32>, f32)
+      outs(%init : tensor<4xi8>) -> tensor<4xi8>
+  return %0 : tensor<4xi8>
+}
+
+// -----
+
+func.func @quantize_affine_vector_input(%input: vector<4xf32>,
+    %scale: f32, %init: tensor<4xi8>) -> tensor<4xi8> {
+  // expected-error @+1 {{operand #0 must be ranked tensor or memref}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0) -> (d0)>,
+                        affine_map<(d0) -> ()>,
+                        affine_map<(d0) -> (d0)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : vector<4xf32>, f32)
+      outs(%init : tensor<4xi8>) -> tensor<4xi8>
+  return %0 : tensor<4xi8>
+}
+
+// -----
+
+func.func @dequantize_affine_unranked_scale(%input: tensor<4xi8>,
+    %scale: tensor<*xf32>, %init: tensor<4xf32>) -> tensor<4xf32> {
+  // expected-error @+1 {{operand #1 must be ranked tensor or memref, or scalar}}
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0) -> (d0)>,
+                        affine_map<(d0) -> ()>,
+                        affine_map<(d0) -> (d0)>]}
+      ins(%input, %scale : tensor<4xi8>, tensor<*xf32>)
+      outs(%init : tensor<4xf32>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+
+func.func @quantize_affine_mixed_float_formats(%input: tensor<4xf16>,
+    %scale: bf16, %init: tensor<4xi8>) -> tensor<4xi8> {
+  // expected-error @+1 {{cannot mix equal-width floating point types 'f16' and 'bf16'}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0) -> (d0)>,
+                        affine_map<(d0) -> ()>,
+                        affine_map<(d0) -> (d0)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<4xf16>, bf16)
+      outs(%init : tensor<4xi8>) -> tensor<4xi8>
+  return %0 : tensor<4xi8>
+}
+
+// -----
+
+func.func @dequantize_affine_mixed_float_formats(%input: tensor<4xi8>,
+    %scale: f16, %init: tensor<4xbf16>) -> tensor<4xbf16> {
+  // expected-error @+1 {{cannot mix equal-width floating point types 'bf16' and 'f16'}}
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0) -> (d0)>,
+                        affine_map<(d0) -> ()>,
+                        affine_map<(d0) -> (d0)>]}
+      ins(%input, %scale : tensor<4xi8>, f16)
+      outs(%init : tensor<4xbf16>) -> tensor<4xbf16>
+  return %0 : tensor<4xbf16>
+}
+
+// -----
+
+func.func @quantize_affine_scalar_scale_nonempty_map(%input: tensor<4xf32>,
+    %scale: f32, %init: tensor<4xi8>) -> tensor<4xi8> {
+  // expected-error @+1 {{expected scalar scale to have an indexing map with no results}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0) -> (d0)>,
+                        affine_map<(d0) -> (d0)>,
+                        affine_map<(d0) -> (d0)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<4xf32>, f32)
+      outs(%init : tensor<4xi8>) -> tensor<4xi8>
+  return %0 : tensor<4xi8>
+}
+
+// -----
+
+func.func @quantize_affine_shape_mismatch(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x32xi8>) -> tensor<128x32xi8> {
+  // expected-error @+1 {{expected input and output to have the same shape}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x32xi8>) -> tensor<128x32xi8>
+  return %0 : tensor<128x32xi8>
+}
+
+// -----
+
+func.func @quantize_affine_bad_map_rank(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected indexing map 0 to have 2 dimensions to match the rank of the quantized value, got 3}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_not_projected_permutation(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected indexing map 1 to be a projected permutation}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d1 floordiv 32)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_scale_rank_mismatch(%input: tensor<128x64xf32>,
+    %scale: tensor<128x64xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected scale to have rank 1 to match the number of results of its indexing map, got 2}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128x64xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_wrong_number_of_maps(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %zp: tensor<128xi8>,
+    %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected 4 indexing maps, one per operand, got 3}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xf32>, tensor<128xf32>, tensor<128xi8>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+// A value map that drops a dimension would leave part of the value unread.
+func.func @quantize_affine_input_map_not_a_permutation(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected the input indexing map to be a permutation with 2 results}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_zp_size_mismatch(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %zp: tensor<32xi8>,
+    %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected zero_point dimension 0 to have size 64 to match dimension 1 of the quantized value, got 32}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xf32>, tensor<128xf32>, tensor<32xi8>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_scale_size_mismatch(%input: tensor<128x64xf32>,
+    %scale: tensor<64xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected scale dimension 0 to have size 128 to match dimension 0 of the quantized value, got 64}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<64xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_zp_rank_mismatch(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %zp: tensor<64xi8>,
+    %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected zero_point to have rank 0 to match the number of results of its indexing map, got 1}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> ()>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xf32>, tensor<128xf32>, tensor<64xi8>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_float_zp(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %zp: tensor<128xf32>,
+    %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected zero_point to have a signless integer element type}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xf32>, tensor<128xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_zp_unsigned_without_zp(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{zp_unsigned is only allowed when a zero_point operand is present}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64, zp_unsigned}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_integer_input(%input: tensor<128x64xi32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected input to have a floating point element type}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xi32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_integer_scale(%input: tensor<128x64xf32>,
+    %scale: tensor<128xi32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected scale to have a floating point element type, got 'i32'}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xi32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_inverted_range(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{expected quant_min to not exceed quant_max}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = 127 : i64, quant_max = -128 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_range_too_wide(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{quantization range [0, 255] is not representable in signed 'i8'}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = 0 : i64, quant_max = 255 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_negative_unsigned_range(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  // expected-error @+1 {{quantization range [-128, 127] is not representable in unsigned 'i8'}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64, storage_unsigned}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+
+// -----
+
+func.func @quantize_affine_signed_storage(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xsi8>) -> tensor<128x64xsi8> {
+  // expected-error @+1 {{expected output to have a signless integer element type, got 'si8'}}
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xsi8>) -> tensor<128x64xsi8>
+  return %0 : tensor<128x64xsi8>
+}
+
+// -----
+
+func.func @dequantize_affine_unsigned_zp(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %zp: tensor<128xui8>,
+    %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  // expected-error @+1 {{expected zero_point to have a signless integer element type, got 'ui8'}}
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xui8>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+
+// -----
+
+func.func @dequantize_affine_float_input(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  // expected-error @+1 {{expected input to have a signless integer element type}}
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+
+// -----
+
+func.func @dequantize_affine_integer_scale(%input: tensor<128x64xi8>,
+    %scale: tensor<128xi32>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  // expected-error @+1 {{expected scale to have a floating point element type, got 'i32'}}
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale : tensor<128x64xi8>, tensor<128xi32>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+
+// -----
+
+func.func @dequantize_affine_half_specified_range(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  // expected-error @+1 {{expected quant_min and quant_max to be specified together}}
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>], quant_min = -127 : i64}
+      ins(%input, %scale : tensor<128x64xi8>, tensor<128xf32>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+
+// -----
+
+// Subtracting a zero point from an i64 value needs 65 bits, so there is no
+// integer type the subtraction can be carried out in.
+func.func @dequantize_affine_zp_difference_too_wide(%input: tensor<128x64xi64>,
+    %scale: tensor<128xf32>, %zp: tensor<128xi64>,
+    %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  // expected-error @+1 {{cannot subtract a zero point from a 'i64' value without exceeding 64 bits}}
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale, %zp : tensor<128x64xi64>, tensor<128xf32>, tensor<128xi64>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+
+// -----
+
+// A constant zero point that is off the quantized grid would be silently
+// truncated by the lowering, so it is rejected here.
+func.func @dequantize_affine_zp_off_grid(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %zp = arith.constant dense<300> : tensor<128xi32>
+  // expected-error @+1 {{zero point 300 is not representable in the storage type 'i8', whose range is [-128, 127]}}
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xi32>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -2742,3 +2742,273 @@ func.func @map_load_memref_static(
 // CHECK:   iree_linalg_ext.yield %[[IDX0]], %[[PAD]]
 // CHECK: } : memref<16xf32> into memref<16xf32>
 // CHECK: return
+
+// -----
+
+func.func @quantize_affine_per_tensor(%input: tensor<128x64xf32>, %scale: tensor<f32>,
+    %zp: tensor<i8>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> ()>,
+                        affine_map<(d0, d1) -> ()>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xf32>, tensor<f32>, tensor<i8>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+//   CHECK-DAG: #[[$IDENTITY:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//   CHECK-DAG: #[[$QPARAM:.+]] = affine_map<(d0, d1) -> ()>
+// CHECK-LABEL: func.func @quantize_affine_per_tensor(
+//  CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[SCALE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ZP:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[INIT:[a-zA-Z0-9_]+]]
+//       CHECK:   iree_linalg_ext.quantize_affine
+//  CHECK-SAME:     indexing_maps = [#[[$IDENTITY]], #[[$QPARAM]], #[[$QPARAM]], #[[$IDENTITY]]]
+//  CHECK-SAME:     quant_max = 127 : i64
+//  CHECK-SAME:     quant_min = -128 : i64
+//  CHECK-SAME:     ins(%[[INPUT]], %[[SCALE]], %[[ZP]] :
+//  CHECK-SAME:     outs(%[[INIT]] :
+
+// -----
+
+func.func @quantize_affine_per_channel_unsigned(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %zp: tensor<128xi32>,
+    %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = 0 : i64, quant_max = 255 : i64,
+       storage_unsigned}
+      ins(%input, %scale, %zp : tensor<128x64xf32>, tensor<128xf32>, tensor<128xi32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+//   CHECK-DAG: #[[$IDENTITY:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//   CHECK-DAG: #[[$QPARAM:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-LABEL: func.func @quantize_affine_per_channel_unsigned(
+//       CHECK:   iree_linalg_ext.quantize_affine
+//  CHECK-SAME:     indexing_maps = [#[[$IDENTITY]], #[[$QPARAM]], #[[$QPARAM]], #[[$IDENTITY]]]
+//  CHECK-SAME:     storage_unsigned
+
+// -----
+
+// Narrow range symmetric weights: no zero point operand, and a range that is
+// deliberately smaller than the range of the storage type.
+func.func @quantize_affine_symmetric_narrow_range(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -127 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+// CHECK-LABEL: func.func @quantize_affine_symmetric_narrow_range(
+//       CHECK:   iree_linalg_ext.quantize_affine
+//  CHECK-SAME:     quant_min = -127 : i64
+//  CHECK-SAME:     ins(%{{.+}}, %{{.+}} : tensor<128x64xf32>, tensor<128xf32>)
+
+// -----
+
+// An f32 scale over an f16 value, which is what PT2E emits for a half model.
+func.func @quantize_affine_wider_scale(%input: tensor<128x64xf16>,
+    %scale: tensor<128xf32>, %zp: tensor<128xi8>,
+    %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xf16>, tensor<128xf32>, tensor<128xi8>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+// CHECK-LABEL: func.func @quantize_affine_wider_scale(
+//       CHECK:   iree_linalg_ext.quantize_affine
+//  CHECK-SAME:     ins(%{{.+}}, %{{.+}}, %{{.+}} : tensor<128x64xf16>, tensor<128xf32>, tensor<128xi8>)
+//  CHECK-SAME:     outs(%{{.+}} : tensor<128x64xi8>)
+
+// -----
+
+func.func @dequantize_affine_per_tensor(%input: tensor<128x64xi8>, %scale: tensor<f32>,
+    %zp: tensor<i8>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> ()>,
+                        affine_map<(d0, d1) -> ()>,
+                        affine_map<(d0, d1) -> (d0, d1)>], input_unsigned, zp_unsigned}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<f32>, tensor<i8>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+//   CHECK-DAG: #[[$IDENTITY:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//   CHECK-DAG: #[[$QPARAM:.+]] = affine_map<(d0, d1) -> ()>
+// CHECK-LABEL: func.func @dequantize_affine_per_tensor(
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     indexing_maps = [#[[$IDENTITY]], #[[$QPARAM]], #[[$QPARAM]], #[[$IDENTITY]]]
+//  CHECK-SAME:     input_unsigned
+//  CHECK-SAME:     zp_unsigned
+
+// -----
+
+func.func @dequantize_affine_independent_qparam_maps(
+    %input: tensor<128x64xi8>, %scale: tensor<128xf32>, %zp: tensor<64xi8>,
+    %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<64xi8>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+// CHECK-LABEL: func.func @dequantize_affine_independent_qparam_maps(
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     indexing_maps = [
+
+// -----
+
+func.func @dequantize_affine_mixed_signedness(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %zp: tensor<128xi32>,
+    %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>], input_unsigned,
+       quant_min = 0 : i64, quant_max = 255 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xi32>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+// CHECK-LABEL: func.func @dequantize_affine_mixed_signedness(
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     input_unsigned
+//  CHECK-SAME:     quant_max = 255 : i64
+//  CHECK-SAME:     quant_min = 0 : i64
+
+// -----
+
+// Blocked int4 weights, expressed on an expanded shape.
+func.func @dequantize_affine_blocked(%input: tensor<128x2x32xi4>,
+    %scale: tensor<128x2xf16>, %zp: tensor<128x2xi4>,
+    %init: tensor<128x2x32xf16>) -> tensor<128x2x32xf16> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1, d2)>]}
+      ins(%input, %scale, %zp : tensor<128x2x32xi4>, tensor<128x2xf16>, tensor<128x2xi4>)
+      outs(%init : tensor<128x2x32xf16>) -> tensor<128x2x32xf16>
+  return %0 : tensor<128x2x32xf16>
+}
+//   CHECK-DAG: #[[$IDENTITY:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+//   CHECK-DAG: #[[$QPARAM:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-LABEL: func.func @dequantize_affine_blocked(
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     indexing_maps = [#[[$IDENTITY]], #[[$QPARAM]], #[[$QPARAM]], #[[$IDENTITY]]]
+
+// -----
+
+func.func @dequantize_affine_dynamic(%input: tensor<?x?xi8>, %scale: tensor<?xf32>,
+    %init: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d1)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale : tensor<?x?xi8>, tensor<?xf32>)
+      outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+//   CHECK-DAG: #[[$IDENTITY:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//   CHECK-DAG: #[[$QPARAM:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-LABEL: func.func @dequantize_affine_dynamic(
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     indexing_maps = [#[[$IDENTITY]], #[[$QPARAM]], #[[$IDENTITY]]]
+
+// -----
+
+func.func @dequantize_affine_memref(%input: memref<128x64xi8>, %scale: memref<128xf32>,
+    %output: memref<128x64xf32>) {
+  iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale : memref<128x64xi8>, memref<128xf32>)
+      outs(%output : memref<128x64xf32>)
+  return
+}
+// CHECK-LABEL: func.func @dequantize_affine_memref(
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     outs(%{{.+}} : memref<128x64xf32>)
+
+// -----
+
+// A transpose folded into the op: the output map is a non-identity permutation,
+// so the dequantized value comes out with its dimensions swapped and the scale
+// stays attached to the input dimension it was per-channel over.
+func.func @dequantize_affine_transposed(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %init: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d1, d0)>]}
+      ins(%input, %scale : tensor<128x64xi8>, tensor<128xf32>)
+      outs(%init : tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %0 : tensor<64x128xf32>
+}
+//   CHECK-DAG: #[[$INPUT:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//   CHECK-DAG: #[[$QPARAM:.+]] = affine_map<(d0, d1) -> (d0)>
+//   CHECK-DAG: #[[$OUTPUT:.+]] = affine_map<(d0, d1) -> (d1, d0)>
+// CHECK-LABEL: func.func @dequantize_affine_transposed(
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     indexing_maps = [#[[$INPUT]], #[[$QPARAM]], #[[$OUTPUT]]]
+
+// -----
+
+// A constant i64 zero point whose values are on the storage type's grid, which
+// is what PT2E emits. The verifier checks constant zero points against the grid
+// because the lowering narrows them, so this guards against a false positive.
+func.func @dequantize_affine_constant_wide_zp(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %zp = arith.constant dense<-128> : tensor<128xi64>
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xi64>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+// CHECK-LABEL: func.func @dequantize_affine_constant_wide_zp(
+//       CHECK:   %[[ZP:.+]] = arith.constant dense<-128> : tensor<128xi64>
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     ins(%{{.+}}, %{{.+}}, %[[ZP]] :
+
+// -----
+
+// The scale need not match the output: the multiply happens in f32 and the
+// product is narrowed to f16 afterwards.
+func.func @dequantize_affine_wider_scale(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xf16>) -> tensor<128x64xf16> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale : tensor<128x64xi8>, tensor<128xf32>)
+      outs(%init : tensor<128x64xf16>) -> tensor<128x64xf16>
+  return %0 : tensor<128x64xf16>
+}
+// CHECK-LABEL: func.func @dequantize_affine_wider_scale(
+//       CHECK:   iree_linalg_ext.dequantize_affine
+//  CHECK-SAME:     ins(%{{.+}}, %{{.+}} : tensor<128x64xi8>, tensor<128xf32>)
+//  CHECK-SAME:     outs(%{{.+}} : tensor<128x64xf16>)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/BUILD.bazel
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "decompose_aggregated_ops_noop.mlir",
             "decompose_im2col.mlir",
             "decompose_map_store.mlir",
+            "decompose_quantization.mlir",
             "decompose_winograd.mlir",
             "distribution.mlir",
             "fold_unit_dims.mlir",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "decompose_aggregated_ops_noop.mlir"
     "decompose_im2col.mlir"
     "decompose_map_store.mlir"
+    "decompose_quantization.mlir"
     "decompose_winograd.mlir"
     "distribution.mlir"
     "fold_unit_dims.mlir"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_quantization.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_quantization.mlir
@@ -1,0 +1,282 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-aggregated-ops{filter-ops=iree_linalg_ext.quantize_affine,iree_linalg_ext.dequantize_affine}))" --split-input-file %s | FileCheck %s
+
+func.func @dequantize_affine_per_channel(%input: tensor<128x64xi8>, %scale: tensor<128xf32>,
+    %zp: tensor<128xi8>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xi8>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+//   CHECK-DAG: #[[$IDENTITY:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//   CHECK-DAG: #[[$QPARAM:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-LABEL: func.func @dequantize_affine_per_channel(
+//  CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[SCALE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[ZP:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[INIT:[a-zA-Z0-9_]+]]
+//       CHECK:   linalg.generic
+//  CHECK-SAME:     indexing_maps = [#[[$IDENTITY]], #[[$QPARAM]], #[[$QPARAM]], #[[$IDENTITY]]]
+//  CHECK-SAME:     iterator_types = ["parallel", "parallel"]
+//  CHECK-SAME:     ins(%[[INPUT]], %[[SCALE]], %[[ZP]] :
+//  CHECK-SAME:     outs(%[[INIT]] :
+//       CHECK:   ^bb0(%[[Q:.+]]: i8, %[[S:.+]]: f32, %[[Z:.+]]: i8, %{{.+}}: f32):
+// The zero point subtraction widens to i16 first: i8 - i8 needs 9 bits.
+//       CHECK:     %[[EXTQ:.+]] = arith.extsi %[[Q]] : i8 to i16
+//       CHECK:     %[[EXTZ:.+]] = arith.extsi %[[Z]] : i8 to i16
+//       CHECK:     %[[SUB:.+]] = arith.subi %[[EXTQ]], %[[EXTZ]] : i16
+//       CHECK:     %[[REAL:.+]] = arith.sitofp %[[SUB]] : i16 to f32
+//       CHECK:     %[[MUL:.+]] = arith.mulf %[[REAL]], %[[S]] : f32
+//       CHECK:     linalg.yield %[[MUL]]
+
+// -----
+
+// An unsigned storage value zero extends. The subtraction width comes from the
+// storage type alone, so a zero point whose element type is wider is narrowed
+// to it: its values lie on the storage type's grid whatever type they arrive in.
+func.func @dequantize_affine_unsigned_input(%input: tensor<128x64xi8>, %scale: tensor<128xf32>,
+    %zp: tensor<128xi32>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>], input_unsigned}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xi32>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+// CHECK-LABEL: func.func @dequantize_affine_unsigned_input(
+//       CHECK:   ^bb0(%[[Q:.+]]: i8, %[[S:.+]]: f32, %[[Z:.+]]: i32, %{{.+}}: f32):
+//       CHECK:     %[[EXTQ:.+]] = arith.extui %[[Q]] : i8 to i16
+//       CHECK:     %[[TRUNCZ:.+]] = arith.trunci %[[Z]] : i32 to i16
+//       CHECK:     %[[SUB:.+]] = arith.subi %[[EXTQ]], %[[TRUNCZ]] : i16
+//       CHECK:     arith.sitofp %[[SUB]] : i16 to f32
+
+// -----
+
+// PT2E emits i64 zero points for i8 data. The subtraction still happens in i16,
+// not i64.
+func.func @dequantize_affine_i64_zp(%input: tensor<128x64xi8>, %scale: tensor<128xf32>,
+    %zp: tensor<128xi64>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xi64>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+// CHECK-LABEL: func.func @dequantize_affine_i64_zp(
+//       CHECK:   ^bb0(%[[Q:.+]]: i8, %[[S:.+]]: f32, %[[Z:.+]]: i64, %{{.+}}: f32):
+//       CHECK:     %[[EXTQ:.+]] = arith.extsi %[[Q]] : i8 to i16
+//       CHECK:     %[[TRUNCZ:.+]] = arith.trunci %[[Z]] : i64 to i16
+//       CHECK:     %[[SUB:.+]] = arith.subi %[[EXTQ]], %[[TRUNCZ]] : i16
+//       CHECK:     arith.sitofp %[[SUB]] : i16 to f32
+
+// -----
+
+// Symmetric dequantization skips the subtraction entirely.
+func.func @dequantize_affine_symmetric(%input: tensor<128x64xi4>, %scale: tensor<128xf16>,
+    %init: tensor<128x64xf16>) -> tensor<128x64xf16> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale : tensor<128x64xi4>, tensor<128xf16>)
+      outs(%init : tensor<128x64xf16>) -> tensor<128x64xf16>
+  return %0 : tensor<128x64xf16>
+}
+// CHECK-LABEL: func.func @dequantize_affine_symmetric(
+//       CHECK:   ^bb0(%[[Q:.+]]: i4, %[[S:.+]]: f16, %{{.+}}: f16):
+//   CHECK-NOT:     arith.subi
+//       CHECK:     %[[REAL:.+]] = arith.sitofp %[[Q]] : i4 to f16
+//       CHECK:     %[[MUL:.+]] = arith.mulf %[[REAL]], %[[S]] : f16
+//       CHECK:     linalg.yield %[[MUL]]
+
+// -----
+
+// The arithmetic happens in the scale's type, so the i8 goes straight to f32
+// and the f32 product is narrowed to the f16 output at the end.
+func.func @dequantize_affine_wider_scale(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xf16>) -> tensor<128x64xf16> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale : tensor<128x64xi8>, tensor<128xf32>)
+      outs(%init : tensor<128x64xf16>) -> tensor<128x64xf16>
+  return %0 : tensor<128x64xf16>
+}
+// CHECK-LABEL: func.func @dequantize_affine_wider_scale(
+//       CHECK:   ^bb0(%[[Q:.+]]: i8, %[[S:.+]]: f32, %{{.+}}: f16):
+//       CHECK:     %[[REAL:.+]] = arith.sitofp %[[Q]] : i8 to f32
+//       CHECK:     %[[MUL:.+]] = arith.mulf %[[REAL]], %[[S]] : f32
+//       CHECK:     %[[RES:.+]] = arith.truncf %[[MUL]] : f32 to f16
+//       CHECK:     linalg.yield %[[RES]]
+
+// -----
+
+func.func @quantize_affine_per_channel(%input: tensor<128x64xf32>, %scale: tensor<128xf32>,
+    %zp: tensor<128xi8>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<128x64xf32>, tensor<128xf32>, tensor<128xi8>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+// CHECK-LABEL: func.func @quantize_affine_per_channel(
+//       CHECK:   ^bb0(%[[X:.+]]: f32, %[[S:.+]]: f32, %[[Z:.+]]: i8, %{{.+}}: i8):
+//       CHECK:     %[[DIV:.+]] = arith.divf %[[X]], %[[S]] : f32
+//       CHECK:     %[[RND:.+]] = math.roundeven %[[DIV]] : f32
+//       CHECK:     %[[ZF:.+]] = arith.sitofp %[[Z]] : i8 to f32
+//       CHECK:     %[[ADD:.+]] = arith.addf %[[RND]], %[[ZF]] : f32
+//       CHECK:     %[[MIN:.+]] = arith.constant -1.280000e+02 : f32
+//       CHECK:     %[[MAX:.+]] = arith.constant 1.270000e+02 : f32
+//       CHECK:     %[[LO:.+]] = arith.maxnumf %[[ADD]], %[[MIN]] : f32
+//       CHECK:     %[[HI:.+]] = arith.minnumf %[[LO]], %[[MAX]] : f32
+//       CHECK:     %[[RES:.+]] = arith.fptosi %[[HI]] : f32 to i8
+//       CHECK:     linalg.yield %[[RES]]
+
+// -----
+
+// Narrow range symmetric weights clamp to the declared range, not to the range
+// of the storage type, and there is no zero point to add.
+func.func @quantize_affine_symmetric_narrow_range(%input: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -127 : i64, quant_max = 127 : i64}
+      ins(%input, %scale : tensor<128x64xf32>, tensor<128xf32>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+// CHECK-LABEL: func.func @quantize_affine_symmetric_narrow_range(
+//       CHECK:   ^bb0(%[[X:.+]]: f32, %[[S:.+]]: f32, %{{.+}}: i8):
+//       CHECK:     %[[DIV:.+]] = arith.divf %[[X]], %[[S]] : f32
+//       CHECK:     %[[RND:.+]] = math.roundeven %[[DIV]] : f32
+//   CHECK-NOT:     arith.addf
+//       CHECK:     %[[MIN:.+]] = arith.constant -1.270000e+02 : f32
+//       CHECK:     %[[MAX:.+]] = arith.constant 1.270000e+02 : f32
+//       CHECK:     %[[LO:.+]] = arith.maxnumf %[[RND]], %[[MIN]] : f32
+//       CHECK:     %[[HI:.+]] = arith.minnumf %[[LO]], %[[MAX]] : f32
+//       CHECK:     arith.fptosi %[[HI]] : f32 to i8
+
+// -----
+
+// Unsigned storage converts with fptoui and clamps to the unsigned range.
+func.func @quantize_affine_unsigned_storage(%input: tensor<128x64xf32>,
+    %scale: tensor<f32>, %zp: tensor<i8>, %init: tensor<128x64xi8>) -> tensor<128x64xi8> {
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> ()>,
+                        affine_map<(d0, d1) -> ()>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = 0 : i64, quant_max = 255 : i64,
+       storage_unsigned, zp_unsigned}
+      ins(%input, %scale, %zp : tensor<128x64xf32>, tensor<f32>, tensor<i8>)
+      outs(%init : tensor<128x64xi8>) -> tensor<128x64xi8>
+  return %0 : tensor<128x64xi8>
+}
+// CHECK-LABEL: func.func @quantize_affine_unsigned_storage(
+//       CHECK:   ^bb0(%[[X:.+]]: f32, %[[S:.+]]: f32, %[[Z:.+]]: i8, %{{.+}}: i8):
+//       CHECK:     arith.uitofp %[[Z]] : i8 to f32
+//       CHECK:     %[[MAX:.+]] = arith.constant 2.550000e+02 : f32
+//       CHECK:     arith.minnumf %{{.+}}, %[[MAX]] : f32
+//       CHECK:     arith.fptoui %{{.+}} : f32 to i8
+
+// -----
+
+// A zero point narrower than the storage type is extended to the same width the
+// storage type needs.
+func.func @dequantize_affine_narrow_zp(%input: tensor<128x64xi16>, %scale: tensor<128xf32>,
+    %zp: tensor<128xi8>, %init: tensor<128x64xf32>) -> tensor<128x64xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%input, %scale, %zp : tensor<128x64xi16>, tensor<128xf32>, tensor<128xi8>)
+      outs(%init : tensor<128x64xf32>) -> tensor<128x64xf32>
+  return %0 : tensor<128x64xf32>
+}
+// CHECK-LABEL: func.func @dequantize_affine_narrow_zp(
+//       CHECK:   ^bb0(%[[Q:.+]]: i16, %[[S:.+]]: f32, %[[Z:.+]]: i8, %{{.+}}: f32):
+//       CHECK:     %[[EXTQ:.+]] = arith.extsi %[[Q]] : i16 to i32
+//       CHECK:     %[[EXTZ:.+]] = arith.extsi %[[Z]] : i8 to i32
+//       CHECK:     %[[SUB:.+]] = arith.subi %[[EXTQ]], %[[EXTZ]] : i32
+//       CHECK:     arith.sitofp %[[SUB]] : i32 to f32
+
+// -----
+
+// A transpose folded into the op carries straight over to the generic's
+// indexing maps; no transpose is materialized.
+func.func @dequantize_affine_transposed(%input: tensor<128x64xi8>,
+    %scale: tensor<128xf32>, %init: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d1, d0)>]}
+      ins(%input, %scale : tensor<128x64xi8>, tensor<128xf32>)
+      outs(%init : tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %0 : tensor<64x128xf32>
+}
+//   CHECK-DAG: #[[$INPUT:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//   CHECK-DAG: #[[$QPARAM:.+]] = affine_map<(d0, d1) -> (d0)>
+//   CHECK-DAG: #[[$OUTPUT:.+]] = affine_map<(d0, d1) -> (d1, d0)>
+// CHECK-LABEL: func.func @dequantize_affine_transposed(
+//   CHECK-NOT:   linalg.transpose
+//       CHECK:   linalg.generic
+//  CHECK-SAME:     indexing_maps = [#[[$INPUT]], #[[$QPARAM]], #[[$OUTPUT]]]
+//  CHECK-SAME:     iterator_types = ["parallel", "parallel"]
+//       CHECK:   ^bb0(%[[Q:.+]]: i8, %[[S:.+]]: f32, %{{.+}}: f32):
+//       CHECK:     %[[F:.+]] = arith.sitofp %[[Q]] : i8 to f32
+//       CHECK:     arith.mulf %[[F]], %[[S]] : f32
+
+// -----
+
+// HWCF convolution weights use a scale and zero point per output channel.
+// The f16 input is extended to f32 before the divide; clamp bounds are f32 too.
+func.func @quantize_affine_wider_scale(%input: tensor<3x3x8x16xf16>,
+    %scale: tensor<16xf32>, %zp: tensor<16xi8>,
+    %init: tensor<3x3x8x16xi8>) -> tensor<3x3x8x16xi8> {
+  %0 = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                        affine_map<(d0, d1, d2, d3) -> (d3)>,
+                        affine_map<(d0, d1, d2, d3) -> (d3)>,
+                        affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%input, %scale, %zp : tensor<3x3x8x16xf16>, tensor<16xf32>, tensor<16xi8>)
+      outs(%init : tensor<3x3x8x16xi8>) -> tensor<3x3x8x16xi8>
+  return %0 : tensor<3x3x8x16xi8>
+}
+//   CHECK-DAG: #[[$IDENTITY:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+//   CHECK-DAG: #[[$CHANNEL:.+]] = affine_map<(d0, d1, d2, d3) -> (d3)>
+// CHECK-LABEL: func.func @quantize_affine_wider_scale(
+//       CHECK:   linalg.generic
+//  CHECK-SAME:     indexing_maps = [#[[$IDENTITY]], #[[$CHANNEL]], #[[$CHANNEL]], #[[$IDENTITY]]]
+//  CHECK-SAME:     iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+//  CHECK-SAME:     ins(%{{.+}}, %{{.+}}, %{{.+}} : tensor<3x3x8x16xf16>, tensor<16xf32>, tensor<16xi8>)
+//  CHECK-SAME:     outs(%{{.+}} : tensor<3x3x8x16xi8>)
+//       CHECK:   ^bb0(%[[X:.+]]: f16, %[[S:.+]]: f32, %[[Z:.+]]: i8, %{{.+}}: i8):
+//       CHECK:     %[[XF:.+]] = arith.extf %[[X]] : f16 to f32
+//       CHECK:     %[[DIV:.+]] = arith.divf %[[XF]], %[[S]] : f32
+//       CHECK:     %[[RND:.+]] = math.roundeven %[[DIV]] : f32
+//       CHECK:     %[[ZF:.+]] = arith.sitofp %[[Z]] : i8 to f32
+//       CHECK:     %[[ADD:.+]] = arith.addf %[[RND]], %[[ZF]] : f32
+//       CHECK:     %[[MIN:.+]] = arith.constant -1.280000e+02 : f32
+//       CHECK:     %[[MAX:.+]] = arith.constant 1.270000e+02 : f32
+//       CHECK:     %[[LO:.+]] = arith.maxnumf %[[ADD]], %[[MIN]] : f32
+//       CHECK:     %[[HI:.+]] = arith.minnumf %[[LO]], %[[MAX]] : f32
+//       CHECK:     %[[RES:.+]] = arith.fptosi %[[HI]] : f32 to i8
+//       CHECK:     linalg.yield %[[RES]]

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
@@ -120,6 +121,15 @@ static void addCleanupPatterns(OpPassManager &passManager) {
 
 static void addDispatchRegionCreationPreprocessingPasses(
     OpPassManager &passManager, const TransformOptions &dispatchOptions) {
+  // Lower the affine quantization ops to elementwise generics before fusion
+  // runs. Nothing past this point matches them by name.
+  FunctionLikeNest(passManager).addPass([]() {
+    return IREE::LinalgExt::createDecomposeAggregatedOpPass(
+        IREE::LinalgExt::DecomposeAggregatedOpPassOptions{
+            /*filterOps=*/"iree_linalg_ext.quantize_affine,"
+                          "iree_linalg_ext.dequantize_affine"});
+  });
+
   // 1. Do some simple elementwise op fusion. This could be skipped,
   //    but could reduce the surface area of ops to handle later.
   FunctionLikeNest(passManager)

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -468,3 +468,31 @@ util.func @split_reduction_2d_by_tiling(%arg0 : tensor<?x2048x128xf32>) -> tenso
 //       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[FORALL]]
 //       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.workgroups[%[[D0]]](%[[DISPATCH0]], %[[D0]])
 //       CHECK:   return %[[DISPATCH1]]
+
+// -----
+
+util.func public @quantization_ops_are_decomposed(%arg0: tensor<128x64xf32>,
+    %scale: tensor<128xf32>, %zp: tensor<128xi8>) -> tensor<128x64xf32> {
+  %qinit = tensor.empty() : tensor<128x64xi8>
+  %q = iree_linalg_ext.quantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>],
+       quant_min = -128 : i64, quant_max = 127 : i64}
+      ins(%arg0, %scale, %zp : tensor<128x64xf32>, tensor<128xf32>, tensor<128xi8>)
+      outs(%qinit : tensor<128x64xi8>) -> tensor<128x64xi8>
+  %dqinit = tensor.empty() : tensor<128x64xf32>
+  %dq = iree_linalg_ext.dequantize_affine
+      {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0)>,
+                        affine_map<(d0, d1) -> (d0, d1)>]}
+      ins(%q, %scale, %zp : tensor<128x64xi8>, tensor<128xf32>, tensor<128xi8>)
+      outs(%dqinit : tensor<128x64xf32>) -> tensor<128x64xf32>
+  util.return %dq : tensor<128x64xf32>
+}
+// CHECK-LABEL: util.func public @quantization_ops_are_decomposed
+//   CHECK-NOT:   iree_linalg_ext.quantize_affine
+//   CHECK-NOT:   iree_linalg_ext.dequantize_affine
+//       CHECK:   linalg.generic


### PR DESCRIPTION
Adds `iree_linalg_ext.quantize_affine` and `iree_linalg_ext.dequantize_affine` to represent QDQ directly in LinalgExt, preserving quantization parameters for subsequent compiler transformations.

Independent indexing maps for the input, scale, zero point, and output express per-tensor, per-channel, and blockwise quantization. The ops support optional zero points, explicit storage and zero-point signedness, and arithmetic in the scale's element type. Quantization rounds ties to even and clamps to the specified storage range.

Includes operation verification, shape reification, and decomposition into elementwise Linalg generics. Dispatch creation decomposes remaining QDQ ops before fusion, allowing earlier optimizations to consume the explicit quantization representation.

Implements the QDQ operation layer of [Linalg(_ext) native QDQ #24862](https://github.com/iree-org/iree/issues/24862).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
