### PR TITLE
Integrate LLVM to llvm/llvm-project@6cce5bca3b90

### DIFF
--- a/compiler/plugins/target/ROCM/test/tuning_spec_mmt_tile_and_fuse.mlir
+++ b/compiler/plugins/target/ROCM/test/tuning_spec_mmt_tile_and_fuse.mlir
@@ -24,7 +24,7 @@ transform.named_sequence @match_mmt(%matmul: !transform.any_op {transform.readon
 
 transform.named_sequence @main(%variant_op: !transform.any_op {transform.consumed}) -> (!transform.any_op)
   attributes { iree_codegen.tuning_spec_entrypoint } {
-  transform.print %variant_op {name="Custom spec"} : !transform.any_op
+  transform.print %variant_op name="Custom spec" : !transform.any_op
   %res = transform.foreach_match in %variant_op
     @match_mmt -> @apply_op_config
     : (!transform.any_op) -> !transform.any_op

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1504,7 +1504,7 @@ func.func @lanes_fully_distributed(%out: memref<100x100xf32, #amdgpu.address_spa
 builtin.module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.test_gpu_vector_distribution %top_level_func {workgroup_size = array<i64: 256, 1, 1>} : !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func <{workgroup_size = array<i64: 256, 1, 1>}> : !transform.any_op
     transform.yield
   }
 }
@@ -1538,7 +1538,7 @@ func.func @threads_fully_distributed(%out: memref<100x100xf32, #amdgpu.address_s
 builtin.module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.test_gpu_vector_distribution %top_level_func {workgroup_size = array<i64: 64, 1, 1>} : !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func <{workgroup_size = array<i64: 64, 1, 1>}> : !transform.any_op
     transform.yield
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -190,7 +190,7 @@ func.func @reduction(%in: memref<2048xf32>, %out: memref<f32>) {
 builtin.module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.test_gpu_vector_distribution %top_level_func  {workgroup_size = array<i64: 512, 1, 1>}
+    transform.iree.test_gpu_vector_distribution %top_level_func  <{workgroup_size = array<i64: 512, 1, 1>}>
     : !transform.any_op
     transform.yield
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/transform_gpu_reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/transform_gpu_reduce_bank_conflicts.mlir
@@ -24,7 +24,7 @@ module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(
       %variant_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.reduce_shared_memory_bank_conflicts %0 { padding_size_bits = 64 } : (!transform.any_op) -> ()
+    transform.iree.reduce_shared_memory_bank_conflicts %0 <{ padding_size_bits = 64 }> : (!transform.any_op) -> ()
     transform.yield
   }
 } // module

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -17,10 +17,10 @@ include "mlir/Dialect/SCF/IR/DeviceMappingInterface.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 
-def ApplyBubbleCollapsePatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.bubble_collapse",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyBubbleCollapsePatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.bubble_collapse",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to fold an expanding tensor.expand_shape operation with
     its producer generic operation by collapsing the dimensions of the generic
@@ -31,10 +31,10 @@ def ApplyBubbleCollapsePatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyBubbleExpandPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.bubble_expand",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyBubbleExpandPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.bubble_expand",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to fold an expanding (collapsing) tensor_reshape
     operation with its producer (consumer) generic operation by expanding
@@ -45,10 +45,10 @@ def ApplyBubbleExpandPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyCollapseForallDestPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.collapse_forall_dest",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyCollapseForallDestPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.collapse_forall_dest",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to collapse the destination of scf.forall ops by hoisting
     expand_shape ops out of the parallel_insert_slice.
@@ -58,10 +58,10 @@ def ApplyCollapseForallDestPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyBubblePackUnpackPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.bubble_pack_unpack",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyBubblePackUnpackPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.bubble_pack_unpack",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to bubble up or down data layout ops across other
     operations.
@@ -71,10 +71,10 @@ def ApplyBubblePackUnpackPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyFoldFillIntoPadPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.fold_fill_into_pad",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyFoldFillIntoPadPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.fold_fill_into_pad",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populates a pattern that folds
     "tensor.pad(cst, tensor.extract*(linalg.fill(cst)))" into
@@ -86,10 +86,11 @@ def ApplyFoldFillIntoPadPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyFoldReshapeIntoTensorHalInterfacePatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.fold_reshape_into_tensor_hal_interface",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyFoldReshapeIntoTensorHalInterfacePatternsOp
+    : Op<Transform_Dialect,
+         "apply_patterns.iree.fold_reshape_into_tensor_hal_interface",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that fold tensor.expand_shape/tensor.collapse_shape into
     the source hal.interface.binding.subspan op.
@@ -99,9 +100,10 @@ def ApplyFoldReshapeIntoTensorHalInterfacePatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyFoldTensorSliceIntoTransferPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.fold_tensor_slice_into_transfer",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+def ApplyFoldTensorSliceIntoTransferPatternsOp
+    : Op<Transform_Dialect,
+         "apply_patterns.iree.fold_tensor_slice_into_transfer",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
   let description = [{
     Indicates that tensor.extract_slice -> vector.transfer_read and
     vector.transfer_write -> tensor.insert_slice op chains should be folded into
@@ -112,9 +114,9 @@ def ApplyFoldTensorSliceIntoTransferPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyHoistForallFromForPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.hoist_forall_from_for",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+def ApplyHoistForallFromForPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.hoist_forall_from_for",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
   let description = [{
     Hoists perfectly nested `scf.forall` ops from parent `scf.for` ops if
     the slice the forall loop operates on is loop invariant w.r.t. the for loop.
@@ -130,10 +132,11 @@ def ApplyHoistForallFromForPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyIREELinalgElementwiseGreedyFusionPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.linalg_elementwise_greedy_fusion",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyIREELinalgElementwiseGreedyFusionPatternsOp
+    : Op<Transform_Dialect,
+         "apply_patterns.iree.linalg_elementwise_greedy_fusion",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to fuse `linalg.generic` -> `linalg.generic` operations
     when both operations are fusable elementwise operations.
@@ -146,10 +149,10 @@ def ApplyIREELinalgElementwiseGreedyFusionPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyPrepareVectorToMMAPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.prepare_vector_to_mma",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyPrepareVectorToMMAPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.prepare_vector_to_mma",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that transform vector ops into a canonical form to
     convert to MMA matrix operations. If `useNvGpu` is true, then the patterns
@@ -159,13 +162,13 @@ def ApplyPrepareVectorToMMAPatternsOp : Op<Transform_Dialect,
 
   let arguments = (ins DefaultValuedAttr<BoolAttr, "true">:$useNvGpu);
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-  let assemblyFormat = "attr-dict";
+  let assemblyFormat = "prop-dict attr-dict";
 }
 
-def ApplyUnrollVectorsGpuMmaSyncPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.unroll_vectors_gpu_mma_sync",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyUnrollVectorsGpuMmaSyncPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.unroll_vectors_gpu_mma_sync",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that unroll vectors. TODO: better documentation.
   }];
@@ -174,10 +177,10 @@ def ApplyUnrollVectorsGpuMmaSyncPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyUnrollVectorsGpuWmmaSyncPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.unroll_vectors_gpu_wmma_sync",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyUnrollVectorsGpuWmmaSyncPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.unroll_vectors_gpu_wmma_sync",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that unroll vectors. TODO: better documentation.
   }];
@@ -186,12 +189,11 @@ def ApplyUnrollVectorsGpuWmmaSyncPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def CopyTensorOperandOp :  Op<Transform_Dialect, "iree.copy_tensor_operand",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     FunctionalStyleTransformOpTrait,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def CopyTensorOperandOp
+    : Op<Transform_Dialect, "iree.copy_tensor_operand",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          FunctionalStyleTransformOpTrait, TransformEachOpTrait,
+          TransformOpInterface, ReportTrackingListenerFailuresOpTrait]> {
   let summary = [{Create a linalg copy of a specified value.}];
   let description = [{
     Inserts a copy of the specified operand of the target operation.
@@ -203,9 +205,8 @@ def CopyTensorOperandOp :  Op<Transform_Dialect, "iree.copy_tensor_operand",
     operand index is out of range or if the operand is not a tensor type.
   }];
 
-  let arguments = (ins
-    TransformHandleTypeInterface:$target,
-    I64Attr:$operand_index);
+  let arguments = (ins TransformHandleTypeInterface:$target,
+      I64Attr:$operand_index);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{
@@ -223,10 +224,10 @@ def CopyTensorOperandOp :  Op<Transform_Dialect, "iree.copy_tensor_operand",
   }];
 }
 
-def GpuDistributeSharedMemoryCopyOp :
-  Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformOpInterface, TransformEachOpTrait]> {
+def GpuDistributeSharedMemoryCopyOp
+    : Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformOpInterface, TransformEachOpTrait]> {
   let summary = [{Distribute shared memory copies.}];
   let description = [{
     Find copies to/from shared memory and distribute the copies based on the
@@ -240,7 +241,8 @@ def GpuDistributeSharedMemoryCopyOp :
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -252,11 +254,11 @@ def GpuDistributeSharedMemoryCopyOp :
   }];
 }
 
-def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def HoistStaticAllocOp
+    : Op<Transform_Dialect, "iree.hoist_static_alloc",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let summary = [{Hoist static allocations.}];
   let description = [{
     Find static allocations and hoist them to the top level.
@@ -270,7 +272,8 @@ def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -282,11 +285,11 @@ def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
   }];
 }
 
-def FlattenForallMappingOp : Op<Transform_Dialect, "iree.flatten_forall_mapping",
-    [TransformEachOpTrait,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def FlattenForallMappingOp
+    : Op<Transform_Dialect, "iree.flatten_forall_mapping",
+         [TransformEachOpTrait,
+          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformOpInterface, ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Flattens the thread mapping of an `scf.forall` op.
 
@@ -313,12 +316,11 @@ def FlattenForallMappingOp : Op<Transform_Dialect, "iree.flatten_forall_mapping"
   }];
 }
 
-def ForallToWorkgroupOp : Op<Transform_Dialect,
-    "iree.forall_to_workgroup",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ForallToWorkgroupOp
+    : Op<Transform_Dialect, "iree.forall_to_workgroup",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target the whole hal.executable_variant op and rewrite the unique topLevel
     scf.forall to distributed workgroup_id and workgroup_count.
@@ -358,7 +360,8 @@ def ForallToWorkgroupOp : Op<Transform_Dialect,
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -370,11 +373,11 @@ def ForallToWorkgroupOp : Op<Transform_Dialect,
   }];
 }
 
-def IREEApplyLoopIndependentCodeMotionOp : Op<Transform_Dialect, "iree.apply_licm",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def IREEApplyLoopIndependentCodeMotionOp
+    : Op<Transform_Dialect, "iree.apply_licm",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Apply loop-independent code motion and single iteration loop promotion.
     This transform is applied to all FuncOps within the target. Distinguished
@@ -400,11 +403,11 @@ def IREEApplyLoopIndependentCodeMotionOp : Op<Transform_Dialect, "iree.apply_lic
   }];
 }
 
-def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     DeclareOpInterfaceMethods<TransformOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def IREEBufferizeOp
+    : Op<Transform_Dialect, "iree.bufferize",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          DeclareOpInterfaceMethods<TransformOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target the whole hal.executable_variant op and call upstream comprehensive
     bufferize with extra IREE hooks.
@@ -427,31 +430,25 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
     This transform consumes the target handle and produces a result handle.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$target,
-          UnitAttr:$target_gpu,
-          UnitAttr:$test_analysis_only,
-          UnitAttr:$print_conflicts
-  );
+  let arguments = (ins TransformHandleTypeInterface:$target,
+      UnitAttr:$target_gpu, UnitAttr:$test_analysis_only,
+      UnitAttr:$print_conflicts);
   let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat = "attr-dict $target `:` functional-type($target, results)";
+  let assemblyFormat =
+      "prop-dict attr-dict $target `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let builders = [
-    OpBuilder<(ins "Value":$target,
-                   CArg<"bool", "false">:$targetGpu,
-                   CArg<"bool", "false">:$testAnalysisOnly,
-                   CArg<"bool", "false">:$printConflicts)>
-  ];
+  let builders = [OpBuilder<(ins "Value":$target,
+      CArg<"bool", "false">:$targetGpu, CArg<"bool", "false">:$testAnalysisOnly,
+      CArg<"bool", "false">:$printConflicts)>];
 }
 
-def IREEEliminateEmptyTensorsOp : Op<
-    Transform_Dialect, "iree.eliminate_empty_tensors",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def IREEEliminateEmptyTensorsOp
+    : Op<Transform_Dialect, "iree.eliminate_empty_tensors",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This is a pre-processing pass for iree.bufferize. It tries to remove
     tensor.empty ops by replacing them with suitable destination tensors,
@@ -468,7 +465,8 @@ def IREEEliminateEmptyTensorsOp : Op<
 
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
-  let assemblyFormat = "attr-dict $target `:` functional-type($target, results)";
+  let assemblyFormat =
+      "attr-dict $target `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -479,10 +477,9 @@ def IREEEliminateEmptyTensorsOp : Op<
   }];
 }
 
-def MatchHasNoLoweringConfigOp : Op<Transform_Dialect, "iree.match.has_no_lowering_config",
-    [MatchOpInterface,
-     SingleOpMatcher,
-     MemoryEffectsOpInterface]> {
+def MatchHasNoLoweringConfigOp
+    : Op<Transform_Dialect, "iree.match.has_no_lowering_config",
+         [MatchOpInterface, SingleOpMatcher, MemoryEffectsOpInterface]> {
   let summary = [{
     Checks that the payload op does not carry a lowering config or compilation info.
   }];
@@ -506,12 +503,12 @@ def MatchHasNoLoweringConfigOp : Op<Transform_Dialect, "iree.match.has_no_loweri
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
-def PopulateWorkgroupCountRegionUsingNumThreadsSliceOp :
-    Op<Transform_Dialect, "iree.populate_workgroup_count_region_using_num_threads_slice",
-      [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-       TransformEachOpTrait,
-       TransformOpInterface,
-       ReportTrackingListenerFailuresOpTrait]> {
+def PopulateWorkgroupCountRegionUsingNumThreadsSliceOp
+    : Op<Transform_Dialect,
+         "iree.populate_workgroup_count_region_using_num_threads_slice",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate the `iree_codegen.dispatch_config` workgroup count region.
 
@@ -537,12 +534,13 @@ def PopulateWorkgroupCountRegionUsingNumThreadsSliceOp :
   }];
 }
 
-def ReduceSharedMemoryBankConflictsOp :  Op<Transform_Dialect, "iree.reduce_shared_memory_bank_conflicts",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
-  let summary = [{Add padding to 'memref.alloc' ops reduce shared memory bank conflicts.}];
+def ReduceSharedMemoryBankConflictsOp
+    : Op<Transform_Dialect, "iree.reduce_shared_memory_bank_conflicts",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
+  let summary =
+      [{Add padding to 'memref.alloc' ops reduce shared memory bank conflicts.}];
   let description = [{
     The `paddingSizeBits` argument should be picked based on the target
     architecture, striking balance between minimizing bank conflicts and keeping
@@ -555,13 +553,12 @@ def ReduceSharedMemoryBankConflictsOp :  Op<Transform_Dialect, "iree.reduce_shar
     This transform does not consume the target handle and always return success.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$target,
-          DefaultValuedOptionalAttr<I64Attr, "64">:$padding_size_bits
-  );
+  let arguments = (ins TransformHandleTypeInterface:$target,
+      DefaultValuedOptionalAttr<I64Attr, "64">:$padding_size_bits);
   let results = (outs);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat =
+      "$target prop-dict attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -573,13 +570,11 @@ def ReduceSharedMemoryBankConflictsOp :  Op<Transform_Dialect, "iree.reduce_shar
   }];
 }
 
-def ShareForallOperandsOp : Op<
-    Transform_Dialect, "iree.share_forall_operands", [
-      FunctionalStyleTransformOpTrait,
-      MemoryEffectsOpInterface,
-      TransformEachOpTrait,
-      TransformOpInterface,
-      ReportTrackingListenerFailuresOpTrait]> {
+def ShareForallOperandsOp
+    : Op<Transform_Dialect, "iree.share_forall_operands",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target a single scf.forall op and shares all uses of the specified
     `share_operands` operand indices.
@@ -624,10 +619,8 @@ def ShareForallOperandsOp : Op<
     the modified `scf.forall` op.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$forall_op,
-          DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$share_operands
-  );
+  let arguments = (ins TransformHandleTypeInterface:$forall_op,
+      DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$share_operands);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -646,12 +639,11 @@ def ShareForallOperandsOp : Op<
   }];
 }
 
-def TestGpuVectorDistribution :
-  Op<Transform_Dialect, "iree.test_gpu_vector_distribution",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def TestGpuVectorDistribution
+    : Op<Transform_Dialect, "iree.test_gpu_vector_distribution",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Run GPUVectorDistribution on the target as the root.
 
@@ -669,16 +661,16 @@ def TestGpuVectorDistribution :
     This transform does not consume the target handle and always return success.
     }];
 
-    let arguments = (ins TransformHandleTypeInterface:$target,
-                         DefaultValuedOptionalAttr<BoolAttr, "false">:$experimental,
-                         DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_size,
-                         DefaultValuedOptionalAttr<I64Attr, "64">:$subgroup_size);
-    let results = (outs);
+  let arguments = (ins TransformHandleTypeInterface:$target,
+      DefaultValuedOptionalAttr<BoolAttr, "false">:$experimental,
+      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_size,
+      DefaultValuedOptionalAttr<I64Attr, "64">:$subgroup_size);
+  let results = (outs);
 
-    let assemblyFormat = [{ $target attr-dict `:` type($target)}];
-    let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let assemblyFormat = [{ $target prop-dict attr-dict `:` type($target)}];
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-    let extraClassDeclaration = [{
+  let extraClassDeclaration = [{
       ::mlir::DiagnosedSilenceableFailure applyToOne(
           ::mlir::transform::TransformRewriter &rewriter,
           ::mlir::FunctionOpInterface funcOp,
@@ -688,20 +680,19 @@ def TestGpuVectorDistribution :
 }
 
 def FuseConsumerOp : Op<Transform_Dialect, "iree.fuse_consumer",
-       [DeclareOpInterfaceMethods<TransformOpInterface>,
-        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-        ReportTrackingListenerFailuresOpTrait]> {
+                        [DeclareOpInterfaceMethods<TransformOpInterface>,
+                         DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                         ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Fuses the consumer of the operation pointed to by the target handle
     using the options provided as attributes.
   }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let arguments =(ins
-      TransformHandleTypeInterface:$target,
+  let arguments = (ins TransformHandleTypeInterface:$target,
       Variadic<TransformHandleTypeInterface>:$loops);
   let results = (outs TransformHandleTypeInterface:$consumer,
-                      TransformHandleTypeInterface:$fused_consumer);
+      TransformHandleTypeInterface:$fused_consumer);
 
   let assemblyFormat = [{
     $target `in` `(` $loops `)` attr-dict `:` functional-type(operands, results)

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -17,10 +17,10 @@ include "mlir/Dialect/SCF/IR/DeviceMappingInterface.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 
-def ApplyBubbleCollapsePatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.bubble_collapse",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyBubbleCollapsePatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.bubble_collapse",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to fold an expanding tensor.expand_shape operation with
     its producer generic operation by collapsing the dimensions of the generic
@@ -31,10 +31,10 @@ def ApplyBubbleCollapsePatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyBubbleExpandPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.bubble_expand",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyBubbleExpandPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.bubble_expand",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to fold an expanding (collapsing) tensor_reshape
     operation with its producer (consumer) generic operation by expanding
@@ -45,10 +45,10 @@ def ApplyBubbleExpandPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyCollapseForallDestPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.collapse_forall_dest",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyCollapseForallDestPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.collapse_forall_dest",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to collapse the destination of scf.forall ops by hoisting
     expand_shape ops out of the parallel_insert_slice.
@@ -58,10 +58,10 @@ def ApplyCollapseForallDestPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyBubblePackUnpackPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.bubble_pack_unpack",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyBubblePackUnpackPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.bubble_pack_unpack",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to bubble up or down data layout ops across other
     operations.
@@ -71,10 +71,10 @@ def ApplyBubblePackUnpackPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyFoldFillIntoPadPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.fold_fill_into_pad",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyFoldFillIntoPadPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.fold_fill_into_pad",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populates a pattern that folds
     "tensor.pad(cst, tensor.extract*(linalg.fill(cst)))" into
@@ -86,11 +86,10 @@ def ApplyFoldFillIntoPadPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyFoldReshapeIntoTensorHalInterfacePatternsOp
-    : Op<Transform_Dialect,
-         "apply_patterns.iree.fold_reshape_into_tensor_hal_interface",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyFoldReshapeIntoTensorHalInterfacePatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.fold_reshape_into_tensor_hal_interface",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that fold tensor.expand_shape/tensor.collapse_shape into
     the source hal.interface.binding.subspan op.
@@ -100,10 +99,9 @@ def ApplyFoldReshapeIntoTensorHalInterfacePatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyFoldTensorSliceIntoTransferPatternsOp
-    : Op<Transform_Dialect,
-         "apply_patterns.iree.fold_tensor_slice_into_transfer",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+def ApplyFoldTensorSliceIntoTransferPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.fold_tensor_slice_into_transfer",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
   let description = [{
     Indicates that tensor.extract_slice -> vector.transfer_read and
     vector.transfer_write -> tensor.insert_slice op chains should be folded into
@@ -114,9 +112,9 @@ def ApplyFoldTensorSliceIntoTransferPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyHoistForallFromForPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.hoist_forall_from_for",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+def ApplyHoistForallFromForPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.hoist_forall_from_for",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
   let description = [{
     Hoists perfectly nested `scf.forall` ops from parent `scf.for` ops if
     the slice the forall loop operates on is loop invariant w.r.t. the for loop.
@@ -132,11 +130,10 @@ def ApplyHoistForallFromForPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyIREELinalgElementwiseGreedyFusionPatternsOp
-    : Op<Transform_Dialect,
-         "apply_patterns.iree.linalg_elementwise_greedy_fusion",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyIREELinalgElementwiseGreedyFusionPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.linalg_elementwise_greedy_fusion",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to fuse `linalg.generic` -> `linalg.generic` operations
     when both operations are fusable elementwise operations.
@@ -149,10 +146,10 @@ def ApplyIREELinalgElementwiseGreedyFusionPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyPrepareVectorToMMAPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.prepare_vector_to_mma",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyPrepareVectorToMMAPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.prepare_vector_to_mma",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that transform vector ops into a canonical form to
     convert to MMA matrix operations. If `useNvGpu` is true, then the patterns
@@ -165,10 +162,10 @@ def ApplyPrepareVectorToMMAPatternsOp
   let assemblyFormat = "prop-dict attr-dict";
 }
 
-def ApplyUnrollVectorsGpuMmaSyncPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.unroll_vectors_gpu_mma_sync",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyUnrollVectorsGpuMmaSyncPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.unroll_vectors_gpu_mma_sync",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that unroll vectors. TODO: better documentation.
   }];
@@ -177,10 +174,10 @@ def ApplyUnrollVectorsGpuMmaSyncPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyUnrollVectorsGpuWmmaSyncPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.unroll_vectors_gpu_wmma_sync",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyUnrollVectorsGpuWmmaSyncPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.unroll_vectors_gpu_wmma_sync",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that unroll vectors. TODO: better documentation.
   }];
@@ -189,11 +186,12 @@ def ApplyUnrollVectorsGpuWmmaSyncPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def CopyTensorOperandOp
-    : Op<Transform_Dialect, "iree.copy_tensor_operand",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          FunctionalStyleTransformOpTrait, TransformEachOpTrait,
-          TransformOpInterface, ReportTrackingListenerFailuresOpTrait]> {
+def CopyTensorOperandOp :  Op<Transform_Dialect, "iree.copy_tensor_operand",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     FunctionalStyleTransformOpTrait,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let summary = [{Create a linalg copy of a specified value.}];
   let description = [{
     Inserts a copy of the specified operand of the target operation.
@@ -205,8 +203,9 @@ def CopyTensorOperandOp
     operand index is out of range or if the operand is not a tensor type.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
-      I64Attr:$operand_index);
+  let arguments = (ins
+    TransformHandleTypeInterface:$target,
+    I64Attr:$operand_index);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{
@@ -224,10 +223,10 @@ def CopyTensorOperandOp
   }];
 }
 
-def GpuDistributeSharedMemoryCopyOp
-    : Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformOpInterface, TransformEachOpTrait]> {
+def GpuDistributeSharedMemoryCopyOp :
+  Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformOpInterface, TransformEachOpTrait]> {
   let summary = [{Distribute shared memory copies.}];
   let description = [{
     Find copies to/from shared memory and distribute the copies based on the
@@ -241,8 +240,7 @@ def GpuDistributeSharedMemoryCopyOp
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat =
-      "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -254,11 +252,11 @@ def GpuDistributeSharedMemoryCopyOp
   }];
 }
 
-def HoistStaticAllocOp
-    : Op<Transform_Dialect, "iree.hoist_static_alloc",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let summary = [{Hoist static allocations.}];
   let description = [{
     Find static allocations and hoist them to the top level.
@@ -272,8 +270,7 @@ def HoistStaticAllocOp
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat =
-      "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -285,11 +282,11 @@ def HoistStaticAllocOp
   }];
 }
 
-def FlattenForallMappingOp
-    : Op<Transform_Dialect, "iree.flatten_forall_mapping",
-         [TransformEachOpTrait,
-          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformOpInterface, ReportTrackingListenerFailuresOpTrait]> {
+def FlattenForallMappingOp : Op<Transform_Dialect, "iree.flatten_forall_mapping",
+    [TransformEachOpTrait,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Flattens the thread mapping of an `scf.forall` op.
 
@@ -316,11 +313,12 @@ def FlattenForallMappingOp
   }];
 }
 
-def ForallToWorkgroupOp
-    : Op<Transform_Dialect, "iree.forall_to_workgroup",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ForallToWorkgroupOp : Op<Transform_Dialect,
+    "iree.forall_to_workgroup",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target the whole hal.executable_variant op and rewrite the unique topLevel
     scf.forall to distributed workgroup_id and workgroup_count.
@@ -360,8 +358,7 @@ def ForallToWorkgroupOp
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat =
-      "$target attr-dict `:` functional-type($target, results)";
+  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -373,11 +370,11 @@ def ForallToWorkgroupOp
   }];
 }
 
-def IREEApplyLoopIndependentCodeMotionOp
-    : Op<Transform_Dialect, "iree.apply_licm",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def IREEApplyLoopIndependentCodeMotionOp : Op<Transform_Dialect, "iree.apply_licm",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Apply loop-independent code motion and single iteration loop promotion.
     This transform is applied to all FuncOps within the target. Distinguished
@@ -403,11 +400,11 @@ def IREEApplyLoopIndependentCodeMotionOp
   }];
 }
 
-def IREEBufferizeOp
-    : Op<Transform_Dialect, "iree.bufferize",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          DeclareOpInterfaceMethods<TransformOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target the whole hal.executable_variant op and call upstream comprehensive
     bufferize with extra IREE hooks.
@@ -430,25 +427,31 @@ def IREEBufferizeOp
     This transform consumes the target handle and produces a result handle.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
-      UnitAttr:$target_gpu, UnitAttr:$test_analysis_only,
-      UnitAttr:$print_conflicts);
+  let arguments = (
+      ins TransformHandleTypeInterface:$target,
+          UnitAttr:$target_gpu,
+          UnitAttr:$test_analysis_only,
+          UnitAttr:$print_conflicts
+  );
   let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat =
-      "prop-dict attr-dict $target `:` functional-type($target, results)";
+  let assemblyFormat = "prop-dict attr-dict $target `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let builders = [OpBuilder<(ins "Value":$target,
-      CArg<"bool", "false">:$targetGpu, CArg<"bool", "false">:$testAnalysisOnly,
-      CArg<"bool", "false">:$printConflicts)>];
+  let builders = [
+    OpBuilder<(ins "Value":$target,
+                   CArg<"bool", "false">:$targetGpu,
+                   CArg<"bool", "false">:$testAnalysisOnly,
+                   CArg<"bool", "false">:$printConflicts)>
+  ];
 }
 
-def IREEEliminateEmptyTensorsOp
-    : Op<Transform_Dialect, "iree.eliminate_empty_tensors",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def IREEEliminateEmptyTensorsOp : Op<
+    Transform_Dialect, "iree.eliminate_empty_tensors",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This is a pre-processing pass for iree.bufferize. It tries to remove
     tensor.empty ops by replacing them with suitable destination tensors,
@@ -465,8 +468,7 @@ def IREEEliminateEmptyTensorsOp
 
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
-  let assemblyFormat =
-      "attr-dict $target `:` functional-type($target, results)";
+  let assemblyFormat = "attr-dict $target `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -477,9 +479,10 @@ def IREEEliminateEmptyTensorsOp
   }];
 }
 
-def MatchHasNoLoweringConfigOp
-    : Op<Transform_Dialect, "iree.match.has_no_lowering_config",
-         [MatchOpInterface, SingleOpMatcher, MemoryEffectsOpInterface]> {
+def MatchHasNoLoweringConfigOp : Op<Transform_Dialect, "iree.match.has_no_lowering_config",
+    [MatchOpInterface,
+     SingleOpMatcher,
+     MemoryEffectsOpInterface]> {
   let summary = [{
     Checks that the payload op does not carry a lowering config or compilation info.
   }];
@@ -503,12 +506,12 @@ def MatchHasNoLoweringConfigOp
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
-def PopulateWorkgroupCountRegionUsingNumThreadsSliceOp
-    : Op<Transform_Dialect,
-         "iree.populate_workgroup_count_region_using_num_threads_slice",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def PopulateWorkgroupCountRegionUsingNumThreadsSliceOp :
+    Op<Transform_Dialect, "iree.populate_workgroup_count_region_using_num_threads_slice",
+      [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+       TransformEachOpTrait,
+       TransformOpInterface,
+       ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate the `iree_codegen.dispatch_config` workgroup count region.
 
@@ -534,13 +537,12 @@ def PopulateWorkgroupCountRegionUsingNumThreadsSliceOp
   }];
 }
 
-def ReduceSharedMemoryBankConflictsOp
-    : Op<Transform_Dialect, "iree.reduce_shared_memory_bank_conflicts",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
-  let summary =
-      [{Add padding to 'memref.alloc' ops reduce shared memory bank conflicts.}];
+def ReduceSharedMemoryBankConflictsOp :  Op<Transform_Dialect, "iree.reduce_shared_memory_bank_conflicts",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let summary = [{Add padding to 'memref.alloc' ops reduce shared memory bank conflicts.}];
   let description = [{
     The `paddingSizeBits` argument should be picked based on the target
     architecture, striking balance between minimizing bank conflicts and keeping
@@ -553,12 +555,13 @@ def ReduceSharedMemoryBankConflictsOp
     This transform does not consume the target handle and always return success.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
-      DefaultValuedOptionalAttr<I64Attr, "64">:$padding_size_bits);
+  let arguments = (
+      ins TransformHandleTypeInterface:$target,
+          DefaultValuedOptionalAttr<I64Attr, "64">:$padding_size_bits
+  );
   let results = (outs);
 
-  let assemblyFormat =
-      "$target prop-dict attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat = "$target prop-dict attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -570,11 +573,13 @@ def ReduceSharedMemoryBankConflictsOp
   }];
 }
 
-def ShareForallOperandsOp
-    : Op<Transform_Dialect, "iree.share_forall_operands",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ShareForallOperandsOp : Op<
+    Transform_Dialect, "iree.share_forall_operands", [
+      FunctionalStyleTransformOpTrait,
+      MemoryEffectsOpInterface,
+      TransformEachOpTrait,
+      TransformOpInterface,
+      ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target a single scf.forall op and shares all uses of the specified
     `share_operands` operand indices.
@@ -619,8 +624,10 @@ def ShareForallOperandsOp
     the modified `scf.forall` op.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$forall_op,
-      DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$share_operands);
+  let arguments = (
+      ins TransformHandleTypeInterface:$forall_op,
+          DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$share_operands
+  );
   let results = (outs TransformHandleTypeInterface:$result);
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -639,11 +646,12 @@ def ShareForallOperandsOp
   }];
 }
 
-def TestGpuVectorDistribution
-    : Op<Transform_Dialect, "iree.test_gpu_vector_distribution",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def TestGpuVectorDistribution :
+  Op<Transform_Dialect, "iree.test_gpu_vector_distribution",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Run GPUVectorDistribution on the target as the root.
 
@@ -661,16 +669,16 @@ def TestGpuVectorDistribution
     This transform does not consume the target handle and always return success.
     }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
-      DefaultValuedOptionalAttr<BoolAttr, "false">:$experimental,
-      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_size,
-      DefaultValuedOptionalAttr<I64Attr, "64">:$subgroup_size);
-  let results = (outs);
+    let arguments = (ins TransformHandleTypeInterface:$target,
+                         DefaultValuedOptionalAttr<BoolAttr, "false">:$experimental,
+                         DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_size,
+                         DefaultValuedOptionalAttr<I64Attr, "64">:$subgroup_size);
+    let results = (outs);
 
-  let assemblyFormat = [{ $target prop-dict attr-dict `:` type($target)}];
-  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+    let assemblyFormat = [{ $target prop-dict attr-dict `:` type($target)}];
+    let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let extraClassDeclaration = [{
+    let extraClassDeclaration = [{
       ::mlir::DiagnosedSilenceableFailure applyToOne(
           ::mlir::transform::TransformRewriter &rewriter,
           ::mlir::FunctionOpInterface funcOp,
@@ -680,19 +688,20 @@ def TestGpuVectorDistribution
 }
 
 def FuseConsumerOp : Op<Transform_Dialect, "iree.fuse_consumer",
-                        [DeclareOpInterfaceMethods<TransformOpInterface>,
-                         DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                         ReportTrackingListenerFailuresOpTrait]> {
+       [DeclareOpInterfaceMethods<TransformOpInterface>,
+        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+        ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Fuses the consumer of the operation pointed to by the target handle
     using the options provided as attributes.
   }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
+  let arguments =(ins
+      TransformHandleTypeInterface:$target,
       Variadic<TransformHandleTypeInterface>:$loops);
   let results = (outs TransformHandleTypeInterface:$consumer,
-      TransformHandleTypeInterface:$fused_consumer);
+                      TransformHandleTypeInterface:$fused_consumer);
 
   let assemblyFormat = [{
     $target `in` `(` $loops `)` attr-dict `:` functional-type(operands, results)

--- a/compiler/src/iree/compiler/Codegen/Common/test/external_strategy_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/external_strategy_spec.mlir
@@ -2,7 +2,7 @@
 
 module @user_spec attributes { transform.with_named_sequence } {
   transform.named_sequence @lowering_strategy(%op: !transform.any_op {transform.readonly}) {
-    transform.print {name = "I am external", skip_regions}
+    transform.print name = "I am external" skip_regions
     transform.yield
   }
   transform.named_sequence @import_lowering_strategy(%op: !transform.any_op {transform.readonly}) -> !transform.any_op

--- a/compiler/src/iree/compiler/Codegen/Common/test/link_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/link_tuning_specs.mlir
@@ -17,7 +17,7 @@ module @td_module_0 attributes { transform.with_named_sequence } {
   module @foo_module attributes { transform.with_named_sequence } {
     transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
       attributes { iree_codegen.tuning_spec_entrypoint } {
-      transform.print {name = "Foo", skip_regions}
+      transform.print name = "Foo" skip_regions
       transform.yield %arg0 : !transform.any_op
     }
   }
@@ -26,7 +26,7 @@ module @td_module_0 attributes { transform.with_named_sequence } {
     transform.named_sequence @bar(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
       attributes { iree_codegen.tuning_spec_entrypoint } {
       transform.match.operation_name %arg0 ["func.func"] : !transform.any_op
-      transform.print {name = "Bar", skip_regions}
+      transform.print name = "Bar" skip_regions
       transform.yield %arg0 : !transform.any_op
     }
   }
@@ -34,7 +34,7 @@ module @td_module_0 attributes { transform.with_named_sequence } {
   module @baz_module attributes { transform.with_named_sequence } {
     transform.named_sequence @baz(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
       attributes { iree_codegen.tuning_spec_entrypoint } {
-      transform.print {name = "Baz", skip_regions}
+      transform.print name = "Baz" skip_regions
       transform.yield %arg0 : !transform.any_op
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/lowering_config_interpreter.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lowering_config_interpreter.mlir
@@ -31,15 +31,15 @@ module attributes { transform.with_named_sequence } {
   }
 
   transform.named_sequence @print_one(%op: !transform.any_op {transform.readonly}) {
-    transform.print %op {name = "one"} : !transform.any_op
+    transform.print %op name = "one" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_two(%op: !transform.any_op {transform.readonly}) {
-    transform.print %op {name = "two"} : !transform.any_op
+    transform.print %op name = "two" : !transform.any_op
     transform.yield
   }
   transform.named_sequence @print_three(%op: !transform.any_op {transform.readonly}) {
-    transform.print %op {name = "three"} : !transform.any_op
+    transform.print %op name = "three" : !transform.any_op
     transform.yield
   }
 }
@@ -73,7 +73,7 @@ module attributes { transform.with_named_sequence } {
   }
 
   transform.named_sequence @lowering_strategy(%op: !transform.any_op {transform.readonly}) {
-    transform.print {name = "I am internal"}
+    transform.print name = "I am internal"
     transform.yield
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
@@ -31,7 +31,7 @@
 // SKIPLINK-LABEL: module @user_spec
 // SKIPLINK-SAME:    iree_codegen.tuning_spec_with_default_entrypoint
 // SKIPLINK-SAME:    transform.with_named_sequence
-// SKIPLINK:         transform.print {name = "Hello Tuning Spec"}
+// SKIPLINK:         transform.print name = "Hello Tuning Spec"
 // SKIPLINK-NOT:    module @{{.+}}
 // SKIPLINK:        module attributes
 // SKIPLINK-SAME:     iree_codegen.tuning_spec_mlirbc = dense<{{.+}}> : vector<{{[0-9]+}}xi8>

--- a/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec.mlir
@@ -3,7 +3,7 @@
 module @user_spec attributes { transform.with_named_sequence } {
   transform.named_sequence @hello(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
     attributes { iree_codegen.tuning_spec_entrypoint } {
-    transform.print {name = "Hello Tuning Spec", skip_regions}
+    transform.print name = "Hello Tuning Spec" skip_regions
     transform.yield %arg0 : !transform.any_op
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec_default.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec_default.mlir
@@ -2,7 +2,7 @@
 
 module @user_spec attributes { transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint } {
   transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
-    transform.print {name = "Hello Tuning Spec"}
+    transform.print name = "Hello Tuning Spec"
     transform.yield %arg : !transform.any_op
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -147,7 +147,7 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
     // expected-error @+1{{'__kernel_config' must start with 'ForeachMatchOp' (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
     transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
         -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-        transform.print {name = "Hello"}
+        transform.print name = "Hello"
         transform.yield %arg0 : !transform.any_op
     }
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -242,7 +242,9 @@ def IREEGPU_InnerTiledSemanticsAttr
 //===----------------------------------------------------------------------===//
 
 class IREEGPU_MmaEnumAttr<EnumAttrInfo enumInfo, string name = "">
-  : EnumAttr<IREEGPU_Dialect, enumInfo, name>;
+  : EnumAttr<IREEGPU_Dialect, enumInfo, name> {
+  let assemblyFormat = "$value";
+}
 
 def IREEGPU_MMAIntrinsicAttr
   : IREEGPU_MmaEnumAttr<IREEGPU_MMAIntrinsic, "mma_intrinsic">;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
@@ -16,10 +16,10 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def ApplyDropInnerTiledOpUnitDims : Op<Transform_Dialect,
-    "apply_patterns.iree.drop_inner_tiled_unit_dims",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyDropInnerTiledOpUnitDims
+    : Op<Transform_Dialect, "apply_patterns.iree.drop_inner_tiled_unit_dims",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to drop the unit dims from inner_tiled ops with
     only unit iteration bounds.
@@ -29,10 +29,10 @@ def ApplyDropInnerTiledOpUnitDims : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyLowerInnerTiledOp : Op<Transform_Dialect,
-    "apply_patterns.iree.lower_inner_tiled",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyLowerInnerTiledOp
+    : Op<Transform_Dialect, "apply_patterns.iree.lower_inner_tiled",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to lowering inner_tiled ops to the intrinsic specified by
     the |kind| attribute.
@@ -42,10 +42,10 @@ def ApplyLowerInnerTiledOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyLowerBarrierRegionPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.iree.lower_barrier_region",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyLowerBarrierRegionPatternsOp
+    : Op<Transform_Dialect, "apply_patterns.iree.lower_barrier_region",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that lowers iree_gpu.barrier_region ops to allocations
     and copies.
@@ -55,10 +55,10 @@ def ApplyLowerBarrierRegionPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyLowerValueBarrierOp : Op<Transform_Dialect,
-    "apply_patterns.iree.lower_value_barrier",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyLowerValueBarrierOp
+    : Op<Transform_Dialect, "apply_patterns.iree.lower_value_barrier",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to convert value barriers on vectors into gpu.barrier ops.
     Barriers on tensors are ignored.
@@ -68,10 +68,10 @@ def ApplyLowerValueBarrierOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyUnrollMultiMmaOp : Op<Transform_Dialect,
-    "apply_patterns.iree.unroll_multi_mma",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ApplyUnrollMultiMmaOp
+    : Op<Transform_Dialect, "apply_patterns.iree.unroll_multi_mma",
+         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to unroll iree_gpu.multi_mma ops to a single intrinsic.
   }];
@@ -80,11 +80,11 @@ def ApplyUnrollMultiMmaOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ConvertToMultiMmaOp : Op<Transform_Dialect, "iree.convert_to_multi_mma",
-    [TransformEachOpTrait,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ConvertToMultiMmaOp
+    : Op<Transform_Dialect, "iree.convert_to_multi_mma",
+         [TransformEachOpTrait,
+          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformOpInterface, ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Converts the target linalg op to a multi_mma operation based on the
     given intrinsic kind.
@@ -94,9 +94,8 @@ def ConvertToMultiMmaOp : Op<Transform_Dialect, "iree.convert_to_multi_mma",
     op or the conversion to the target mma fails.
   }];
 
-  let arguments = (ins
-    TransformHandleTypeInterface:$target,
-    IREEGPU_AnyMmaAttr:$intrinsic_kind);
+  let arguments = (ins TransformHandleTypeInterface:$target,
+      IREEGPU_AnyMmaAttr:$intrinsic_kind);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{
@@ -114,11 +113,11 @@ def ConvertToMultiMmaOp : Op<Transform_Dialect, "iree.convert_to_multi_mma",
   }];
 }
 
-def DistributeInnerTiledOp : Op<Transform_Dialect, "iree.distribute_inner_tiled",
-    [TransformEachOpTrait,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def DistributeInnerTiledOp
+    : Op<Transform_Dialect, "iree.distribute_inner_tiled",
+         [TransformEachOpTrait,
+          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformOpInterface, ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Distributes the target inner_tiled op to lanes.
 
@@ -144,12 +143,10 @@ def DistributeInnerTiledOp : Op<Transform_Dialect, "iree.distribute_inner_tiled"
   }];
 }
 
-def ForallToLanesOp : Op<Transform_Dialect,
-    "iree.forall_to_lanes",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ForallToLanesOp : Op<Transform_Dialect, "iree.forall_to_lanes",
+                         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                          TransformEachOpTrait, TransformOpInterface,
+                          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Collect all of the scf.forall ops in the target that are distributed to
     lanes.
@@ -161,7 +158,8 @@ def ForallToLanesOp : Op<Transform_Dialect,
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -174,10 +172,10 @@ def ForallToLanesOp : Op<Transform_Dialect,
 }
 
 def FuseForallOp : Op<Transform_Dialect, "iree.fuse_forall",
-    [FunctionalStyleTransformOpTrait,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     DeclareOpInterfaceMethods<TransformOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+                      [FunctionalStyleTransformOpTrait,
+                       DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                       DeclareOpInterfaceMethods<TransformOpInterface>,
+                       ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Fuses a producer-consumer pair of scf.forall ops that share the same
     iterator mapping types and trip counts. An allocation is created to
@@ -201,25 +199,24 @@ def FuseForallOp : Op<Transform_Dialect, "iree.fuse_forall",
     scf.forall ops.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$producer,
-          TransformHandleTypeInterface:$consumer,
-          OptionalAttr<AnyAttr>:$address_space
-  );
+  let arguments = (ins TransformHandleTypeInterface:$producer,
+      TransformHandleTypeInterface:$consumer,
+      OptionalAttr<AnyAttr>:$address_space);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{
-    $producer `into` $consumer attr-dict
+    $producer `into` $consumer prop-dict attr-dict
     `:` functional-type(operands, results)
   }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
-def FuseCollapseShapeIntoForallOp : Op<Transform_Dialect, "iree.fuse_collapse_shape_into_forall",
-    [FunctionalStyleTransformOpTrait,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     DeclareOpInterfaceMethods<TransformOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def FuseCollapseShapeIntoForallOp
+    : Op<Transform_Dialect, "iree.fuse_collapse_shape_into_forall",
+         [FunctionalStyleTransformOpTrait,
+          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          DeclareOpInterfaceMethods<TransformOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Fuses a consumer tensor.collapse_shape op into a producer scf.forall op.
     The users of the block argument for the corresponding forall output operand
@@ -236,10 +233,8 @@ def FuseCollapseShapeIntoForallOp : Op<Transform_Dialect, "iree.fuse_collapse_sh
     if the consumer is not a tensor.collapse_shape op.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$producer,
-          TransformHandleTypeInterface:$consumer
-  );
+  let arguments = (ins TransformHandleTypeInterface:$producer,
+      TransformHandleTypeInterface:$consumer);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{
@@ -249,11 +244,12 @@ def FuseCollapseShapeIntoForallOp : Op<Transform_Dialect, "iree.fuse_collapse_sh
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
-def FuseExtractSliceIntoForallOp : Op<Transform_Dialect, "iree.fuse_extract_slice_into_forall",
-    [FunctionalStyleTransformOpTrait,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     DeclareOpInterfaceMethods<TransformOpInterface>,
-     ReportTrackingListenerFailuresOpTrait]> {
+def FuseExtractSliceIntoForallOp
+    : Op<Transform_Dialect, "iree.fuse_extract_slice_into_forall",
+         [FunctionalStyleTransformOpTrait,
+          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          DeclareOpInterfaceMethods<TransformOpInterface>,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Fuses a consumer tensor.extract_slice op into a producer scf.forall op.
     This transform is supported if the extract_slice op has all zero offsets,
@@ -270,10 +266,8 @@ def FuseExtractSliceIntoForallOp : Op<Transform_Dialect, "iree.fuse_extract_slic
     if the consumer is not a tensor.extract_slice op.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$producer,
-          TransformHandleTypeInterface:$consumer
-  );
+  let arguments = (ins TransformHandleTypeInterface:$producer,
+      TransformHandleTypeInterface:$consumer);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
@@ -16,10 +16,10 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def ApplyDropInnerTiledOpUnitDims
-    : Op<Transform_Dialect, "apply_patterns.iree.drop_inner_tiled_unit_dims",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyDropInnerTiledOpUnitDims : Op<Transform_Dialect,
+    "apply_patterns.iree.drop_inner_tiled_unit_dims",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to drop the unit dims from inner_tiled ops with
     only unit iteration bounds.
@@ -29,10 +29,10 @@ def ApplyDropInnerTiledOpUnitDims
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyLowerInnerTiledOp
-    : Op<Transform_Dialect, "apply_patterns.iree.lower_inner_tiled",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyLowerInnerTiledOp : Op<Transform_Dialect,
+    "apply_patterns.iree.lower_inner_tiled",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to lowering inner_tiled ops to the intrinsic specified by
     the |kind| attribute.
@@ -42,10 +42,10 @@ def ApplyLowerInnerTiledOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyLowerBarrierRegionPatternsOp
-    : Op<Transform_Dialect, "apply_patterns.iree.lower_barrier_region",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyLowerBarrierRegionPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.lower_barrier_region",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns that lowers iree_gpu.barrier_region ops to allocations
     and copies.
@@ -55,10 +55,10 @@ def ApplyLowerBarrierRegionPatternsOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyLowerValueBarrierOp
-    : Op<Transform_Dialect, "apply_patterns.iree.lower_value_barrier",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyLowerValueBarrierOp : Op<Transform_Dialect,
+    "apply_patterns.iree.lower_value_barrier",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to convert value barriers on vectors into gpu.barrier ops.
     Barriers on tensors are ignored.
@@ -68,10 +68,10 @@ def ApplyLowerValueBarrierOp
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyUnrollMultiMmaOp
-    : Op<Transform_Dialect, "apply_patterns.iree.unroll_multi_mma",
-         [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ApplyUnrollMultiMmaOp : Op<Transform_Dialect,
+    "apply_patterns.iree.unroll_multi_mma",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Populate patterns to unroll iree_gpu.multi_mma ops to a single intrinsic.
   }];
@@ -80,11 +80,11 @@ def ApplyUnrollMultiMmaOp
   let assemblyFormat = "attr-dict";
 }
 
-def ConvertToMultiMmaOp
-    : Op<Transform_Dialect, "iree.convert_to_multi_mma",
-         [TransformEachOpTrait,
-          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformOpInterface, ReportTrackingListenerFailuresOpTrait]> {
+def ConvertToMultiMmaOp : Op<Transform_Dialect, "iree.convert_to_multi_mma",
+    [TransformEachOpTrait,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Converts the target linalg op to a multi_mma operation based on the
     given intrinsic kind.
@@ -94,8 +94,9 @@ def ConvertToMultiMmaOp
     op or the conversion to the target mma fails.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
-      IREEGPU_AnyMmaAttr:$intrinsic_kind);
+  let arguments = (ins
+    TransformHandleTypeInterface:$target,
+    IREEGPU_AnyMmaAttr:$intrinsic_kind);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{
@@ -113,11 +114,11 @@ def ConvertToMultiMmaOp
   }];
 }
 
-def DistributeInnerTiledOp
-    : Op<Transform_Dialect, "iree.distribute_inner_tiled",
-         [TransformEachOpTrait,
-          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformOpInterface, ReportTrackingListenerFailuresOpTrait]> {
+def DistributeInnerTiledOp : Op<Transform_Dialect, "iree.distribute_inner_tiled",
+    [TransformEachOpTrait,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Distributes the target inner_tiled op to lanes.
 
@@ -143,10 +144,12 @@ def DistributeInnerTiledOp
   }];
 }
 
-def ForallToLanesOp : Op<Transform_Dialect, "iree.forall_to_lanes",
-                         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                          TransformEachOpTrait, TransformOpInterface,
-                          ReportTrackingListenerFailuresOpTrait]> {
+def ForallToLanesOp : Op<Transform_Dialect,
+    "iree.forall_to_lanes",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Collect all of the scf.forall ops in the target that are distributed to
     lanes.
@@ -158,8 +161,7 @@ def ForallToLanesOp : Op<Transform_Dialect, "iree.forall_to_lanes",
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat =
-      "$target attr-dict `:` functional-type($target, results)";
+  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -172,10 +174,10 @@ def ForallToLanesOp : Op<Transform_Dialect, "iree.forall_to_lanes",
 }
 
 def FuseForallOp : Op<Transform_Dialect, "iree.fuse_forall",
-                      [FunctionalStyleTransformOpTrait,
-                       DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                       DeclareOpInterfaceMethods<TransformOpInterface>,
-                       ReportTrackingListenerFailuresOpTrait]> {
+    [FunctionalStyleTransformOpTrait,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     DeclareOpInterfaceMethods<TransformOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Fuses a producer-consumer pair of scf.forall ops that share the same
     iterator mapping types and trip counts. An allocation is created to
@@ -199,9 +201,11 @@ def FuseForallOp : Op<Transform_Dialect, "iree.fuse_forall",
     scf.forall ops.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$producer,
-      TransformHandleTypeInterface:$consumer,
-      OptionalAttr<AnyAttr>:$address_space);
+  let arguments = (
+      ins TransformHandleTypeInterface:$producer,
+          TransformHandleTypeInterface:$consumer,
+          OptionalAttr<AnyAttr>:$address_space
+  );
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{
@@ -211,12 +215,11 @@ def FuseForallOp : Op<Transform_Dialect, "iree.fuse_forall",
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
-def FuseCollapseShapeIntoForallOp
-    : Op<Transform_Dialect, "iree.fuse_collapse_shape_into_forall",
-         [FunctionalStyleTransformOpTrait,
-          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          DeclareOpInterfaceMethods<TransformOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def FuseCollapseShapeIntoForallOp : Op<Transform_Dialect, "iree.fuse_collapse_shape_into_forall",
+    [FunctionalStyleTransformOpTrait,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     DeclareOpInterfaceMethods<TransformOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Fuses a consumer tensor.collapse_shape op into a producer scf.forall op.
     The users of the block argument for the corresponding forall output operand
@@ -233,8 +236,10 @@ def FuseCollapseShapeIntoForallOp
     if the consumer is not a tensor.collapse_shape op.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$producer,
-      TransformHandleTypeInterface:$consumer);
+  let arguments = (
+      ins TransformHandleTypeInterface:$producer,
+          TransformHandleTypeInterface:$consumer
+  );
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{
@@ -244,12 +249,11 @@ def FuseCollapseShapeIntoForallOp
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
-def FuseExtractSliceIntoForallOp
-    : Op<Transform_Dialect, "iree.fuse_extract_slice_into_forall",
-         [FunctionalStyleTransformOpTrait,
-          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          DeclareOpInterfaceMethods<TransformOpInterface>,
-          ReportTrackingListenerFailuresOpTrait]> {
+def FuseExtractSliceIntoForallOp : Op<Transform_Dialect, "iree.fuse_extract_slice_into_forall",
+    [FunctionalStyleTransformOpTrait,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     DeclareOpInterfaceMethods<TransformOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Fuses a consumer tensor.extract_slice op into a producer scf.forall op.
     This transform is supported if the extract_slice op has all zero offsets,
@@ -266,8 +270,10 @@ def FuseExtractSliceIntoForallOp
     if the consumer is not a tensor.extract_slice op.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$producer,
-      TransformHandleTypeInterface:$consumer);
+  let arguments = (
+      ins TransformHandleTypeInterface:$producer,
+          TransformHandleTypeInterface:$consumer
+  );
   let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -873,7 +873,7 @@ private:
     LLVM::InlineAsmOp asmOp = LLVM::InlineAsmOp::create(
         rewriter, loc, returnType, inputs, code, constraints,
         /*has_side_effects=*/false, /*is_align_stack=*/false,
-        LLVM::TailCallKind::None, dialectAttr,
+        LLVM::TailCallKind::None, /*convergent=*/false, dialectAttr,
         /*operand_attrs=*/ArrayAttr());
     // Extract result vectors from the asm op.
     SmallVector<Value> resVec;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -78,6 +78,7 @@ struct LowerGlobalSubgroupBarrier
           /*asm_string=*/asmStr, /*constraints=*/"",
           /*has_side_effects=*/true,
           /*is_align_stack=*/false, LLVM::TailCallKind::None,
+          /*convergent=*/true,
           /*asm_dialect=*/asmDialectAttr,
           /*operand_attrs=*/ArrayAttr());
     } else if (chipset.majorVersion < 12) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -13,11 +13,12 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def MapNestedForallToGpuThreadsOp
-    : Op<Transform_Dialect, "iree.map_nested_forall_to_gpu_threads",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def MapNestedForallToGpuThreadsOp :
+  Op<Transform_Dialect, "iree.map_nested_forall_to_gpu_threads",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target the whole hal.executable_variant op and rewrite all scf.forall
     to distributed gpu.thread_id and translation_info attribute.
@@ -88,9 +89,9 @@ def MapNestedForallToGpuThreadsOp
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_dims,
-      DefaultValuedOptionalAttr<I64Attr, "32">:$subgroup_size,
-      DefaultValuedOptionalAttr<BoolAttr, "true">:$sync_after_distribution);
+                   DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_dims,
+                   DefaultValuedOptionalAttr<I64Attr, "32">:$subgroup_size,
+                   DefaultValuedOptionalAttr<BoolAttr, "true">:$sync_after_distribution);
   let results = (outs);
 
   let assemblyFormat = [{
@@ -112,11 +113,12 @@ def MapNestedForallToGpuThreadsOp
   }];
 }
 
-def VectorToWarpExecuteOnLane0Op
-    : Op<Transform_Dialect, "iree.vector.to_warp_execute_on_lane_0",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_execute_on_lane_0",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Given an scf.if target predicated by `if (threadIdx.x == 0)`, rewrite its
     body to vector.execute_on_lane_0 running ***on a single warp***.
@@ -200,14 +202,15 @@ def VectorToWarpExecuteOnLane0Op
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-      DefaultValuedAttr<I64Attr, "{}">:$warp_size);
+                   DefaultValuedAttr<I64Attr, "{}">:$warp_size);
   let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat =
-      "$target prop-dict attr-dict `:` functional-type($target, $result)";
+  let assemblyFormat = "$target prop-dict attr-dict `:` functional-type($target, $result)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let builders = [OpBuilder<(ins "Value":$target, "int64_t":$warpSize)>];
+  let builders = [
+    OpBuilder<(ins "Value":$target, "int64_t":$warpSize)>
+  ];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
@@ -217,11 +220,11 @@ def VectorToWarpExecuteOnLane0Op
   }];
 }
 
-def VectorWarpDistributionOp
-    : Op<Transform_Dialect, "iree.vector.warp_distribute",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribute",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Given a vector.warp_execute_on_lane_0, apply the patterns to rewrite into
     distributed form with warp synchronization. This produces IR that runs
@@ -319,7 +322,9 @@ def VectorWarpDistributionOp
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$target)>];
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
+  ];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
@@ -329,11 +334,11 @@ def VectorWarpDistributionOp
   }];
 }
 
-def VectorToMMAConversionOp
-    : Op<Transform_Dialect, "iree.vector.vector_to_mma_conversion",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def VectorToMMAConversionOp : Op<Transform_Dialect, "iree.vector.vector_to_mma_conversion",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This converts slices of operations containing vector.contract op into
     mma operations, targeting warp level tensorcore operations. If the vector
@@ -348,7 +353,8 @@ def VectorToMMAConversionOp
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-      UnitAttr:$use_mma_sync, UnitAttr:$use_wmma);
+                       UnitAttr:$use_mma_sync,
+                       UnitAttr:$use_wmma);
   let results = (outs);
 
   let assemblyFormat = [{
@@ -367,11 +373,13 @@ def VectorToMMAConversionOp
   }];
 }
 
-def PromoteOperandsOp
-    : Op<Transform_Dialect, "iree.promote_operands",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def PromoteOperandsOp :
+  Op<Transform_Dialect, "iree.promote_operands",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This op promotes the specified operands of the provided target handle.
 
@@ -384,11 +392,10 @@ def PromoteOperandsOp
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$indices);
+                   DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$indices);
   let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
-  let assemblyFormat =
-      [{ $target $indices attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat = [{ $target $indices attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -400,11 +407,13 @@ def PromoteOperandsOp
   }];
 }
 
-def PipelineSharedMemoryCopiesOp
-    : Op<Transform_Dialect, "iree.pipeline_shared_memory_copies",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def PipelineSharedMemoryCopiesOp : Op<
+    Transform_Dialect, "iree.pipeline_shared_memory_copies", [
+      FunctionalStyleTransformOpTrait,
+      MemoryEffectsOpInterface,
+      TransformEachOpTrait,
+      TransformOpInterface,
+      ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This applies software pipelining to a given scf.for loop. The pipelining
     strategy will look for a copy to shared memory and pipeline it to overlap
@@ -422,8 +431,11 @@ def PipelineSharedMemoryCopiesOp
     existing scf.for loop (failure case).
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$for_op, I64Attr:$depth,
-      UnitAttr:$peel_epilogue, UnitAttr:$use_mma_sync);
+  let arguments = (
+      ins TransformHandleTypeInterface:$for_op,
+          I64Attr:$depth,
+          UnitAttr:$peel_epilogue,
+          UnitAttr:$use_mma_sync);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -442,10 +454,12 @@ def PipelineSharedMemoryCopiesOp
   }];
 }
 
-def SynchronizeLoopOp : Op<Transform_Dialect, "iree.synchronize_loop",
-                           [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                            TransformEachOpTrait, TransformOpInterface,
-                            ReportTrackingListenerFailuresOpTrait]> {
+def SynchronizeLoopOp : Op<
+    Transform_Dialect, "iree.synchronize_loop", [
+      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+      TransformEachOpTrait,
+      TransformOpInterface,
+      ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This inserts a gpu.barrier after a given scf.for loop.
 
@@ -455,7 +469,8 @@ def SynchronizeLoopOp : Op<Transform_Dialect, "iree.synchronize_loop",
     cannot be pipelined or if there are no shared memory copies.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$for_op);
+  let arguments = (
+      ins TransformHandleTypeInterface:$for_op);
   let results = (outs);
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -474,11 +489,12 @@ def SynchronizeLoopOp : Op<Transform_Dialect, "iree.synchronize_loop",
   }];
 }
 
-def CreateAsyncGroupsOp
-    : Op<Transform_Dialect, "iree.create_async_groups",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def CreateAsyncGroupsOp :
+  Op<Transform_Dialect, "iree.create_async_groups",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Convert copies to shared memory to async copies. This creates groups
     of consecutive copies and emit wait operation right after.
@@ -493,7 +509,7 @@ def CreateAsyncGroupsOp
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-      UnitAttr:$use_mma_sync);
+                   UnitAttr:$use_mma_sync);
   let results = (outs);
 
   let assemblyFormat = [{
@@ -511,11 +527,13 @@ def CreateAsyncGroupsOp
   }];
 }
 
-def ReorderTransposeOp
-    : Op<Transform_Dialect, "iree.reorder_transpose",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ReorderTransposeOp :
+  Op<Transform_Dialect, "iree.reorder_transpose",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Targets the whole func op and finds transpose ops whose source
     comes from an elementwise op. For each of those transpose ops,
@@ -538,8 +556,7 @@ def ReorderTransposeOp
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
-  let assemblyFormat =
-      [{ $target attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat = [{ $target attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -549,13 +566,16 @@ def ReorderTransposeOp
         ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
+
 }
 
-def EliminateGpuBarriersOp
-    : Op<Transform_Dialect, "iree.eliminate_gpu_barriers",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def EliminateGpuBarriersOp :
+  Op<Transform_Dialect, "iree.eliminate_gpu_barriers",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Removes unnecessary GPU barriers from the function. If a barrier does not
     enforce any conflicting pair of memory effects, including a pair that is
@@ -570,11 +590,12 @@ def EliminateGpuBarriersOp
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat =
-      [{ $target attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat = [{ $target attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let builders = [OpBuilder<(ins "Value":$target)>];
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
+  ];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -585,11 +606,11 @@ def EliminateGpuBarriersOp
   }];
 }
 
-def PackSharedMemoryAllocOp
-    : Op<Transform_Dialect, "iree.pack_shared_memory_alloc",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def PackSharedMemoryAllocOp :  Op<Transform_Dialect, "iree.pack_shared_memory_alloc",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let summary = [{Pack shared memory allocation to reduce memory usage.}];
   let description = [{
     Looks for allocs in shared memory space with overlapping liveness and
@@ -602,11 +623,12 @@ def PackSharedMemoryAllocOp
     It does not consume the target handle and always return success.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target);
+  let arguments = (
+      ins TransformHandleTypeInterface:$target
+  );
   let results = (outs);
 
-  let assemblyFormat =
-      "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -618,11 +640,13 @@ def PackSharedMemoryAllocOp
   }];
 }
 
-def PrefetchSharedMemoryCopiesOp
-    : Op<Transform_Dialect, "iree.prefetch_shared_memory_copies",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def PrefetchSharedMemoryCopiesOp : Op<
+    Transform_Dialect, "iree.prefetch_shared_memory_copies", [
+      FunctionalStyleTransformOpTrait,
+      MemoryEffectsOpInterface,
+      TransformEachOpTrait,
+      TransformOpInterface,
+      ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     #### Return modes
     This transform consumes the scf.for handle and produces a result handle
@@ -649,11 +673,12 @@ def PrefetchSharedMemoryCopiesOp
   }];
 }
 
-def AMDGPUDistributeVectorsOp
-    : Op<Transform_Dialect, "iree.amdgpu_distribute_vectors",
-         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-          TransformEachOpTrait, TransformOpInterface,
-          ReportTrackingListenerFailuresOpTrait]> {
+def AMDGPUDistributeVectorsOp :
+  Op<Transform_Dialect, "iree.amdgpu_distribute_vectors",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Run AMDGPU Vector Contraction distribution on the target as the root.
 
@@ -669,19 +694,19 @@ def AMDGPUDistributeVectorsOp
     This transform does not consume the target handle and always return success.
     }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
-      UnitAttr:$test_conversion,
-      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_size,
-      DefaultValuedOptionalAttr<I64Attr, "64">:$subgroup_size);
-  let results = (outs TransformHandleTypeInterface:$result);
+    let arguments = (ins TransformHandleTypeInterface:$target,
+                         UnitAttr:$test_conversion,
+                         DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_size,
+                         DefaultValuedOptionalAttr<I64Attr, "64">:$subgroup_size);
+    let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat = [{
+    let assemblyFormat = [{
       $target (`test_conversion` $test_conversion^)?
       prop-dict attr-dict `:` functional-type(operands, results)
     }];
-  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+    let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let extraClassDeclaration = [{
+    let extraClassDeclaration = [{
       ::mlir::DiagnosedSilenceableFailure applyToOne(
           ::mlir::transform::TransformRewriter &rewriter,
           ::mlir::FunctionOpInterface funcOp,
@@ -690,11 +715,11 @@ def AMDGPUDistributeVectorsOp
     }];
 }
 
-def CreateMatmulMfmaTileSizesOp
-    : Op<Transform_Dialect, "iree.create_matmul_mfma_tile_sizes",
-         [MemoryEffectsOpInterface,
-          DeclareOpInterfaceMethods<TransformOpInterface>,
-          ParamProducerTransformOpTrait]> {
+def CreateMatmulMfmaTileSizesOp :
+  Op<Transform_Dialect, "iree.create_matmul_mfma_tile_sizes",
+    [MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>,
+     ParamProducerTransformOpTrait]> {
   let description = [{
     Create param of tile sizes based on the matmul sizes.
     This operation won't succeed if the matmul shape size is not 2.
@@ -703,10 +728,9 @@ def CreateMatmulMfmaTileSizesOp
 
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs TransformParamTypeInterface:$workgroup_tile_sizes,
-      TransformParamTypeInterface:$problem_specific_sizes);
+                      TransformParamTypeInterface:$problem_specific_sizes);
 
-  let assemblyFormat =
-      "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -13,12 +13,11 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def MapNestedForallToGpuThreadsOp :
-  Op<Transform_Dialect, "iree.map_nested_forall_to_gpu_threads",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def MapNestedForallToGpuThreadsOp
+    : Op<Transform_Dialect, "iree.map_nested_forall_to_gpu_threads",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target the whole hal.executable_variant op and rewrite all scf.forall
     to distributed gpu.thread_id and translation_info attribute.
@@ -89,9 +88,9 @@ def MapNestedForallToGpuThreadsOp :
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-                   DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_dims,
-                   DefaultValuedOptionalAttr<I64Attr, "32">:$subgroup_size,
-                   DefaultValuedOptionalAttr<BoolAttr, "true">:$sync_after_distribution);
+      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_dims,
+      DefaultValuedOptionalAttr<I64Attr, "32">:$subgroup_size,
+      DefaultValuedOptionalAttr<BoolAttr, "true">:$sync_after_distribution);
   let results = (outs);
 
   let assemblyFormat = [{
@@ -113,12 +112,11 @@ def MapNestedForallToGpuThreadsOp :
   }];
 }
 
-def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_execute_on_lane_0",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def VectorToWarpExecuteOnLane0Op
+    : Op<Transform_Dialect, "iree.vector.to_warp_execute_on_lane_0",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Given an scf.if target predicated by `if (threadIdx.x == 0)`, rewrite its
     body to vector.execute_on_lane_0 running ***on a single warp***.
@@ -202,15 +200,14 @@ def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_ex
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-                   DefaultValuedAttr<I64Attr, "{}">:$warp_size);
+      DefaultValuedAttr<I64Attr, "{}">:$warp_size);
   let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type($target, $result)";
+  let assemblyFormat =
+      "$target prop-dict attr-dict `:` functional-type($target, $result)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let builders = [
-    OpBuilder<(ins "Value":$target, "int64_t":$warpSize)>
-  ];
+  let builders = [OpBuilder<(ins "Value":$target, "int64_t":$warpSize)>];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
@@ -220,11 +217,11 @@ def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_ex
   }];
 }
 
-def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribute",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def VectorWarpDistributionOp
+    : Op<Transform_Dialect, "iree.vector.warp_distribute",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Given a vector.warp_execute_on_lane_0, apply the patterns to rewrite into
     distributed form with warp synchronization. This produces IR that runs
@@ -322,9 +319,7 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "Value":$target)>
-  ];
+  let builders = [OpBuilder<(ins "Value":$target)>];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
@@ -334,11 +329,11 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
   }];
 }
 
-def VectorToMMAConversionOp : Op<Transform_Dialect, "iree.vector.vector_to_mma_conversion",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def VectorToMMAConversionOp
+    : Op<Transform_Dialect, "iree.vector.vector_to_mma_conversion",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This converts slices of operations containing vector.contract op into
     mma operations, targeting warp level tensorcore operations. If the vector
@@ -353,13 +348,12 @@ def VectorToMMAConversionOp : Op<Transform_Dialect, "iree.vector.vector_to_mma_c
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-                       UnitAttr:$use_mma_sync,
-                       UnitAttr:$use_wmma);
+      UnitAttr:$use_mma_sync, UnitAttr:$use_wmma);
   let results = (outs);
 
   let assemblyFormat = [{
     $target
-    attr-dict
+    prop-dict attr-dict
     `:` functional-type($target, results)
   }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -373,13 +367,11 @@ def VectorToMMAConversionOp : Op<Transform_Dialect, "iree.vector.vector_to_mma_c
   }];
 }
 
-def PromoteOperandsOp :
-  Op<Transform_Dialect, "iree.promote_operands",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def PromoteOperandsOp
+    : Op<Transform_Dialect, "iree.promote_operands",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This op promotes the specified operands of the provided target handle.
 
@@ -392,10 +384,11 @@ def PromoteOperandsOp :
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-                   DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$indices);
+      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$indices);
   let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
-  let assemblyFormat = [{ $target $indices attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat =
+      [{ $target $indices attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -407,13 +400,11 @@ def PromoteOperandsOp :
   }];
 }
 
-def PipelineSharedMemoryCopiesOp : Op<
-    Transform_Dialect, "iree.pipeline_shared_memory_copies", [
-      FunctionalStyleTransformOpTrait,
-      MemoryEffectsOpInterface,
-      TransformEachOpTrait,
-      TransformOpInterface,
-      ReportTrackingListenerFailuresOpTrait]> {
+def PipelineSharedMemoryCopiesOp
+    : Op<Transform_Dialect, "iree.pipeline_shared_memory_copies",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This applies software pipelining to a given scf.for loop. The pipelining
     strategy will look for a copy to shared memory and pipeline it to overlap
@@ -431,18 +422,15 @@ def PipelineSharedMemoryCopiesOp : Op<
     existing scf.for loop (failure case).
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$for_op,
-          I64Attr:$depth,
-          UnitAttr:$peel_epilogue,
-          UnitAttr:$use_mma_sync);
+  let arguments = (ins TransformHandleTypeInterface:$for_op, I64Attr:$depth,
+      UnitAttr:$peel_epilogue, UnitAttr:$use_mma_sync);
   let results = (outs TransformHandleTypeInterface:$result);
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let assemblyFormat = [{
     $for_op
-    attr-dict
+    prop-dict attr-dict
     `:` functional-type(operands, results)}];
 
   let extraClassDeclaration = [{
@@ -454,12 +442,10 @@ def PipelineSharedMemoryCopiesOp : Op<
   }];
 }
 
-def SynchronizeLoopOp : Op<
-    Transform_Dialect, "iree.synchronize_loop", [
-      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-      TransformEachOpTrait,
-      TransformOpInterface,
-      ReportTrackingListenerFailuresOpTrait]> {
+def SynchronizeLoopOp : Op<Transform_Dialect, "iree.synchronize_loop",
+                           [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+                            TransformEachOpTrait, TransformOpInterface,
+                            ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     This inserts a gpu.barrier after a given scf.for loop.
 
@@ -469,8 +455,7 @@ def SynchronizeLoopOp : Op<
     cannot be pipelined or if there are no shared memory copies.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$for_op);
+  let arguments = (ins TransformHandleTypeInterface:$for_op);
   let results = (outs);
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -489,12 +474,11 @@ def SynchronizeLoopOp : Op<
   }];
 }
 
-def CreateAsyncGroupsOp :
-  Op<Transform_Dialect, "iree.create_async_groups",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def CreateAsyncGroupsOp
+    : Op<Transform_Dialect, "iree.create_async_groups",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Convert copies to shared memory to async copies. This creates groups
     of consecutive copies and emit wait operation right after.
@@ -509,12 +493,12 @@ def CreateAsyncGroupsOp :
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target,
-                   UnitAttr:$use_mma_sync);
+      UnitAttr:$use_mma_sync);
   let results = (outs);
 
   let assemblyFormat = [{
     $target
-    attr-dict
+    prop-dict attr-dict
     `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
@@ -527,13 +511,11 @@ def CreateAsyncGroupsOp :
   }];
 }
 
-def ReorderTransposeOp :
-  Op<Transform_Dialect, "iree.reorder_transpose",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ReorderTransposeOp
+    : Op<Transform_Dialect, "iree.reorder_transpose",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Targets the whole func op and finds transpose ops whose source
     comes from an elementwise op. For each of those transpose ops,
@@ -556,7 +538,8 @@ def ReorderTransposeOp :
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
-  let assemblyFormat = [{ $target attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat =
+      [{ $target attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -566,16 +549,13 @@ def ReorderTransposeOp :
         ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
-
 }
 
-def EliminateGpuBarriersOp :
-  Op<Transform_Dialect, "iree.eliminate_gpu_barriers",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def EliminateGpuBarriersOp
+    : Op<Transform_Dialect, "iree.eliminate_gpu_barriers",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Removes unnecessary GPU barriers from the function. If a barrier does not
     enforce any conflicting pair of memory effects, including a pair that is
@@ -590,12 +570,11 @@ def EliminateGpuBarriersOp :
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs TransformHandleTypeInterface:$result);
 
-  let assemblyFormat = [{ $target attr-dict `:` functional-type(operands, results)}];
+  let assemblyFormat =
+      [{ $target attr-dict `:` functional-type(operands, results)}];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-  let builders = [
-    OpBuilder<(ins "Value":$target)>
-  ];
+  let builders = [OpBuilder<(ins "Value":$target)>];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -606,11 +585,11 @@ def EliminateGpuBarriersOp :
   }];
 }
 
-def PackSharedMemoryAllocOp :  Op<Transform_Dialect, "iree.pack_shared_memory_alloc",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def PackSharedMemoryAllocOp
+    : Op<Transform_Dialect, "iree.pack_shared_memory_alloc",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let summary = [{Pack shared memory allocation to reduce memory usage.}];
   let description = [{
     Looks for allocs in shared memory space with overlapping liveness and
@@ -623,12 +602,11 @@ def PackSharedMemoryAllocOp :  Op<Transform_Dialect, "iree.pack_shared_memory_al
     It does not consume the target handle and always return success.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$target
-  );
+  let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
@@ -640,13 +618,11 @@ def PackSharedMemoryAllocOp :  Op<Transform_Dialect, "iree.pack_shared_memory_al
   }];
 }
 
-def PrefetchSharedMemoryCopiesOp : Op<
-    Transform_Dialect, "iree.prefetch_shared_memory_copies", [
-      FunctionalStyleTransformOpTrait,
-      MemoryEffectsOpInterface,
-      TransformEachOpTrait,
-      TransformOpInterface,
-      ReportTrackingListenerFailuresOpTrait]> {
+def PrefetchSharedMemoryCopiesOp
+    : Op<Transform_Dialect, "iree.prefetch_shared_memory_copies",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     #### Return modes
     This transform consumes the scf.for handle and produces a result handle
@@ -673,12 +649,11 @@ def PrefetchSharedMemoryCopiesOp : Op<
   }];
 }
 
-def AMDGPUDistributeVectorsOp :
-  Op<Transform_Dialect, "iree.amdgpu_distribute_vectors",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+def AMDGPUDistributeVectorsOp
+    : Op<Transform_Dialect, "iree.amdgpu_distribute_vectors",
+         [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+          TransformEachOpTrait, TransformOpInterface,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Run AMDGPU Vector Contraction distribution on the target as the root.
 
@@ -694,19 +669,19 @@ def AMDGPUDistributeVectorsOp :
     This transform does not consume the target handle and always return success.
     }];
 
-    let arguments = (ins TransformHandleTypeInterface:$target,
-                         UnitAttr:$test_conversion,
-                         DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_size,
-                         DefaultValuedOptionalAttr<I64Attr, "64">:$subgroup_size);
-    let results = (outs TransformHandleTypeInterface:$result);
+  let arguments = (ins TransformHandleTypeInterface:$target,
+      UnitAttr:$test_conversion,
+      DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$workgroup_size,
+      DefaultValuedOptionalAttr<I64Attr, "64">:$subgroup_size);
+  let results = (outs TransformHandleTypeInterface:$result);
 
-    let assemblyFormat = [{
+  let assemblyFormat = [{
       $target (`test_conversion` $test_conversion^)?
-      attr-dict `:` functional-type(operands, results)
+      prop-dict attr-dict `:` functional-type(operands, results)
     }];
-    let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
-    let extraClassDeclaration = [{
+  let extraClassDeclaration = [{
       ::mlir::DiagnosedSilenceableFailure applyToOne(
           ::mlir::transform::TransformRewriter &rewriter,
           ::mlir::FunctionOpInterface funcOp,
@@ -715,11 +690,11 @@ def AMDGPUDistributeVectorsOp :
     }];
 }
 
-def CreateMatmulMfmaTileSizesOp :
-  Op<Transform_Dialect, "iree.create_matmul_mfma_tile_sizes",
-    [MemoryEffectsOpInterface,
-     DeclareOpInterfaceMethods<TransformOpInterface>,
-     ParamProducerTransformOpTrait]> {
+def CreateMatmulMfmaTileSizesOp
+    : Op<Transform_Dialect, "iree.create_matmul_mfma_tile_sizes",
+         [MemoryEffectsOpInterface,
+          DeclareOpInterfaceMethods<TransformOpInterface>,
+          ParamProducerTransformOpTrait]> {
   let description = [{
     Create param of tile sizes based on the matmul sizes.
     This operation won't succeed if the matmul shape size is not 2.
@@ -728,9 +703,10 @@ def CreateMatmulMfmaTileSizesOp :
 
   let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs TransformParamTypeInterface:$workgroup_tile_sizes,
-                      TransformParamTypeInterface:$problem_specific_sizes);
+      TransformParamTypeInterface:$problem_specific_sizes);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -344,4 +344,4 @@ builtin.module {
 }
 
 // CHECK-LABEL: llvm.func @global_subgroup_barrier
-//       CHECK:   llvm.inline_asm has_side_effects asm_dialect = att ";;;WARNING: BREAKS DEBUG WATCHES{{.*}}s_barrier"
+//       CHECK:   llvm.inline_asm has_side_effects convergent asm_dialect = att ";;;WARNING: BREAKS DEBUG WATCHES{{.*}}s_barrier"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/create_async_groups.mlir
@@ -26,7 +26,7 @@ builtin.module {
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
     %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    transform.iree.create_async_groups %top_level_func {use_mma_sync} : (!transform.any_op) -> ()
+    transform.iree.create_async_groups %top_level_func <{use_mma_sync}> : (!transform.any_op) -> ()
     transform.yield
   }
 } // module

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
@@ -34,7 +34,7 @@ builtin.module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
     %func = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
     transform.iree.eliminate_empty_tensors %func : (!transform.any_op) -> ()
-    %_ = transform.iree.bufferize { target_gpu } %func: (!transform.any_op) -> !transform.any_op
+    %_ = transform.iree.bufferize <{ target_gpu }> %func: (!transform.any_op) -> !transform.any_op
     transform.yield
   } // @__transform_main
 } // module

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
@@ -3,9 +3,9 @@ module attributes { transform.with_named_sequence } {
 
     %if_op = transform.structured.match ops{["scf.if"]} in %variant_op
       : (!transform.any_op) -> !transform.any_op
-    %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op <{ warp_size = 32 }>
       : (!transform.any_op) -> !transform.any_op
-    %isolated = transform.get_parent_op %warp {isolated_from_above}
+    %isolated = transform.get_parent_op %warp <{isolated_from_above}>
       : (!transform.any_op) -> !transform.any_op
     transform.iree.vector.warp_distribute %isolated
       : (!transform.any_op) -> ()

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
@@ -3,7 +3,7 @@ module attributes { transform.with_named_sequence } {
 
     %if_op = transform.structured.match ops{["scf.if"]} in %variant_op
       : (!transform.any_op) -> !transform.any_op
-    transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    transform.iree.vector.to_warp_execute_on_lane_0 %if_op <{ warp_size = 32 }>
       : (!transform.any_op) -> !transform.any_op
 
     // Late canonicalizations to cleanup and pass the checks.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_vector_to_nvgpu_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_vector_to_nvgpu_mma.mlir
@@ -35,7 +35,7 @@ module attributes { transform.with_named_sequence } {
     transform.apply_patterns to %func {
       transform.apply_patterns.iree.unroll_vectors_gpu_wmma_sync
     } : !transform.any_op
-    transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!transform.any_op) -> ()
+    transform.iree.vector.vector_to_mma_conversion %func <{ use_wmma }> : (!transform.any_op) -> ()
 
     // Apply canonicalization post-hoc to trigger DCE and pass the test
     // (i.e. all vector.contract are dead).
@@ -83,7 +83,7 @@ module attributes { transform.with_named_sequence } {
     transform.apply_patterns to %func {
       transform.apply_patterns.iree.unroll_vectors_gpu_mma_sync
     } : !transform.any_op
-    transform.iree.vector.vector_to_mma_conversion %func { use_mma_sync } : (!transform.any_op) -> ()
+    transform.iree.vector.vector_to_mma_conversion %func <{ use_mma_sync }> : (!transform.any_op) -> ()
 
     // Apply canonicalization post-hoc to trigger DCE and pass the test
     // (i.e. all vector.contract are dead).

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_gpu_pipelining.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_gpu_pipelining.mlir
@@ -60,7 +60,7 @@ module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
     %for = transform.structured.match ops{["scf.for"]} in %root : (!transform.any_op) -> !transform.any_op
     %1 = transform.cast %for : !transform.any_op to !transform.op<"scf.for">
-    %2 = transform.iree.pipeline_shared_memory_copies %1 { depth = 4 } : (!transform.op<"scf.for">) -> !transform.op<"scf.for">
+    %2 = transform.iree.pipeline_shared_memory_copies %1 <{ depth = 4 }> : (!transform.op<"scf.for">) -> !transform.op<"scf.for">
     transform.yield
   } // @__transform_main
 } // module

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
@@ -56,7 +56,7 @@ module attributes { transform.with_named_sequence } {
     transform.apply_patterns to %func {
       transform.apply_patterns.iree.unroll_vectors_gpu_wmma_sync
     } : !transform.any_op
-    transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!transform.any_op) -> ()
+    transform.iree.vector.vector_to_mma_conversion %func <{ use_wmma }> : (!transform.any_op) -> ()
 
     // Apply canonicalization post-hoc to trigger DCE and pass the test
     // (i.e. all vector.contract are dead).
@@ -140,7 +140,7 @@ builtin.module attributes { transform.with_named_sequence } {
   transform.apply_patterns to %func {
     transform.apply_patterns.iree.unroll_vectors_gpu_wmma_sync
   } : !transform.any_op
-  transform.iree.vector.vector_to_mma_conversion %func { use_wmma } : (!transform.any_op) -> ()
+  transform.iree.vector.vector_to_mma_conversion %func <{ use_wmma }> : (!transform.any_op) -> ()
   transform.apply_patterns to %func {
     transform.apply_patterns.canonicalization
   } : !transform.any_op

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -24,7 +24,9 @@ class IREEEncoding_I32EnumAttr<string name, string summary, list<I32EnumAttrCase
 }
 
 class IREEEncoding_EnumAttr<EnumAttrInfo enumInfo, string name = "">
-  : EnumAttr<IREEEncoding_Dialect, enumInfo, name>;
+  : EnumAttr<IREEEncoding_Dialect, enumInfo, name> {
+  let assemblyFormat = "$value";
+}
 
 // Enums for tagging operand operation in an EncodingAttr
 def MATMUL : I32EnumAttrCase<"matmul", 0>;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/AnnotateDispatches.cpp
@@ -519,7 +519,7 @@ struct AnnotateDispatchesPass
 
         exportOp.setSymName(newName);
         exportOp.setFunctionRef(newName);
-        funcOp.setName(newName);
+        funcOp.setSymbolName(newName);
 
         auto newSymbolRefAttr =
             SymbolRefAttr::get(&getContext(), executableOp.getName(),

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/TransformExtensions/LinalgExtExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/TransformExtensions/LinalgExtExtensionsOps.td
@@ -12,18 +12,21 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def DecomposeAggregateOp
-    : Op<Transform_Dialect, "iree.decompose_aggregate_op",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformOpInterface, TransformEachOpTrait,
-          ReportTrackingListenerFailuresOpTrait]> {
+def DecomposeAggregateOp : Op<Transform_Dialect, "iree.decompose_aggregate_op",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformOpInterface,
+     TransformEachOpTrait,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target iree_linalg_ext.attention ops and decompose them.
     This transform consumes the target handle and produces a result handle.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target,
-      OptionalAttr<I64Attr>:$tile_size);
+  let arguments = (
+      ins TransformHandleTypeInterface:$target,
+          OptionalAttr<I64Attr>:$tile_size
+  );
   let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
@@ -41,21 +44,23 @@ def DecomposeAggregateOp
   }];
 }
 
-def ConvertToOnlineAttention
-    : Op<Transform_Dialect, "iree.convert_to_online_attention",
-         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
-          TransformOpInterface, TransformEachOpTrait,
-          ReportTrackingListenerFailuresOpTrait]> {
+def ConvertToOnlineAttention : Op<Transform_Dialect, "iree.convert_to_online_attention",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformOpInterface,
+     TransformEachOpTrait,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target iree_linalg_ext.attention ops and decompose them.
     This transform consumes the target handle and produces a result handle.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target);
+  let arguments = (
+      ins TransformHandleTypeInterface:$target
+  );
   let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
-  let assemblyFormat =
-      "attr-dict $target `:` functional-type(operands, results)";
+  let assemblyFormat = "attr-dict $target `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/TransformExtensions/LinalgExtExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/TransformExtensions/LinalgExtExtensionsOps.td
@@ -12,28 +12,24 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def DecomposeAggregateOp : Op<Transform_Dialect, "iree.decompose_aggregate_op",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     TransformOpInterface,
-     TransformEachOpTrait,
-     ReportTrackingListenerFailuresOpTrait]> {
+def DecomposeAggregateOp
+    : Op<Transform_Dialect, "iree.decompose_aggregate_op",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformOpInterface, TransformEachOpTrait,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target iree_linalg_ext.attention ops and decompose them.
     This transform consumes the target handle and produces a result handle.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$target,
-          OptionalAttr<I64Attr>:$tile_size
-  );
+  let arguments = (ins TransformHandleTypeInterface:$target,
+      OptionalAttr<I64Attr>:$tile_size);
   let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
-  let assemblyFormat = "attr-dict $target `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
 
   let assemblyFormat = [{
-    $target attr-dict `:` functional-type(operands, results)
+    $target prop-dict attr-dict `:` functional-type(operands, results)
   }];
 
   let extraClassDeclaration = [{
@@ -45,23 +41,21 @@ def DecomposeAggregateOp : Op<Transform_Dialect, "iree.decompose_aggregate_op",
   }];
 }
 
-def ConvertToOnlineAttention : Op<Transform_Dialect, "iree.convert_to_online_attention",
-    [FunctionalStyleTransformOpTrait,
-     MemoryEffectsOpInterface,
-     TransformOpInterface,
-     TransformEachOpTrait,
-     ReportTrackingListenerFailuresOpTrait]> {
+def ConvertToOnlineAttention
+    : Op<Transform_Dialect, "iree.convert_to_online_attention",
+         [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+          TransformOpInterface, TransformEachOpTrait,
+          ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
     Target iree_linalg_ext.attention ops and decompose them.
     This transform consumes the target handle and produces a result handle.
   }];
 
-  let arguments = (
-      ins TransformHandleTypeInterface:$target
-  );
+  let arguments = (ins TransformHandleTypeInterface:$target);
   let results = (outs Variadic<TransformHandleTypeInterface>:$result);
 
-  let assemblyFormat = "attr-dict $target `:` functional-type(operands, results)";
+  let assemblyFormat =
+      "attr-dict $target `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/distribution.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/distribution.mlir
@@ -17,7 +17,7 @@ func.func @scatter_tiling_distribution(
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.scatter"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %forall, %tiled_op = transform.structured.tile_using_forall %0 tile_sizes [10, 30, 0] { mapping = [#gpu.thread<y>, #gpu.thread<x>] } : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %forall, %tiled_op = transform.structured.tile_using_forall %0 tile_sizes [10, 30, 0] ( mapping = [#gpu.thread<y>, #gpu.thread<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     transform.yield
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/LinkModules.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/LinkModules.cpp
@@ -695,9 +695,9 @@ LogicalResult ConflictResolver::applyRenames(
 
       // Rename the operation.
       if (auto funcOp = dyn_cast<FunctionOpInterface>(info->op)) {
-        funcOp.setName(rename.newName);
+        funcOp.setSymbolName(rename.newName);
       } else if (auto symOp = dyn_cast<SymbolOpInterface>(info->op)) {
-        symOp.setName(rename.newName);
+        symOp.setSymbolName(rename.newName);
       }
 
       // Update SymbolInfo's names to reflect the rename.

--- a/samples/transform_dialect/transform_library.mlir
+++ b/samples/transform_dialect/transform_library.mlir
@@ -40,7 +40,7 @@ module attributes { transform.with_named_sequence } {
     transform.apply_patterns to %func_1 {
       transform.apply_patterns.linalg.erase_unnecessary_inputs
     } : !transform.any_op
-    %memref_func = transform.iree.bufferize { target_gpu } %func_1 : (!transform.any_op) -> (!transform.any_op)
+    %memref_func = transform.iree.bufferize <{ target_gpu }> %func_1 : (!transform.any_op) -> (!transform.any_op)
 
     // Step 6. Post-bufferization vector distribution
     // ===========================================================================
@@ -48,30 +48,30 @@ module attributes { transform.with_named_sequence } {
     transform.iree.forall_to_workgroup %func_7 : (!transform.any_op) -> ()
     transform.iree.map_nested_forall_to_gpu_threads %func_7
         workgroup_dims = [4, 8, 1] : (!transform.any_op) -> ()
-    transform.print {name = "Ran custom_transform_strategy"}
+    transform.print name = "Ran custom_transform_strategy"
     transform.yield
   }
 
   // Send it down a custom transform dialect pipeline.
   transform.named_sequence @custom_matmul(%matmul: !transform.any_op {transform.readonly}) {
-    %variant_op = transform.get_parent_op %matmul {op_name = "hal.executable.variant"} : (!transform.any_op) -> !transform.any_op
+    %variant_op = transform.get_parent_op %matmul <{op_name = "hal.executable.variant"}> : (!transform.any_op) -> !transform.any_op
     %funcs = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     %subgroup_reduce = transform.param.constant #iree_codegen.translation_info<pipeline = #iree_codegen.transform_dialect_codegen
                                                                                codegen_spec = @custom_transform_strategy> -> !transform.any_param
     transform.annotate %funcs "translation_info" = %subgroup_reduce : !transform.any_op, !transform.any_param
-    transform.print {name = "Setting matmul strategy to custom_transform_strategy"}
+    transform.print name = "Setting matmul strategy to custom_transform_strategy"
     transform.yield
   }
 
   // Send it down subgroup reduce with a custom tiling configuration.
   transform.named_sequence @use_base_vectorize(%reduce: !transform.any_op {transform.readonly}) {
-    %variant_op = transform.get_parent_op %reduce {op_name = "hal.executable.variant"} : (!transform.any_op) -> !transform.any_op
+    %variant_op = transform.get_parent_op %reduce <{op_name = "hal.executable.variant"}> : (!transform.any_op) -> !transform.any_op
     %lowering_config = transform.param.constant #iree_codegen.lowering_config<tile_sizes = [[8, 0], [1, 0], [0, 0, 4]]> -> !transform.any_param
     transform.annotate %reduce "lowering_config" = %lowering_config : !transform.any_op, !transform.any_param
     %funcs = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     %subgroup_reduce = transform.param.constant #iree_codegen.translation_info<pipeline = #iree_gpu.spirv_pipeline<BaseVectorize> workgroup_size = [16, 1, 1]> -> !transform.any_param
     transform.annotate %funcs "translation_info" = %subgroup_reduce : !transform.any_op, !transform.any_param
-    transform.print {name = "Setting reduce strategy to base vectorize"}
+    transform.print name = "Setting reduce strategy to base vectorize"
     transform.yield
   }
 
@@ -105,7 +105,7 @@ module attributes { transform.with_named_sequence } {
       %c2 = transform.param.constant 2 : i64 -> !transform.param<i64>
       %rank = transform.match.structured.rank %arg1 : (!transform.any_op) -> !transform.param<i64>
       transform.match.param.cmpi eq %rank, %c2 : !transform.param<i64>
-      transform.match.structured.dim %arg1[-1] {reduction} : !transform.any_op
+      transform.match.structured.dim %arg1[-1] reduction : !transform.any_op
       transform.match.structured.yield %arg1 : !transform.any_op
     }
     transform.yield %matched : !transform.any_op


### PR DESCRIPTION
* Add prop-dict to IREE operations for strict property assembly formats introduced by llvm/llvm-project#196269 and enabled for Transform by llvm/llvm-project#217290.
* Preserve StableHLO's bare enum syntax after llvm/llvm-project#220608 changed EnumAttr's default assembly format to angle brackets.
* Replace deprecated setName() calls with setSymbolName() following llvm/llvm-project#218921.
* Cherry-pick e45b19d32e7c (llvm/llvm-project#222395) to fix the missing RemarkStreamer Bazel dependency exposed by llvm/llvm-project#222300.

Assisted by Codex.