### PR TITLE
[Codegen][GPU] Add RDNA4 materialize encoding test

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -92,6 +92,7 @@ iree_lit_test_suite(
             "materialize_encoding_conv_x86_64.mlir",
             "materialize_encoding_for_iree_ops.mlir",
             "materialize_encoding_gfx1100.mlir",
+            "materialize_encoding_gfx1201.mlir",
             "materialize_encoding_gfx908.mlir",
             "materialize_encoding_gfx90a.mlir",
             "materialize_encoding_gfx942.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -87,6 +87,7 @@ iree_lit_test_suite(
     "materialize_encoding_conv_x86_64.mlir"
     "materialize_encoding_for_iree_ops.mlir"
     "materialize_encoding_gfx1100.mlir"
+    "materialize_encoding_gfx1201.mlir"
     "materialize_encoding_gfx908.mlir"
     "materialize_encoding_gfx90a.mlir"
     "materialize_encoding_gfx942.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1201.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_gfx1201.mlir
@@ -1,0 +1,34 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-materialize-device-encoding{test-gpu-encoding-resolver=gpu_data_tiling}))" \
+// RUN:   --iree-gpu-test-target=gfx1201 \
+// RUN:   --split-input-file %s | FileCheck %s
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_lowering_WMMAR4_F32_16x16x16_F16(
+  %lhs: tensor<?x?xf16, #encoding_lhs>,
+  %rhs: tensor<?x?xf16, #encoding_rhs>,
+  %acc: tensor<?x?xf32, #encoding_result>
+) -> tensor<?x?xf32, #encoding_result> {
+  %result = linalg.matmul
+    ins(%lhs, %rhs : tensor<?x?xf16, #encoding_lhs>, tensor<?x?xf16, #encoding_rhs>)
+    outs(%acc : tensor<?x?xf32, #encoding_result>)
+    -> tensor<?x?xf32, #encoding_result>
+  return %result : tensor<?x?xf32, #encoding_result>
+}
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK:     func.func @matmul_lowering_WMMAR4_F32_16x16x16_F16(
+// CHECK-SAME:   %[[LHS:.+]]: tensor<?x?x2x2x2x16x8xf16>, %[[RHS:.+]]: tensor<?x?x2x2x2x16x8xf16>
+// CHECK-SAME:   %[[ACC:.+]]: tensor<?x?x2x2x2x2x2x16x8xf32>
+// CHECK-SAME: ) -> tensor<?x?x2x2x2x2x2x16x8xf32>
+// CHECK:       %[[MMA:.+]] = iree_codegen.inner_tiled ins(%[[LHS]], %[[RHS]]) outs(%[[ACC]])
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
+// CHECK-SAME:    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = WMMAR4_F32_16x16x16_F16, intrinsics_m = 2, subgroups_m = 2, intrinsics_n = 2, subgroups_n = 2, operands_interleaving_intrinsics_k = [0, 1]>
+// CHECK-SAME:    into tensor<?x?x2x2x2x2x2x16x8xf32>
+// CHECK:       return %[[MMA]]


### PR DESCRIPTION
Fixes #20618.

## Summary

Add materialize-device-encoding test coverage for RDNA4/gfx1201, corresponding to the existing gfx1100 test.

The lit test runs `iree-codegen-materialize-device-encoding` with the GPU data-tiling resolver and `--iree-gpu-test-target=gfx1201`, so it exercises RDNA4 encoding selection without requiring RDNA4 hardware.

The test verifies:

- Selection of the RDNA4 `WMMAR4_F32_16x16x16_F16` intrinsic.
- Packed LHS, RHS, accumulator, and result tensor shapes.
- Conversion of `linalg.matmul` to `iree_codegen.inner_tiled`.
- The indexing maps, iterator types, and data-tiled MMA layout.

## Testing

- Bazel: `bazel test //compiler/src/iree/compiler/Codegen/Common/test:materialize_encoding_gfx1201.mlir.test`
- Bazel regression: `bazel test //compiler/src/iree/compiler/Codegen/Common/test:materialize_encoding_gfx1100.mlir.test`
- CMake/CTest (`llvm-lit`, 2/2 passed): `ctest --test-dir /tmp/iree-rdna4-cmake -R "^iree/compiler/Codegen/Common/test/materialize_encoding_gfx(1100|1201).mlir.test$" --output-on-failure -j 2`
- `git diff --check origin/main...HEAD`

Assisted-by: ChatGPT