### PR TITLE
[LLVMCPU] Vectorize pack/unpack on AArch64 targets with vector masking (SVE/SME)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2033,6 +2033,20 @@ getPackVectorTileSizes(mlir::FunctionOpInterface entryPointFn,
   return tileSizes;
 }
 
+/// Returns true if the target prefers decomposing pack/unpack ops over
+/// vectorizing them directly. Targets that support vector masking (x86,
+/// RISC-V, and AArch64 with SVE or SME) can vectorize the ops as-is, while the
+/// decomposed form can't be vectorized.
+static bool preferPackUnPackDecomposition(DictionaryAttr targetConfig) {
+  if (isX86(targetConfig) || isRISCV(targetConfig)) {
+    return false;
+  }
+  bool isAArch64WithMasking =
+      isAArch64(targetConfig) &&
+      (hasAnySVEFeature(targetConfig) || hasSMEFeature(targetConfig));
+  return !isAArch64WithMasking;
+}
+
 static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
                                    linalg::PackOp op) {
   assert(!getLoweringConfig(op) && "expected lowering_config is not set");
@@ -2065,15 +2079,15 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
       getDefaultDistributedLevelTileSizes(op, distConfig);
 
   // Dynamic inner tiles lead to unbounded stack allocation (which is introduced
-  // by tensor.pad op), so we do not decompose the cases. The x86 and risc-v
-  // backends prefer to not decompose the ops.
+  // by tensor.pad op), so we do not decompose the cases. Targets with vector
+  // masking support prefer to not decompose the ops.
   DictionaryAttr pipelineConfig;
   auto target = IREE::HAL::ExecutableTargetAttr::lookup(entryPointFn);
   DictionaryAttr targetConfig = target ? target.getConfiguration() : nullptr;
   bool hasDynamicInnerTile =
       llvm::any_of(op.getMixedTiles(), llvm::IsaPred<Value>);
-  if (!hasDynamicInnerTile && targetConfig && !isX86(targetConfig) &&
-      !isRISCV(targetConfig)) {
+  if (!hasDynamicInnerTile && targetConfig &&
+      preferPackUnPackDecomposition(targetConfig)) {
     pipelineConfig = getPipelineConfWithDecompositionAttr(op.getContext());
   }
 
@@ -2135,9 +2149,9 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   }
 
   // Dynamic inner tiles lead to unbounded stack allocation (which is introduced
-  // by tensor.pad op), so we do not decompose the cases. The x86 and risc-v
-  // backends, as well as the aarch64 backend in case of scalable inner tiles,
-  // prefer to not decompose the ops.
+  // by tensor.pad op), so we do not decompose the cases. Targets with vector
+  // masking support, as well as the aarch64 backend in case of scalable inner
+  // tiles, prefer to not decompose the ops.
   // TODO: Enable scalable vectorization of unpack ops and adjust the below
   // condition to account for dynamic and scalable inner tiles separately.
   DictionaryAttr pipelineConfig;
@@ -2145,8 +2159,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   bool hasDynamicOrScalableInnerTile =
       llvm::any_of(op.getMixedTiles(), llvm::IsaPred<Value>);
   if (!hasDynamicOrScalableInnerTile && target &&
-      !isX86(target.getConfiguration()) &&
-      !isRISCV(target.getConfiguration())) {
+      preferPackUnPackDecomposition(target.getConfiguration())) {
     pipelineConfig = getPipelineConfWithDecompositionAttr(op.getContext());
   }
   LoweringConfigGenerator generator(op);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
@@ -114,3 +114,58 @@ module {
 // CHECK-LABEL:     func.func @unaligned_pack
 // CHECK-COUNT-16:    vector.maskedload {{.+}} vector<16xf32>
 // CHECK-COUNT-64:    vector.shuffle
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sme", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+module {
+  func.func @unaligned_pack_aarch64_sme() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x511xf32>>
+    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x512x8x1xf32>>
+    %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 511], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x511xf32>> -> tensor<512x511xf32>
+    %3 = tensor.empty() : tensor<64x512x8x1xf32>
+    %pack = linalg.pack %2 padding_value(%cst : f32) outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 1] into %3 : tensor<512x511xf32> -> tensor<64x512x8x1xf32>
+    iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [64, 512, 8, 1], strides = [1, 1, 1, 1] : tensor<64x512x8x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x512x8x1xf32>>
+    return
+  }
+}
+
+// AArch64 with SME (and no classic SVE, e.g., Apple M4) supports vector
+// masking, so the padded pack op is vectorized with masked loads instead of
+// being decomposed.
+// CHECK-LABEL:     func.func @unaligned_pack_aarch64_sme
+// CHECK:             vector.maskedload {{.+}} vector<8xf32>
+// CHECK:             vector.store {{.+}} vector<8xf32>
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+module {
+  func.func @unaligned_pack_aarch64_sve() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x509xf32>>
+    %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x512x8x1xf32>>
+    %2 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 509], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<512x509xf32>> -> tensor<512x509xf32>
+    %3 = tensor.empty() : tensor<64x512x8x1xf32>
+    %pack = linalg.pack %2 padding_value(%cst : f32) outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 1] into %3 : tensor<512x509xf32> -> tensor<64x512x8x1xf32>
+    iree_tensor_ext.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [64, 512, 8, 1], strides = [1, 1, 1, 1] : tensor<64x512x8x1xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<64x512x8x1xf32>>
+    return
+  }
+}
+
+// AArch64 with SVE supports vector masking, so the padded pack op is
+// vectorized with masked loads instead of being decomposed.
+// CHECK-LABEL:     func.func @unaligned_pack_aarch64_sve
+// CHECK:             vector.maskedload {{.+}} vector<8xf32>
+// CHECK:             vector.store {{.+}} vector<8xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
@@ -140,3 +140,31 @@ func.func @matmul_tensors_i8i8_i32_with_sme(%7: tensor<?x?xi8>, %8: tensor<?x?xi
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.matmul
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+// SME implies vector masking support (even without classic SVE, e.g., Apple
+// M4), so static inner tile pack ops are not decomposed and can be vectorized.
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @pack_sme(%arg0: tensor<512x512xf32>) -> tensor<64x512x8x1xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %empty = tensor.empty() : tensor<64x512x8x1xf32>
+  %pack = linalg.pack %arg0 outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 1] into %empty : tensor<512x512xf32> -> tensor<64x512x8x1xf32>
+  return %pack : tensor<64x512x8x1xf32>
+}
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DataTiling>>
+//       CHECK: func.func @pack_sme(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.pack
+
+// -----
+
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @unpack_sme(%arg0: tensor<64x64x8x8xf32>) -> tensor<512x512xf32> attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %empty = tensor.empty() : tensor<512x512xf32>
+  %unpack = linalg.unpack %arg0 inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %empty : tensor<64x64x8x8xf32> -> tensor<512x512xf32>
+  return %unpack : tensor<512x512xf32>
+}
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DataTiling>>
+//       CHECK: func.func @unpack_sme(
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.unpack

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy.mlir
@@ -308,6 +308,22 @@ func.func @pack(%arg0: tensor<20x48xf32>) -> tensor<2x?x16x?xf32> attributes {ha
 
 // -----
 
+// SVE supports vector masking, so pack ops with static inner tiles are not
+// decomposed either.
+#executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
+func.func @pack_static_inner_tiles(%arg0: tensor<20x48xf32>) -> tensor<3x48x8x1xf32> attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<3x48x8x1xf32>
+  %pack = linalg.pack %arg0 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 1] into %empty : tensor<20x48xf32> -> tensor<3x48x8x1xf32>
+  return %pack : tensor<3x48x8x1xf32>
+}
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = #iree_cpu.pipeline<DataTiling>>
+//      CHECK: func.func @pack_static_inner_tiles(
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   linalg.pack
+
+// -----
+
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {cpu = "", cpu_features = "+v9a,+sve", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", link_embedded = false, native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android34"}>
 #map_elem_pack = affine_map<()[s0] -> (384 ceildiv s0)>
 #map = affine_map<(d0, d1) -> (d0, d1)>


### PR DESCRIPTION
Data-tiling `linalg.pack`/`linalg.unpack` ops with static inner tiles get the `enable_decomposition` attribute on every target except x86 and RISC-V. On AArch64 with SVE or SME, `enableVectorMasking` is already true, but decomposition still runs first. The result is that padded tiles are filled by a scalar per-element loop instead of a `vector.maskedload`.

This PR adds `preferPackUnPackDecomposition`. Pack/unpack ops are not decomposed on x86, RISC-V, and AArch64 with `+sve` or `+sme`. AArch64 NEON only is unchanged and still decomposes.


Fixes #24888.

AI-assisted.
