### PR TITLE
publish_website: only publish from main, verify-only on release candidates

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -87,10 +87,22 @@ jobs:
           key: ${{ github.job }}
       - name: Building documentation files
         run: ./docs/website/generate_extra_files.sh
+      # Release candidate releases (tags like `iree-3.6.0rc20250910`) are
+      # published automatically by the candidate release workflows. Deploying
+      # the website from them would overwrite the site last published from
+      # main, so for those runs everything above only serves to verify that
+      # the website still builds and the deployment steps are skipped.
+      - name: Skipping deployment (release candidate)
+        if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'rc') }}
+        run: |
+          echo "Triggered by a release candidate release; skipping deploy to gh-pages."
+
       - name: Setting git config
+        if: ${{ github.event_name != 'release' || !contains(github.event.release.tag_name, 'rc') }}
         run: |
           git config --local user.email "iree-github-actions-bot@google.com"
           git config --local user.name "Website Publish Action"
       - name: Deploying to gh-pages
+        if: ${{ github.event_name != 'release' || !contains(github.event.release.tag_name, 'rc') }}
         working-directory: docs/website
         run: mkdocs gh-deploy


### PR DESCRIPTION
The Publish Website workflow is triggered by `release: [published, unpublished]` events. Release candidate releases (tags like `iree-3.6.0rc20250910`) go through the same path: the candidate release workflows create a draft prerelease, Build Release Packages fills it, and Validate and Publish Release publishes it -- which fires the `published` event and made Publish Website deploy the site from the RC, overwriting whatever main had last published (losing a blogpost recently).

Keep running the site build steps as verification, but skip the gh-pages deployment when the run was triggered by a release candidate release. Deployment still happens for main pushes, schedules, manual dispatches, and stable releases.

Fixes #24764

Assisted-by: Claude Code / glm-5.3-flash
