### PR TITLE
[Codegen][CPU] Materialize and lower RISC-V V inner_tiled MMA (f32, f16, bf16, i8)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv_inner_tiled.mlir
@@ -361,3 +361,187 @@ func.func @matmul_f16_castf32_zvfh_implies_zvfhmin(%arg0 : tensor<?x?xf16>, %arg
 // CHECK-LABEL: func @matmul_f16_castf32_zvfh_implies_zvfhmin(
 //       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, intrinsics_m = 7, vlen = 256>
+
+// -----
+
+// bf16→f32 vfwmaccbf16. N tile is vlen/8; cost model picks intrinsics_m = 7.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_bf16_zvl128b(%arg0 : tensor<?x?xbf16>, %arg1 : tensor<?x?xbf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfbfwma,+zvl128b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xbf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xbf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xbf16> -> tensor<?x?xbf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xbf16> -> tensor<?x?xbf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xbf16, #lhs>, tensor<?x?xbf16, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_bf16_zvl128b(
+//       CHECK:   %[[PACK_LHS:.+]] = linalg.pack {{.*}}inner_tiles = [7, 1]
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [16, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16, intrinsics_m = 7, vlen = 128>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_bf16_zvl256b(%arg0 : tensor<?x?xbf16>, %arg1 : tensor<?x?xbf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfbfwma,+zvl256b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xbf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xbf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xbf16> -> tensor<?x?xbf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xbf16> -> tensor<?x?xbf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xbf16, #lhs>, tensor<?x?xbf16, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_bf16_zvl256b(
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [32, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16, intrinsics_m = 7, vlen = 256>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [bf16, bf16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_bf16_zvl512b(%arg0 : tensor<?x?xbf16>, %arg1 : tensor<?x?xbf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfbfwma,+zvl512b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xbf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xbf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xbf16> -> tensor<?x?xbf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xbf16> -> tensor<?x?xbf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xbf16, #lhs>, tensor<?x?xbf16, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_bf16_zvl512b(
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [64, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16, intrinsics_m = 7, vlen = 512>
+
+// -----
+
+// i8→i32 CASTI16. N tile is vlen/8; cost model picks intrinsics_m = 7.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_i8_zvl128b(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?xi8>, %m: index, %n: index, %k: index) -> tensor<?x?xi32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvl128b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0 : i32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xi8>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xi8>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xi8> -> tensor<?x?xi8, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xi8> -> tensor<?x?xi8, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xi32, #acc>
+  %3 = linalg.fill ins(%cst : i32) outs(%2 : tensor<?x?xi32, #acc>) -> tensor<?x?xi32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xi8, #lhs>, tensor<?x?xi8, #rhs>)
+      outs(%3 : tensor<?x?xi32, #acc>) -> tensor<?x?xi32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xi32, #acc> -> tensor<?x?xi32>{%d0, %d1}
+  return %5 : tensor<?x?xi32>
+}
+// CHECK-LABEL: func @matmul_i8_zvl128b(
+//       CHECK:   %[[PACK_LHS:.+]] = linalg.pack {{.*}}inner_tiles = [7, 1]
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [16, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16, intrinsics_m = 7, vlen = 128>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_i8_zvl256b(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?xi8>, %m: index, %n: index, %k: index) -> tensor<?x?xi32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvl256b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0 : i32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xi8>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xi8>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xi8> -> tensor<?x?xi8, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xi8> -> tensor<?x?xi8, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xi32, #acc>
+  %3 = linalg.fill ins(%cst : i32) outs(%2 : tensor<?x?xi32, #acc>) -> tensor<?x?xi32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xi8, #lhs>, tensor<?x?xi8, #rhs>)
+      outs(%3 : tensor<?x?xi32, #acc>) -> tensor<?x?xi32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xi32, #acc> -> tensor<?x?xi32>{%d0, %d1}
+  return %5 : tensor<?x?xi32>
+}
+// CHECK-LABEL: func @matmul_i8_zvl256b(
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [32, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16, intrinsics_m = 7, vlen = 256>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_i8_zvl512b(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?xi8>, %m: index, %n: index, %k: index) -> tensor<?x?xi32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvl512b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0 : i32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xi8>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xi8>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xi8> -> tensor<?x?xi8, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xi8> -> tensor<?x?xi8, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xi32, #acc>
+  %3 = linalg.fill ins(%cst : i32) outs(%2 : tensor<?x?xi32, #acc>) -> tensor<?x?xi32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xi8, #lhs>, tensor<?x?xi8, #rhs>)
+      outs(%3 : tensor<?x?xi32, #acc>) -> tensor<?x?xi32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xi32, #acc> -> tensor<?x?xi32>{%d0, %d1}
+  return %5 : tensor<?x?xi32>
+}
+// CHECK-LABEL: func @matmul_i8_zvl512b(
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [64, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16, intrinsics_m = 7, vlen = 512>

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_riscv_inner_tiled.mlir
@@ -111,3 +111,253 @@ func.func @matmul_f16_no_zvfh(%arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, 
 //       CHECK:   iree_codegen.inner_tiled
 //  CHECK-SAME:       intrinsic = MMA_GENERIC_SCALAR_1x1x1_REG16
 //   CHECK-NOT:       vlen
+
+// -----
+
+// f32 vfmacc.vf. N tile is vlen/8; intrinsics_m stays 6.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f32_zvl128b(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvl128b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf32, #lhs>, tensor<?x?xf32, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_f32_zvl128b(
+//       CHECK:   %[[PACK_LHS:.+]] = linalg.pack {{.*}}inner_tiles = [6, 1]
+//  CHECK-SAME:       -> tensor<?x?x6x1xf32>
+//       CHECK:   %[[EXPANDED:.+]] = tensor.expand_shape %[[PACK_LHS]] {{\[}}[0], [1], [2], [3, 4]{{\]}}
+//  CHECK-SAME:       tensor<?x?x6x1xf32> into tensor<?x?x6x1x1xf32>
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [16, 1]
+//  CHECK-SAME:       -> tensor<?x?x16x1xf32>
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled ins(%[[EXPANDED]], %[[PACK_RHS]])
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32, intrinsics_m = 6, vlen = 128>
+//  CHECK-SAME:       tensor<?x?x6x1x1xf32>, tensor<?x?x16x1xf32> into tensor<?x?x6x1x16xf32>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f32_zvl256b(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvl256b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf32, #lhs>, tensor<?x?xf32, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_f32_zvl256b(
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [32, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32, intrinsics_m = 6, vlen = 256>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f32_zvl512b(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvl512b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf32, #lhs>, tensor<?x?xf32, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_f32_zvl512b(
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [64, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32, intrinsics_m = 6, vlen = 512>
+
+// -----
+
+// Plain +v falls back to VLEN=128.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f32_plain_v(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf32> -> tensor<?x?xf32, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf32, #lhs>, tensor<?x?xf32, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_f32_plain_v(
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32, intrinsics_m = 6, vlen = 128>
+
+// -----
+
+// f16→f32 CASTF32 via Zvfhmin. N tile is vlen/8; cost model picks intrinsics_m = 7.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f16_castf32_zvl128b(%arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfhmin,+zvl128b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf16, #lhs>, tensor<?x?xf16, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_f16_castf32_zvl128b(
+//       CHECK:   %[[PACK_LHS:.+]] = linalg.pack {{.*}}inner_tiles = [7, 1]
+//  CHECK-SAME:       -> tensor<?x?x7x1xf16>
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [16, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, intrinsics_m = 7, vlen = 128>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f16_castf32_zvl256b(%arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfhmin,+zvl256b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf16, #lhs>, tensor<?x?xf16, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_f16_castf32_zvl256b(
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [32, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, intrinsics_m = 7, vlen = 256>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f16_castf32_zvl512b(%arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfhmin,+zvl512b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf16, #lhs>, tensor<?x?xf16, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_f16_castf32_zvl512b(
+//       CHECK:   %[[PACK_RHS:.+]] = linalg.pack {{.*}}inner_tiles = [64, 1]
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, intrinsics_m = 7, vlen = 512>
+
+// -----
+
+// +zvfh implies +zvfhmin, so f16f16f32 still selects CASTF32.
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+#acc = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], iteration_sizes = [?, ?, ?]>
+func.func @matmul_f16_castf32_zvfh_implies_zvfhmin(%arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, %m: index, %n: index, %k: index) -> tensor<?x?xf32> attributes {
+   hal.executable.target = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {target_triple = "riscv64-unknown-unknown-eabi-elf", cpu_features = "+m,+a,+f,+d,+c,+v,+zvfh,+zvl256b", enable_inner_tiled = true, iree.encoding.resolver = #iree_cpu.cpu_encoding_resolver<>}>
+} {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %0 = iree_encoding.set_encoding %arg0 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #lhs>
+  %1 = iree_encoding.set_encoding %arg1 encoding_dims{%m, %n, %k} : tensor<?x?xf16> -> tensor<?x?xf16, #rhs>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #acc>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf16, #lhs>, tensor<?x?xf16, #rhs>)
+      outs(%3 : tensor<?x?xf32, #acc>) -> tensor<?x?xf32, #acc>
+  %5 = iree_encoding.unset_encoding %4 encoding_dims{%m, %n, %k} : tensor<?x?xf32, #acc> -> tensor<?x?xf32>{%d0, %d1}
+  return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_f16_castf32_zvfh_implies_zvfhmin(
+//       CHECK:   %[[INNER:.+]] = iree_codegen.inner_tiled
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, intrinsics_m = 7, vlen = 256>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -491,7 +491,11 @@ getIntrinsicMNKShape(MMAIntrinsic intrinsic, int64_t vlen) {
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16:
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16:
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32:
-  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32: {
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16:
+  case MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_8VLsx1x1_F32_BF16:
+  case MMAIntrinsic::MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16: {
     int64_t vl = vlen / 8;
     bool transposed = (static_cast<uint32_t>(intrinsic) & 1) != 0;
     return transposed ? Tuple{vl, 1, 1} : Tuple{1, vl, 1};
@@ -755,6 +759,8 @@ std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
     return {f16, f16, f16};
   case MMAIntrinsic::MMA_X86_AVX512BF16_1x16x2_F32_BF16:
   case MMAIntrinsic::MMA_X86_AVX512BF16_16x1x2_F32_BF16:
+  case MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16:
+  case MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_8VLsx1x1_F32_BF16:
     return {bf16, bf16, f32};
   case MMAIntrinsic::MMA_X86_AVX512_1x16x2_I32_I16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_1x16x2_I32_I16:
@@ -766,6 +772,8 @@ std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
   case MMAIntrinsic::MMA_X86_AVX512_16x1x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x2_I32_I8_CASTI16:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16:
     return {i8, i8, i32};
   // vpdpbusd: returned types preserve signedness for the cost model to
   // match against the encoding's `element_types`; tile types in IR are
@@ -1024,6 +1032,68 @@ static Value lowerRiscvVFmaccLike(OpBuilder &b, Location loc,
                                            /*pos=*/0);
 }
 
+// i8→i32: vsext.vf2 (i8m1→i16m2) then vwmacc.vx into i32m4. Scalar is
+// sign-extended to i16. nxv8 insert; vl is vlen/8; policy=0 (tail undisturbed).
+static Value lowerRiscvVWmaccCastI16(OpBuilder &b, Location loc,
+                                     MMAIntrinsic intrinsic, int64_t vlen,
+                                     Value lhs, Value rhs, Value acc) {
+  bool lhsIsScalar = (static_cast<uint32_t>(intrinsic) & 1) == 0;
+  Value scalarSrc = lhsIsScalar ? lhs : rhs;
+  Value vec = lhsIsScalar ? rhs : lhs;
+
+  auto flattenIfNeeded = [&](Value v) -> Value {
+    auto vt = dyn_cast<VectorType>(v.getType());
+    if (!vt || vt.getRank() <= 1) {
+      return v;
+    }
+    return vector::ShapeCastOp::create(
+        b, loc, VectorType::get({vt.getNumElements()}, vt.getElementType()), v);
+  };
+  vec = flattenIfNeeded(vec);
+  acc = flattenIfNeeded(acc);
+  scalarSrc = flattenIfNeeded(scalarSrc);
+
+  auto scalarTy = cast<VectorType>(scalarSrc.getType());
+  SmallVector<int64_t> zeros(scalarTy.getRank(), 0);
+  Value scalarI8 = vector::ExtractOp::create(b, loc, scalarSrc, zeros);
+  Value scalar = arith::ExtSIOp::create(b, loc, b.getI16Type(), scalarI8);
+
+  auto insertNxv8 = [&](Value v) {
+    auto fixedTy = cast<VectorType>(v.getType());
+    auto scalableTy = VectorType::get({8}, fixedTy.getElementType(), {true});
+    Value pad = vector::BroadcastOp::create(
+        b, loc, scalableTy,
+        arith::ConstantOp::create(b, loc,
+                                  b.getZeroAttr(fixedTy.getElementType())));
+    Value scalable =
+        vector::ScalableInsertOp::create(b, loc, v, pad, /*pos=*/0);
+    return std::pair<Value, VectorType>{scalable, fixedTy};
+  };
+  auto [vecI8Scalable, vecFixedTy] = insertNxv8(vec);
+  (void)vecFixedTy;
+  auto [accScalable, accFixedTy] = insertNxv8(acc);
+
+  int64_t lanes = vlen / 8;
+  Value vl = arith::ConstantOp::create(b, loc, b.getI64IntegerAttr(lanes));
+  auto i16ScalableTy = VectorType::get({8}, b.getI16Type(), {true});
+  Value i16Pad = vector::BroadcastOp::create(
+      b, loc, i16ScalableTy,
+      arith::ConstantOp::create(b, loc, b.getZeroAttr(b.getI16Type())));
+  Value vecI16Scalable =
+      LLVM::CallIntrinsicOp::create(b, loc, i16ScalableTy,
+                                    b.getStringAttr("llvm.riscv.vsext"),
+                                    ValueRange{i16Pad, vecI8Scalable, vl})
+          .getResult(0);
+  Value policy = arith::ConstantOp::create(b, loc, b.getI64IntegerAttr(0));
+  Value resultScalable =
+      LLVM::CallIntrinsicOp::create(
+          b, loc, accScalable.getType(), b.getStringAttr("llvm.riscv.vwmacc"),
+          ValueRange{accScalable, scalar, vecI16Scalable, vl, policy})
+          .getResult(0);
+  return vector::ScalableExtractOp::create(b, loc, accFixedTy, resultScalable,
+                                           /*pos=*/0);
+}
+
 // Lowers a MMAIntrinsic to a llvm.call_intrinsic op, plus any necessary
 // additional ops (potentially broadcasting or widening LHS/RHS or creating an
 // add op if the intrinsic isn't already adding the accumulator).
@@ -1052,6 +1122,16 @@ static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
     };
     return lowerRiscvVFmaccLike(builder, loc, intrinsic, vlen, widenF16(lhs),
                                 widenF16(rhs), acc, "llvm.riscv.vfmacc");
+  }
+  if (intrinsic == MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16 ||
+      intrinsic == MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_8VLsx1x1_F32_BF16) {
+    return lowerRiscvVFmaccLike(builder, loc, intrinsic, vlen, lhs, rhs, acc,
+                                "llvm.riscv.vfwmaccbf16");
+  }
+  if (intrinsic == MMAIntrinsic::MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16 ||
+      intrinsic == MMAIntrinsic::MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16) {
+    return lowerRiscvVWmaccCastI16(builder, loc, intrinsic, vlen, lhs, rhs,
+                                   acc);
   }
   // Sign-/float-extend a vector to a wider element type. Used by the
   // *_CASTF32 (f16 → f32) and *_CASTI16 (i8 → i16) variants where the

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.cpp
@@ -485,12 +485,15 @@ getIntrinsicMNKShape(MMAIntrinsic intrinsic, int64_t vlen) {
     return Tuple{1, 4, 1};
   case MMAIntrinsic::MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32:
     return Tuple{4, 1, 1};
-  // VLs = vlen / 8 lanes, one LMUL=2 register group at 16-bit elements.
+  // RVV: M or N is vlen/8. Enum bit 0 is the swapped orientation.
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32:
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16:
-  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16: {
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32: {
     int64_t vl = vlen / 8;
-    bool transposed =
-        intrinsic == MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16;
+    bool transposed = (static_cast<uint32_t>(intrinsic) & 1) != 0;
     return transposed ? Tuple{vl, 1, 1} : Tuple{1, vl, 1};
   }
   default:
@@ -737,9 +740,13 @@ std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *ctx,
     return {f64, f64, f64};
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F32:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F32:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32:
     return {f32, f32, f32};
   case MMAIntrinsic::MMA_X86_AVX512_1x16x1_F32_F16_CASTF32:
   case MMAIntrinsic::MMA_X86_AVX512_16x1x1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32:
     return {f16, f16, f32};
   case MMAIntrinsic::MMA_X86_AVX512FP16_1x32x1_F16_F16:
   case MMAIntrinsic::MMA_X86_AVX512FP16_32x1x1_F16_F16:
@@ -962,16 +969,89 @@ static Value lowerX86Avx512Vnni16x16x2I8(OpBuilder &b, Location loc, Value lhs,
   return result;
 }
 
+// RVV `.vf` FMA (`vfmacc` / `vfwmaccbf16`). Enum bit 0 selects which operand
+// is the scalar (swapped => RHS). Each operand is inserted into nxv8 so
+// 8 * vscale == vlen/8 lanes; frm=7 is DYN, policy=0 is tail undisturbed.
+static Value lowerRiscvVFmaccLike(OpBuilder &b, Location loc,
+                                  MMAIntrinsic intrinsic, int64_t vlen,
+                                  Value lhs, Value rhs, Value acc,
+                                  StringRef llvmName) {
+  bool lhsIsScalar = (static_cast<uint32_t>(intrinsic) & 1) == 0;
+  Value scalarSrc = lhsIsScalar ? lhs : rhs;
+  Value vec = lhsIsScalar ? rhs : lhs;
+
+  auto flattenIfNeeded = [&](Value v) -> Value {
+    auto vt = dyn_cast<VectorType>(v.getType());
+    if (!vt || vt.getRank() <= 1) {
+      return v;
+    }
+    return vector::ShapeCastOp::create(
+        b, loc, VectorType::get({vt.getNumElements()}, vt.getElementType()), v);
+  };
+  vec = flattenIfNeeded(vec);
+  acc = flattenIfNeeded(acc);
+  scalarSrc = flattenIfNeeded(scalarSrc);
+
+  auto scalarTy = cast<VectorType>(scalarSrc.getType());
+  SmallVector<int64_t> zeros(scalarTy.getRank(), 0);
+  Value scalar = vector::ExtractOp::create(b, loc, scalarSrc, zeros);
+
+  auto insertNxv8 = [&](Value v) {
+    auto fixedTy = cast<VectorType>(v.getType());
+    auto scalableTy = VectorType::get({8}, fixedTy.getElementType(), {true});
+    Value pad = vector::BroadcastOp::create(
+        b, loc, scalableTy,
+        arith::ConstantOp::create(b, loc,
+                                  b.getZeroAttr(fixedTy.getElementType())));
+    Value scalable =
+        vector::ScalableInsertOp::create(b, loc, v, pad, /*pos=*/0);
+    return std::pair<Value, VectorType>{scalable, fixedTy};
+  };
+  auto [accScalable, accFixedTy] = insertNxv8(acc);
+  auto [vecScalable, vecFixedTy] = insertNxv8(vec);
+  (void)vecFixedTy;
+
+  int64_t lanes = vlen / 8;
+  Value frm = arith::ConstantOp::create(b, loc, b.getI64IntegerAttr(7));
+  Value vl = arith::ConstantOp::create(b, loc, b.getI64IntegerAttr(lanes));
+  Value policy = arith::ConstantOp::create(b, loc, b.getI64IntegerAttr(0));
+  Value resultScalable =
+      LLVM::CallIntrinsicOp::create(
+          b, loc, accScalable.getType(), b.getStringAttr(llvmName),
+          ValueRange{accScalable, scalar, vecScalable, frm, vl, policy})
+          .getResult(0);
+  return vector::ScalableExtractOp::create(b, loc, accFixedTy, resultScalable,
+                                           /*pos=*/0);
+}
+
 // Lowers a MMAIntrinsic to a llvm.call_intrinsic op, plus any necessary
 // additional ops (potentially broadcasting or widening LHS/RHS or creating an
 // add op if the intrinsic isn't already adding the accumulator).
 static Value createCpuMmaIntrinsicCall(OpBuilder &builder, Location loc,
                                        MMAIntrinsic intrinsic, Value lhs,
-                                       Value rhs, Value acc) {
+                                       Value rhs, Value acc, int64_t vlen) {
   // The 16x16x2 i8 intrinsic processes whole panels and has its own widen /
   // shuffle scheme; it bypasses the per-row widen + broadcast path below.
   if (intrinsic == MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16) {
     return lowerX86Avx512Vnni16x16x2I8(builder, loc, lhs, rhs, acc);
+  }
+  if (intrinsic == MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32 ||
+      intrinsic == MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32 ||
+      intrinsic == MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16 ||
+      intrinsic == MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16) {
+    return lowerRiscvVFmaccLike(builder, loc, intrinsic, vlen, lhs, rhs, acc,
+                                "llvm.riscv.vfmacc");
+  }
+  if (intrinsic == MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32 ||
+      intrinsic == MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32) {
+    Type f32 = builder.getF32Type();
+    auto widenF16 = [&](Value v) -> Value {
+      auto vt = cast<VectorType>(v.getType());
+      return arith::ExtFOp::create(builder, loc,
+                                   VectorType::get(vt.getShape(), f32), v);
+    };
+    return lowerRiscvVFmaccLike(builder, loc, intrinsic, vlen, widenF16(lhs),
+                                widenF16(rhs), acc, "llvm.riscv.vfmacc");
   }
   // Sign-/float-extend a vector to a wider element type. Used by the
   // *_CASTF32 (f16 → f32) and *_CASTI16 (i8 → i16) variants where the
@@ -1253,7 +1333,8 @@ LogicalResult DataTiledMMAAttr::buildUnderlyingOperations(
   }
   auto emitIntrinsic = [&](OpBuilder &b, Location loc, Value lhs, Value rhs,
                            Value acc) -> Value {
-    return createCpuMmaIntrinsicCall(b, loc, intrinsic, lhs, rhs, acc);
+    return createCpuMmaIntrinsicCall(b, loc, intrinsic, lhs, rhs, acc,
+                                     getVlen());
   };
   return Codegen::buildDataTiledMMAUnderlyingOperations(
       builder, loc, getSwizzle(*this, /*operandIdx=*/0),

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -198,6 +198,18 @@ def MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32
 def MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32
     : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32", 0x3123>;
 
+// vfwmaccbf16.vf, N=vlen/8 (bf16m2→f32m4). Requires +zvfbfwma.
+def MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16
+    : I32EnumAttrCase<"MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16", 0x3130>;
+def MMA_RISCV_V_VFWMACCBF16_8VLsx1x1_F32_BF16
+    : I32EnumAttrCase<"MMA_RISCV_V_VFWMACCBF16_8VLsx1x1_F32_BF16", 0x3131>;
+
+// vsext.vf2 (i8m1→i16m2) then vwmacc.vx into i32m4. N=vlen/8. Requires +v.
+def MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16
+    : I32EnumAttrCase<"MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16", 0x31C0>;
+def MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16
+    : I32EnumAttrCase<"MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16", 0x31C1>;
+
 // Architecture-agnostic, type-polymorphic generic-scalar fallback. Tile
 // shape is 1×1×1, lowering is a single `vector.contract` over the
 // unrolled (`intrinsics_m`, `intrinsics_n`, `intrinsics_k`) tile. Unlike
@@ -253,6 +265,10 @@ def IREECPU_MMAIntrinsic
            MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16,
            MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32,
            MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32,
+           MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16,
+           MMA_RISCV_V_VFWMACCBF16_8VLsx1x1_F32_BF16,
+           MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16,
+           MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16,
 
            // Architecture-agnostic generic-scalar fallback (type-polymorphic).
            MMA_GENERIC_SCALAR_1x1x1_REG8, MMA_GENERIC_SCALAR_1x1x1_REG16]>;

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUEnums.td
@@ -174,6 +174,13 @@ def MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32
 def MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32
     : I32EnumAttrCase<"MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32", 0x2211>;
 
+// RISC-V V `vfmacc.vf` (f32, f32). 1x8VLsx1 or swapped 8VLsx1x1.
+// 8VLs = LMUL=4; lane count is DataTiledMMAAttr.vlen/8. Requires +v.
+def MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32
+    : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32", 0x3110>;
+def MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32
+    : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32", 0x3111>;
+
 // RISC-V V `vfmacc.vf` (f16, f16): a 1x8VLsx1 matmul tile, or 8VLsx1x1 in the
 // M<->N-swapped orientation. `8VLs` is 8 f16 elements per 64-bit vector-length
 // unit, i.e. one LMUL=2 register group, and s stands for static. The LHS is a
@@ -183,6 +190,13 @@ def MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16
     : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16", 0x3120>;
 def MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16
     : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16", 0x3121>;
+
+// f16→f32: extf then f32 vfmacc.vf (LMUL=4). Requires +zvfhmin (implied by
+// +zvfh). Native Zvfh f16 ACC still matches f16f16f16 encodings first.
+def MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32
+    : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32", 0x3122>;
+def MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32
+    : I32EnumAttrCase<"MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32", 0x3123>;
 
 // Architecture-agnostic, type-polymorphic generic-scalar fallback. Tile
 // shape is 1×1×1, lowering is a single `vector.contract` over the
@@ -233,8 +247,12 @@ def IREECPU_MMAIntrinsic
            MMA_ARM_SVE_FMLA_1x4VLx1_F32_F32, MMA_ARM_SVE_FMLA_4VLx1x1_F32_F32,
 
            // RISC-V V
+           MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32,
+           MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32,
            MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16,
            MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16,
+           MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32,
+           MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32,
 
            // Architecture-agnostic generic-scalar fallback (type-polymorphic).
            MMA_GENERIC_SCALAR_1x1x1_REG8, MMA_GENERIC_SCALAR_1x1x1_REG16]>;

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
@@ -400,3 +400,51 @@ func.func @cpu_riscv_v_vfmacc_f16_castf32(
 //       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, vlen = 256>
 //  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16 at vlen = 256, intrinsics 1x1x1
+func.func @cpu_riscv_v_vfwmaccbf16(
+    %lhs: vector<1x1x1xbf16>, %rhs: vector<1x1x32xbf16>, %acc: vector<1x1x32xf32>)
+    -> vector<1x1x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x1xbf16>, vector<1x1x32xbf16> into vector<1x1x32xf32>
+  return %0 : vector<1x1x32xf32>
+}
+// CHECK-LABEL: func @cpu_riscv_v_vfwmaccbf16
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16, vlen = 256>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16 at vlen = 256, intrinsics 1x1x1
+func.func @cpu_riscv_v_vwmacc_i8(
+    %lhs: vector<1x1x1xi8>, %rhs: vector<1x1x32xi8>, %acc: vector<1x1x32xi32>)
+    -> vector<1x1x32xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x1xi8>, vector<1x1x32xi8> into vector<1x1x32xi32>
+  return %0 : vector<1x1x32xi32>
+}
+// CHECK-LABEL: func @cpu_riscv_v_vwmacc_i8
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16, vlen = 256>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/iree_cpu_inner_tiled_ops.mlir
@@ -327,3 +327,76 @@ func.func @cpu_riscv_v_vfmacc_f16_swapped(
 // CHECK-LABEL: func @cpu_riscv_v_vfmacc_f16_swapped
 //       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
 //  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16, vlen = 512>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32 at vlen = 256, intrinsics 1x1x1
+func.func @cpu_riscv_v_vfmacc_f32(
+    %lhs: vector<1x1x1xf32>, %rhs: vector<1x1x32xf32>, %acc: vector<1x1x32xf32>)
+    -> vector<1x1x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x1xf32>, vector<1x1x32xf32> into vector<1x1x32xf32>
+  return %0 : vector<1x1x32xf32>
+}
+// CHECK-LABEL: func @cpu_riscv_v_vfmacc_f32
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32, vlen = 256>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32 at vlen = 128, intrinsics 1x1x1
+func.func @cpu_riscv_v_vfmacc_f32_swapped(
+    %lhs: vector<1x1x16xf32>, %rhs: vector<1x1x1xf32>, %acc: vector<1x1x16xf32>)
+    -> vector<1x1x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32, vlen = 128>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x16xf32>, vector<1x1x1xf32> into vector<1x1x16xf32>
+  return %0 : vector<1x1x16xf32>
+}
+// CHECK-LABEL: func @cpu_riscv_v_vfmacc_f32_swapped
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32, vlen = 128>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>
+
+// -----
+
+#contraction_accesses = [
+  affine_map<(i, j, k) -> (i, k)>,
+  affine_map<(i, j, k) -> (k, j)>,
+  affine_map<(i, j, k) -> (i, j)>
+]
+// MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32 at vlen = 256, intrinsics 1x1x1
+func.func @cpu_riscv_v_vfmacc_f16_castf32(
+    %lhs: vector<1x1x1xf16>, %rhs: vector<1x1x32xf16>, %acc: vector<1x1x32xf32>)
+    -> vector<1x1x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1x1xf16>, vector<1x1x32xf16> into vector<1x1x32xf32>
+  return %0 : vector<1x1x32xf32>
+}
+// CHECK-LABEL: func @cpu_riscv_v_vfmacc_f16_castf32
+//       CHECK:   iree_codegen.inner_tiled ins(%arg0, %arg1) outs(%arg2)
+//  CHECK-SAME:       kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, vlen = 256>
+//  CHECK-SAME:       semantics = #iree_cpu.mma_semantics<>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -419,3 +419,312 @@ module attributes { transform.with_named_sequence } {
 //   CHECK-DAG:   vector.shuffle %{{.+}} [0, 0, 0, 0, 4, 4, 4, 4, 8, 8, 8, 8, 12, 12, 12, 12]
 //   CHECK-DAG:   vector.shuffle %{{.+}} [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
 //       CHECK-COUNT-16:   llvm.call_intrinsic "llvm.x86.avx512.vpdpwssd.512"
+
+// -----
+
+// RISC-V VLEN=256 1×32×1 f32: scalar .vf, not splat.
+
+#contraction_accesses_rvv = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_f32_vlen256(
+    %lhs: vector<1x1xf32>, %rhs: vector<32x1xf32>, %acc: vector<1x32xf32>)
+    -> vector<1x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xf32>, vector<32x1xf32> into vector<1x32xf32>
+  return %0 : vector<1x32xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_f32_vlen256
+//       CHECK:   vector.extract {{.*}} : f32 from vector<{{1x1|1}}xf32>
+//   CHECK-NOT:   vector.broadcast {{.*}} : f32 to vector<32xf32>
+//       CHECK:   vector.scalable.insert {{.*}} : vector<32xf32> into vector<[8]xf32>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf32>, f32, vector<[8]xf32>, i64, i64, i64) -> vector<[8]xf32>
+//       CHECK:   vector.scalable.extract {{.*}} : vector<32xf32> from vector<[8]xf32>
+
+// -----
+
+// RISC-V VLEN=128: lane count tracks vlen/8.
+
+#contraction_accesses_rvv128 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_f32_vlen128(
+    %lhs: vector<1x1xf32>, %rhs: vector<16x1xf32>, %acc: vector<1x16xf32>)
+    -> vector<1x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv128,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32, vlen = 128>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xf32>, vector<16x1xf32> into vector<1x16xf32>
+  return %0 : vector<1x16xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_f32_vlen128
+//       CHECK:   vector.extract {{.*}} : f32 from vector<{{1x1|1}}xf32>
+//       CHECK:   vector.scalable.insert {{.*}} : vector<16xf32> into vector<[8]xf32>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf32>, f32, vector<[8]xf32>, i64, i64, i64) -> vector<[8]xf32>
+//       CHECK:   vector.scalable.extract {{.*}} : vector<16xf32> from vector<[8]xf32>
+
+// -----
+
+// RISC-V VLEN=256 32×1×1 f32: scalar from unit-N RHS.
+
+#contraction_accesses_rvv_t = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_8vlsx1x1_f32_vlen256(
+    %lhs: vector<32x1xf32>, %rhs: vector<1x1xf32>, %acc: vector<32x1xf32>)
+    -> vector<32x1xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_t,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<32x1xf32>, vector<1x1xf32> into vector<32x1xf32>
+  return %0 : vector<32x1xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_8vlsx1x1_f32_vlen256
+//       CHECK:   vector.extract {{.*}} : f32 from vector<{{1x1|1}}xf32>
+//   CHECK-NOT:   vector.broadcast {{.*}} : f32 to vector<32xf32>
+//       CHECK:   vector.scalable.insert {{.*}} : vector<32xf32> into vector<[8]xf32>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf32>, f32, vector<[8]xf32>, i64, i64, i64) -> vector<[8]xf32>
+//       CHECK:   vector.scalable.extract {{.*}} : vector<32xf32> from vector<[8]xf32>
+
+// -----
+
+// RISC-V VLEN=256 1×32×1 f16: same vfmacc.vf path, nxv8f16 (f16m2).
+
+#contraction_accesses_rvv_f16 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_f16_vlen256(
+    %lhs: vector<1x1xf16>, %rhs: vector<32x1xf16>, %acc: vector<1x32xf16>)
+    -> vector<1x32xf16> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_f16,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xf16>, vector<32x1xf16> into vector<1x32xf16>
+  return %0 : vector<1x32xf16>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_f16_vlen256
+//       CHECK:   vector.extract {{.*}} : f16 from vector<{{1x1|1}}xf16>
+//   CHECK-NOT:   vector.broadcast {{.*}} : f16 to vector<32xf16>
+//       CHECK:   vector.scalable.insert {{.*}} : vector<32xf16> into vector<[8]xf16>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf16>, f16, vector<[8]xf16>, i64, i64, i64) -> vector<[8]xf16>
+//       CHECK:   vector.scalable.extract {{.*}} : vector<32xf16> from vector<[8]xf16>
+
+// -----
+
+// RISC-V VLEN=128 f16: lane count tracks vlen/8.
+
+#contraction_accesses_rvv_f16_128 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_f16_vlen128(
+    %lhs: vector<1x1xf16>, %rhs: vector<16x1xf16>, %acc: vector<1x16xf16>)
+    -> vector<1x16xf16> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_f16_128,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16, vlen = 128>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xf16>, vector<16x1xf16> into vector<1x16xf16>
+  return %0 : vector<1x16xf16>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_f16_vlen128
+//       CHECK:   vector.extract {{.*}} : f16 from vector<{{1x1|1}}xf16>
+//       CHECK:   vector.scalable.insert {{.*}} : vector<16xf16> into vector<[8]xf16>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf16>, f16, vector<[8]xf16>, i64, i64, i64) -> vector<[8]xf16>
+//       CHECK:   vector.scalable.extract {{.*}} : vector<16xf16> from vector<[8]xf16>
+
+// -----
+
+// RISC-V VLEN=256 f16→f32 CASTF32: widen once, then f32 vfmacc.vf.
+
+#contraction_accesses_rvv_castf32 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_f16_castf32_vlen256(
+    %lhs: vector<1x1xf16>, %rhs: vector<32x1xf16>, %acc: vector<1x32xf32>)
+    -> vector<1x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_castf32,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xf16>, vector<32x1xf16> into vector<1x32xf32>
+  return %0 : vector<1x32xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_f16_castf32_vlen256
+//       CHECK:   arith.extf {{.*}} : vector<{{1x1|1}}xf16> to vector<{{1x1|1}}xf32>
+//       CHECK:   arith.extf {{.*}} : vector<{{32x1|32}}xf16> to vector<{{32x1|32}}xf32>
+//       CHECK:   vector.extract {{.*}} : f32 from vector<{{1x1|1}}xf32>
+//       CHECK:   vector.scalable.insert {{.*}} : vector<32xf32> into vector<[8]xf32>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf32>, f32, vector<[8]xf32>, i64, i64, i64) -> vector<[8]xf32>
+//       CHECK:   vector.scalable.extract {{.*}} : vector<32xf32> from vector<[8]xf32>
+
+// -----
+
+// RISC-V VLEN=256 swapped CASTF32: scalar from unit-N RHS.
+
+#contraction_accesses_rvv_castf32_t = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_8vlsx1x1_f16_castf32_vlen256(
+    %lhs: vector<32x1xf16>, %rhs: vector<1x1xf16>, %acc: vector<32x1xf32>)
+    -> vector<32x1xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_castf32_t,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<32x1xf16>, vector<1x1xf16> into vector<32x1xf32>
+  return %0 : vector<32x1xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_8vlsx1x1_f16_castf32_vlen256
+//       CHECK:   arith.extf {{.*}} : vector<{{32x1|32}}xf16> to vector<{{32x1|32}}xf32>
+//       CHECK:   arith.extf {{.*}} : vector<{{1x1|1}}xf16> to vector<{{1x1|1}}xf32>
+//       CHECK:   vector.extract {{.*}} : f32 from vector<{{1x1|1}}xf32>
+//   CHECK-NOT:   vector.broadcast {{.*}} : f32 to vector<32xf32>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf32>, f32, vector<[8]xf32>, i64, i64, i64) -> vector<[8]xf32>
+
+// -----
+
+// RISC-V VLEN=128 f16→f32 CASTF32.
+
+#contraction_accesses_rvv_castf32_128 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_f16_castf32_vlen128(
+    %lhs: vector<1x1xf16>, %rhs: vector<16x1xf16>, %acc: vector<1x16xf32>)
+    -> vector<1x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_castf32_128,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32, vlen = 128>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xf16>, vector<16x1xf16> into vector<1x16xf32>
+  return %0 : vector<1x16xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_f16_castf32_vlen128
+//       CHECK:   arith.extf {{.*}} : vector<{{1x1|1}}xf16> to vector<{{1x1|1}}xf32>
+//       CHECK:   arith.extf {{.*}} : vector<{{16x1|16}}xf16> to vector<{{16x1|16}}xf32>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf32>, f32, vector<[8]xf32>, i64, i64, i64) -> vector<[8]xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/test/lower_inner_tiled.mlir
@@ -728,3 +728,192 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:   arith.extf {{.*}} : vector<{{1x1|1}}xf16> to vector<{{1x1|1}}xf32>
 //       CHECK:   arith.extf {{.*}} : vector<{{16x1|16}}xf16> to vector<{{16x1|16}}xf32>
 //       CHECK:   llvm.call_intrinsic "llvm.riscv.vfmacc{{.*}}"({{.*}}) : (vector<[8]xf32>, f32, vector<[8]xf32>, i64, i64, i64) -> vector<[8]xf32>
+
+// -----
+
+// RISC-V VLEN=256 bf16→f32 vfwmaccbf16.vf.
+
+#contraction_accesses_rvv_bf16 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_bf16_vlen256(
+    %lhs: vector<1x1xbf16>, %rhs: vector<32x1xbf16>, %acc: vector<1x32xf32>)
+    -> vector<1x32xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_bf16,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xbf16>, vector<32x1xbf16> into vector<1x32xf32>
+  return %0 : vector<1x32xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_bf16_vlen256
+//       CHECK:   vector.extract {{.*}} : bf16 from vector<{{1x1|1}}xbf16>
+//       CHECK:   vector.scalable.insert {{.*}} : vector<32xf32> into vector<[8]xf32>
+//       CHECK:   vector.scalable.insert {{.*}} : vector<32xbf16> into vector<[8]xbf16>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfwmaccbf16{{.*}}"({{.*}}) : (vector<[8]xf32>, bf16, vector<[8]xbf16>, i64, i64, i64) -> vector<[8]xf32>
+//       CHECK:   vector.scalable.extract {{.*}} : vector<32xf32> from vector<[8]xf32>
+
+// -----
+
+// RISC-V VLEN=128 bf16→f32 vfwmaccbf16.vf.
+
+#contraction_accesses_rvv_bf16_128 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_bf16_vlen128(
+    %lhs: vector<1x1xbf16>, %rhs: vector<16x1xbf16>, %acc: vector<1x16xf32>)
+    -> vector<1x16xf32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_bf16_128,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16, vlen = 128>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xbf16>, vector<16x1xbf16> into vector<1x16xf32>
+  return %0 : vector<1x16xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_bf16_vlen128
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vfwmaccbf16{{.*}}"({{.*}}) : (vector<[8]xf32>, bf16, vector<[8]xbf16>, i64, i64, i64) -> vector<[8]xf32>
+
+// -----
+
+// RISC-V VLEN=256 i8→i32: vsext.vf2 then vwmacc.vx.
+
+#contraction_accesses_rvv_i8 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_i8_vlen256(
+    %lhs: vector<1x1xi8>, %rhs: vector<32x1xi8>, %acc: vector<1x32xi32>)
+    -> vector<1x32xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_i8,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xi8>, vector<32x1xi8> into vector<1x32xi32>
+  return %0 : vector<1x32xi32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_i8_vlen256
+//       CHECK:   vector.extract {{.*}} : i8 from vector<{{1x1|1}}xi8>
+//       CHECK:   arith.extsi {{.*}} : i8 to i16
+//       CHECK:   vector.scalable.insert {{.*}} : vector<32xi8> into vector<[8]xi8>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vsext{{.*}}"({{.*}}) : (vector<[8]xi16>, vector<[8]xi8>, i64) -> vector<[8]xi16>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vwmacc{{.*}}"({{.*}}) : (vector<[8]xi32>, i16, vector<[8]xi16>, i64, i64) -> vector<[8]xi32>
+//       CHECK:   vector.scalable.extract {{.*}} : vector<32xi32> from vector<[8]xi32>
+
+// -----
+
+// RISC-V VLEN=256 swapped i8 CASTI16: scalar from unit-N RHS.
+
+#contraction_accesses_rvv_i8_t = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_8vlsx1x1_i8_vlen256(
+    %lhs: vector<32x1xi8>, %rhs: vector<1x1xi8>, %acc: vector<32x1xi32>)
+    -> vector<32x1xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_i8_t,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16, vlen = 256>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<32x1xi8>, vector<1x1xi8> into vector<32x1xi32>
+  return %0 : vector<32x1xi32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_8vlsx1x1_i8_vlen256
+//       CHECK:   vector.extract {{.*}} : i8 from vector<{{1x1|1}}xi8>
+//       CHECK:   arith.extsi {{.*}} : i8 to i16
+//   CHECK-NOT:   vector.broadcast {{.*}} : i16 to vector<32xi16>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vsext{{.*}}"({{.*}}) : (vector<[8]xi16>, vector<[8]xi8>, i64) -> vector<[8]xi16>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vwmacc{{.*}}"({{.*}}) : (vector<[8]xi32>, i16, vector<[8]xi16>, i64, i64) -> vector<[8]xi32>
+
+// -----
+
+// RISC-V VLEN=128 i8→i32 CASTI16.
+
+#contraction_accesses_rvv_i8_128 = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_riscv_v_1x8vlsx1_i8_vlen128(
+    %lhs: vector<1x1xi8>, %rhs: vector<16x1xi8>, %acc: vector<1x16xi32>)
+    -> vector<1x16xi32> {
+  %0 = iree_codegen.inner_tiled ins(%lhs, %rhs) outs(%acc) {
+    indexing_maps = #contraction_accesses_rvv_i8_128,
+    iterator_types = [],
+    kind = #iree_cpu.data_tiled_mma_layout<intrinsic = MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16, vlen = 128>,
+    semantics = #iree_cpu.mma_semantics<>
+  } : vector<1x1xi8>, vector<16x1xi8> into vector<1x16xi32>
+  return %0 : vector<1x16xi32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root
+        : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_inner_tiled
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_riscv_v_1x8vlsx1_i8_vlen128
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vsext{{.*}}"({{.*}}) : (vector<[8]xi16>, vector<[8]xi8>, i64) -> vector<[8]xi16>
+//       CHECK:   llvm.call_intrinsic "llvm.riscv.vwmacc{{.*}}"({{.*}}) : (vector<[8]xi32>, i16, vector<[8]xi16>, i64, i64) -> vector<[8]xi32>

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -432,9 +432,15 @@ getMmaIntrinsicRequiredFeatures(IREE::CPU::MMAIntrinsic intr) {
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x1x4_I32_I8_UI8:
   case MMAIntrinsic::MMA_X86_AVX512VNNI_16x16x2_I32_I8_CASTI16:
     return {"+avx512vnni"};
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32:
+    return {"+v"};
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16:
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16:
     return {"+v", "+zvfh"};
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32:
+  case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32:
+    return {"+v", "+zvfhmin"};
   default:
     return {};
   }
@@ -566,8 +572,13 @@ checkIntrinsicRequiredFeatures(DictionaryAttr config,
     if (required.empty()) {
       continue;
     }
-    if (llvm::all_of(required,
-                     [&](StringRef f) { return hasFeature(config, f); })) {
+    if (llvm::all_of(required, [&](StringRef f) {
+          if (hasFeature(config, f)) {
+            return true;
+          }
+          // Zvfh includes Zvfhmin; IREE matches feature strings exactly.
+          return f == "+zvfhmin" && hasFeature(config, "+zvfh");
+        })) {
       out.push_back(intr);
     }
   }
@@ -617,8 +628,12 @@ getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
   }
   if (isRISCV64(config)) {
     static const MMAIntrinsic kAllRiscvV[] = {
+        MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32,
+        MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32,
         MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16,
         MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16,
+        MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32,
+        MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32,
     };
     checkIntrinsicRequiredFeatures(config, kAllRiscvV, out);
   }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -434,6 +434,8 @@ getMmaIntrinsicRequiredFeatures(IREE::CPU::MMAIntrinsic intr) {
     return {"+avx512vnni"};
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F32:
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F32:
+  case MMAIntrinsic::MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16:
+  case MMAIntrinsic::MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16:
     return {"+v"};
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F16_F16:
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16:
@@ -441,6 +443,9 @@ getMmaIntrinsicRequiredFeatures(IREE::CPU::MMAIntrinsic intr) {
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32:
   case MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32:
     return {"+v", "+zvfhmin"};
+  case MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16:
+  case MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_8VLsx1x1_F32_BF16:
+    return {"+v", "+zvfbfwma"};
   default:
     return {};
   }
@@ -634,6 +639,10 @@ getMmaIntrinsicsForTargetConfig(DictionaryAttr config) {
         MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F16_F16,
         MMAIntrinsic::MMA_RISCV_V_VFMACC_1x8VLsx1_F32_F16_CASTF32,
         MMAIntrinsic::MMA_RISCV_V_VFMACC_8VLsx1x1_F32_F16_CASTF32,
+        MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_1x8VLsx1_F32_BF16,
+        MMAIntrinsic::MMA_RISCV_V_VFWMACCBF16_8VLsx1x1_F32_BF16,
+        MMAIntrinsic::MMA_RISCV_V_VWMACC_1x8VLsx1_I32_I8_CASTI16,
+        MMAIntrinsic::MMA_RISCV_V_VWMACC_8VLsx1x1_I32_I8_CASTI16,
     };
     checkIntrinsicRequiredFeatures(config, kAllRiscvV, out);
   }


### PR DESCRIPTION
[#24858](https://github.com/iree-org/iree/pull/24858) added `vlen` on `DataTiledMMAAttr` and f16 `inner_tiled` materialization on RISC-V V, but did not lower to LLVM. This continues that work for [#24311](https://github.com/iree-org/iree/issues/24311): more RVV MMA enums, encoding selection, and lowering of `iree_codegen.inner_tiled` to `llvm.call_intrinsic`.

One enum pair still covers every `+zvl*b` length. Tile N is `vlen/8` (`8VLs`); the swapped sibling is the M↔N orientation. LHS is the scalar `.vf` / `.vx` operand so `m_bcst` can fold, matching the mmt4d ukernels.

| Family | Intrinsic | Features | Lowering |
| --- | --- | --- | --- |
| f32×f32→f32 | `vfmacc.vf` | `+v` | `llvm.riscv.vfmacc` |
| f16×f16→f16 | `vfmacc.vf` | `+zvfh` | `llvm.riscv.vfmacc` |
| f16×f16→f32 CASTF32 | extf + f32 `vfmacc.vf` | `+zvfhmin` (`+zvfh` implies it) | `arith.extf` then `llvm.riscv.vfmacc` |
| bf16×bf16→f32 | `vfwmaccbf16.vf` | `+zvfbfwma` | `llvm.riscv.vfwmaccbf16` |
| i8×i8→i32 CASTI16 | `vsext` + `vwmacc.vx` | `+v` | `arith.extsi` + `llvm.riscv.vsext` + `llvm.riscv.vwmacc` |

Native Zvfh still wins over CASTF32 when both are legal.

Towards #24311

Assisted-by: Cursor 